### PR TITLE
fix: rebalance power score weights to 28.5/28.5/43 (OFF/DEF/SOS)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -142,9 +142,9 @@ RANKING_CONFIG = {
     'opponent_adjust_clip_max': float(os.getenv("OPPONENT_ADJUST_CLIP_MAX", 1.6)),  # V53EConfig.OPPONENT_ADJUST_CLIP_MAX
 
     # Layer 10 weights
-    'off_weight': float(os.getenv("OFF_WEIGHT", 0.35)),  # V53EConfig.OFF_WEIGHT
-    'def_weight': float(os.getenv("DEF_WEIGHT", 0.35)),  # V53EConfig.DEF_WEIGHT
-    'sos_weight': float(os.getenv("SOS_WEIGHT", 0.30)),  # V53EConfig.SOS_WEIGHT
+    'off_weight': float(os.getenv("OFF_WEIGHT", 0.285)),  # V53EConfig.OFF_WEIGHT
+    'def_weight': float(os.getenv("DEF_WEIGHT", 0.285)),  # V53EConfig.DEF_WEIGHT
+    'sos_weight': float(os.getenv("SOS_WEIGHT", 0.43)),  # V53EConfig.SOS_WEIGHT
     
     # Provisional
     'min_games_for_ranking': int(os.getenv("MIN_GAMES_FOR_RANKING", 5)),  # V53EConfig.MIN_GAMES_PROVISIONAL

--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -84,9 +84,9 @@ class V53EConfig:
     OPPONENT_ADJUST_CLIP_MAX: float = 1.6  # Max multiplier (conservative bounds)
 
     # Layer 10 weights
-    OFF_WEIGHT: float = 0.35
-    DEF_WEIGHT: float = 0.35
-    SOS_WEIGHT: float = 0.30
+    OFF_WEIGHT: float = 0.285
+    DEF_WEIGHT: float = 0.285
+    SOS_WEIGHT: float = 0.43
 
     # Provisional
     MIN_GAMES_PROVISIONAL: int = 5

--- a/tests/unit/test_sos_validation.py
+++ b/tests/unit/test_sos_validation.py
@@ -56,27 +56,18 @@ class TestPowerScoreWeights:
         assert abs(total_weight - 1.0) < 0.0001, \
             f"PowerScore weights must sum to 1.0, got {total_weight}"
 
-    def test_sos_weight_is_thirty_percent(self):
-        """Verify SOS has 30% weight in PowerScore (reduced from 50% to avoid double-counting
-        with opponent-adjusted OFF/DEF)"""
+    def test_sos_weight(self):
+        """Verify SOS has 43% weight in PowerScore"""
         cfg = V53EConfig()
-        assert cfg.SOS_WEIGHT == 0.30, "SOS should have 30% weight"
+        assert cfg.SOS_WEIGHT == 0.43, "SOS should have 43% weight"
 
     def test_off_def_weights_balanced(self):
         """Verify offense and defense have equal weights"""
         cfg = V53EConfig()
         assert cfg.OFF_WEIGHT == cfg.DEF_WEIGHT, \
             "Offense and defense should have equal weights"
-        assert cfg.OFF_WEIGHT == 0.35, "Offense weight should be 35%"
-        assert cfg.DEF_WEIGHT == 0.35, "Defense weight should be 35%"
-
-    def test_off_def_have_highest_weight(self):
-        """Verify OFF/DEF each have higher weight than SOS (since OFF/DEF are opponent-adjusted)"""
-        cfg = V53EConfig()
-        assert cfg.OFF_WEIGHT > cfg.SOS_WEIGHT, \
-            "Offense weight should be greater than SOS weight"
-        assert cfg.DEF_WEIGHT > cfg.SOS_WEIGHT, \
-            "Defense weight should be greater than SOS weight"
+        assert cfg.OFF_WEIGHT == 0.285, "Offense weight should be 28.5%"
+        assert cfg.DEF_WEIGHT == 0.285, "Defense weight should be 28.5%"
 
 
 class TestSOSValueRanges:
@@ -216,9 +207,9 @@ class TestSOSDocumentation:
         assert cfg.UNRANKED_SOS_BASE == 0.35, \
             "UNRANKED_SOS_BASE should be 0.35 as documented"
 
-        # SOS_WEIGHT = 0.30 (reduced from 50% since OFF/DEF are opponent-adjusted)
-        assert cfg.SOS_WEIGHT == 0.30, \
-            "SOS_WEIGHT should be 30%"
+        # SOS_WEIGHT = 0.43 (reduced from 50% since OFF/DEF are opponent-adjusted)
+        assert cfg.SOS_WEIGHT == 0.43, \
+            "SOS_WEIGHT should be 43%"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Increase SOS weight from 30% to 43% to better reward teams with tough schedules. OFF/DEF reduced equally to 28.5% each.

https://claude.ai/code/session_01FYw7KgAKKyuDUA31n3zGws

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

