### PR TITLE
Fix teams not loading due to rankings_view query timeout

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { isNetworkError } from '@/lib/errors';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   // Handle unhandled promise rejections
@@ -56,7 +57,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider delayDuration={300} skipDelayDuration={100}>
+        {children}
+      </TooltipProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -291,7 +291,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
             <div className="overflow-x-auto -mx-4 sm:mx-0 touch-pan-x">
               <div className={`inline-block min-w-full align-middle ${region ? 'min-w-[500px] sm:min-w-[600px]' : 'min-w-[550px] sm:min-w-[650px] md:min-w-[700px]'}`}>
                 {/* Table Header */}
-                <div className="grid border-b-2 border-primary bg-secondary/50 sticky top-0 z-10" style={{ gridTemplateColumns: region ? '50px 2fr 1fr 0.9fr 0.9fr 1fr' : '50px 2fr 1fr 0.9fr 0.9fr 1fr 1fr' }}>
+                <div className="grid border-b-2 border-primary bg-secondary/50 sticky top-0 z-10" style={{ gridTemplateColumns: '50px 2fr 1fr 0.9fr 0.9fr 1fr' }}>
                   <div className="px-1.5 sm:px-4 py-2 sm:py-4 font-semibold text-xs sm:text-sm uppercase tracking-wide min-w-0 overflow-hidden">
                     <SortButton field="rank" label="Rank" />
                   </div>
