### PR TITLE
Fix TypeScript type mismatches in event payloads

### DIFF
--- a/frontend/types/events.ts
+++ b/frontend/types/events.ts
@@ -1,6 +1,7 @@
 /**
  * Analytics Event Payload Types
  * Type definitions for GA4 custom event payloads
+ * Note: These types use `| null` to match database types (TeamWithRanking, etc.)
  */
 
 /**
@@ -11,11 +12,11 @@ export interface TeamEventPayload {
   team_name: string;
   club_name?: string | null;
   state?: string | null;
-  age?: number;
-  gender?: 'M' | 'F' | 'B' | 'G';
+  age?: number | null;
+  gender?: 'M' | 'F' | 'B' | 'G' | null;
   rank_in_cohort_final?: number | null;
   rank_in_state_final?: number | null;
-  power_score_final?: number;
+  power_score_final?: number | null;
 }
 
 /**
@@ -34,7 +35,7 @@ export interface SortEventPayload {
   column: string;
   direction: 'asc' | 'desc';
   region?: string | null;
-  age_group?: string;
+  age_group?: string | null;
   gender?: string | null;
 }
 
@@ -63,10 +64,10 @@ export interface PredictionEventPayload {
   team_a_name: string;
   team_b_id: string;
   team_b_name: string;
-  win_probability_a?: number;
-  win_probability_b?: number;
-  draw_probability?: number;
-  predicted_winner?: string;
+  win_probability_a?: number | null;
+  win_probability_b?: number | null;
+  draw_probability?: number | null;
+  predicted_winner?: string | null;
 }
 
 /**
@@ -75,7 +76,7 @@ export interface PredictionEventPayload {
 export interface ChartViewEventPayload {
   chart_type: 'momentum' | 'trajectory';
   team_id_master: string;
-  team_name?: string;
+  team_name?: string | null;
 }
 
 /**
@@ -84,5 +85,5 @@ export interface ChartViewEventPayload {
 export interface MissingGameEventPayload {
   team_id_master: string;
   team_name: string;
-  game_date?: string;
+  game_date?: string | null;
 }


### PR DESCRIPTION
Update event payload types to accept `null` values to match database types (TeamWithRanking, etc.):
- age: number | null
- gender: string | null
- power_score_final: number | null
- And other optional fields

The gtagEvent function already filters out null values before sending.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

