### PR TITLE
Fix unknown team link not updating after linking

### DIFF
--- a/frontend/components/UnknownOpponentLink.tsx
+++ b/frontend/components/UnknownOpponentLink.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef, useEffect, useDeferredValue, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -131,6 +132,7 @@ export function UnknownOpponentLink({
   defaultAge,
   defaultGender,
 }: UnknownOpponentLinkProps) {
+  const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTeam, setSelectedTeam] = useState<RankingRow | null>(null);
@@ -317,11 +319,18 @@ export function UnknownOpponentLink({
 
       setLinkSuccess(true);
 
-      // Close modal after short delay and refresh
+      // Invalidate the games cache to ensure fresh data is fetched
+      // This is more reliable than just refetch() as it clears the cache entirely
+      await queryClient.invalidateQueries({ queryKey: ['team-games', currentTeamId] });
+
+      // Also invalidate the team search cache in case a new team was somehow involved
+      await queryClient.invalidateQueries({ queryKey: ['team-search'] });
+
+      // Close modal after short delay and call onLinked callback
       setTimeout(() => {
         setIsOpen(false);
         onLinked?.();
-      }, 1500);
+      }, 1000);
     } catch (err) {
       setLinkError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -361,11 +370,18 @@ export function UnknownOpponentLink({
 
       setLinkSuccess(true);
 
-      // Close modal after short delay and refresh
+      // Invalidate the games cache to ensure fresh data is fetched
+      // This is more reliable than just refetch() as it clears the cache entirely
+      await queryClient.invalidateQueries({ queryKey: ['team-games', currentTeamId] });
+
+      // Invalidate team search cache so the new team appears in searches
+      await queryClient.invalidateQueries({ queryKey: ['team-search'] });
+
+      // Close modal after short delay and call onLinked callback
       setTimeout(() => {
         setIsOpen(false);
         onLinked?.();
-      }, 1500);
+      }, 1000);
     } catch (err) {
       setLinkError(err instanceof Error ? err.message : 'An error occurred');
     } finally {


### PR DESCRIPTION
The issue was that after linking an unknown team to a known team, the game history table wasn't refreshing to show the linked team name. The previous implementation used refetch() which wasn't reliably clearing the React Query cache.

Changes:
- Added useQueryClient to get access to the query client
- After successful team link/creation, invalidate the 'team-games' query cache to force fresh data fetch
- Also invalidate 'team-search' cache to ensure newly created teams appear in search results
- Reduced the modal close delay from 1.5s to 1s since cache invalidation now happens immediately after API success

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

