### PR TITLE
Fix team age_group extraction to prioritize birth year in team name

### DIFF
--- a/scripts/fix_team_age_groups.py
+++ b/scripts/fix_team_age_groups.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Fix team age_groups based on birth year in team names.
+
+This script finds teams where the age_group doesn't match the birth year
+indicated in the team name (e.g., "ILLINOIS MAGIC FC 2014" should be U12, not U13).
+
+Usage:
+    python scripts/fix_team_age_groups.py --dry-run  # Preview changes
+    python scripts/fix_team_age_groups.py            # Apply fixes
+"""
+
+import os
+import sys
+import re
+import argparse
+from datetime import datetime
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from supabase import create_client
+
+# Current year for age calculation
+CURRENT_YEAR = 2025
+
+
+def calculate_age_group(birth_year: int) -> str:
+    """Calculate age group from birth year.
+
+    Formula: age_group = current_year - birth_year + 1
+    Example: 2025 - 2014 + 1 = 12 → U12
+    """
+    age = CURRENT_YEAR - birth_year + 1
+    if 7 <= age <= 19:
+        return f"u{age}"
+    return None
+
+
+def extract_birth_year(team_name: str) -> int:
+    """Extract birth year from team name.
+
+    Looks for 4-digit years starting with 20 (e.g., 2014, 2013).
+    Returns the birth year if found and valid, None otherwise.
+    """
+    # Match years like 2014, 2013, 2015, etc.
+    match = re.search(r'\b(20\d{2})\b', team_name)
+    if match:
+        year = int(match.group(1))
+        # Validate it's a reasonable birth year (2005-2018 for youth soccer)
+        if 2005 <= year <= 2018:
+            return year
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fix team age_groups based on birth year in names")
+    parser.add_argument('--dry-run', action='store_true', help="Preview changes without applying")
+    parser.add_argument('--team-name', type=str, help="Fix only teams matching this name (partial match)")
+    args = parser.parse_args()
+
+    # Initialize Supabase client
+    supabase_url = os.getenv("SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+
+    if not supabase_url or not supabase_key:
+        print("❌ Missing SUPABASE_URL or SUPABASE_KEY environment variables")
+        sys.exit(1)
+
+    client = create_client(supabase_url, supabase_key)
+
+    print("=" * 70)
+    print("TEAM AGE GROUP FIX SCRIPT")
+    print("=" * 70)
+    print(f"Current Year: {CURRENT_YEAR}")
+    print(f"Mode: {'DRY RUN (no changes)' if args.dry_run else 'LIVE (applying changes)'}")
+    print()
+
+    # Fetch all teams
+    print("📥 Fetching teams from database...")
+
+    query = client.table('teams').select('team_id_master, team_name, age_group, birth_year, gender, state_code')
+
+    if args.team_name:
+        query = query.ilike('team_name', f'%{args.team_name}%')
+
+    result = query.execute()
+    teams = result.data if result.data else []
+
+    print(f"✅ Found {len(teams)} teams")
+    print()
+
+    # Find mismatches
+    mismatches = []
+
+    for team in teams:
+        team_name = team.get('team_name', '')
+        current_age_group = (team.get('age_group') or '').lower()
+
+        # Extract birth year from team name
+        birth_year = extract_birth_year(team_name)
+
+        if birth_year:
+            expected_age_group = calculate_age_group(birth_year)
+
+            if expected_age_group and expected_age_group != current_age_group:
+                mismatches.append({
+                    'team_id_master': team['team_id_master'],
+                    'team_name': team_name,
+                    'current_age_group': current_age_group,
+                    'expected_age_group': expected_age_group,
+                    'birth_year': birth_year,
+                    'gender': team.get('gender'),
+                    'state_code': team.get('state_code')
+                })
+
+    if not mismatches:
+        print("✅ No age group mismatches found!")
+        return
+
+    print(f"⚠️  Found {len(mismatches)} teams with age group mismatches:")
+    print("-" * 70)
+    print(f"{'Team Name':<40} {'Current':^10} {'Expected':^10} {'Birth Year':^10}")
+    print("-" * 70)
+
+    for m in mismatches[:50]:  # Show first 50
+        name = m['team_name'][:38] + '..' if len(m['team_name']) > 40 else m['team_name']
+        print(f"{name:<40} {m['current_age_group']:^10} {m['expected_age_group']:^10} {m['birth_year']:^10}")
+
+    if len(mismatches) > 50:
+        print(f"... and {len(mismatches) - 50} more")
+
+    print("-" * 70)
+    print()
+
+    if args.dry_run:
+        print("🔍 DRY RUN - No changes applied")
+        print("   Run without --dry-run to apply fixes")
+        return
+
+    # Apply fixes
+    print("🔧 Applying fixes...")
+    fixed_count = 0
+    error_count = 0
+
+    for m in mismatches:
+        try:
+            # Update team's age_group and birth_year
+            client.table('teams').update({
+                'age_group': m['expected_age_group'],
+                'birth_year': m['birth_year'],
+                'updated_at': datetime.now().isoformat()
+            }).eq('team_id_master', m['team_id_master']).execute()
+
+            fixed_count += 1
+            print(f"  ✓ Fixed: {m['team_name'][:50]} ({m['current_age_group']} → {m['expected_age_group']})")
+
+        except Exception as e:
+            error_count += 1
+            print(f"  ✗ Error fixing {m['team_name'][:50]}: {e}")
+
+    print()
+    print("=" * 70)
+    print(f"SUMMARY: Fixed {fixed_count} teams, {error_count} errors")
+    print("=" * 70)
+
+    if fixed_count > 0:
+        print()
+        print("⚠️  IMPORTANT: You need to recalculate rankings for the affected teams.")
+        print("   Run: python -m src.rankings.calculator")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/team_utils.py
+++ b/src/utils/team_utils.py
@@ -1,0 +1,136 @@
+"""Team-related utility functions"""
+
+import re
+from typing import Optional, Tuple
+
+# Current year for age calculations (update annually)
+CURRENT_YEAR = 2025
+
+
+def extract_birth_year_from_name(team_name: str) -> Optional[int]:
+    """
+    Extract birth year from a team name.
+
+    Looks for 4-digit years starting with 20 (e.g., 2014, 2013, 2015).
+    Returns the birth year if found and valid, None otherwise.
+
+    Args:
+        team_name: The team name to extract birth year from
+
+    Returns:
+        Birth year as integer, or None if not found
+
+    Examples:
+        >>> extract_birth_year_from_name("ILLINOIS MAGIC FC 2014")
+        2014
+        >>> extract_birth_year_from_name("FC Chicago 2013-2014 Elite")
+        2013  # Returns first match
+        >>> extract_birth_year_from_name("Chicago Fire Academy")
+        None
+    """
+    if not team_name:
+        return None
+
+    # Match years like 2010-2018 (valid youth soccer birth years)
+    match = re.search(r'\b(20\d{2})\b', team_name)
+    if match:
+        year = int(match.group(1))
+        # Validate it's a reasonable birth year for youth soccer
+        # 2005-2018 covers U7 to U20 for 2025 season
+        if 2005 <= year <= 2018:
+            return year
+    return None
+
+
+def calculate_age_group_from_birth_year(birth_year: int, current_year: int = CURRENT_YEAR) -> Optional[str]:
+    """
+    Calculate age group from birth year.
+
+    Formula: age = current_year - birth_year + 1 → f"U{age}"
+
+    Args:
+        birth_year: The birth year (e.g., 2014)
+        current_year: The current year for calculation (default: 2025)
+
+    Returns:
+        Age group string like "U12", or None if invalid
+
+    Examples:
+        >>> calculate_age_group_from_birth_year(2014, 2025)
+        'U12'
+        >>> calculate_age_group_from_birth_year(2013, 2025)
+        'U13'
+    """
+    age = current_year - birth_year + 1
+    if 7 <= age <= 19:  # Valid youth soccer age range
+        return f"U{age}"
+    return None
+
+
+def get_age_group_from_team_name(team_name: str, fallback_age_group: Optional[str] = None) -> Tuple[Optional[str], Optional[int]]:
+    """
+    Get age group from team name, with optional fallback.
+
+    Prioritizes birth year in team name over any fallback value.
+    This ensures teams playing up are ranked by their actual age group.
+
+    Args:
+        team_name: The team name to extract age group from
+        fallback_age_group: Optional fallback age group (e.g., from bracket)
+
+    Returns:
+        Tuple of (age_group, birth_year) - birth_year is None if using fallback
+
+    Examples:
+        >>> get_age_group_from_team_name("ILLINOIS MAGIC FC 2014", "U13")
+        ('U12', 2014)  # Birth year takes priority over bracket age
+        >>> get_age_group_from_team_name("FC Chicago Elite", "U13")
+        ('U13', None)  # Falls back to provided age group
+    """
+    birth_year = extract_birth_year_from_name(team_name)
+    if birth_year:
+        age_group = calculate_age_group_from_birth_year(birth_year)
+        if age_group:
+            return (age_group, birth_year)
+
+    # Normalize fallback age group
+    if fallback_age_group:
+        fallback = fallback_age_group.strip().upper()
+        if not fallback.startswith('U'):
+            fallback = f"U{fallback}"
+        return (fallback, None)
+
+    return (None, None)
+
+
+def is_playing_up(actual_age_group: str, bracket_age_group: str) -> bool:
+    """
+    Determine if a team is playing up (in an older bracket).
+
+    Args:
+        actual_age_group: Team's actual age group (e.g., "U11")
+        bracket_age_group: The bracket/division age group (e.g., "U12")
+
+    Returns:
+        True if team is playing up, False otherwise
+
+    Examples:
+        >>> is_playing_up("U11", "U12")
+        True
+        >>> is_playing_up("U12", "U12")
+        False
+        >>> is_playing_up("U13", "U12")
+        False  # Playing down
+    """
+    if not actual_age_group or not bracket_age_group:
+        return False
+
+    actual_match = re.search(r'U?(\d+)', actual_age_group, re.I)
+    bracket_match = re.search(r'U?(\d+)', bracket_age_group, re.I)
+
+    if actual_match and bracket_match:
+        actual_age = int(actual_match.group(1))
+        bracket_age = int(bracket_match.group(1))
+        return bracket_age > actual_age
+
+    return False

--- a/supabase/migrations/20251204000000_fix_team_age_groups_from_birth_year.sql
+++ b/supabase/migrations/20251204000000_fix_team_age_groups_from_birth_year.sql
@@ -1,0 +1,81 @@
+-- Migration: Fix team age_groups based on birth year in team names
+-- Date: 2025-12-04
+-- Purpose: Correct teams where age_group doesn't match the birth year in their name
+--          (e.g., "ILLINOIS MAGIC FC 2014" should be U12, not U13)
+--
+-- Formula: age_group = 2025 - birth_year + 1
+-- Example: 2025 - 2014 + 1 = 12 → U12
+
+-- =====================================================
+-- Step 1: Preview affected teams (run this first)
+-- =====================================================
+
+-- This query shows teams that need fixing
+-- Run this SELECT first to see what will be updated:
+
+/*
+SELECT
+    team_id_master,
+    team_name,
+    age_group AS current_age_group,
+    CASE
+        WHEN team_name ~ '\b20(1[0-8])\b' THEN
+            'u' || (2025 - (2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER) + 1)::TEXT
+        ELSE NULL
+    END AS expected_age_group,
+    CASE
+        WHEN team_name ~ '\b20(1[0-8])\b' THEN
+            2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER
+        ELSE NULL
+    END AS extracted_birth_year,
+    gender,
+    state_code
+FROM teams
+WHERE
+    -- Has a birth year in the name (2010-2018)
+    team_name ~ '\b20(1[0-8])\b'
+    -- And current age_group doesn't match expected
+    AND age_group != 'u' || (2025 - (2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER) + 1)::TEXT
+ORDER BY team_name;
+*/
+
+-- =====================================================
+-- Step 2: Apply the fix
+-- =====================================================
+
+-- Update teams where age_group doesn't match birth year in name
+UPDATE teams
+SET
+    age_group = 'u' || (2025 - (2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER) + 1)::TEXT,
+    birth_year = 2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER,
+    updated_at = NOW()
+WHERE
+    -- Has a birth year in the name (2010-2018 range for youth soccer)
+    team_name ~ '\b20(1[0-8])\b'
+    -- And current age_group doesn't match expected
+    AND age_group != 'u' || (2025 - (2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER) + 1)::TEXT;
+
+-- =====================================================
+-- Step 3: Verify the fix
+-- =====================================================
+
+-- Run this after the update to verify no mismatches remain:
+/*
+SELECT COUNT(*) AS remaining_mismatches
+FROM teams
+WHERE
+    team_name ~ '\b20(1[0-8])\b'
+    AND age_group != 'u' || (2025 - (2000 + (regexp_match(team_name, '\b20(1[0-8])\b'))[1]::INTEGER) + 1)::TEXT;
+*/
+
+-- =====================================================
+-- Notes
+-- =====================================================
+-- This migration:
+-- 1. Extracts 4-digit birth years (2010-2018) from team names
+-- 2. Calculates the correct age_group using: 2025 - birth_year + 1
+-- 3. Updates both age_group and birth_year columns
+-- 4. Only affects teams where there's a mismatch
+--
+-- After running this migration, you MUST recalculate rankings:
+--   python scripts/calculate_rankings.py


### PR DESCRIPTION
Issue: Teams like "ILLINOIS MAGIC FC 2014" were appearing in U13 rankings instead of U12 because the bracket age was used instead of the birth year from the team name.

Changes:
- Update gotsport_event.py fallback code paths to extract birth year from team name before falling back to bracket/header age
- Add SQL migration to fix existing teams with mismatched age_groups
- Add fix_team_age_groups.py script for manual corrections
- Add team_utils.py utility module with centralized birth year extraction

Formula: age_group = 2025 - birth_year + 1
Example: ILLINOIS MAGIC FC 2014 → 2025 - 2014 + 1 = 12 → U12

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

