### PR TITLE
Fix Supabase client to lazy-load at runtime instead of build time

### DIFF
--- a/frontend/lib/supabaseClient.ts
+++ b/frontend/lib/supabaseClient.ts
@@ -1,19 +1,40 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// Lazy-load Supabase client to avoid build-time initialization issues
+// This ensures environment variables are read at RUNTIME, not BUILD TIME
+let supabaseInstance: SupabaseClient | null = null;
 
-// Create client with fallback empty strings for build time
-// Runtime errors will be handled by API functions
-export const supabase = createClient(
-  supabaseUrl || 'https://placeholder.supabase.co',
-  supabaseAnonKey || 'placeholder-key'
-);
+function getSupabaseClient(): SupabaseClient {
+  if (supabaseInstance) {
+    return supabaseInstance;
+  }
 
-// Validate environment variables at runtime (not build time)
-if (typeof window !== 'undefined' && (!supabaseUrl || !supabaseAnonKey)) {
-  console.error(
-    'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in .env.local'
-  );
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error(
+      'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY'
+    );
+    // Throw error to make the issue obvious instead of silently failing
+    throw new Error('Supabase environment variables not configured');
+  }
+
+  supabaseInstance = createClient(supabaseUrl, supabaseAnonKey);
+  return supabaseInstance;
 }
+
+// Export a proxy that lazy-loads the actual client
+// This ensures the client is only created when first accessed at runtime
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_, prop) {
+    const client = getSupabaseClient();
+    const value = client[prop as keyof SupabaseClient];
+    // Bind methods to the client instance
+    if (typeof value === 'function') {
+      return value.bind(client);
+    }
+    return value;
+  },
+});
 


### PR DESCRIPTION
Root cause: The Supabase client was being created at module load time, which meant environment variables were read during the Next.js BUILD process. If NEXT_PUBLIC_SUPABASE_URL wasn't set at build time, the placeholder URL got permanently baked into the JavaScript bundle.

Solution: Use lazy-loading with a Proxy pattern (same approach used for Stripe client) to ensure:
1. Environment variables are read at RUNTIME, not build time
2. Client is only created when first accessed
3. Missing env vars throw a clear error instead of silently failing

This prevents the issue where changing env vars in Vercel requires a rebuild with cache disabled to take effect.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

