### PR TITLE
fix: disable Power-SOS loop that was erasing SCF + PageRank dampening

### DIFF
--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -57,10 +57,13 @@ class V53EConfig:
     SOS_ITERATIONS: int = 1  # Single-pass: direct opponent strength only (no transitive propagation)
     SOS_TRANSITIVITY_LAMBDA: float = 0.0  # Pure direct SOS — transitive propagation causes closed-league inflation
 
-    # Power-SOS Co-Calculation: Use opponent's FULL power score (including their SOS) for SOS calculation
-    # This ensures that playing teams with tough schedules properly boosts your SOS
-    # Set to 0 to disable (use old off/def-only approach), 3-5 iterations recommended
-    SOS_POWER_ITERATIONS: int = 5  # Number of power-SOS refinement cycles (0 = disabled)
+    # Power-SOS Co-Calculation: DISABLED — loop erases SCF + PageRank dampening
+    # The loop recomputes SOS from abs_strength (same inputs as the initial pass) but
+    # WITHOUT re-applying PageRank dampening, SCF, or isolation caps. After 5 iterations
+    # the 80/20 blend washes away all anti-inflation corrections, causing isolated regional
+    # bubble teams to show inflated SOS over nationally-scheduled teams.
+    # Set to 0 until the loop is redesigned to re-apply corrections each iteration.
+    SOS_POWER_ITERATIONS: int = 0  # DISABLED: was erasing SCF/PageRank (see comment above)
     SOS_POWER_DAMPING: float = 0.80  # Damping factor to prevent oscillation (0.5-0.9 recommended)
 
     # SOS sample size weighting


### PR DESCRIPTION
The Power-SOS co-calculation loop (SOS_POWER_ITERATIONS=5) recomputed SOS from abs_strength without re-applying PageRank dampening, SCF, or isolation caps. After 5 iterations with 80/20 blending, all anti-inflation corrections were washed away (~99.97% erased), causing isolated regional bubble teams to show inflated SOS over nationally-scheduled teams.

Setting SOS_POWER_ITERATIONS=0 preserves the correctly-dampened SOS values from the initial pass, where SCF, PageRank, and isolation caps are applied.

https://claude.ai/code/session_01TqKgKKEsfKZPDGU3WZs4pg

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

