### PR TITLE
Refactor rankings engine for cleaner tuning and cohort-based SOS

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -65,16 +65,18 @@ PROVIDERS = {
 }
 
 # Age Groups with metadata
+# NOTE: anchor_score values are aligned with v53e.py AGE_TO_ANCHOR mapping
+# These provide linear progression from U10 (0.40) to U18 (1.00)
 AGE_GROUPS = {
-    'u10': {'birth_year': 2016, 'anchor_score': 0.40},
-    'u11': {'birth_year': 2015, 'anchor_score': 0.44},
-    'u12': {'birth_year': 2014, 'anchor_score': 0.49},
-    'u13': {'birth_year': 2013, 'anchor_score': 0.55},
-    'u14': {'birth_year': 2012, 'anchor_score': 0.62},
-    'u15': {'birth_year': 2011, 'anchor_score': 0.70},
-    'u16': {'birth_year': 2010, 'anchor_score': 0.79},
-    'u17': {'birth_year': 2009, 'anchor_score': 0.89},
-    'u18': {'birth_year': 2008, 'anchor_score': 1.00}
+    'u10': {'birth_year': 2016, 'anchor_score': 0.400},
+    'u11': {'birth_year': 2015, 'anchor_score': 0.475},
+    'u12': {'birth_year': 2014, 'anchor_score': 0.550},
+    'u13': {'birth_year': 2013, 'anchor_score': 0.625},
+    'u14': {'birth_year': 2012, 'anchor_score': 0.700},
+    'u15': {'birth_year': 2011, 'anchor_score': 0.775},
+    'u16': {'birth_year': 2010, 'anchor_score': 0.850},
+    'u17': {'birth_year': 2009, 'anchor_score': 0.925},
+    'u18': {'birth_year': 2008, 'anchor_score': 1.000}
 }
 
 # Ranking Configuration (aligned with v53e V53EConfig)
@@ -105,7 +107,9 @@ RANKING_CONFIG = {
     'team_outlier_guard_zscore': float(os.getenv("TEAM_OUTLIER_GUARD_ZSCORE", 2.5)),  # V53EConfig.TEAM_OUTLIER_GUARD_ZSCORE
     
     # Layer 6 (Performance)
-    'performance_k': float(os.getenv("PERFORMANCE_K", 0.15)),  # V53EConfig.PERFORMANCE_K
+    'performance_k': float(os.getenv("PERFORMANCE_K", 0.15)),  # V53EConfig.PERFORMANCE_K (legacy, use perf_* instead)
+    'perf_game_scale': float(os.getenv("PERF_GAME_SCALE", 0.15)),  # V53EConfig.PERF_GAME_SCALE - scales per-game residual
+    'perf_blend_weight': float(os.getenv("PERF_BLEND_WEIGHT", 0.15)),  # V53EConfig.PERF_BLEND_WEIGHT - weight in powerscore
     'performance_decay_rate': float(os.getenv("PERFORMANCE_DECAY_RATE", 0.08)),  # V53EConfig.PERFORMANCE_DECAY_RATE
     'performance_threshold': float(os.getenv("PERFORMANCE_THRESHOLD", 2.0)),  # V53EConfig.PERFORMANCE_THRESHOLD
     'performance_goal_scale': float(os.getenv("PERFORMANCE_GOAL_SCALE", 5.0)),  # V53EConfig.PERFORMANCE_GOAL_SCALE


### PR DESCRIPTION
Key changes:
- Split PERFORMANCE_K into PERF_GAME_SCALE and PERF_BLEND_WEIGHT for intuitive tuning
- Replace block recency weighting with exponential decay (decay_rate=0.05)
- Remove sos_presos placeholder; power_presos now uses only OFF/DEF (50% each)
- Replace hard SOS cap with soft shrinkage toward 0.5 for low-sample teams
- Disable national SOS recalculation in PowerScore (keep cohort-based)
- Align settings.py anchors with v53e.py AGE_TO_ANCHOR mapping
- Add distribution diagnostics for sos_norm and powerscore_adj per cohort

National/state SOS metrics are still computed for display but no longer affect rankings, preserving the principle that teams compete within their cohort (age/gender).

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

