### PR TITLE
Fix cross-age SOS lookup bug - convert opp_id to string

### DIFF
--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -631,8 +631,10 @@ def compute_rankings(
         if opp_id in base_strength_map:
             return base_strength_map[opp_id]
         # Fall back to global map (cross-age/cross-gender)
-        if global_strength_map and opp_id in global_strength_map:
-            return global_strength_map[opp_id]
+        # global_strength_map uses string keys, so convert opp_id to string
+        opp_id_str = str(opp_id)
+        if global_strength_map and opp_id_str in global_strength_map:
+            return global_strength_map[opp_id_str]
         # Unknown opponent
         return cfg.UNRANKED_SOS_BASE
 
@@ -669,8 +671,10 @@ def compute_rankings(
             if opp_id in opp_sos_map:
                 return opp_sos_map[opp_id]
             # For cross-age opponents not in SOS map, use their global strength as proxy
-            if global_strength_map and opp_id in global_strength_map:
-                return global_strength_map[opp_id]
+            # global_strength_map uses string keys, so convert opp_id to string
+            opp_id_str = str(opp_id)
+            if global_strength_map and opp_id_str in global_strength_map:
+                return global_strength_map[opp_id_str]
             return cfg.UNRANKED_SOS_BASE
 
         g_sos["opp_sos"] = g_sos["opp_id"].map(get_opponent_sos)


### PR DESCRIPTION
The global_strength_map is built with string keys (via str(row["team_id"])) in calculator.py, but the lookup functions in v53e.py were comparing raw opp_id values (which could be UUID type from Supabase) against string keys.

This caused cross-age opponent strength lookups to fail, falling back to UNRANKED_SOS_BASE (0.35) instead of using the opponent's actual strength.

The fix converts opp_id to string before looking up in global_strength_map in both get_opponent_strength() and get_opponent_sos() functions.

Impact: Teams that "play up" against older age groups (like Southeast 2015 Boys Red who plays U12 opponents as a U11 team) will now correctly use their opponents' actual strength instead of the 0.35 fallback value.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

