### PR TITLE
Fix URL to pitchrank.io and adjust slash positioning

### DIFF
--- a/frontend/components/infographics/Top10Infographic.tsx
+++ b/frontend/components/infographics/Top10Infographic.tsx
@@ -170,7 +170,7 @@ export const Top10Infographic = forwardRef<HTMLDivElement, Top10InfographicProps
                 textDecoration: 'none',
               }}
             >
-              pitchrank.com
+              pitchrank.io
             </div>
             <div
               style={{

--- a/frontend/components/infographics/U12Top10Infographic.tsx
+++ b/frontend/components/infographics/U12Top10Infographic.tsx
@@ -152,7 +152,7 @@ export const U12Top10Infographic = forwardRef<HTMLDivElement, U12Top10Infographi
                 color: 'rgba(255, 255, 255, 0.6)',
               }}
             >
-              pitchrank.com
+              pitchrank.io
             </div>
             <div
               style={{

--- a/frontend/components/infographics/canvasRenderer.ts
+++ b/frontend/components/infographics/canvasRenderer.ts
@@ -75,10 +75,10 @@ export async function renderInfographicToCanvas(options: RenderOptions): Promise
 
   // Yellow slash bar - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 10, logoY - titleSize * 0.4);
+  ctx.translate(logoStartX - 4, logoY - titleSize * 0.4);
   ctx.transform(1, 0, -0.2, 1, 0, 0); // Skew
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 10, titleSize * 0.8);
+  ctx.fillRect(-10, 0, 10, titleSize * 0.8);
   ctx.restore();
 
   // Draw PITCH in white
@@ -241,11 +241,11 @@ export async function renderInfographicToCanvas(options: RenderOptions): Promise
   ctx.lineTo(dimensions.width - padding, currentY - 16);
   ctx.stroke();
 
-  // pitchrank.com
+  // pitchrank.io
   ctx.textAlign = 'left';
   ctx.fillStyle = '#999999';
   ctx.font = `400 ${statsSize - 2}px "DM Sans", Arial, sans-serif`;
-  ctx.fillText('pitchrank.com', padding, currentY);
+  ctx.fillText('pitchrank.io', padding, currentY);
 
   // Hashtags
   const hashtags = `#YouthSoccer #${ageGroup}Soccer${region ? ` #${regionName}Soccer` : ''}`;

--- a/frontend/components/infographics/coverImageRenderer.ts
+++ b/frontend/components/infographics/coverImageRenderer.ts
@@ -99,10 +99,10 @@ export async function renderCoverImageToCanvas(options: CoverImageOptions): Prom
 
   // Yellow slash (larger and more prominent for cover images) - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 14, logoY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, logoY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 12, logoSize * 0.7);
+  ctx.fillRect(-12, 0, 12, logoSize * 0.7);
   ctx.restore();
 
   // Logo text
@@ -197,7 +197,7 @@ export async function renderCoverImageToCanvas(options: CoverImageOptions): Prom
   ctx.textAlign = 'right';
   ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
   ctx.font = `400 ${subtitleSize - 2}px "DM Sans", Arial, sans-serif`;
-  ctx.fillText('pitchrank.com', dimensions.width - 60, dimensions.height - 25);
+  ctx.fillText('pitchrank.io', dimensions.width - 60, dimensions.height - 25);
 
   return canvas;
 }

--- a/frontend/components/infographics/headToHeadRenderer.ts
+++ b/frontend/components/infographics/headToHeadRenderer.ts
@@ -82,10 +82,10 @@ export async function renderHeadToHeadToCanvas(options: HeadToHeadOptions): Prom
 
   // Yellow slash - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 8, logoY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, logoY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 7, logoSize * 0.7);
+  ctx.fillRect(-7, 0, 7, logoSize * 0.7);
   ctx.restore();
 
   // Logo text
@@ -264,7 +264,7 @@ export async function renderHeadToHeadToCanvas(options: HeadToHeadOptions): Prom
 
   ctx.textAlign = 'right';
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillText('pitchrank.com', dimensions.width - padding, currentY);
+  ctx.fillText('pitchrank.io', dimensions.width - padding, currentY);
 
   return canvas;
 }

