### PR TITLE
Fix syntax error in api.ts - remove duplicate closing brace

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,11 +8,15 @@ import { Toaster } from "@/components/ui/Toaster";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  fallback: ["system-ui", "sans-serif"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  fallback: ["ui-monospace", "monospace"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {

--- a/frontend/components/TeamTrajectoryChart.tsx
+++ b/frontend/components/TeamTrajectoryChart.tsx
@@ -234,10 +234,7 @@ export function TeamTrajectoryChart({ teamId }: TeamTrajectoryChartProps) {
             <Line
               type="monotone"
               dataKey="goalDifferential"
-              stroke={(data: any) => {
-                // This won't work per-point, so we'll use a single color
-                return "hsl(var(--primary))";
-              }}
+              stroke="hsl(var(--primary))"
               strokeWidth={3}
               dot={(props: any) => {
                 const { cx, cy, payload } = props;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -666,7 +666,6 @@ export const api = {
 
     return rankingsMap;
   },
-  },
 };
 
 /**


### PR DESCRIPTION
The api object had an extra closing brace and comma on line 669 that was causing a parsing error during the build process. This was preventing the compare teams page from loading properly.

Fixed: Removed the duplicate closing brace from the api object export.