### PR TITLE
Filter out inactive teams (>180 days since last game) from rankings

### DIFF
--- a/frontend/hooks/useRankings.ts
+++ b/frontend/hooks/useRankings.ts
@@ -31,7 +31,8 @@ export function useRankings(
         // National rankings = return full slice from rankings_view
         let query = supabase
           .from('rankings_view')
-          .select('*');
+          .select('*')
+          .eq('status', 'Active'); // Filter out inactive teams (>180 days since last game)
 
         let normalizedAge: number | null = null;
         if (ageGroup) {
@@ -96,7 +97,8 @@ export function useRankings(
         let query = supabase
           .from('state_rankings_view')
           .select('*')
-          .eq('state', normalizedRegion);
+          .eq('state', normalizedRegion)
+          .eq('status', 'Active'); // Filter out inactive teams (>180 days since last game)
 
         if (ageGroup) {
           // Normalize age group to integer

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -30,7 +30,8 @@ export const api = {
     gender?: 'M' | 'F' | 'B' | 'G' | null
   ): Promise<RankingWithTeam[]> {
     const table = region ? 'state_rankings_view' : 'rankings_view';
-    let query = supabase.from(table).select('*');
+    let query = supabase.from(table).select('*')
+      .eq('status', 'Active'); // Filter out inactive teams (>180 days since last game)
 
     if (ageGroup) {
       // Normalize age group to integer

--- a/frontend/types/RankingRow.ts
+++ b/frontend/types/RankingRow.ts
@@ -35,6 +35,9 @@ export interface RankingRow {
   // Rank change tracking (from rankings_full table)
   rank_change_7d?: number | null; // Rank change over 7 days (positive = improved)
   rank_change_30d?: number | null; // Rank change over 30 days (positive = improved)
+  // Activity status (for filtering inactive teams)
+  status?: 'Active' | 'Inactive' | 'Not Enough Ranked Games' | null; // Team activity status
+  last_game?: string | null; // ISO timestamp of last game played
   // Deprecated fields (do not use)
   /** @deprecated Use state instead */
   state_code?: never;

--- a/supabase/migrations/20251123000000_add_status_to_rankings_views.sql
+++ b/supabase/migrations/20251123000000_add_status_to_rankings_views.sql
@@ -1,0 +1,223 @@
+-- Add status and last_game fields to rankings views
+-- Date: 2025-11-19
+-- Purpose: Expose team activity status to frontend to filter out inactive teams (>180 days since last game)
+
+-- =====================================================
+-- Step 1: Drop existing views
+-- =====================================================
+
+DROP VIEW IF EXISTS state_rankings_view CASCADE;
+DROP VIEW IF EXISTS rankings_view CASCADE;
+
+-- =====================================================
+-- Step 2: Recreate rankings_view with status fields
+-- =====================================================
+
+CREATE VIEW rankings_view
+WITH (security_invoker = true)
+AS
+SELECT
+    -- Team identity fields
+    t.team_id_master,
+    t.team_name,
+    t.club_name,
+    t.state_code AS state,
+    CASE
+      -- If it's already a number (e.g., "12"), cast directly
+      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+      -- If it starts with 'u' or 'U' followed by digits (e.g., "u12", "U12"), extract the number
+      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+      -- Try to extract any number from the string as fallback
+      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+      ELSE NULL
+    END AS age,
+    CASE
+      WHEN rf.gender = 'Male' THEN 'M'
+      WHEN rf.gender = 'Female' THEN 'F'
+      WHEN rf.gender = 'Boys' THEN 'M'
+      WHEN rf.gender = 'Girls' THEN 'F'
+      WHEN rf.gender = 'M' THEN 'M'
+      WHEN rf.gender = 'F' THEN 'F'
+      ELSE rf.gender
+    END AS gender,
+
+    -- Record stats (from rankings_full with fallback - these are CAPPED AT 30 GAMES for rankings algorithm)
+    COALESCE(rf.games_played, cr.games_played) AS games_played,
+    COALESCE(rf.wins, cr.wins) AS wins,
+    COALESCE(rf.losses, cr.losses) AS losses,
+    COALESCE(rf.draws, cr.draws) AS draws,
+
+    -- Total games count (ALL games, not capped) for display
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+    ) AS total_games_played,
+
+    -- Total wins/losses/draws from ALL games (for accurate win% calculation)
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score > g.away_score)
+            OR (g.away_team_master_id = t.team_id_master AND g.away_score > g.home_score))
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+    ) AS total_wins,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score < g.away_score)
+            OR (g.away_team_master_id = t.team_id_master AND g.away_score < g.home_score))
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+    ) AS total_losses,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+       AND g.home_score = g.away_score
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+    ) AS total_draws,
+
+    -- Recalculated win_percentage based on TOTAL games (not capped)
+    CASE
+      WHEN (SELECT COUNT(*)
+            FROM games g
+            WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+              AND g.home_score IS NOT NULL
+              AND g.away_score IS NOT NULL) > 0
+      THEN (
+        (
+          (SELECT COUNT(*)::NUMERIC
+           FROM games g
+           WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score > g.away_score)
+                  OR (g.away_team_master_id = t.team_id_master AND g.away_score > g.home_score))
+             AND g.home_score IS NOT NULL
+             AND g.away_score IS NOT NULL)
+          +
+          (SELECT COUNT(*)::NUMERIC
+           FROM games g
+           WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+             AND g.home_score = g.away_score
+             AND g.home_score IS NOT NULL
+             AND g.away_score IS NOT NULL) * 0.5
+        ) /
+        (SELECT COUNT(*)::NUMERIC
+         FROM games g
+         WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+           AND g.home_score IS NOT NULL
+           AND g.away_score IS NOT NULL)
+      ) * 100
+      ELSE NULL
+    END AS win_percentage,
+
+    -- Metrics (ONLY from rankings_full, NO fallback)
+    rf.power_score_final,
+    rf.sos_norm,
+    rf.off_norm AS offense_norm,
+    rf.def_norm AS defense_norm,
+
+    -- Rank (use precomputed ML ranking from rankings_full, do NOT recompute)
+    COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS rank_in_cohort_final,
+
+    -- Rank change tracking (historical data from rankings_full)
+    rf.rank_change_7d,
+    rf.rank_change_30d,
+
+    -- NEW: Activity status fields for filtering inactive teams
+    rf.status,                -- 'Active', 'Inactive', or 'Not Enough Ranked Games'
+    rf.last_game,             -- Timestamp of last game played
+
+    -- Metadata
+    rf.last_calculated
+
+FROM rankings_full rf
+JOIN teams t ON rf.team_id = t.team_id_master
+LEFT JOIN current_rankings cr ON cr.team_id = t.team_id_master
+WHERE rf.power_score_final IS NOT NULL;
+
+COMMENT ON VIEW rankings_view IS 'National rankings view using rankings_full as primary source. Includes rank change tracking (7-day and 30-day) for Recent Movers feature, total_games_played (all games, not capped at 30), recalculated win_percentage based on total games, and activity status fields (status, last_game) for filtering inactive teams.';
+
+-- =====================================================
+-- Step 3: Recreate state_rankings_view with status
+-- =====================================================
+
+CREATE VIEW state_rankings_view
+WITH (security_invoker = true)
+AS
+SELECT
+    -- Team identity fields
+    rv.team_id_master,
+    rv.team_name,
+    rv.club_name,
+    rv.state AS state,
+    rv.age AS age,
+    rv.gender,
+
+    -- Record stats (capped at 30 for rankings algorithm)
+    rv.games_played,
+    rv.wins,
+    rv.losses,
+    rv.draws,
+
+    -- Total games and record (all games, not capped)
+    rv.total_games_played,
+    rv.total_wins,
+    rv.total_losses,
+    rv.total_draws,
+    rv.win_percentage, -- Already recalculated from total games in base view
+
+    -- Metrics
+    rv.power_score_final,
+    rv.sos_norm,
+    rv.offense_norm,
+    rv.defense_norm,
+
+    -- National rank (from base view)
+    rv.rank_in_cohort_final,
+
+    -- State rank (computed live in view)
+    ROW_NUMBER() OVER (
+        PARTITION BY rv.state, rv.age, rv.gender
+        ORDER BY rv.power_score_final DESC
+    ) AS rank_in_state_final,
+
+    -- Rank change tracking (passed through from base view)
+    rv.rank_change_7d,
+    rv.rank_change_30d,
+
+    -- NEW: Activity status fields (passed through from base view)
+    rv.status,
+    rv.last_game,
+
+    -- Metadata
+    rv.last_calculated
+
+FROM rankings_view rv
+WHERE rv.state IS NOT NULL;
+
+COMMENT ON VIEW state_rankings_view IS 'State rankings view: National rankings filtered by state, with dynamically calculated rank_in_state_final. Includes rank change tracking (7-day and 30-day), total_games_played, recalculated win_percentage based on all games, and activity status fields for filtering inactive teams.';
+
+-- =====================================================
+-- Step 4: Grant SELECT permissions
+-- =====================================================
+
+GRANT SELECT ON rankings_view TO authenticated;
+GRANT SELECT ON rankings_view TO anon;
+GRANT SELECT ON state_rankings_view TO authenticated;
+GRANT SELECT ON state_rankings_view TO anon;
+
+-- =====================================================
+-- Notes
+-- =====================================================
+-- This migration adds status and last_game fields from rankings_full to both
+-- rankings_view and state_rankings_view. These fields enable frontend filtering
+-- of inactive teams (teams that haven't played a game in >180 days).
+--
+-- Status values:
+-- - 'Active': Team has played within last 180 days
+-- - 'Inactive': Team hasn't played in >180 days
+-- - 'Not Enough Ranked Games': Team has <5 games total
+--
+-- Frontend should filter WHERE status = 'Active' to show only active teams.


### PR DESCRIPTION
This fix addresses the issue where teams that haven't played a game in over 180 days were still appearing in the rankings display.

Changes:
1. Database views: Added `status` and `last_game` fields from rankings_full to both rankings_view and state_rankings_view
2. TypeScript types: Updated RankingRow interface to include status and last_game fields
3. Frontend filters: Added .eq('status', 'Active') filter to:
   - useRankings hook (both national and state queries)
   - api.getRankings function
4. Migration: Created 20251123000000_add_status_to_rankings_views.sql

The backend v53e ranking engine already calculates inactive status for teams with no games in 180+ days. Now the frontend properly filters these out.

Teams are marked as:
- 'Active': Played within last 180 days
- 'Inactive': No games in >180 days (now filtered out)
- 'Not Enough Ranked Games': <5 total games (also filtered out)

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

