### PR TITLE
Fix groupby operations to preserve team_id column - remove group_keys…

### DIFF
--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -273,7 +273,7 @@ def compute_rankings(
         out["ga"] = _clip_outliers_series(out["ga"], cfg.OUTLIER_GUARD_ZSCORE)
         return out
 
-    g = g.groupby("team_id", group_keys=False).apply(clip_team_games)
+    g = g.groupby("team_id").apply(clip_team_games).reset_index(drop=True)
     g["gd"] = (g["gf"] - g["ga"]).clip(-cfg.GOAL_DIFF_CAP, cfg.GOAL_DIFF_CAP)
 
     # keep last N games per team (by date)
@@ -295,7 +295,7 @@ def compute_rankings(
         out["w_base"] = w
         return out
 
-    g = g.groupby("team_id", group_keys=False).apply(apply_recency)
+    g = g.groupby("team_id").apply(apply_recency).reset_index(drop=True)
 
     # -------------------------
     # Context multipliers (tournament/KO)
@@ -365,7 +365,7 @@ def compute_rankings(
         out["def_shrunk"] = 1.0 / (out["sad_shrunk"] + cfg.RIDGE_GA)
         return out
 
-    team = team.groupby(["age", "gender"], group_keys=False).apply(shrink_grp)
+    team = team.groupby(["age", "gender"]).apply(shrink_grp).reset_index(drop=True)
 
     # -------------------------
     # Layer 5: team-level outlier guard (OFF/DEF)
@@ -380,7 +380,7 @@ def compute_rankings(
                                   mu + cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd)
         return out
 
-    team = team.groupby(["age", "gender"], group_keys=False).apply(clip_team_level)
+    team = team.groupby(["age", "gender"]).apply(clip_team_level).reset_index(drop=True)
 
     # -------------------------
     # Layer 9: normalize OFF/DEF
@@ -567,7 +567,7 @@ def compute_rankings(
             out["def_shrunk"] = 1.0 / (out["sad_shrunk"] + cfg.RIDGE_GA)
             return out
 
-        team = team.groupby(["age", "gender"], group_keys=False).apply(shrink_grp_adj)
+        team = team.groupby(["age", "gender"]).apply(shrink_grp_adj).reset_index(drop=True)
 
         # Re-apply outlier clipping
         def clip_team_level_adj(df: pd.DataFrame) -> pd.DataFrame:
@@ -580,7 +580,7 @@ def compute_rankings(
                                       mu + cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd)
             return out
 
-        team = team.groupby(["age", "gender"], group_keys=False).apply(clip_team_level_adj)
+        team = team.groupby(["age", "gender"]).apply(clip_team_level_adj).reset_index(drop=True)
 
         # Re-normalize
         team = _normalize_by_cohort(team, "off_shrunk", "off_norm", cfg.NORM_MODE)


### PR DESCRIPTION
…=False and reset index

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

