### PR TITLE
Fix team linking not saving in game history component

### DIFF
--- a/frontend/components/GameHistoryTable.tsx
+++ b/frontend/components/GameHistoryTable.tsx
@@ -234,16 +234,29 @@ export function GameHistoryTable({ teamId, limit, teamName }: GameHistoryTablePr
                     {formatGameDate(game.game_date)}
                   </TableCell>
                   <TableCell>
-                    {opponentId && opponent ? (
+                    {opponentId ? (
+                      // Team is linked - show link or fallback text
                       <div className="flex flex-col">
-                        <Link
-                          href={`/teams/${opponentId}`}
-                          onMouseEnter={() => prefetchTeam(opponentId)}
-                          className="font-medium hover:text-primary transition-colors duration-300 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer inline-block"
-                          aria-label={`View ${opponent} team details`}
-                        >
-                          {opponent}
-                        </Link>
+                        {opponent ? (
+                          <Link
+                            href={`/teams/${opponentId}`}
+                            onMouseEnter={() => prefetchTeam(opponentId)}
+                            className="font-medium hover:text-primary transition-colors duration-300 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer inline-block"
+                            aria-label={`View ${opponent} team details`}
+                          >
+                            {opponent}
+                          </Link>
+                        ) : (
+                          // Team is linked but name lookup failed - still show link
+                          <Link
+                            href={`/teams/${opponentId}`}
+                            onMouseEnter={() => prefetchTeam(opponentId)}
+                            className="font-medium hover:text-primary transition-colors duration-300 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer inline-block text-muted-foreground"
+                            aria-label="View team details"
+                          >
+                            (Team linked)
+                          </Link>
+                        )}
                         {opponentClub && (
                           <span className="text-xs text-muted-foreground mt-0.5">
                             {opponentClub}
@@ -251,6 +264,7 @@ export function GameHistoryTable({ teamId, limit, teamName }: GameHistoryTablePr
                         )}
                       </div>
                     ) : opponentProviderId ? (
+                      // Team is NOT linked but has provider ID - show linking option
                       <UnknownOpponentLink
                         game={game}
                         currentTeamId={teamId}
@@ -260,6 +274,7 @@ export function GameHistoryTable({ teamId, limit, teamName }: GameHistoryTablePr
                         defaultGender={team?.gender}
                       />
                     ) : (
+                      // No team ID and no provider ID - truly unknown
                       <span className="text-muted-foreground">{opponent || 'Unknown'}</span>
                     )}
                   </TableCell>

--- a/frontend/components/UnknownOpponentLink.tsx
+++ b/frontend/components/UnknownOpponentLink.tsx
@@ -314,15 +314,27 @@ export function UnknownOpponentLink({
       const data = await response.json();
 
       if (!response.ok) {
+        // Handle specific error cases with user-friendly messages
+        if (data.error?.includes('already linked')) {
+          throw new Error('This opponent is already linked to a team. Please refresh the page to see the updated data.');
+        }
+        if (data.error?.includes('does not match')) {
+          throw new Error('Unable to match this opponent. The game data may have changed. Please refresh and try again.');
+        }
         throw new Error(data.error || 'Failed to link team');
       }
 
       // Log the full response for debugging
       console.log('[UnknownOpponentLink] API Response:', data);
 
-      // Check if any games were actually updated
+      // Show warning if no games were updated (edge case - alias created but no games matched)
       if (data.gamesUpdated === 0) {
         console.warn('[UnknownOpponentLink] No games were updated! Debug info:', data.debug);
+        // Still show success but with a note
+        setLinkError('Team alias created, but no games were updated. The opponent may already be linked.');
+        setIsLinking(false);
+        // Don't close modal automatically so user sees the message
+        return;
       }
 
       setLinkSuccess(true);


### PR DESCRIPTION
Root cause: The condition `opponentId && opponent` in GameHistoryTable.tsx caused the UnknownOpponentLink to appear even when a team was already linked (if the team name lookup failed). Users could click "save" but nothing would happen because the API found the team already linked.

Fixes:
- GameHistoryTable.tsx: Check only `opponentId` to determine if linked, with fallback "(Team linked)" text when name lookup fails
- link-opponent/route.ts: Add early validation to return proper 400 error when team is already linked or provider ID doesn't match
- UnknownOpponentLink.tsx: Add user-friendly error messages and handle edge case where no games are updated

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

