### PR TITLE
Use server action for password update to fix session cookie issue

### DIFF
--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -61,14 +61,9 @@ export async function GET(request: Request) {
 
   // Handle OAuth/PKCE (code exchange flow)
   if (code) {
-    // For password recovery, pass the code to the client so the session is
-    // established directly in the browser. Server-side code exchange sets
-    // cookies that the browser Supabase client can't always read, causing
-    // updateUser() to hang.
     const isRecovery = type === "recovery" || cookieStore.get("password_reset_pending")?.value === "true";
     if (isRecovery) {
       cookieStore.set("password_reset_pending", "", { path: "/", maxAge: 0 });
-      return NextResponse.redirect(`${origin}/reset-password?code=${encodeURIComponent(code)}`);
     }
 
     const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
@@ -91,6 +86,11 @@ export async function GET(request: Request) {
       }
 
       return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(exchangeError.message)}`);
+    }
+
+    // For recovery, redirect to reset-password page
+    if (isRecovery) {
+      return NextResponse.redirect(`${origin}/reset-password`);
     }
 
     return NextResponse.redirect(`${origin}${next}`);

--- a/frontend/app/reset-password/actions.ts
+++ b/frontend/app/reset-password/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { createServerSupabase } from "@/lib/supabase/server";
+
+export async function updatePassword(password: string): Promise<{ error: string | null }> {
+  const supabase = await createServerSupabase();
+
+  const { error } = await supabase.auth.updateUser({ password });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { error: null };
+}

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Suspense, useState, useEffect, useMemo } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClientSupabase } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,36 +15,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Loader2, Lock, CheckCircle2 } from "lucide-react";
+import { updatePassword } from "./actions";
 
-function ResetPasswordForm() {
+export default function ResetPasswordPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const supabase = useMemo(() => createClientSupabase(), []);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [isInitializing, setIsInitializing] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
-
-  // Exchange the PKCE code client-side to establish the session in the browser
-  useEffect(() => {
-    const code = searchParams.get("code");
-    if (!code) {
-      setIsInitializing(false);
-      return;
-    }
-
-    supabase.auth.exchangeCodeForSession(code).then(({ error: exchangeError }) => {
-      if (exchangeError) {
-        console.error("[ResetPassword] Code exchange error:", exchangeError.message);
-        setError("Your reset link has expired or is invalid. Please request a new one.");
-      }
-      // Clean the code from the URL without triggering a navigation
-      window.history.replaceState({}, "", "/reset-password");
-      setIsInitializing(false);
-    });
-  }, [searchParams, supabase]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -64,17 +42,16 @@ function ResetPasswordForm() {
     setIsLoading(true);
 
     try {
-      const { error: updateError } = await supabase.auth.updateUser({
-        password,
-      });
+      const result = await updatePassword(password);
 
-      if (updateError) {
-        throw updateError;
+      if (result.error) {
+        setError(result.error);
+        return;
       }
 
       setIsSuccess(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to reset password. Please try again.");
+    } catch {
+      setError("Failed to reset password. Please try again.");
     } finally {
       setIsLoading(false);
     }
@@ -101,14 +78,6 @@ function ResetPasswordForm() {
             </Button>
           </CardFooter>
         </Card>
-      </div>
-    );
-  }
-
-  if (isInitializing) {
-    return (
-      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
   }
@@ -192,19 +161,5 @@ function ResetPasswordForm() {
         </form>
       </Card>
     </div>
-  );
-}
-
-export default function ResetPasswordPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
-      }
-    >
-      <ResetPasswordForm />
-    </Suspense>
   );
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(request: NextRequest) {
   const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
 
-  if ((code || tokenHash) && pathname !== "/auth/callback" && pathname !== "/reset-password") {
+  if ((code || tokenHash) && pathname !== "/auth/callback") {
     const callbackUrl = new URL("/auth/callback", request.url);
     searchParams.forEach((value, key) => {
       callbackUrl.searchParams.set(key, value);


### PR DESCRIPTION
The browser Supabase client can't read session cookies set by the server-side code exchange, causing updateUser() to hang. Instead of trying to establish a client-side session, use a server action that has direct access to the session cookies.

- Revert callback to server-side code exchange (which works)
- Add server action (actions.ts) that calls updateUser server-side
- Simplify reset-password page: no more client-side code exchange, Suspense boundary, or useSearchParams
- Revert middleware exception (no longer passing code to reset page)

https://claude.ai/code/session_01KrPhvUMSS7kvk71zEwa22Z

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

