### PR TITLE
Align frontend with canonical schema contract

### DIFF
--- a/frontend/components/ComparePanel.tsx
+++ b/frontend/components/ComparePanel.tsx
@@ -83,7 +83,7 @@ export function ComparePanel() {
   // Get rankings for percentile calculation
   const { data: allRankings, isLoading: rankingsLoading, isError: rankingsError, error: rankingsErrorObj, refetch: refetchRankings } = useRankings(
     team1Data?.state || null,
-    team1Data?.age != null ? `u${team1Data.age}` : team1Data?.age_group,
+    team1Data?.age != null ? `u${team1Data.age}` : null,
     team1Data?.gender
   );
 

--- a/frontend/components/ComparePanel.tsx
+++ b/frontend/components/ComparePanel.tsx
@@ -82,8 +82,8 @@ export function ComparePanel() {
   
   // Get rankings for percentile calculation
   const { data: allRankings, isLoading: rankingsLoading, isError: rankingsError, error: rankingsErrorObj, refetch: refetchRankings } = useRankings(
-    team1Data?.state || null,
-    team1Data?.age != null ? `u${team1Data.age}` : null,
+    team1Data?.state || undefined,
+    team1Data?.age != null ? `u${team1Data.age}` : undefined,
     team1Data?.gender
   );
 

--- a/frontend/components/TeamHeader.tsx
+++ b/frontend/components/TeamHeader.tsx
@@ -140,7 +140,7 @@ export function TeamHeader({ teamId }: TeamHeaderProps) {
                   </Badge>
                 )}
                 <Badge variant="outline">
-                  {team.age != null ? `U${team.age}` : (team as any).age_group?.toUpperCase() || 'N/A'} {team.gender === 'M' ? 'Boys' : team.gender === 'F' ? 'Girls' : team.gender === 'B' ? 'Boys' : team.gender === 'G' ? 'Girls' : team.gender}
+                  {team.age != null ? `U${team.age}` : 'N/A'} {team.gender === 'M' ? 'Boys' : team.gender === 'F' ? 'Girls' : team.gender === 'B' ? 'Boys' : team.gender === 'G' ? 'Girls' : team.gender}
                 </Badge>
               </div>
             </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -40,38 +40,6 @@ export interface Game {
   created_at: string;
 }
 
-export interface Ranking {
-  team_id: string; // UUID - references teams.team_id_master
-  team_id_master?: string;
-  // Correct ranking fields (backend contract)
-  national_rank: number | null;
-  state_rank: number | null;
-  national_sos_rank: number | null;
-  state_sos_rank: number | null;
-  power_score_final: number | null; // ML-adjusted power score (ML > global > adj > national)
-  sos_norm: number | null; // Normalized SOS (percentile/z-score within cohort)
-  // Record
-  wins: number;
-  losses: number;
-  draws: number;
-  games_played: number;
-  win_percentage: number | null;
-  goals_for?: number;
-  goals_against?: number;
-  last_game_date: string | null; // ISO date string
-  last_calculated?: string;
-  // Deprecated fields (do not use)
-  /** @deprecated Use power_score_final instead */
-  national_power_score?: never;
-  /** @deprecated Use sos_norm instead */
-  strength_of_schedule?: never;
-  /** @deprecated Use sos_norm instead */
-  sos?: never;
-  /** @deprecated Use sos_norm instead */
-  sos_rank?: never;
-  global_power_score?: number | null; // Kept for backward compatibility but prefer power_score_final
-}
-
 /**
  * Ranking with team details (from rankings_view / state_rankings_view)
  * This matches the exact columns returned by the rankings views (RankingRow contract)


### PR DESCRIPTION
Remove deprecated field fallbacks and unused types to ensure frontend fully aligns with canonical backend contract.

Changes:
- ComparePanel.tsx: Remove fallback to deprecated age_group field
- TeamHeader.tsx: Remove fallback to deprecated age_group field
- lib/types.ts: Remove unused Ranking interface with deprecated fields

All frontend components now use canonical field names:
- age (integer) instead of age_group
- rank_in_cohort_final instead of national_rank
- rank_in_state_final instead of state_rank
- power_score_final instead of national_power_score
- sos_norm instead of strength_of_schedule

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

