### PR TITLE
Fix /teams route returning 404 on page refresh

### DIFF
--- a/frontend/app/teams/page.tsx
+++ b/frontend/app/teams/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * /teams route - redirects to rankings page
+ *
+ * This page exists to handle Next.js RSC prefetch requests that hit /teams
+ * when navigating to or refreshing on /teams/[id] pages.
+ * Without this, users would see a 404 error on refresh.
+ */
+export default function TeamsPage() {
+  redirect('/rankings');
+}


### PR DESCRIPTION
When refreshing a team detail page (/teams/[id]), Next.js RSC makes a prefetch request to the parent /teams route. Without a page.tsx there, this returns 404 and breaks the page load.

Fix: Add /teams/page.tsx that redirects to /rankings. This handles the RSC prefetch gracefully and also provides a reasonable UX if users somehow navigate directly to /teams.

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