--- a/frontend/components/infographics/rankingMoversRenderer.ts
+++ b/frontend/components/infographics/rankingMoversRenderer.ts
@@ -71,10 +71,10 @@ export async function renderRankingMoversToCanvas(options: RankingMoversOptions)
 
   // Yellow slash - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 8, logoY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, logoY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 8, logoSize * 0.7);
+  ctx.fillRect(-8, 0, 8, logoSize * 0.7);
   ctx.restore();
 
   // Logo text - PITCH in white
@@ -210,7 +210,7 @@ export async function renderRankingMoversToCanvas(options: RankingMoversOptions)
 
   ctx.textAlign = 'right';
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillText('pitchrank.com', dimensions.width - padding, currentY);
+  ctx.fillText('pitchrank.io', dimensions.width - padding, currentY);
 
   return canvas;
 }

--- a/frontend/components/infographics/stateChampionsRenderer.ts
+++ b/frontend/components/infographics/stateChampionsRenderer.ts
@@ -82,10 +82,10 @@ export async function renderStateChampionsToCanvas(options: StateChampionsOption
 
   // Yellow slash - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 8, logoY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, logoY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 8, logoSize * 0.7);
+  ctx.fillRect(-8, 0, 8, logoSize * 0.7);
   ctx.restore();
 
   // Logo text
@@ -205,7 +205,7 @@ export async function renderStateChampionsToCanvas(options: StateChampionsOption
 
   ctx.textAlign = 'right';
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillText('pitchrank.com', dimensions.width - padding, currentY);
+  ctx.fillText('pitchrank.io', dimensions.width - padding, currentY);
 
   return canvas;
 }

--- a/frontend/components/infographics/storyTemplateRenderer.ts
+++ b/frontend/components/infographics/storyTemplateRenderer.ts
@@ -104,10 +104,10 @@ export async function renderStoryTemplateToCanvas(options: StoryTemplateOptions)
 
   // Yellow slash - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 10, currentY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, currentY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 9, logoSize * 0.7);
+  ctx.fillRect(-9, 0, 9, logoSize * 0.7);
   ctx.restore();
 
   // Logo text
@@ -180,7 +180,7 @@ export async function renderStoryTemplateToCanvas(options: StoryTemplateOptions)
   // ===== BOTTOM URL =====
   ctx.fillStyle = 'rgba(255, 255, 255, 0.4)';
   ctx.font = `400 18px "DM Sans", Arial, sans-serif`;
-  ctx.fillText('pitchrank.com', centerX, dimensions.height - padding);
+  ctx.fillText('pitchrank.io', centerX, dimensions.height - padding);
 
   return canvas;
 }

--- a/frontend/components/infographics/teamSpotlightRenderer.ts
+++ b/frontend/components/infographics/teamSpotlightRenderer.ts
@@ -75,10 +75,10 @@ export async function renderTeamSpotlightToCanvas(options: TeamSpotlightOptions)
 
   // Yellow slash - positioned right before the P
   ctx.save();
-  ctx.translate(logoStartX - 8, logoY - logoSize * 0.35);
+  ctx.translate(logoStartX - 4, logoY - logoSize * 0.35);
   ctx.transform(1, 0, -0.2, 1, 0, 0);
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillRect(0, 0, 8, logoSize * 0.7);
+  ctx.fillRect(-8, 0, 8, logoSize * 0.7);
   ctx.restore();
 
   // Logo text - PITCH in white
@@ -215,7 +215,7 @@ export async function renderTeamSpotlightToCanvas(options: TeamSpotlightOptions)
   // URL
   ctx.textAlign = 'right';
   ctx.fillStyle = BRAND_COLORS.electricYellow;
-  ctx.fillText('pitchrank.com', dimensions.width - padding, currentY);
+  ctx.fillText('pitchrank.io', dimensions.width - padding, currentY);
 
   return canvas;
 }


### PR DESCRIPTION
- Changed all URLs from pitchrank.com to pitchrank.io
- Moved yellow slash closer to the P in PITCHRANK logo
- Fixed in all 9 infographic files

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

