### PR TITLE
feat: add ranking history chart showing weekly Monday snapshots

### DIFF
--- a/frontend/components/RankHistoryChart.tsx
+++ b/frontend/components/RankHistoryChart.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartSkeleton } from '@/components/ui/skeletons';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { useRankHistory } from '@/lib/hooks';
+import { useMemo, useEffect, useRef } from 'react';
+import { TrendingUp } from 'lucide-react';
+import { trackChartViewed } from '@/lib/events';
+
+interface RankHistoryChartProps {
+  teamId: string;
+}
+
+/**
+ * Compact rank history line chart showing Monday snapshots over the last 12 months.
+ * Y-axis is inverted (rank #1 at top). Displays above MomentumMeter on team detail page.
+ */
+export function RankHistoryChart({ teamId }: RankHistoryChartProps) {
+  const { data: history, isLoading, isError, error, refetch } = useRankHistory(teamId);
+  const hasTrackedView = useRef(false);
+
+  useEffect(() => {
+    if (history && history.length > 0 && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      trackChartViewed({
+        chart_type: 'rank_history',
+        team_id_master: teamId,
+      });
+    }
+  }, [history, teamId]);
+
+  const chartData = useMemo(() => {
+    if (!history || history.length === 0) return [];
+
+    return history.map((point) => {
+      const d = new Date(point.snapshot_date + 'T00:00:00');
+      const month = d.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' });
+      const day = d.getUTCDate();
+      return {
+        label: `${month} ${day}`,
+        fullDate: point.snapshot_date,
+        rank: point.rank,
+      };
+    });
+  }, [history]);
+
+  // Calculate Y-axis domain: pad slightly beyond min/max rank
+  const yDomain = useMemo(() => {
+    if (chartData.length === 0) return [1, 50];
+    const ranks = chartData.map((d) => d.rank);
+    const minRank = Math.min(...ranks);
+    const maxRank = Math.max(...ranks);
+    // Pad 10% on each side, minimum 1 at top
+    const padding = Math.max(2, Math.ceil((maxRank - minRank) * 0.1));
+    return [Math.max(1, minRank - padding), maxRank + padding];
+  }, [chartData]);
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Ranking History
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartSkeleton height={180} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Ranking History
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ErrorDisplay
+            error="Unable to load ranking history"
+            retry={() => refetch()}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Not enough data to chart
+  if (chartData.length < 2) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Ranking History
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Not enough data yet — ranking history builds each Monday
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Summary: current vs earliest rank
+  const currentRank = chartData[chartData.length - 1].rank;
+  const earliestRank = chartData[0].rank;
+  const rankDelta = earliestRank - currentRank; // positive = improved
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Ranking History
+          </CardTitle>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-mono font-semibold">#{currentRank}</span>
+            {rankDelta !== 0 && (
+              <span
+                className={
+                  rankDelta > 0
+                    ? 'text-green-600 dark:text-green-400 text-xs'
+                    : 'text-red-600 dark:text-red-400 text-xs'
+                }
+              >
+                {rankDelta > 0 ? `+${rankDelta}` : rankDelta}
+              </span>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="h-[180px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
+                className="fill-muted-foreground"
+              />
+              <YAxis
+                reversed
+                domain={yDomain}
+                tick={{ fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(v: number) => `#${v}`}
+                className="fill-muted-foreground"
+                width={42}
+              />
+              <RechartsTooltip
+                content={({ active, payload }: { active?: boolean; payload?: Array<{ payload: (typeof chartData)[0] }> }) => {
+                  if (!active || !payload?.[0]) return null;
+                  const d = payload[0].payload;
+                  return (
+                    <div className="rounded-lg border bg-background p-2 shadow-md text-xs">
+                      <p className="font-medium">{d.fullDate}</p>
+                      <p className="text-primary font-mono font-semibold">Rank #{d.rank}</p>
+                    </div>
+                  );
+                }}
+              />
+              <Line
+                type="monotone"
+                dataKey="rank"
+                stroke="hsl(var(--primary))"
+                strokeWidth={2}
+                dot={chartData.length <= 16}
+                activeDot={{ r: 4, strokeWidth: 2 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/TeamPageShell.tsx
+++ b/frontend/components/TeamPageShell.tsx
@@ -30,6 +30,11 @@ const LazyTeamInsightsCard = dynamic(
   { ssr: true, loading: () => <div className="h-40 animate-pulse bg-muted rounded-lg" /> }
 );
 
+const LazyRankHistoryChart = dynamic(
+  () => import('@/components/RankHistoryChart').then(mod => ({ default: mod.RankHistoryChart })),
+  { ssr: true, loading: () => <div className="h-[240px] animate-pulse bg-muted rounded-lg" /> }
+);
+
 interface TeamPageShellProps {
   id: string;
 }
@@ -103,6 +108,7 @@ export function TeamPageShell({ id }: TeamPageShellProps) {
       queryClient.invalidateQueries({ queryKey: ['team', id] });
       queryClient.invalidateQueries({ queryKey: ['team-games', id] });
       queryClient.invalidateQueries({ queryKey: ['team-trajectory', id] });
+      queryClient.invalidateQueries({ queryKey: ['rank-history', id] });
     }
     previousIdRef.current = id;
   }, [id, queryClient]);
@@ -135,8 +141,11 @@ export function TeamPageShell({ id }: TeamPageShellProps) {
             <SectionErrorBoundary fallbackTitle="Failed to load game history.">
               <GameHistoryTable teamId={id} />
             </SectionErrorBoundary>
-            {/* Right column: Momentum + Insights stacked */}
+            {/* Right column: Rank History + Momentum + Insights stacked */}
             <div className="flex flex-col gap-4">
+              <SectionErrorBoundary fallbackTitle="Failed to load ranking history.">
+                <LazyRankHistoryChart teamId={id} />
+              </SectionErrorBoundary>
               <SectionErrorBoundary fallbackTitle="Failed to load momentum data.">
                 <LazyMomentumMeter teamId={id} />
               </SectionErrorBoundary>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   TeamTrajectory,
   GameWithTeams,
   TeamWithRanking,
+  RankHistoryPoint,
 } from './types';
 import type { TeamPredictive } from '@/types/TeamPredictive';
 
@@ -1012,6 +1013,60 @@ export const api = {
       totalGames: gamesCount || 0,
       totalTeams: teamsCount || 0,
     };
+  },
+
+  /**
+   * Get ranking history snapshots for a team (weekly Monday snapshots, up to 12 months)
+   * Returns data points aligned to Mondays for the rank history chart
+   * @param id - team_id_master UUID
+   * @returns Array of RankHistoryPoint sorted oldest-to-newest
+   */
+  async getRankHistory(id: string): Promise<RankHistoryPoint[]> {
+    // Go back 12 months
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - 1);
+    const cutoffStr = cutoff.toISOString().split('T')[0];
+
+    const { data, error } = await supabase
+      .from('ranking_history')
+      .select('snapshot_date, rank_in_cohort, rank_in_cohort_ml')
+      .eq('team_id', id)
+      .gte('snapshot_date', cutoffStr)
+      .order('snapshot_date', { ascending: true });
+
+    if (error) {
+      console.error('[api.getRankHistory] Error:', error.message);
+      throw error;
+    }
+
+    if (!data || data.length === 0) return [];
+
+    // Filter to only Monday snapshots (day 1) and dedupe by week
+    const seen = new Set<string>();
+    const points: RankHistoryPoint[] = [];
+
+    for (const row of data as Array<{
+      snapshot_date: string;
+      rank_in_cohort: number;
+      rank_in_cohort_ml: number | null;
+    }>) {
+      // Find the Monday of this snapshot's week
+      const d = new Date(row.snapshot_date + 'T00:00:00');
+      const day = d.getUTCDay(); // 0=Sun, 1=Mon, ...
+      const diff = day === 0 ? -6 : 1 - day; // shift to Monday
+      d.setUTCDate(d.getUTCDate() + diff);
+      const mondayKey = d.toISOString().split('T')[0];
+
+      if (seen.has(mondayKey)) continue;
+      seen.add(mondayKey);
+
+      points.push({
+        snapshot_date: mondayKey,
+        rank: row.rank_in_cohort_ml ?? row.rank_in_cohort,
+      });
+    }
+
+    return points;
   },
 };
 

--- a/frontend/lib/hooks.ts
+++ b/frontend/lib/hooks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './api';
-import type { Team, RankingWithTeam, TeamTrajectory, GameWithTeams, TeamWithRanking } from './types';
+import type { Team, RankingWithTeam, TeamTrajectory, GameWithTeams, TeamWithRanking, RankHistoryPoint } from './types';
 import type { TeamPredictive } from '@/types/TeamPredictive';
 
 /**
@@ -77,6 +77,22 @@ export function useTeamGames(id: string, limit: number = 50) {
     staleTime: 2 * 60 * 1000, // 2 minutes - games update more frequently
     gcTime: 15 * 60 * 1000, // Keep in cache for 15 minutes
     retry: 1, // Retry once on failure (overrides global network-only retry)
+  });
+}
+
+/**
+ * Get ranking history for a team (weekly Monday snapshots, up to 12 months)
+ * @param id - team_id_master UUID
+ * @returns React Query hook result with RankHistoryPoint[]
+ */
+export function useRankHistory(id: string) {
+  return useQuery<RankHistoryPoint[]>({
+    queryKey: ['rank-history', id],
+    queryFn: () => api.getRankHistory(id),
+    enabled: !!id,
+    staleTime: 30 * 60 * 1000, // 30 minutes (rankings update weekly on Mondays)
+    gcTime: 60 * 60 * 1000, // 1 hour cache
+    retry: 1,
   });
 }
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -170,6 +170,14 @@ export interface TeamTrajectory {
 }
 
 /**
+ * Ranking history snapshot - weekly rank position for charting
+ */
+export interface RankHistoryPoint {
+  snapshot_date: string; // ISO date string (Monday)
+  rank: number;
+}
+
+/**
  * Game with team names (for display purposes)
  * Extends Game interface which already includes ml_overperformance
  */

--- a/frontend/types/events.ts
+++ b/frontend/types/events.ts
@@ -74,7 +74,7 @@ export interface PredictionEventPayload {
  * Payload for chart view events
  */
 export interface ChartViewEventPayload {
-  chart_type: 'momentum' | 'trajectory';
+  chart_type: 'momentum' | 'trajectory' | 'rank_history';
   team_id_master: string;
   team_name?: string | null;
 }


### PR DESCRIPTION
Adds a compact line chart to the team detail page (right column, above MomentumMeter) that shows the team's national rank at each Monday over the last 12 months. Y-axis is inverted so rank #1 is at the top.

Implementation:
- api.getRankHistory() queries ranking_history table, filters to Monday- aligned snapshots, prefers ML-adjusted rank when available
- useRankHistory() React Query hook with 30-minute stale time
- RankHistoryChart component using Recharts LineChart with responsive container, custom tooltip, and rank delta summary in header
- Lazy-loaded via next/dynamic in TeamPageShell
- Cache invalidated on team navigation

Chart shows "Not enough data yet" gracefully when < 2 snapshots exist, which will resolve as weekly Monday ranking runs accumulate data.

https://claude.ai/code/session_01MFZ1FW67KDaEBaQwERKEYn

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

