### PR TITLE
Revert united/real from NOISE_WORDS, add RL hard block, add regional

### DIFF
--- a/scripts/find_fuzzy_duplicate_teams.py
+++ b/scripts/find_fuzzy_duplicate_teams.py
@@ -60,6 +60,7 @@ PROGRAM_WORDS = frozenset({
     "ga", "rl", "comp", "recreational", "tal", "stxcl", "dpl", "scdsl",
     "next", "copa", "nal", "reserve", "classic", "division", "fdl",
     "pre",  # qualifier in PRE-ECNL
+    "regional",  # alternate name for RL (ECNL Regional League)
 })
 
 # ── Location / region codes (sub-club branches) ────────────────────
@@ -81,7 +82,6 @@ NOISE_WORDS = frozenset({
     "soccer", "club", "futbol", "football", "youth",
     "boys", "girls", "the", "of", "and",
     "b", "g", "m", "f",
-    "united", "city", "real", "inter", "sporting", "athletic",  # common club suffixes
 })
 
 # US state codes — not differentiating (just the team's state)
@@ -264,7 +264,16 @@ def _should_skip_pair(name_a: str, name_b: str, club_name: str = "") -> bool:
     # Programs/leagues: only block when BOTH have programs that conflict.
     # If only one side has a league tag (e.g. PRE-ECNL vs none), it's a
     # naming difference from different providers, not a different team.
-    if da["programs"] and db["programs"] and da["programs"] != db["programs"]:
+    prog_a, prog_b = da["programs"], db["programs"]
+    if prog_a and prog_b and prog_a != prog_b:
+        return True
+
+    # RL (ECNL Regional League) is a different competitive tier from main
+    # ECNL — always block RL vs non-RL even when one side has no programs.
+    # RL can appear as "rl", "ecnl-rl", "ecnl rl", or "regional".
+    has_rl_a = "rl" in prog_a
+    has_rl_b = "rl" in prog_b
+    if has_rl_a != has_rl_b:
         return True
 
     # Team numbers must match (1 vs 2, I vs II)

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -210,7 +210,7 @@ def extract_team_variant(name):
                     'strikers', 'raiders', 'warriors', 'knights', 'spartans', 'titans', 'trojans',
                     # League/program abbreviations (synced from find_fuzzy_duplicate_teams.PROGRAM_WORDS)
                     'stxcl', 'scdsl', 'dpl', 'dplo', 'npl', 'tal', 'fdl', 'copa', 'nal',
-                    'comp', 'recreational', 'reserve', 'classic', 'division', 'ecrl',
+                    'comp', 'recreational', 'reserve', 'classic', 'division', 'ecrl', 'regional',
                     'showcase', 'challenge', 'development', 'competitive',
                     # Common squad/mascot names that appear in team names
                     'royal', 'cosmos', 'celtic', 'rovers', 'arsenal', 'mustangs', 'wolves',


### PR DESCRIPTION
Fixes from reviewing dry run results:

1. Reverted "united", "city", "real", "inter", "sporting", "athletic" from NOISE_WORDS — these can be squad differentiators within a club (e.g. "SAC Premier Blue" vs "SAC United Blue"). Club name stripping via the club_name parameter handles the legitimate case where "United" is part of the club name.

2. Added RL (ECNL Regional League) hard block in _should_skip_pair — RL vs non-RL is always a different competitive tier, even when one side has no programs. Prevents "2015 Green RL" merging with "2015 Green AR" (AR=state code, not a league).

3. Added "regional" to PROGRAM_WORDS and extract_team_variant skip sets since RL can appear as "regional" in team names.

https://claude.ai/code/session_01QRFrQbGEMThQqSNbE7nSRK

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

