### PR TITLE
Use cookie to reliably detect password reset flow in PKCE callback

### DIFF
--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -83,8 +83,13 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(exchangeError.message)}`);
     }
 
-    // If the recovery type param survived the redirect chain, go to reset-password
-    if (type === "recovery") {
+    // Check if this is a password recovery flow:
+    // 1. The type=recovery param may survive the redirect chain
+    // 2. A cookie set by the forgot-password page signals recovery intent
+    const isRecovery = type === "recovery" || cookieStore.get("password_reset_pending")?.value === "true";
+    if (isRecovery) {
+      // Clear the cookie
+      cookieStore.set("password_reset_pending", "", { path: "/", maxAge: 0 });
       return NextResponse.redirect(`${origin}/reset-password`);
     }
 

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -29,6 +29,11 @@ export default function ForgotPasswordPage() {
     setIsLoading(true);
 
     try {
+      // Set a cookie so the auth callback knows this is a password reset flow.
+      // With PKCE, query params on redirectTo can get lost during Supabase's
+      // server-side redirect, so we use a cookie as a reliable signal.
+      document.cookie = "password_reset_pending=true; path=/; max-age=3600; SameSite=Lax";
+
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         email.trim().toLowerCase(),
         {


### PR DESCRIPTION
The previous fix relied on query params (next=/reset-password) and the PASSWORD_RECOVERY auth event, but with PKCE the query params get lost in Supabase's redirect chain and the auth event doesn't fire client-side when code exchange happens server-side.

New approach: forgot-password page sets a password_reset_pending cookie before sending the reset email. The auth callback checks this cookie after PKCE code exchange and redirects to /reset-password if set.

https://claude.ai/code/session_01KrPhvUMSS7kvk71zEwa22Z

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

