### PR TITLE
Fix timezone offset causing dates to display off by one day

### DIFF
--- a/frontend/components/GameHistoryTable.tsx
+++ b/frontend/components/GameHistoryTable.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useTeamGames, useTeam } from '@/lib/hooks';
-// Using native Date formatting instead of date-fns
+import { formatGameDate } from '@/lib/dateUtils';
 import Link from 'next/link';
 import { usePrefetchTeam } from '@/lib/hooks';
 import type { GameWithTeams } from '@/lib/types';
@@ -231,11 +231,7 @@ export function GameHistoryTable({ teamId, limit, teamName }: GameHistoryTablePr
               return (
                 <TableRow key={game.id}>
                   <TableCell className="text-sm">
-                    {new Date(game.game_date).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
+                    {formatGameDate(game.game_date)}
                   </TableCell>
                   <TableCell>
                     {opponentId && opponent ? (

--- a/frontend/components/TeamTrajectoryChart.tsx
+++ b/frontend/components/TeamTrajectoryChart.tsx
@@ -21,6 +21,7 @@ import { useMemo, useEffect, useRef } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { trackChartViewed } from '@/lib/events';
+import { formatChartDate } from '@/lib/dateUtils';
 
 interface TeamTrajectoryChartProps {
   teamId: string;
@@ -49,10 +50,7 @@ export function TeamTrajectoryChart({ teamId }: TeamTrajectoryChartProps) {
 
     // First pass: calculate base data
     const baseData = trajectory.map((point) => ({
-      period: new Date(point.period_start).toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-      }),
+      period: formatChartDate(point.period_start),
       goalDifferential: point.avg_goals_for - point.avg_goals_against,
       avgGoalsFor: point.avg_goals_for,
       avgGoalsAgainst: point.avg_goals_against,

--- a/frontend/components/UnknownOpponentLink.tsx
+++ b/frontend/components/UnknownOpponentLink.tsx
@@ -27,6 +27,7 @@ import {
 import type Fuse from 'fuse.js';
 import type { RankingRow } from '@/types/RankingRow';
 import type { GameWithTeams } from '@/lib/types';
+import { formatGameDate } from '@/lib/dateUtils';
 
 interface UnknownOpponentLinkProps {
   game: GameWithTeams;
@@ -176,12 +177,8 @@ export function UnknownOpponentLink({
     }
   }, [FuseClass]);
 
-  // Format game date
-  const gameDate = new Date(game.game_date).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  // Format game date (using timezone-safe utility)
+  const gameDate = formatGameDate(game.game_date);
 
   // Get score
   const isHome = game.home_team_master_id === currentTeamId;

--- a/frontend/lib/dateUtils.ts
+++ b/frontend/lib/dateUtils.ts
@@ -1,0 +1,65 @@
+/**
+ * Date utility functions for timezone-safe date handling.
+ *
+ * Problem: When JavaScript parses a date-only string like "2025-11-02" with new Date(),
+ * it interprets it as UTC midnight. When displayed in a local timezone (e.g., Mountain Time),
+ * this can shift the date by a day (Nov 2 UTC midnight = Nov 1 5PM MT).
+ *
+ * Solution: Parse date-only strings as local dates for display purposes.
+ */
+
+/**
+ * Parse a date-only string (YYYY-MM-DD) as a local date.
+ *
+ * Use this instead of `new Date(dateString)` when you have a date-only string
+ * and want to display it in the user's local timezone without day shifting.
+ *
+ * @param dateString - Date string in YYYY-MM-DD format (e.g., "2025-11-02")
+ * @returns Date object representing local midnight on that date
+ *
+ * @example
+ * // Instead of: new Date("2025-11-02") // UTC midnight, may show wrong day
+ * // Use: parseLocalDate("2025-11-02") // Local midnight, correct day
+ */
+export function parseLocalDate(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day); // month is 0-indexed in JS
+}
+
+/**
+ * Format a date-only string for display.
+ *
+ * Safely formats a YYYY-MM-DD date string without timezone shifting.
+ *
+ * @param dateString - Date string in YYYY-MM-DD format
+ * @param options - Intl.DateTimeFormat options (defaults to short month, day, year)
+ * @returns Formatted date string (e.g., "Nov 2, 2025")
+ *
+ * @example
+ * formatGameDate("2025-11-02") // "Nov 2, 2025"
+ * formatGameDate("2025-11-02", { month: 'long' }) // "November 2, 2025"
+ */
+export function formatGameDate(
+  dateString: string,
+  options: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }
+): string {
+  const date = parseLocalDate(dateString);
+  return date.toLocaleDateString('en-US', options);
+}
+
+/**
+ * Format a date for chart axis labels (short format).
+ *
+ * @param dateString - Date string in YYYY-MM-DD format
+ * @returns Short formatted date (e.g., "Nov 2")
+ */
+export function formatChartDate(dateString: string): string {
+  return formatGameDate(dateString, {
+    month: 'short',
+    day: 'numeric',
+  });
+}


### PR DESCRIPTION
When JavaScript parses date-only strings like "2025-11-02" with new Date(), it interprets them as UTC midnight. In Mountain Time (UTC-7), this shifts the displayed date back by a day (Nov 2 UTC midnight = Nov 1 5PM MT).

Added dateUtils.ts with timezone-safe date formatting functions that parse YYYY-MM-DD strings as local dates for display purposes. Updated three components to use these utilities:
- GameHistoryTable.tsx
- UnknownOpponentLink.tsx
- TeamTrajectoryChart.tsx

Note: Date comparisons and sorting (which use .getTime() milliseconds) are unaffected - only display formatting was changed.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

