### PR TITLE
Fix password reset flow redirecting to rankings instead of reset page

### DIFF
--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -83,6 +83,11 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(exchangeError.message)}`);
     }
 
+    // If the recovery type param survived the redirect chain, go to reset-password
+    if (type === "recovery") {
+      return NextResponse.redirect(`${origin}/reset-password`);
+    }
+
     return NextResponse.redirect(`${origin}${next}`);
   }
 

--- a/frontend/hooks/useUser.ts
+++ b/frontend/hooks/useUser.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { createClientSupabase } from "@/lib/supabase/client";
 import type { User, Session, AuthChangeEvent } from "@supabase/supabase-js";
 
@@ -48,6 +49,7 @@ export interface UseUserReturn {
 }
 
 export function useUser(): UseUserReturn {
+  const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [session, setSession] = useState<Session | null>(null);
@@ -172,6 +174,15 @@ export function useUser(): UseUserReturn {
     // Listen for auth changes - but only process updates after initial load completes
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (event: AuthChangeEvent, currentSession: Session | null) => {
+        // When a recovery token is exchanged via PKCE, Supabase fires PASSWORD_RECOVERY.
+        // The server-side callback may have lost the ?next=/reset-password param during
+        // the redirect chain, so we catch it here and redirect to the reset page.
+        // This must run before the isInitialized check so it's never skipped.
+        if (event === "PASSWORD_RECOVERY" && isMounted) {
+          router.push("/reset-password");
+          return;
+        }
+
         // Skip processing auth changes until initial load is complete to avoid race conditions
         if (!isInitialized) {
           console.log("[useUser] Skipping auth state change - initial load not complete:", event);
@@ -201,7 +212,7 @@ export function useUser(): UseUserReturn {
       isMounted = false;
       subscription.unsubscribe();
     };
-  }, [supabase, fetchProfile]);
+  }, [supabase, fetchProfile, router]);
 
   return {
     user,


### PR DESCRIPTION
With Supabase PKCE flow, the ?next=/reset-password query param can get lost during the server-side redirect chain, causing the callback to default to /rankings. Added two fixes:

1. Server-side: check type=recovery param in the PKCE code exchange path
2. Client-side: listen for PASSWORD_RECOVERY auth event in useUser hook and redirect to /reset-password as a fallback

https://claude.ai/code/session_01KrPhvUMSS7kvk71zEwa22Z

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