@@ -389,7 +389,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                             ${borderClass}
                           `}
                           style={{
-                            gridTemplateColumns: region ? '50px 2fr 1fr 0.9fr 0.9fr 1fr' : '50px 2fr 1fr 0.9fr 0.9fr 1fr 1fr',
+                            gridTemplateColumns: '50px 2fr 1fr 0.9fr 0.9fr 1fr',
                             position: 'absolute',
                             top: 0,
                             left: 0,

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -21,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  )
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
 function TooltipTrigger({

--- a/supabase/migrations/20251208000005_fix_rankings_view_performance.sql
+++ b/supabase/migrations/20251208000005_fix_rankings_view_performance.sql
@@ -1,0 +1,193 @@
+-- Migration: Fix rankings_view performance issue
+-- Purpose: Remove expensive correlated subqueries that call resolve_team_id()
+--          causing query timeouts
+--
+-- Problem: The previous migration (20251208000004) added correlated subqueries
+--          that scan the entire games table for each team, calling resolve_team_id()
+--          on every row. This creates O(teams × games × 2) complexity which times out.
+--
+-- Solution: Use pre-computed values from current_rankings table instead of
+--           calculating them live in the view with correlated subqueries.
+
+-- =====================================================
+-- Step 1: Drop existing views
+-- =====================================================
+
+DROP VIEW IF EXISTS state_rankings_view CASCADE;
+DROP VIEW IF EXISTS rankings_view CASCADE;
+
+-- =====================================================
+-- Step 2: Recreate rankings_view WITHOUT expensive correlated subqueries
+-- =====================================================
+
+CREATE VIEW rankings_view
+WITH (security_invoker = true)
+AS
+SELECT
+    -- Team identity fields (always canonical, never deprecated)
+    t.team_id_master,
+    t.team_name,
+    t.club_name,
+    t.state_code AS state,
+    CASE
+      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+      ELSE NULL
+    END AS age,
+    CASE
+      WHEN rf.gender = 'Male' THEN 'M'
+      WHEN rf.gender = 'Female' THEN 'F'
+      WHEN rf.gender = 'Boys' THEN 'M'
+      WHEN rf.gender = 'Girls' THEN 'F'
+      WHEN rf.gender = 'M' THEN 'M'
+      WHEN rf.gender = 'F' THEN 'F'
+      ELSE rf.gender
+    END AS gender,
+
+    -- Record stats (from rankings_full - CAPPED AT 30 GAMES for rankings algorithm)
+    COALESCE(rf.games_played, cr.games_played) AS games_played,
+    COALESCE(rf.wins, cr.wins) AS wins,
+    COALESCE(rf.losses, cr.losses) AS losses,
+    COALESCE(rf.draws, cr.draws) AS draws,
+
+    -- Total games count - use pre-computed values from current_rankings
+    -- NOTE: These values do NOT include merged team games until the rankings
+    -- calculator is updated to resolve merged teams. This is a tradeoff for
+    -- performance. The merge resolution can be added to the rankings calculator
+    -- instead of computing it live in the view.
+    COALESCE(cr.games_played, rf.games_played) AS total_games_played,
+    COALESCE(cr.wins, rf.wins) AS total_wins,
+    COALESCE(cr.losses, rf.losses) AS total_losses,
+    COALESCE(cr.draws, rf.draws) AS total_draws,
+
+    -- Win percentage from pre-computed values
+    cr.win_percentage,
+
+    -- Metrics (ONLY from rankings_full)
+    rf.power_score_final,
+    rf.sos_norm,
+    rf.off_norm AS offense_norm,
+    rf.def_norm AS defense_norm,
+
+    -- Rank (use precomputed ML ranking from rankings_full)
+    COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS rank_in_cohort_final,
+
+    -- SOS Ranks (pre-calculated in rankings engine)
+    rf.sos_rank_national,
+    rf.sos_rank_state,
+
+    -- Rank change tracking
+    rf.rank_change_7d,
+    rf.rank_change_30d,
+
+    -- Activity status fields
+    rf.status,
+    rf.last_game,
+
+    -- Metadata
+    rf.last_calculated
+
+FROM rankings_full rf
+JOIN teams t ON rf.team_id = t.team_id_master
+LEFT JOIN current_rankings cr ON cr.team_id = t.team_id_master
+WHERE rf.power_score_final IS NOT NULL
+  AND t.is_deprecated = FALSE;  -- Exclude deprecated teams from results
+
+COMMENT ON VIEW rankings_view IS 'National rankings view with deprecated team filtering. Uses pre-computed game counts from current_rankings for performance. Merged team game resolution should be done in the rankings calculator, not live in the view.';
+
+-- =====================================================
+-- Step 3: Recreate state_rankings_view
+-- =====================================================
+
+CREATE VIEW state_rankings_view
+WITH (security_invoker = true)
+AS
+SELECT
+    -- Team identity fields
+    rv.team_id_master,
+    rv.team_name,
+    rv.club_name,
+    rv.state AS state,
+    rv.age AS age,
+    rv.gender,
+
+    -- Record stats (capped at 30 for rankings algorithm)
+    rv.games_played,
+    rv.wins,
+    rv.losses,
+    rv.draws,
+
+    -- Total games and record (all games, not capped)
+    rv.total_games_played,
+    rv.total_wins,
+    rv.total_losses,
+    rv.total_draws,
+    rv.win_percentage,
+
+    -- Metrics
+    rv.power_score_final,
+    rv.sos_norm,
+    rv.offense_norm,
+    rv.defense_norm,
+
+    -- National rank (from base view)
+    rv.rank_in_cohort_final,
+
+    -- State rank (computed live in view - this is fast with proper indexes)
+    ROW_NUMBER() OVER (
+        PARTITION BY rv.state, rv.age, rv.gender
+        ORDER BY rv.power_score_final DESC
+    ) AS rank_in_state_final,
+
+    -- SOS Ranks
+    rv.sos_rank_national,
+    rv.sos_rank_state,
+
+    -- Rank change tracking
+    rv.rank_change_7d,
+    rv.rank_change_30d,
+
+    -- Activity status fields
+    rv.status,
+    rv.last_game,
+
+    -- Metadata
+    rv.last_calculated
+
+FROM rankings_view rv
+WHERE rv.state IS NOT NULL;
+
+COMMENT ON VIEW state_rankings_view IS 'State rankings view. Deprecated teams excluded via rankings_view filter.';
+
+-- =====================================================
+-- Step 4: Grant SELECT permissions
+-- =====================================================
+
+GRANT SELECT ON rankings_view TO authenticated;
+GRANT SELECT ON rankings_view TO anon;
+GRANT SELECT ON state_rankings_view TO authenticated;
+GRANT SELECT ON state_rankings_view TO anon;
+
+-- =====================================================
+-- Verification
+-- =====================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.views
+        WHERE table_name = 'rankings_view'
+    ) THEN
+        RAISE EXCEPTION 'Migration failed: rankings_view not created';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.views
+        WHERE table_name = 'state_rankings_view'
+    ) THEN
+        RAISE EXCEPTION 'Migration failed: state_rankings_view not created';
+    END IF;
+
+    RAISE NOTICE 'Migration successful: Fixed rankings_view performance by removing correlated subqueries';
+END $$;


### PR DESCRIPTION
Root cause: The migration 20251208000004 added expensive correlated subqueries to rankings_view that call resolve_team_id() for every game row for every team, creating O(teams × games × 2) complexity.

Database fix:
- Add migration 20251208000005 to fix rankings_view performance
- Remove correlated subqueries that were causing statement timeouts
- Use pre-computed values from current_rankings instead

Frontend improvements (while investigating):
- Add global TooltipProvider to providers.tsx for better tooltip handling
- Simplify Tooltip component to use global provider
- Fix grid column count mismatch in RankingsTable (7 columns defined but only 6 rendered)

Note: The database migration needs to be applied to Supabase to fix the timeout issue. The frontend changes are incremental improvements.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

