### PR TITLE
Team game history

### DIFF
--- a/.github/workflows/unknown-opponent-hygiene-weekly.yml
+++ b/.github/workflows/unknown-opponent-hygiene-weekly.yml
@@ -1,0 +1,190 @@
+name: Unknown Opponent Hygiene Weekly
+
+on:
+  schedule:
+    # Weekly on Tuesday at 18:00 UTC
+    - cron: '0 18 * * 2'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only (never execute writes)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      provider:
+        description: "Provider code to process"
+        required: false
+        default: "gotsport"
+        type: string
+      max_rows:
+        description: "Optional cap for partial games export (blank = all)"
+        required: false
+        default: ""
+        type: string
+      limit:
+        description: "Optional cap for match rows processed (blank = all)"
+        required: false
+        default: ""
+        type: string
+
+env:
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+  SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+  SUPABASE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  unknown-opponent-hygiene:
+    name: Unknown Opponent Hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install supabase python-dotenv requests
+
+      - name: Validate secrets
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "::error::Missing SUPABASE_URL or SUPABASE_SERVICE_KEY secret."
+            exit 1
+          fi
+
+      - name: Export unknown opponents
+        id: export
+        run: |
+          mkdir -p data/exports logs
+          TS="$(date +%Y%m%d_%H%M%S)"
+          PREFIX="data/exports/unknown_opponents_weekly_${TS}"
+          MAX_ROWS_FLAG=""
+          if [ -n "${{ github.event.inputs.max_rows }}" ]; then
+            MAX_ROWS_FLAG="--max-rows ${{ github.event.inputs.max_rows }}"
+          fi
+
+          python3 scripts/export_unknown_opponents.py \
+            --provider "${{ github.event.inputs.provider || 'gotsport' }}" \
+            --output-prefix "$PREFIX" \
+            $MAX_ROWS_FLAG | tee logs/unknown_export.log
+
+          echo "timestamp=$TS" >> "$GITHUB_OUTPUT"
+          echo "export_prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "aggregate_csv=${PREFIX}_aggregate.csv" >> "$GITHUB_OUTPUT"
+          echo "detail_csv=${PREFIX}_details.csv" >> "$GITHUB_OUTPUT"
+
+      - name: Auto-match unknown opponents (dry run)
+        id: match
+        run: |
+          MATCH_CSV="data/exports/unknown_opponent_match_report_weekly_${{ steps.export.outputs.timestamp }}.csv"
+          LIMIT_FLAG=""
+          if [ -n "${{ github.event.inputs.limit }}" ]; then
+            LIMIT_FLAG="--limit ${{ github.event.inputs.limit }}"
+          fi
+
+          python3 scripts/auto_match_unknown_opponents.py \
+            --input "${{ steps.export.outputs.aggregate_csv }}" \
+            --provider "${{ github.event.inputs.provider || 'gotsport' }}" \
+            --auto-threshold 0.95 \
+            --review-threshold 0.90 \
+            --max-candidates 160 \
+            --output "$MATCH_CSV" \
+            $LIMIT_FLAG | tee logs/unknown_match.log
+
+          echo "match_csv=$MATCH_CSV" >> "$GITHUB_OUTPUT"
+
+      - name: Due diligence gate
+        id: due
+        run: |
+          DD_PREFIX="data/exports/unknown_opponent_due_diligence_weekly_${{ steps.export.outputs.timestamp }}"
+          python3 scripts/due_diligence_unknown_opponents.py \
+            --match-report "${{ steps.match.outputs.match_csv }}" \
+            --output-prefix "$DD_PREFIX" | tee logs/unknown_due_diligence.log
+
+          python3 - <<'PY'
+          import os
+          import pathlib
+
+          log = pathlib.Path("logs/unknown_due_diligence.log").read_text(encoding="utf-8").splitlines()
+          values = {}
+          for line in log:
+              if "=" in line and line.startswith("DUE_DILIGENCE_"):
+                  k, v = line.split("=", 1)
+                  values[k] = v
+
+          mapping = {
+              "all_pass": values.get("DUE_DILIGENCE_ALL_PASS", "false"),
+              "auto_link_count": values.get("DUE_DILIGENCE_AUTO_LINK_COUNT", "0"),
+              "approved_count": values.get("DUE_DILIGENCE_APPROVED_COUNT", "0"),
+              "review_count": values.get("DUE_DILIGENCE_REVIEW_COUNT", "0"),
+              "all_csv": values.get("DUE_DILIGENCE_ALL_CSV", ""),
+              "approved_csv": values.get("DUE_DILIGENCE_APPROVED_CSV", ""),
+              "review_csv": values.get("DUE_DILIGENCE_REVIEW_CSV", ""),
+          }
+          github_output = os.environ["GITHUB_OUTPUT"]
+          with open(github_output, "a", encoding="utf-8") as f:
+              for key, val in mapping.items():
+                  f.write(f"{key}={val}\n")
+          PY
+
+      - name: Execute approved matches
+        if: ${{ steps.due.outputs.all_pass == 'true' && steps.due.outputs.approved_count != '0' && github.event.inputs.dry_run != 'true' }}
+        run: |
+          python3 scripts/apply_unknown_opponent_matches.py \
+            --approved-csv "${{ steps.due.outputs.approved_csv }}" \
+            --require-approved-rows | tee logs/unknown_apply.log
+
+      - name: Skip execution note
+        if: ${{ !(steps.due.outputs.all_pass == 'true' && steps.due.outputs.approved_count != '0' && github.event.inputs.dry_run != 'true') }}
+        run: |
+          echo "Execution skipped."
+          echo "all_pass=${{ steps.due.outputs.all_pass }}"
+          echo "approved_count=${{ steps.due.outputs.approved_count }}"
+          echo "dry_run=${{ github.event.inputs.dry_run || 'false' }}"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unknown-opponent-weekly-${{ github.run_number }}
+          path: |
+            logs/unknown_*.log
+            ${{ steps.export.outputs.aggregate_csv }}
+            ${{ steps.export.outputs.detail_csv }}
+            ${{ steps.match.outputs.match_csv }}
+            ${{ steps.due.outputs.all_csv }}
+            ${{ steps.due.outputs.approved_csv }}
+            ${{ steps.due.outputs.review_csv }}
+          retention-days: 30
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          MODE="AUTO-EXECUTE"
+          if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
+            MODE="DRY-RUN"
+          fi
+
+          echo "## Unknown Opponent Hygiene Weekly" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mode: **$MODE**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Provider: **${{ github.event.inputs.provider || 'gotsport' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Auto-link candidates: **${{ steps.due.outputs.auto_link_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Due diligence approved: **${{ steps.due.outputs.approved_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Due diligence needs review: **${{ steps.due.outputs.review_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- All pass gate: **${{ steps.due.outputs.all_pass || 'false' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Execution happens only when all due diligence rows are approved." >> "$GITHUB_STEP_SUMMARY"

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,8 @@
 import streamlit as st
 import pandas as pd
 import os
+import sys
+import subprocess
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 import time
@@ -838,6 +840,124 @@ elif section == "🧩 Unknown Opponent Review":
 
     exports_dir = Path("data/exports")
     exports_dir.mkdir(parents=True, exist_ok=True)
+    repo_root = Path(__file__).resolve().parent
+
+    st.subheader("Generate Fresh Unknown-Opponent Files")
+    gen_c1, gen_c2, gen_c3, gen_c4 = st.columns(4)
+    with gen_c1:
+        gen_provider = st.selectbox(
+            "Provider",
+            options=["gotsport", "tgs", "sincsports", "modular11"],
+            index=0,
+            key="uo_gen_provider",
+        )
+    with gen_c2:
+        gen_max_rows = st.number_input(
+            "Max partial game rows (0 = all)",
+            min_value=0,
+            value=0,
+            step=100,
+            key="uo_gen_max_rows",
+        )
+    with gen_c3:
+        gen_limit = st.number_input(
+            "Max unknown rows to match (0 = all)",
+            min_value=0,
+            value=0,
+            step=100,
+            key="uo_gen_limit",
+        )
+    with gen_c4:
+        auto_threshold = st.number_input(
+            "Auto threshold",
+            min_value=0.50,
+            max_value=1.00,
+            value=0.95,
+            step=0.01,
+            key="uo_gen_auto_threshold",
+        )
+
+    generate_clicked = st.button(
+        "🚀 Generate Fresh Files",
+        type="primary",
+        use_container_width=True,
+        key="uo_generate_btn",
+    )
+
+    if generate_clicked:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        export_prefix = exports_dir / f"unknown_opponents_ui_{ts}"
+        match_csv = exports_dir / f"unknown_opponent_match_report_ui_{ts}.csv"
+        due_prefix = exports_dir / f"unknown_opponent_due_diligence_ui_{ts}"
+
+        max_rows_args = ["--max-rows", str(int(gen_max_rows))] if int(gen_max_rows) > 0 else []
+        limit_args = ["--limit", str(int(gen_limit))] if int(gen_limit) > 0 else []
+
+        cmd_export = [
+            sys.executable,
+            str(repo_root / "scripts" / "export_unknown_opponents.py"),
+            "--provider",
+            gen_provider,
+            "--output-prefix",
+            str(export_prefix),
+            *max_rows_args,
+        ]
+        cmd_match = [
+            sys.executable,
+            str(repo_root / "scripts" / "auto_match_unknown_opponents.py"),
+            "--input",
+            f"{export_prefix}_aggregate.csv",
+            "--provider",
+            gen_provider,
+            "--auto-threshold",
+            f"{float(auto_threshold):.2f}",
+            "--review-threshold",
+            "0.90",
+            "--output",
+            str(match_csv),
+            *limit_args,
+        ]
+        cmd_due = [
+            sys.executable,
+            str(repo_root / "scripts" / "due_diligence_unknown_opponents.py"),
+            "--match-report",
+            str(match_csv),
+            "--output-prefix",
+            str(due_prefix),
+        ]
+
+        logs = []
+        with st.spinner("Generating export -> match report -> due diligence..."):
+            for label, cmd in [
+                ("Export unknown opponents", cmd_export),
+                ("Auto-match unknown opponents", cmd_match),
+                ("Due diligence", cmd_due),
+            ]:
+                result = subprocess.run(
+                    cmd,
+                    cwd=str(repo_root),
+                    capture_output=True,
+                    text=True,
+                )
+                logs.append(
+                    f"$ {' '.join(cmd)}\n"
+                    f"[exit={result.returncode}]\n"
+                    f"{result.stdout}\n"
+                    f"{result.stderr}"
+                )
+                if result.returncode != 0:
+                    st.error(f"{label} failed (exit code {result.returncode}). See logs below.")
+                    with st.expander("Generation logs", expanded=True):
+                        st.code("\n\n".join(logs))
+                    st.stop()
+
+        st.success(
+            "Fresh files generated successfully. "
+            f"Latest due diligence: `{due_prefix}_all.csv`"
+        )
+        with st.expander("Generation logs"):
+            st.code("\n\n".join(logs))
+        st.rerun()
 
     def latest_csv(pattern: str):
         files = list(exports_dir.glob(pattern))

--- a/dashboard.py
+++ b/dashboard.py
@@ -975,6 +975,13 @@ elif section == "🧩 Unknown Opponent Review":
     )
     selected = latest_due if source.startswith("Due Diligence") else latest_match
 
+    # Apply controls always use a due-diligence _all.csv snapshot.
+    active_due_file = None
+    if selected and selected.name.startswith("unknown_opponent_due_diligence_") and selected.name.endswith("_all.csv"):
+        active_due_file = selected
+    elif latest_due and latest_due.name.endswith("_all.csv"):
+        active_due_file = latest_due
+
     if not selected:
         st.warning(
             "No export file found yet in `data/exports`.\n\n"
@@ -990,6 +997,108 @@ elif section == "🧩 Unknown Opponent Review":
         except Exception as exc:
             st.error(f"Failed to read {selected.name}: {exc}")
             df = pd.DataFrame()
+
+        # ------------------------------------------------------------------
+        # Apply Approved controls
+        # ------------------------------------------------------------------
+        st.subheader("Apply Approved Matches")
+        if not active_due_file:
+            st.info("No due-diligence `_all.csv` file found yet, so apply controls are unavailable.")
+        else:
+            due_approved_file = Path(str(active_due_file).replace("_all.csv", "_approved.csv"))
+            due_review_file = Path(str(active_due_file).replace("_all.csv", "_needs_review.csv"))
+            st.caption(f"Using due-diligence file: `{active_due_file}`")
+
+            try:
+                due_df = pd.read_csv(active_due_file)
+            except Exception as exc:
+                st.error(f"Could not read due-diligence file: {exc}")
+                due_df = pd.DataFrame()
+
+            if due_df.empty or "verdict" not in due_df.columns:
+                st.warning("Due-diligence file is empty or missing `verdict` column.")
+            else:
+                due_approved_count = int((due_df["verdict"] == "approved").sum())
+                due_review_count = int((due_df["verdict"] != "approved").sum())
+                due_approved_games = 0
+                if "total_games_impacted" in due_df.columns:
+                    due_approved_games = int(
+                        pd.to_numeric(
+                            due_df[due_df["verdict"] == "approved"]["total_games_impacted"],
+                            errors="coerce",
+                        ).fillna(0).sum()
+                    )
+
+                a1, a2, a3 = st.columns(3)
+                a1.metric("Approved Rows", f"{due_approved_count:,}")
+                a2.metric("Needs Review Rows", f"{due_review_count:,}")
+                a3.metric("Approved Games Impacted", f"{due_approved_games:,}")
+
+                if due_review_count > 0:
+                    st.warning(
+                        "Real apply is blocked because some rows still need manual review. "
+                        "Use Dry-Run Apply to preview."
+                    )
+                elif due_approved_count == 0:
+                    st.info("No approved rows available to apply.")
+                else:
+                    st.success("All due-diligence rows are approved. Real apply is enabled.")
+
+                dry_col, apply_col = st.columns(2)
+                dry_clicked = dry_col.button(
+                    "🧪 Dry-Run Apply Approved",
+                    use_container_width=True,
+                    disabled=(due_approved_count == 0 or not due_approved_file.exists()),
+                    key="uo_apply_dry_run",
+                )
+                apply_clicked = apply_col.button(
+                    "✅ Apply Approved Now",
+                    type="primary",
+                    use_container_width=True,
+                    disabled=(
+                        due_approved_count == 0
+                        or due_review_count != 0
+                        or not due_approved_file.exists()
+                    ),
+                    key="uo_apply_execute",
+                )
+
+                if dry_clicked or apply_clicked:
+                    cmd_apply = [
+                        sys.executable,
+                        str(repo_root / "scripts" / "apply_unknown_opponent_matches.py"),
+                        "--approved-csv",
+                        str(due_approved_file),
+                        "--require-approved-rows",
+                    ]
+                    if dry_clicked:
+                        cmd_apply.append("--dry-run")
+
+                    with st.spinner("Running apply step..."):
+                        result = subprocess.run(
+                            cmd_apply,
+                            cwd=str(repo_root),
+                            capture_output=True,
+                            text=True,
+                        )
+
+                    mode_label = "dry-run" if dry_clicked else "execute"
+                    if result.returncode == 0:
+                        st.success(f"Apply ({mode_label}) completed successfully.")
+                    else:
+                        st.error(f"Apply ({mode_label}) failed with exit code {result.returncode}.")
+
+                    with st.expander("Apply logs", expanded=True):
+                        st.code(
+                            f"$ {' '.join(cmd_apply)}\n"
+                            f"[exit={result.returncode}]\n"
+                            f"{result.stdout}\n"
+                            f"{result.stderr}"
+                        )
+
+                    if result.returncode == 0 and apply_clicked:
+                        # Re-render after successful write to pick up freshest files/metrics.
+                        st.rerun()
 
         if df.empty:
             st.info("Selected file has no rows.")

--- a/dashboard.py
+++ b/dashboard.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 import time
+from pathlib import Path
 from supabase import create_client
 from config.settings import (
     RANKING_CONFIG,
@@ -95,6 +96,7 @@ section = st.sidebar.radio(
         "📋 Review Queue",
         "👥 Age Groups",
         "📈 Database Import Stats",
+        "🧩 Unknown Opponent Review",
         "🗺️ State Coverage",
         "📍 Missing State Codes",
         "🔀 Team Merge Manager",
@@ -823,6 +825,137 @@ elif section == "📋 Review Queue":
             st.error(f"Error loading review queue: {e}")
             import traceback
             st.code(traceback.format_exc())
+
+# ============================================================================
+# UNKNOWN OPPONENT REVIEW SECTION
+# ============================================================================
+elif section == "🧩 Unknown Opponent Review":
+    st.header("Unknown Opponent Review")
+    st.markdown(
+        "Shows the latest unknown-opponent matching exports. "
+        "Focus on rows that still require manual review."
+    )
+
+    exports_dir = Path("data/exports")
+    exports_dir.mkdir(parents=True, exist_ok=True)
+
+    def latest_csv(pattern: str):
+        files = list(exports_dir.glob(pattern))
+        if not files:
+            return None
+        return max(files, key=lambda p: p.stat().st_mtime)
+
+    latest_due = latest_csv("unknown_opponent_due_diligence_*_all.csv")
+    latest_match = latest_csv("unknown_opponent_match_report_*.csv")
+
+    source = st.radio(
+        "Source",
+        ["Due Diligence (latest)", "Match Report (latest)"],
+        horizontal=True,
+    )
+    selected = latest_due if source.startswith("Due Diligence") else latest_match
+
+    if not selected:
+        st.warning(
+            "No export file found yet in `data/exports`.\n\n"
+            "Run:\n"
+            "- export_unknown_opponents.py\n"
+            "- auto_match_unknown_opponents.py\n"
+            "- due_diligence_unknown_opponents.py"
+        )
+    else:
+        st.caption(f"Using file: `{selected}`")
+        try:
+            df = pd.read_csv(selected)
+        except Exception as exc:
+            st.error(f"Failed to read {selected.name}: {exc}")
+            df = pd.DataFrame()
+
+        if df.empty:
+            st.info("Selected file has no rows.")
+        else:
+            c1, c2, c3 = st.columns(3)
+            with c1:
+                provider_options = ["All"]
+                if "provider_code" in df.columns:
+                    provider_options += sorted(df["provider_code"].dropna().astype(str).unique().tolist())
+                provider_filter = st.selectbox("Provider", provider_options)
+            with c2:
+                min_games = st.number_input("Min games impacted", min_value=0, value=0, step=1)
+            with c3:
+                pid_query = st.text_input("Unknown provider team ID contains")
+
+            filtered = df.copy()
+            if provider_filter != "All" and "provider_code" in filtered.columns:
+                filtered = filtered[filtered["provider_code"].astype(str) == provider_filter]
+
+            game_col = "total_games_impacted" if "total_games_impacted" in filtered.columns else "games_count" if "games_count" in filtered.columns else None
+            if game_col:
+                filtered[game_col] = pd.to_numeric(filtered[game_col], errors="coerce").fillna(0).astype(int)
+                filtered = filtered[filtered[game_col] >= int(min_games)]
+
+            if pid_query and "unknown_provider_team_id" in filtered.columns:
+                filtered = filtered[
+                    filtered["unknown_provider_team_id"].astype(str).str.contains(pid_query, case=False, na=False)
+                ]
+
+            if "verdict" in filtered.columns:
+                approved_count = int((filtered["verdict"] == "approved").sum())
+                review_count = int((filtered["verdict"] != "approved").sum())
+                m1, m2, m3 = st.columns(3)
+                m1.metric("Rows", f"{len(filtered):,}")
+                m2.metric("Approved", f"{approved_count:,}")
+                m3.metric("Needs Review", f"{review_count:,}")
+
+                needs_review = filtered[filtered["verdict"] != "approved"].copy()
+                st.subheader("Needs Manual Review")
+                if needs_review.empty:
+                    st.success("No rows currently require manual review.")
+                else:
+                    cols = [
+                        col
+                        for col in [
+                            "provider_code",
+                            "unknown_provider_team_id",
+                            "matched_team_name",
+                            "best_score",
+                            "total_games_impacted",
+                            "club_check",
+                            "age_check",
+                            "gender_check",
+                            "state_check",
+                            "cohort_age_check",
+                            "cohort_gender_check",
+                            "alias_conflict",
+                            "verdict",
+                        ]
+                        if col in needs_review.columns
+                    ]
+                    sort_cols = [c for c in ["best_score", "total_games_impacted"] if c in needs_review.columns]
+                    if sort_cols:
+                        needs_review = needs_review.sort_values(by=sort_cols, ascending=False)
+                    st.dataframe(needs_review[cols], use_container_width=True, hide_index=True)
+            else:
+                m1, m2, m3, m4 = st.columns(4)
+                m1.metric("Rows", f"{len(filtered):,}")
+                if "action" in filtered.columns:
+                    counts = filtered["action"].value_counts().to_dict()
+                    m2.metric("Auto-link", f"{counts.get('auto_link', 0):,}")
+                    m3.metric("Review", f"{counts.get('review', 0):,}")
+                    m4.metric(
+                        "No Match / Skipped",
+                        f"{counts.get('no_match', 0) + counts.get('skip_protected_division', 0):,}",
+                    )
+                    manual = filtered[filtered["action"].isin(["review", "no_match", "skip_protected_division"])].copy()
+                    st.subheader("Needs Manual Review")
+                    st.dataframe(manual, use_container_width=True, hide_index=True)
+                else:
+                    m2.metric("Auto-link", "N/A")
+                    m3.metric("Review", "N/A")
+                    m4.metric("No Match / Skipped", "N/A")
+
+            with st.expander("Show filtered source data"):
+                st.dataframe(filtered, use_container_width=True, hide_index=True)
 
 # ============================================================================
 # AGE GROUPS SECTION

--- a/scripts/apply_unknown_opponent_matches.py
+++ b/scripts/apply_unknown_opponent_matches.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Apply approved unknown-opponent matches to DB.
+
+Reads a CSV from due_diligence_unknown_opponents.py (approved rows) and:
+  1) upserts team_alias_map(provider_id, provider_team_id -> team_id_master)
+  2) backfills missing home/away team_master links in games
+
+Safety behavior:
+  - If alias already exists for another team_id_master, row is skipped (conflict)
+  - Never overwrites non-null home_team_master_id / away_team_master_id
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from dotenv import load_dotenv
+from supabase import create_client
+
+
+def load_env() -> None:
+    env_local = Path(".env.local")
+    if env_local.exists():
+        load_dotenv(env_local, override=True)
+    else:
+        load_dotenv()
+
+
+def get_supabase():
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
+    if not supabase_url or not supabase_key:
+        raise ValueError(
+            "Missing Supabase credentials. Need SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY/SUPABASE_KEY."
+        )
+    return create_client(supabase_url, supabase_key)
+
+
+def parse_rows(path: str, require_approved: bool) -> List[Dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    if require_approved:
+        rows = [r for r in rows if (r.get("verdict") or "").strip().lower() == "approved"]
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Apply approved unknown-opponent mappings")
+    parser.add_argument("--approved-csv", required=True, help="CSV path from due_diligence script")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without DB writes")
+    parser.add_argument("--require-approved-rows", action="store_true", help="Only process rows where verdict=approved")
+    parser.add_argument(
+        "--only-unknown-ids",
+        default=None,
+        help="Optional comma-separated unknown_provider_team_id allowlist",
+    )
+    args = parser.parse_args()
+
+    rows = parse_rows(args.approved_csv, require_approved=args.require_approved_rows)
+    if args.only_unknown_ids:
+        allow = {x.strip() for x in args.only_unknown_ids.split(",") if x.strip()}
+        rows = [r for r in rows if (r.get("unknown_provider_team_id") or "").strip() in allow]
+
+    if not rows:
+        print("No rows to process.")
+        return
+
+    load_env()
+    db = get_supabase()
+
+    stats = {
+        "rows_total": len(rows),
+        "rows_applied": 0,
+        "rows_conflict": 0,
+        "rows_error": 0,
+        "home_backfilled": 0,
+        "away_backfilled": 0,
+    }
+
+    for row in rows:
+        provider_id = (row.get("provider_id") or "").strip()
+        unknown_pid = (row.get("unknown_provider_team_id") or "").strip()
+        team_id = (row.get("matched_team_id_master") or "").strip()
+
+        if not provider_id or not unknown_pid or not team_id:
+            stats["rows_error"] += 1
+            print(f"SKIP invalid row: provider_id={provider_id} unknown_pid={unknown_pid} team_id={team_id}")
+            continue
+
+        # Alias conflict guard.
+        existing_alias = (
+            db.table("team_alias_map")
+            .select("team_id_master")
+            .eq("provider_id", provider_id)
+            .eq("provider_team_id", unknown_pid)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if existing_alias and existing_alias[0].get("team_id_master") != team_id:
+            stats["rows_conflict"] += 1
+            print(
+                f"CONFLICT unknown_pid={unknown_pid}: existing team_id_master={existing_alias[0].get('team_id_master')} "
+                f"!= proposed {team_id}"
+            )
+            continue
+
+        if args.dry_run:
+            stats["rows_applied"] += 1
+            print(f"DRY-RUN would link unknown_pid={unknown_pid} -> team_id={team_id}")
+            continue
+
+        try:
+            # Upsert alias
+            db.table("team_alias_map").upsert(
+                {
+                    "provider_id": provider_id,
+                    "provider_team_id": unknown_pid,
+                    "team_id_master": team_id,
+                    "match_method": "fuzzy_auto",
+                    "match_confidence": 1.0,
+                    "review_status": "approved",
+                },
+                on_conflict="provider_id,provider_team_id",
+            ).execute()
+
+            # Backfill both sides safely (only NULL fields).
+            # Count first, then update without `.select()` to avoid client incompatibility.
+            home_count = (
+                db.table("games")
+                .select("id", count="exact", head=True)
+                .eq("provider_id", provider_id)
+                .eq("home_provider_id", unknown_pid)
+                .is_("home_team_master_id", "null")
+                .execute()
+                .count
+                or 0
+            )
+            away_count = (
+                db.table("games")
+                .select("id", count="exact", head=True)
+                .eq("provider_id", provider_id)
+                .eq("away_provider_id", unknown_pid)
+                .is_("away_team_master_id", "null")
+                .execute()
+                .count
+                or 0
+            )
+
+            db.table("games").update({"home_team_master_id": team_id}).eq(
+                "provider_id", provider_id
+            ).eq("home_provider_id", unknown_pid).is_("home_team_master_id", "null").execute()
+
+            db.table("games").update({"away_team_master_id": team_id}).eq(
+                "provider_id", provider_id
+            ).eq("away_provider_id", unknown_pid).is_("away_team_master_id", "null").execute()
+            stats["home_backfilled"] += home_count
+            stats["away_backfilled"] += away_count
+            stats["rows_applied"] += 1
+
+            print(
+                f"APPLIED unknown_pid={unknown_pid} -> team_id={team_id} "
+                f"(home_backfilled={home_count}, away_backfilled={away_count})"
+            )
+        except Exception as exc:
+            stats["rows_error"] += 1
+            print(f"ERROR unknown_pid={unknown_pid}: {exc}")
+
+    print("\n=== Apply Unknown Opponent Matches Summary ===")
+    for k, v in stats.items():
+        print(f"{k}={v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/auto_match_unknown_opponents.py
+++ b/scripts/auto_match_unknown_opponents.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""
+Auto-match unknown opponents exported from partial-linked games.
+
+Pipeline:
+1) Read aggregate CSV from export_unknown_opponents.py
+2) Build unknown team profile (optionally resolve GotSport team details)
+3) Score candidates using Step-3-style logic (score_team_pair)
+4) Classify into auto/review/no_match buckets
+5) Optional --execute:
+   - upsert team_alias_map
+   - backfill missing home/away team_master_id in games
+
+Examples:
+    python3 scripts/auto_match_unknown_opponents.py --input data/exports/unknown_opponents_*.csv
+    python3 scripts/auto_match_unknown_opponents.py --input ... --provider gotsport --limit 500
+    python3 scripts/auto_match_unknown_opponents.py --input ... --execute --auto-threshold 0.97
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import requests
+from dotenv import load_dotenv
+from supabase import create_client
+
+# Reuse existing queue/step-3 matching logic
+from find_fuzzy_duplicate_teams import score_team_pair
+from find_queue_matches import extract_age_group, extract_gender, has_protected_division
+
+
+def load_env() -> None:
+    env_local = Path(".env.local")
+    if env_local.exists():
+        load_dotenv(env_local, override=True)
+    else:
+        load_dotenv()
+
+
+def get_supabase():
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
+    if not supabase_url or not supabase_key:
+        raise ValueError(
+            "Missing Supabase credentials. Need SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY/SUPABASE_KEY."
+        )
+    return create_client(supabase_url, supabase_key)
+
+
+def _to_gender_full(v: Optional[str]) -> Optional[str]:
+    if not v:
+        return None
+    s = str(v).strip().lower()
+    if s in {"male", "m", "boys", "boy", "b"}:
+        return "Male"
+    if s in {"female", "f", "girls", "girl", "g"}:
+        return "Female"
+    return None
+
+
+def _to_age_group(v: Optional[str]) -> Optional[str]:
+    if not v:
+        return None
+    s = str(v).strip().lower()
+    if s.startswith("u") and s[1:].isdigit():
+        return s
+    if s.isdigit():
+        return f"u{s}"
+    # unknown_age from gotsport may be "12", already handled above
+    return None
+
+
+class GotSportResolver:
+    BASE_URL = "https://system.gotsport.com/api/v1/team_ranking_data/team_details"
+
+    def __init__(self, timeout: int = 15):
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.cache: Dict[str, Dict[str, str]] = {}
+
+    def resolve(self, provider_team_id: str) -> Dict[str, str]:
+        key = str(provider_team_id).strip()
+        if not key:
+            return {}
+        if key in self.cache:
+            return self.cache[key]
+        try:
+            response = self.session.get(
+                self.BASE_URL,
+                params={"team_id": key},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json() if response.content else {}
+            if not isinstance(payload, dict):
+                payload = {}
+        except Exception:
+            payload = {}
+
+        resolved = {
+            "unknown_team_name": str(payload.get("name") or "").strip(),
+            "unknown_team_full_name": str(payload.get("full_name") or "").strip(),
+            "unknown_club_name": str(payload.get("club_name") or "").strip(),
+            "unknown_state": str(payload.get("state") or "").strip(),
+            "unknown_age": str(payload.get("age") or "").strip(),
+            "unknown_gender": str(payload.get("gender") or "").strip(),
+        }
+        self.cache[key] = resolved
+        return resolved
+
+
+@dataclass
+class UnknownProfile:
+    team_name: str
+    club_name: str
+    age_group: Optional[str]
+    gender: Optional[str]
+    state_code: Optional[str]
+
+
+def build_unknown_profile(row: Dict[str, str], resolver: Optional[GotSportResolver]) -> UnknownProfile:
+    provider_code = (row.get("provider_code") or "").strip().lower()
+    unknown_provider_team_id = (row.get("unknown_provider_team_id") or "").strip()
+
+    # Start with CSV fields
+    full_name = (row.get("unknown_team_full_name") or "").strip()
+    short_name = (row.get("unknown_team_name") or "").strip()
+    club_name = (row.get("unknown_club_name") or "").strip()
+    state = (row.get("unknown_state") or "").strip()
+    age_group = _to_age_group(row.get("unknown_age"))
+    gender = _to_gender_full(row.get("unknown_gender"))
+
+    # Optional resolver backfill
+    if resolver and provider_code == "gotsport":
+        if not full_name and unknown_provider_team_id:
+            resolved = resolver.resolve(unknown_provider_team_id)
+            full_name = full_name or resolved.get("unknown_team_full_name", "")
+            short_name = short_name or resolved.get("unknown_team_name", "")
+            club_name = club_name or resolved.get("unknown_club_name", "")
+            state = state or resolved.get("unknown_state", "")
+            age_group = age_group or _to_age_group(resolved.get("unknown_age"))
+            gender = gender or _to_gender_full(resolved.get("unknown_gender"))
+
+    # Prefer full_name for fuzzy matching, then short_name
+    name = full_name or short_name or f"unknown_{unknown_provider_team_id}"
+
+    # Fallback age/gender/state from known-side context in export row
+    if not age_group:
+        age_group = _to_age_group(row.get("top_known_team_age_group"))
+    if not gender:
+        gender = _to_gender_full(row.get("top_known_team_gender"))
+    if not state:
+        state = (row.get("top_known_team_state") or "").strip()
+
+    # Parse from name if still missing
+    details = {"age_group": age_group, "gender": gender}
+    parsed_age = extract_age_group(name, details)
+    parsed_gender = extract_gender(name, details)
+    if not age_group and parsed_age:
+        age_group = parsed_age.lower()
+    if not gender and parsed_gender:
+        gender = _to_gender_full(parsed_gender)
+
+    return UnknownProfile(
+        team_name=name,
+        club_name=club_name,
+        age_group=age_group,
+        gender=gender,
+        state_code=state.upper() if state else None,
+    )
+
+
+def fetch_candidates(
+    supabase,
+    profile: UnknownProfile,
+    strict_club: bool,
+    max_candidates: int,
+    cache: Dict[Tuple, List[Dict]],
+) -> List[Dict]:
+    key = (
+        profile.club_name.lower(),
+        profile.age_group or "",
+        profile.gender or "",
+        profile.state_code or "",
+        strict_club,
+        max_candidates,
+    )
+    if key in cache:
+        return cache[key]
+
+    # Base query
+    query = supabase.table("teams").select(
+        "team_id_master,team_name,club_name,age_group,gender,state_code,is_deprecated"
+    ).eq("is_deprecated", False)
+
+    if profile.gender:
+        query = query.ilike("gender", profile.gender)
+    if profile.age_group:
+        age = profile.age_group.upper()
+        query = query.or_(f"age_group.eq.{age},age_group.eq.{age.lower()},age_group.eq.{age.upper()}")
+    if profile.state_code:
+        query = query.eq("state_code", profile.state_code)
+
+    # Club-first narrowing
+    candidates: List[Dict] = []
+    if profile.club_name:
+        club_q = query.ilike("club_name", profile.club_name)
+        candidates = club_q.limit(max_candidates).execute().data or []
+
+    if strict_club and profile.club_name:
+        cache[key] = candidates
+        return candidates
+
+    # Fallback broader query if strict club off and club-specific results are sparse.
+    if not candidates:
+        candidates = query.limit(max_candidates).execute().data or []
+
+    cache[key] = candidates
+    return candidates
+
+
+def match_row(
+    row: Dict[str, str],
+    supabase,
+    resolver: Optional[GotSportResolver],
+    strict_club: bool,
+    max_candidates: int,
+    auto_threshold: float,
+    review_threshold: float,
+    candidate_cache: Dict[Tuple, List[Dict]],
+) -> Dict[str, object]:
+    profile = build_unknown_profile(row, resolver)
+
+    if has_protected_division(profile.team_name):
+        return {
+            "action": "skip_protected_division",
+            "best_score": 0.0,
+            "best_match": None,
+            "profile": profile,
+            "candidate_count": 0,
+        }
+
+    candidates = fetch_candidates(
+        supabase=supabase,
+        profile=profile,
+        strict_club=strict_club,
+        max_candidates=max_candidates,
+        cache=candidate_cache,
+    )
+
+    best = None
+    best_score = 0.0
+    unknown_team = {"team_name": profile.team_name, "club_name": profile.club_name}
+
+    for candidate in candidates:
+        score = score_team_pair(unknown_team, candidate)
+        if score is None:
+            continue
+        if score > best_score:
+            best_score = score
+            best = candidate
+
+    if not best:
+        action = "no_match"
+    elif best_score >= auto_threshold:
+        action = "auto_link"
+    elif best_score >= review_threshold:
+        action = "review"
+    else:
+        action = "no_match"
+
+    return {
+        "action": action,
+        "best_score": best_score,
+        "best_match": best,
+        "profile": profile,
+        "candidate_count": len(candidates),
+    }
+
+
+def execute_auto_link(
+    supabase,
+    provider_id: str,
+    provider_code: str,
+    unknown_provider_team_id: str,
+    missing_side: str,
+    match_team_id: str,
+    match_score: float,
+) -> Tuple[str, int]:
+    # Check existing alias first for safety.
+    existing = (
+        supabase.table("team_alias_map")
+        .select("id,team_id_master")
+        .eq("provider_id", provider_id)
+        .eq("provider_team_id", unknown_provider_team_id)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if existing and existing[0].get("team_id_master") != match_team_id:
+        return "alias_conflict", 0
+
+    # Upsert alias mapping
+    supabase.table("team_alias_map").upsert(
+        {
+            "provider_id": provider_id,
+            "provider_team_id": unknown_provider_team_id,
+            "team_id_master": match_team_id,
+            "match_method": "fuzzy_auto",
+            "match_confidence": float(f"{match_score:.4f}"),
+            "review_status": "approved",
+        },
+        on_conflict="provider_id,provider_team_id",
+    ).execute()
+
+    # Backfill missing side only.
+    if missing_side == "home":
+        update = (
+            supabase.table("games")
+            .update({"home_team_master_id": match_team_id})
+            .eq("provider_id", provider_id)
+            .eq("home_provider_id", unknown_provider_team_id)
+            .is_("home_team_master_id", "null")
+            .select("id")
+            .execute()
+        )
+    else:
+        update = (
+            supabase.table("games")
+            .update({"away_team_master_id": match_team_id})
+            .eq("provider_id", provider_id)
+            .eq("away_provider_id", unknown_provider_team_id)
+            .is_("away_team_master_id", "null")
+            .select("id")
+            .execute()
+        )
+    updated_rows = len(update.data or [])
+    return "linked", updated_rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Auto-match unknown opponents from export CSV")
+    parser.add_argument("--input", required=True, help="Aggregate CSV from export_unknown_opponents.py")
+    parser.add_argument("--provider", default=None, help="Optional provider code filter")
+    parser.add_argument("--limit", type=int, default=None, help="Limit rows processed from input CSV")
+    parser.add_argument("--auto-threshold", type=float, default=0.95, help="Score threshold for auto-link")
+    parser.add_argument("--review-threshold", type=float, default=0.90, help="Score threshold for review bucket")
+    parser.add_argument("--strict-club", action="store_true", help="Require exact club filtering when club is known")
+    parser.add_argument("--max-candidates", type=int, default=120, help="Max team candidates per unknown row")
+    parser.add_argument("--resolve-gotsport-details", action="store_true", help="Fetch missing unknown team details from GotSport API")
+    parser.add_argument("--execute", action="store_true", help="Apply auto_link rows (alias + backfill)")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output report CSV path (default: data/exports/unknown_opponent_match_report_<timestamp>.csv)",
+    )
+    args = parser.parse_args()
+
+    if args.review_threshold > args.auto_threshold:
+        raise ValueError("--review-threshold cannot be greater than --auto-threshold")
+
+    load_env()
+    supabase = get_supabase()
+
+    providers = supabase.table("providers").select("id,code,name").execute().data or []
+    code_to_id = {p["code"]: p["id"] for p in providers}
+
+    provider_filter = args.provider.lower() if args.provider else None
+    if provider_filter and provider_filter not in code_to_id:
+        raise ValueError(f"Unknown provider code: {provider_filter}")
+
+    # Read input rows
+    with open(args.input, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = [r for r in reader]
+
+    if provider_filter:
+        rows = [r for r in rows if (r.get("provider_code") or "").strip().lower() == provider_filter]
+    if args.limit:
+        rows = rows[: args.limit]
+
+    resolver = GotSportResolver() if args.resolve_gotsport_details else None
+    candidate_cache: Dict[Tuple, List[Dict]] = {}
+
+    report_rows: List[Dict[str, object]] = []
+    stats = {
+        "total": 0,
+        "auto_link": 0,
+        "review": 0,
+        "no_match": 0,
+        "skip_protected_division": 0,
+        "executed_linked": 0,
+        "executed_conflict": 0,
+        "games_backfilled": 0,
+    }
+
+    for idx, row in enumerate(rows, start=1):
+        provider_code = (row.get("provider_code") or "").strip().lower()
+        provider_id = (row.get("provider_id") or "").strip() or code_to_id.get(provider_code, "")
+        unknown_pid = (row.get("unknown_provider_team_id") or "").strip()
+        missing_side = (row.get("missing_side") or "").strip().lower()
+
+        result = match_row(
+            row=row,
+            supabase=supabase,
+            resolver=resolver,
+            strict_club=args.strict_club,
+            max_candidates=args.max_candidates,
+            auto_threshold=args.auto_threshold,
+            review_threshold=args.review_threshold,
+            candidate_cache=candidate_cache,
+        )
+
+        action = result["action"]
+        best_score = float(result["best_score"])
+        best_match = result["best_match"]
+        profile: UnknownProfile = result["profile"]  # type: ignore[assignment]
+        candidate_count = int(result["candidate_count"])
+
+        stats["total"] += 1
+        if action in stats:
+            stats[action] += 1
+
+        exec_status = "dry_run"
+        updated_rows = 0
+
+        if args.execute and action == "auto_link" and best_match and provider_id and unknown_pid and missing_side in {"home", "away"}:
+            exec_status, updated_rows = execute_auto_link(
+                supabase=supabase,
+                provider_id=provider_id,
+                provider_code=provider_code,
+                unknown_provider_team_id=unknown_pid,
+                missing_side=missing_side,
+                match_team_id=best_match["team_id_master"],
+                match_score=best_score,
+            )
+            if exec_status == "linked":
+                stats["executed_linked"] += 1
+                stats["games_backfilled"] += updated_rows
+            elif exec_status == "alias_conflict":
+                stats["executed_conflict"] += 1
+
+        report_rows.append(
+            {
+                "provider_code": provider_code,
+                "provider_id": provider_id,
+                "unknown_provider_team_id": unknown_pid,
+                "missing_side": missing_side,
+                "games_count": row.get("games_count", ""),
+                "unknown_team_name_used": profile.team_name,
+                "unknown_club_name_used": profile.club_name,
+                "unknown_age_group_used": profile.age_group or "",
+                "unknown_gender_used": profile.gender or "",
+                "unknown_state_used": profile.state_code or "",
+                "candidate_count": candidate_count,
+                "action": action,
+                "best_score": f"{best_score:.4f}",
+                "matched_team_id_master": best_match["team_id_master"] if best_match else "",
+                "matched_team_name": best_match["team_name"] if best_match else "",
+                "matched_team_club": best_match["club_name"] if best_match else "",
+                "matched_team_age_group": best_match["age_group"] if best_match else "",
+                "matched_team_gender": best_match["gender"] if best_match else "",
+                "matched_team_state": best_match["state_code"] if best_match else "",
+                "execute_status": exec_status,
+                "games_backfilled": updated_rows,
+            }
+        )
+
+        if idx % 200 == 0:
+            print(f"Processed {idx}/{len(rows)} rows...")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = Path(
+        args.output
+        or f"data/exports/unknown_opponent_match_report_{timestamp}.csv"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(report_rows[0].keys()) if report_rows else [])
+        if report_rows:
+            writer.writeheader()
+            for report_row in report_rows:
+                writer.writerow(report_row)
+
+    print("=== Unknown Opponent Auto-Match ===")
+    print(f"Input rows processed: {stats['total']:,}")
+    print(f"Auto-link candidates: {stats['auto_link']:,}")
+    print(f"Review bucket: {stats['review']:,}")
+    print(f"No match: {stats['no_match']:,}")
+    print(f"Skipped (protected division): {stats['skip_protected_division']:,}")
+    if args.execute:
+        print(f"Executed links: {stats['executed_linked']:,}")
+        print(f"Alias conflicts: {stats['executed_conflict']:,}")
+        print(f"Games backfilled: {stats['games_backfilled']:,}")
+    print(f"Report CSV: {output_path}")
+
+    # Print top sample auto-link suggestions
+    top = [r for r in report_rows if r["action"] == "auto_link"]
+    top.sort(key=lambda r: float(str(r["best_score"])), reverse=True)
+    print("\nTop 10 auto-link suggestions:")
+    for i, row in enumerate(top[:10], start=1):
+        print(
+            f"  {i:>2}. [{row['provider_code']}] {row['unknown_provider_team_id']} "
+            f"-> {row['matched_team_name']} ({row['matched_team_id_master']}) "
+            f"score={row['best_score']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/due_diligence_unknown_opponents.py
+++ b/scripts/due_diligence_unknown_opponents.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Run due diligence checks for unknown-opponent auto-match recommendations.
+
+Input: match report CSV from scripts/auto_match_unknown_opponents.py
+Output:
+  - due diligence full CSV
+  - approved-only CSV
+  - needs-review CSV
+
+Checks per auto_link row:
+  1) alias conflict (provider_team_id already mapped to another master team?)
+  2) metadata agreement with provider API (club/state/age/gender)
+  3) cohort agreement from known linked opponents in those games (age/gender)
+
+Typical usage:
+  python3 scripts/due_diligence_unknown_opponents.py \\
+    --match-report data/exports/unknown_opponent_match_report_weekly.csv \\
+    --output-prefix data/exports/unknown_opponent_due_diligence_weekly
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import requests
+from dotenv import load_dotenv
+from supabase import create_client
+
+
+def load_env() -> None:
+    env_local = Path(".env.local")
+    if env_local.exists():
+        load_dotenv(env_local, override=True)
+    else:
+        load_dotenv()
+
+
+def get_supabase():
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
+    if not supabase_url or not supabase_key:
+        raise ValueError(
+            "Missing Supabase credentials. Need SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY/SUPABASE_KEY."
+        )
+    return create_client(supabase_url, supabase_key)
+
+
+def _normalize_gender(g: Optional[str]) -> Optional[str]:
+    if not g:
+        return None
+    s = str(g).strip().lower()
+    if s in {"m", "male", "boy", "boys", "b"}:
+        return "male"
+    if s in {"f", "female", "girl", "girls", "g"}:
+        return "female"
+    return None
+
+
+def _normalize_age_group(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip().lower()
+    if not s:
+        return None
+    if s.startswith("u") and s[1:].isdigit():
+        return s
+    if s.isdigit():
+        return f"u{s}"
+    return None
+
+
+def _normalize_text(s: Optional[str]) -> str:
+    if not s:
+        return ""
+    out = str(s).lower().strip()
+    out = re.sub(r"[^a-z0-9 ]+", " ", out)
+    out = " ".join(out.split())
+    return out
+
+
+def _club_compare(unknown_club: str, matched_club: str) -> str:
+    u = _normalize_text(unknown_club)
+    m = _normalize_text(matched_club)
+    if not u or not m:
+        return "unknown"
+    if u == m:
+        return "exact"
+    if u in m or m in u:
+        return "partial"
+    ut = set(u.split())
+    mt = set(m.split())
+    if not ut or not mt:
+        return "unknown"
+    overlap = len(ut & mt) / max(1, len(ut | mt))
+    return "partial" if overlap >= 0.5 else "mismatch"
+
+
+class GotSportResolver:
+    BASE_URL = "https://system.gotsport.com/api/v1/team_ranking_data/team_details"
+
+    def __init__(self, timeout: int = 20):
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.cache: Dict[str, Dict[str, str]] = {}
+
+    def resolve(self, provider_team_id: str) -> Dict[str, str]:
+        key = str(provider_team_id).strip()
+        if not key:
+            return {}
+        if key in self.cache:
+            return self.cache[key]
+
+        try:
+            response = self.session.get(
+                self.BASE_URL,
+                params={"team_id": key},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json() if response.content else {}
+            if not isinstance(payload, dict):
+                payload = {}
+        except Exception:
+            payload = {}
+
+        resolved = {
+            "full_name": str(payload.get("full_name") or "").strip(),
+            "name": str(payload.get("name") or "").strip(),
+            "club_name": str(payload.get("club_name") or "").strip(),
+            "state": str(payload.get("state") or "").strip().upper(),
+            "age_group": _normalize_age_group(payload.get("age")),
+            "gender": _normalize_gender(payload.get("gender")),
+        }
+        self.cache[key] = resolved
+        return resolved
+
+
+def _write_csv(path: Path, rows: List[Dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        with path.open("w", newline="", encoding="utf-8") as f:
+            f.write("")
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Due diligence checks for unknown-opponent auto matches")
+    parser.add_argument("--match-report", required=True, help="CSV from auto_match_unknown_opponents.py")
+    parser.add_argument(
+        "--output-prefix",
+        default=None,
+        help="Output prefix (default: data/exports/unknown_opponent_due_diligence_<timestamp>)",
+    )
+    parser.add_argument(
+        "--strict-name-check",
+        action="store_true",
+        help="Require literal name check in addition to core identity checks",
+    )
+    parser.add_argument(
+        "--require-all-passing",
+        action="store_true",
+        help="Exit non-zero unless every auto_link row is approved",
+    )
+    args = parser.parse_args()
+
+    load_env()
+    supabase = get_supabase()
+    resolver = GotSportResolver()
+
+    with open(args.match_report, "r", encoding="utf-8") as f:
+        all_rows = list(csv.DictReader(f))
+
+    auto_rows = [r for r in all_rows if (r.get("action") or "") == "auto_link"]
+
+    # Collapse by unknown provider team ID to avoid duplicate home/away lines.
+    grouped: Dict[Tuple[str, str, str], List[Dict]] = {}
+    for row in auto_rows:
+        key = (
+            (row.get("provider_code") or "").strip().lower(),
+            (row.get("provider_id") or "").strip(),
+            (row.get("unknown_provider_team_id") or "").strip(),
+        )
+        grouped.setdefault(key, []).append(row)
+
+    verdict_rows: List[Dict] = []
+    approved_rows: List[Dict] = []
+    review_rows: List[Dict] = []
+
+    for (provider_code, provider_id, unknown_pid), items in grouped.items():
+        # Best row as representative; aggregate side/games.
+        best = max(items, key=lambda r: float(r.get("best_score") or 0))
+        sides = sorted({(r.get("missing_side") or "").strip().lower() for r in items if r.get("missing_side")})
+        total_games = sum(int(r.get("games_count") or 0) for r in items)
+        best_score = float(best.get("best_score") or 0)
+        matched_team_id = (best.get("matched_team_id_master") or "").strip()
+
+        # Fetch matched team from DB.
+        team_data = (
+            supabase.table("teams")
+            .select("team_id_master,team_name,club_name,age_group,gender,state_code")
+            .eq("team_id_master", matched_team_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        team = team_data[0] if team_data else {}
+
+        # Alias conflict check.
+        alias_rows = (
+            supabase.table("team_alias_map")
+            .select("team_id_master")
+            .eq("provider_id", provider_id)
+            .eq("provider_team_id", unknown_pid)
+            .execute()
+            .data
+            or []
+        )
+        alias_conflict = bool(alias_rows and alias_rows[0].get("team_id_master") != matched_team_id)
+
+        # Provider metadata check (currently strong coverage for gotsport).
+        unknown = resolver.resolve(unknown_pid) if provider_code == "gotsport" else {}
+
+        unknown_age = unknown.get("age_group")
+        unknown_gender = unknown.get("gender")
+        unknown_state = unknown.get("state")
+        unknown_club = unknown.get("club_name", "")
+        unknown_full_name = unknown.get("full_name", "") or unknown.get("name", "")
+
+        team_age = _normalize_age_group(team.get("age_group"))
+        team_gender = _normalize_gender(team.get("gender"))
+        team_state = str(team.get("state_code") or "").upper() or None
+        team_club = str(team.get("club_name") or "")
+
+        age_check = "unknown" if not unknown_age or not team_age else ("ok" if unknown_age == team_age else "mismatch")
+        gender_check = (
+            "unknown" if not unknown_gender or not team_gender else ("ok" if unknown_gender == team_gender else "mismatch")
+        )
+        state_check = (
+            "unknown" if not unknown_state or not team_state else ("ok" if unknown_state == team_state else "mismatch")
+        )
+        club_check = _club_compare(unknown_club, team_club)
+
+        # Name literal check: relaxed contains/substring matching.
+        norm_full = _normalize_text(unknown_full_name)
+        norm_team = _normalize_text(str(team.get("team_name") or ""))
+        name_literal_check = bool(norm_full and norm_team and (norm_team in norm_full or norm_full in norm_team))
+
+        # Cohort check from already linked opponents in those unresolved games.
+        games = (
+            supabase.table("games")
+            .select("home_provider_id,away_provider_id,home_team_master_id,away_team_master_id")
+            .eq("provider_id", provider_id)
+            .or_(f"home_provider_id.eq.{unknown_pid},away_provider_id.eq.{unknown_pid}")
+            .execute()
+            .data
+            or []
+        )
+        known_team_ids = []
+        for g in games:
+            if str(g.get("home_provider_id")) == unknown_pid and g.get("away_team_master_id"):
+                known_team_ids.append(g["away_team_master_id"])
+            elif str(g.get("away_provider_id")) == unknown_pid and g.get("home_team_master_id"):
+                known_team_ids.append(g["home_team_master_id"])
+
+        cohort_age = None
+        cohort_gender = None
+        if known_team_ids:
+            unique_ids = list(dict.fromkeys(known_team_ids))
+            cohort_rows = []
+            for i in range(0, len(unique_ids), 500):
+                cohort_rows.extend(
+                    (
+                        supabase.table("teams")
+                        .select("team_id_master,age_group,gender")
+                        .in_("team_id_master", unique_ids[i : i + 500])
+                        .execute()
+                        .data
+                        or []
+                    )
+                )
+            age_counter = Counter(_normalize_age_group(r.get("age_group")) for r in cohort_rows if r.get("age_group"))
+            gen_counter = Counter(_normalize_gender(r.get("gender")) for r in cohort_rows if r.get("gender"))
+            cohort_age = age_counter.most_common(1)[0][0] if age_counter else None
+            cohort_gender = gen_counter.most_common(1)[0][0] if gen_counter else None
+
+        cohort_age_check = "unknown" if not cohort_age or not team_age else ("ok" if cohort_age == team_age else "mismatch")
+        cohort_gender_check = (
+            "unknown" if not cohort_gender or not team_gender else ("ok" if cohort_gender == team_gender else "mismatch")
+        )
+
+        # Core verdict rule.
+        core_ok = all(
+            [
+                not alias_conflict,
+                club_check != "mismatch",
+                age_check != "mismatch",
+                gender_check != "mismatch",
+                state_check != "mismatch",
+                cohort_age_check != "mismatch",
+                cohort_gender_check != "mismatch",
+            ]
+        )
+        if args.strict_name_check:
+            core_ok = core_ok and name_literal_check
+
+        verdict = "approved" if core_ok else "needs_review"
+
+        verdict_row = {
+            "provider_code": provider_code,
+            "provider_id": provider_id,
+            "unknown_provider_team_id": unknown_pid,
+            "matched_team_id_master": matched_team_id,
+            "matched_team_name": team.get("team_name", ""),
+            "matched_team_club": team_club,
+            "matched_team_age_group": team_age or "",
+            "matched_team_gender": team_gender or "",
+            "matched_team_state": team_state or "",
+            "rows_collapsed": len(items),
+            "sides": "/".join(sides),
+            "total_games_impacted": total_games,
+            "best_score": f"{best_score:.4f}",
+            "alias_conflict": alias_conflict,
+            "name_literal_check": name_literal_check,
+            "club_check": club_check,
+            "age_check": age_check,
+            "gender_check": gender_check,
+            "state_check": state_check,
+            "cohort_age_check": cohort_age_check,
+            "cohort_gender_check": cohort_gender_check,
+            "unknown_api_full_name": unknown_full_name,
+            "unknown_api_club_name": unknown_club,
+            "unknown_api_age_group": unknown_age or "",
+            "unknown_api_gender": unknown_gender or "",
+            "unknown_api_state": unknown_state or "",
+            "verdict": verdict,
+        }
+        verdict_rows.append(verdict_row)
+        if verdict == "approved":
+            approved_rows.append(verdict_row)
+        else:
+            review_rows.append(verdict_row)
+
+    # Sort for readability.
+    verdict_rows.sort(key=lambda r: (r["verdict"] != "approved", -float(r["best_score"]), -int(r["total_games_impacted"])))
+    approved_rows.sort(key=lambda r: (-float(r["best_score"]), -int(r["total_games_impacted"])))
+    review_rows.sort(key=lambda r: (-float(r["best_score"]), -int(r["total_games_impacted"])))
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    prefix = args.output_prefix or f"data/exports/unknown_opponent_due_diligence_{timestamp}"
+    all_path = Path(f"{prefix}_all.csv")
+    approved_path = Path(f"{prefix}_approved.csv")
+    review_path = Path(f"{prefix}_needs_review.csv")
+
+    _write_csv(all_path, verdict_rows)
+    _write_csv(approved_path, approved_rows)
+    _write_csv(review_path, review_rows)
+
+    auto_link_count = len(grouped)
+    approved_count = len(approved_rows)
+    review_count = len(review_rows)
+    all_pass = auto_link_count == approved_count
+
+    print("=== Unknown Opponent Due Diligence ===")
+    print(f"Auto-link candidates: {auto_link_count}")
+    print(f"Approved: {approved_count}")
+    print(f"Needs review: {review_count}")
+    print(f"All pass: {all_pass}")
+    print(f"All CSV: {all_path}")
+    print(f"Approved CSV: {approved_path}")
+    print(f"Needs-review CSV: {review_path}")
+
+    # CI-friendly key lines
+    print(f"DUE_DILIGENCE_AUTO_LINK_COUNT={auto_link_count}")
+    print(f"DUE_DILIGENCE_APPROVED_COUNT={approved_count}")
+    print(f"DUE_DILIGENCE_REVIEW_COUNT={review_count}")
+    print(f"DUE_DILIGENCE_ALL_PASS={'true' if all_pass else 'false'}")
+    print(f"DUE_DILIGENCE_ALL_CSV={all_path}")
+    print(f"DUE_DILIGENCE_APPROVED_CSV={approved_path}")
+    print(f"DUE_DILIGENCE_REVIEW_CSV={review_path}")
+
+    if args.require_all_passing and not all_pass:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_unknown_opponents.py
+++ b/scripts/export_unknown_opponents.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Export unresolved ("unknown opponent") game links from partial-linked games.
+
+This script finds games where exactly one side is linked to a team_id_master
+and the other side is still NULL, then exports:
+
+1) Aggregate CSV (one row per unresolved provider team ID + side)
+2) Detail CSV (one row per game)
+
+Optional:
+- Resolve GotSport team details (full_name, club_name, age, state) for unknown IDs.
+
+Examples:
+    python3 scripts/export_unknown_opponents.py
+    python3 scripts/export_unknown_opponents.py --provider gotsport --resolve-gotsport-details
+    python3 scripts/export_unknown_opponents.py --include-excluded --max-rows 50000
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import requests
+from dotenv import load_dotenv
+from supabase import create_client
+
+
+def load_env() -> None:
+    env_local = Path(".env.local")
+    if env_local.exists():
+        load_dotenv(env_local, override=True)
+    else:
+        load_dotenv()
+
+
+def get_supabase():
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        or os.getenv("SUPABASE_SERVICE_KEY")
+        or os.getenv("SUPABASE_KEY")
+    )
+    if not supabase_url or not supabase_key:
+        raise ValueError(
+            "Missing Supabase credentials. Need SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY/SUPABASE_KEY."
+        )
+    return create_client(supabase_url, supabase_key)
+
+
+def _is_nullish(value: object) -> bool:
+    if value is None:
+        return True
+    s = str(value).strip().lower()
+    return s in {"", "none", "null", "nan"}
+
+
+@dataclass
+class UnknownSide:
+    missing_side: str  # "home" or "away"
+    unknown_provider_team_id: str
+    known_team_id: Optional[str]
+
+
+def classify_unknown_side(game: Dict) -> Optional[UnknownSide]:
+    home_master = game.get("home_team_master_id")
+    away_master = game.get("away_team_master_id")
+
+    home_missing = home_master is None
+    away_missing = away_master is None
+
+    if home_missing and not away_missing:
+        unknown_provider_id = game.get("home_provider_id")
+        if _is_nullish(unknown_provider_id):
+            return None
+        return UnknownSide(
+            missing_side="home",
+            unknown_provider_team_id=str(unknown_provider_id).strip(),
+            known_team_id=away_master,
+        )
+
+    if away_missing and not home_missing:
+        unknown_provider_id = game.get("away_provider_id")
+        if _is_nullish(unknown_provider_id):
+            return None
+        return UnknownSide(
+            missing_side="away",
+            unknown_provider_team_id=str(unknown_provider_id).strip(),
+            known_team_id=home_master,
+        )
+
+    # Skip fully linked and fully unlinked rows.
+    return None
+
+
+class GotSportResolver:
+    BASE_URL = "https://system.gotsport.com/api/v1/team_ranking_data/team_details"
+
+    def __init__(self, timeout: int = 15):
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.cache: Dict[str, Dict[str, str]] = {}
+
+    def resolve(self, provider_team_id: str) -> Dict[str, str]:
+        key = str(provider_team_id).strip()
+        if not key:
+            return {}
+        if key in self.cache:
+            return self.cache[key]
+
+        try:
+            response = self.session.get(
+                self.BASE_URL,
+                params={"team_id": key},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json() if response.content else {}
+            if not isinstance(payload, dict):
+                payload = {}
+        except Exception:
+            payload = {}
+
+        resolved = {
+            "unknown_team_name": str(payload.get("name") or "").strip(),
+            "unknown_team_full_name": str(payload.get("full_name") or "").strip(),
+            "unknown_club_name": str(payload.get("club_name") or "").strip(),
+            "unknown_state": str(payload.get("state") or "").strip(),
+            "unknown_age": str(payload.get("age") or "").strip(),
+            "unknown_gender": str(payload.get("gender") or "").strip(),
+        }
+        self.cache[key] = resolved
+        return resolved
+
+
+def fetch_partial_games(
+    supabase,
+    provider_id: Optional[str],
+    include_excluded: bool,
+    max_rows: Optional[int],
+) -> List[Dict]:
+    select_cols = (
+        "id,provider_id,game_date,competition,is_excluded,"
+        "home_provider_id,away_provider_id,"
+        "home_team_master_id,away_team_master_id,"
+        "home_score,away_score"
+    )
+    page_size = 1000
+    offset = 0
+    rows: List[Dict] = []
+
+    while True:
+        query = supabase.table("games").select(select_cols).or_(
+            "home_team_master_id.is.null,away_team_master_id.is.null"
+        )
+
+        if provider_id:
+            query = query.eq("provider_id", provider_id)
+        if not include_excluded:
+            query = query.eq("is_excluded", False)
+
+        batch = query.range(offset, offset + page_size - 1).execute().data or []
+        if not batch:
+            break
+
+        rows.extend(batch)
+        if max_rows and len(rows) >= max_rows:
+            rows = rows[:max_rows]
+            break
+
+        if len(batch) < page_size:
+            break
+        offset += page_size
+
+    return rows
+
+
+def fetch_team_lookup(supabase, team_ids: List[str]) -> Dict[str, Dict]:
+    lookup: Dict[str, Dict] = {}
+    if not team_ids:
+        return lookup
+
+    for i in range(0, len(team_ids), 500):
+        batch = team_ids[i : i + 500]
+        data = (
+            supabase.table("teams")
+            .select("team_id_master,team_name,age_group,gender,club_name,state_code")
+            .in_("team_id_master", batch)
+            .execute()
+            .data
+            or []
+        )
+        for row in data:
+            lookup[row["team_id_master"]] = row
+    return lookup
+
+
+def write_csv(path: Path, fieldnames: List[str], rows: List[Dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export unknown opponents from partial-linked games")
+    parser.add_argument("--provider", default=None, help="Provider code filter (e.g. gotsport, tgs)")
+    parser.add_argument("--include-excluded", action="store_true", help="Include games where is_excluded=true")
+    parser.add_argument("--max-rows", type=int, default=None, help="Optional cap for fetched game rows")
+    parser.add_argument("--resolve-gotsport-details", action="store_true", help="Fetch GotSport team details for unknown provider team IDs")
+    parser.add_argument(
+        "--output-prefix",
+        default=None,
+        help="Output file prefix (default: data/exports/unknown_opponents_<timestamp>)",
+    )
+    args = parser.parse_args()
+
+    load_env()
+    supabase = get_supabase()
+
+    providers = supabase.table("providers").select("id,code,name").execute().data or []
+    code_to_id = {p["code"]: p["id"] for p in providers}
+    id_to_code = {p["id"]: p["code"] for p in providers}
+
+    provider_id = None
+    if args.provider:
+        provider_id = code_to_id.get(args.provider)
+        if not provider_id:
+            raise ValueError(f"Unknown provider code: {args.provider}")
+
+    partial_rows = fetch_partial_games(
+        supabase=supabase,
+        provider_id=provider_id,
+        include_excluded=args.include_excluded,
+        max_rows=args.max_rows,
+    )
+
+    # Build known team lookup
+    known_ids = set()
+    for game in partial_rows:
+        unknown = classify_unknown_side(game)
+        if unknown and unknown.known_team_id:
+            known_ids.add(unknown.known_team_id)
+    team_lookup = fetch_team_lookup(supabase, sorted(known_ids))
+
+    resolver = GotSportResolver() if args.resolve_gotsport_details else None
+
+    # Aggregate
+    groups: Dict[Tuple[str, str, str, str], Dict] = {}
+    detail_rows: List[Dict] = []
+
+    for game in partial_rows:
+        unknown = classify_unknown_side(game)
+        if not unknown:
+            continue
+
+        pid = game.get("provider_id")
+        pcode = id_to_code.get(pid, str(pid))
+        key = (pcode, str(pid), unknown.unknown_provider_team_id, unknown.missing_side)
+
+        known_team = team_lookup.get(unknown.known_team_id or "", {})
+        got_details: Dict[str, str] = {}
+        if resolver and pcode == "gotsport":
+            got_details = resolver.resolve(unknown.unknown_provider_team_id)
+
+        if key not in groups:
+            groups[key] = {
+                "games_count": 0,
+                "first_game_date": None,
+                "last_game_date": None,
+                "known_team_counts": Counter(),
+                "competition_counts": Counter(),
+                "sample_game_ids": [],
+                "resolved_unknown": got_details,
+            }
+
+        g = groups[key]
+        g["games_count"] += 1
+        game_date = game.get("game_date")
+        if game_date:
+            if not g["first_game_date"] or game_date < g["first_game_date"]:
+                g["first_game_date"] = game_date
+            if not g["last_game_date"] or game_date > g["last_game_date"]:
+                g["last_game_date"] = game_date
+        if unknown.known_team_id:
+            g["known_team_counts"][unknown.known_team_id] += 1
+        if game.get("competition"):
+            g["competition_counts"][game["competition"]] += 1
+        if len(g["sample_game_ids"]) < 5:
+            g["sample_game_ids"].append(game["id"])
+
+        detail_rows.append(
+            {
+                "game_id": game.get("id", ""),
+                "provider_code": pcode,
+                "provider_id": pid,
+                "game_date": game.get("game_date", ""),
+                "competition": game.get("competition", ""),
+                "home_provider_id": game.get("home_provider_id", ""),
+                "away_provider_id": game.get("away_provider_id", ""),
+                "home_team_master_id": game.get("home_team_master_id", ""),
+                "away_team_master_id": game.get("away_team_master_id", ""),
+                "home_score": game.get("home_score", ""),
+                "away_score": game.get("away_score", ""),
+                "missing_side": unknown.missing_side,
+                "unknown_provider_team_id": unknown.unknown_provider_team_id,
+                "known_team_id": unknown.known_team_id or "",
+                "known_team_name": known_team.get("team_name", ""),
+                "known_team_age_group": known_team.get("age_group", ""),
+                "known_team_gender": known_team.get("gender", ""),
+                "known_team_club": known_team.get("club_name", ""),
+                "known_team_state": known_team.get("state_code", ""),
+                "unknown_team_name": got_details.get("unknown_team_name", ""),
+                "unknown_team_full_name": got_details.get("unknown_team_full_name", ""),
+                "unknown_club_name": got_details.get("unknown_club_name", ""),
+                "unknown_state": got_details.get("unknown_state", ""),
+                "unknown_age": got_details.get("unknown_age", ""),
+                "unknown_gender": got_details.get("unknown_gender", ""),
+            }
+        )
+
+    aggregate_rows: List[Dict] = []
+    for (pcode, pid, unknown_pid, side), data in sorted(
+        groups.items(), key=lambda kv: kv[1]["games_count"], reverse=True
+    ):
+        top_known_id = data["known_team_counts"].most_common(1)[0][0] if data["known_team_counts"] else ""
+        top_known = team_lookup.get(top_known_id, {}) if top_known_id else {}
+        top_comp = data["competition_counts"].most_common(1)[0][0] if data["competition_counts"] else ""
+        resolved_unknown = data.get("resolved_unknown", {}) or {}
+
+        aggregate_rows.append(
+            {
+                "provider_code": pcode,
+                "provider_id": pid,
+                "unknown_provider_team_id": unknown_pid,
+                "missing_side": side,
+                "games_count": data["games_count"],
+                "first_game_date": data["first_game_date"] or "",
+                "last_game_date": data["last_game_date"] or "",
+                "top_known_team_id": top_known_id,
+                "top_known_team_name": top_known.get("team_name", ""),
+                "top_known_team_age_group": top_known.get("age_group", ""),
+                "top_known_team_gender": top_known.get("gender", ""),
+                "top_known_team_club": top_known.get("club_name", ""),
+                "top_known_team_state": top_known.get("state_code", ""),
+                "top_competition": top_comp,
+                "sample_game_ids": ";".join(data["sample_game_ids"]),
+                "unknown_team_name": resolved_unknown.get("unknown_team_name", ""),
+                "unknown_team_full_name": resolved_unknown.get("unknown_team_full_name", ""),
+                "unknown_club_name": resolved_unknown.get("unknown_club_name", ""),
+                "unknown_state": resolved_unknown.get("unknown_state", ""),
+                "unknown_age": resolved_unknown.get("unknown_age", ""),
+                "unknown_gender": resolved_unknown.get("unknown_gender", ""),
+            }
+        )
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    prefix = args.output_prefix or f"data/exports/unknown_opponents_{timestamp}"
+    aggregate_path = Path(f"{prefix}_aggregate.csv")
+    detail_path = Path(f"{prefix}_games.csv")
+
+    write_csv(
+        aggregate_path,
+        fieldnames=[
+            "provider_code",
+            "provider_id",
+            "unknown_provider_team_id",
+            "missing_side",
+            "games_count",
+            "first_game_date",
+            "last_game_date",
+            "top_known_team_id",
+            "top_known_team_name",
+            "top_known_team_age_group",
+            "top_known_team_gender",
+            "top_known_team_club",
+            "top_known_team_state",
+            "top_competition",
+            "sample_game_ids",
+            "unknown_team_name",
+            "unknown_team_full_name",
+            "unknown_club_name",
+            "unknown_state",
+            "unknown_age",
+            "unknown_gender",
+        ],
+        rows=aggregate_rows,
+    )
+
+    write_csv(
+        detail_path,
+        fieldnames=[
+            "game_id",
+            "provider_code",
+            "provider_id",
+            "game_date",
+            "competition",
+            "home_provider_id",
+            "away_provider_id",
+            "home_team_master_id",
+            "away_team_master_id",
+            "home_score",
+            "away_score",
+            "missing_side",
+            "unknown_provider_team_id",
+            "known_team_id",
+            "known_team_name",
+            "known_team_age_group",
+            "known_team_gender",
+            "known_team_club",
+            "known_team_state",
+            "unknown_team_name",
+            "unknown_team_full_name",
+            "unknown_club_name",
+            "unknown_state",
+            "unknown_age",
+            "unknown_gender",
+        ],
+        rows=detail_rows,
+    )
+
+    print("=== Unknown Opponent Export ===")
+    if args.provider:
+        print(f"Provider filter: {args.provider}")
+    print(f"Fetched partial rows: {len(partial_rows):,}")
+    print(f"Aggregate groups: {len(aggregate_rows):,}")
+    print(f"Detail rows: {len(detail_rows):,}")
+    print(f"Aggregate CSV: {aggregate_path}")
+    print(f"Detail CSV: {detail_path}")
+
+    print("\nTop 10 unresolved provider IDs:")
+    for idx, row in enumerate(aggregate_rows[:10], start=1):
+        print(
+            f"  {idx:>2}. [{row['provider_code']}] {row['unknown_provider_team_id']} "
+            f"({row['missing_side']}) games={row['games_count']} "
+            f"known={row['top_known_team_name']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -53,7 +53,8 @@ class ImportMetrics:
     skipped_empty_game_date: int = 0  # Games skipped due to empty game_date
     skipped_empty_scores: int = 0  # Games skipped due to missing both scores
     duplicate_key_violations: int = 0  # Games rejected due to unique constraint (already in DB)
-    
+    duplicate_links_backfilled: int = 0  # Duplicate games where missing master IDs were healed
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert metrics to dictionary for JSONB storage"""
         return {
@@ -76,7 +77,8 @@ class ImportMetrics:
             'skipped_empty_provider_ids': self.skipped_empty_provider_ids,
             'skipped_empty_game_date': self.skipped_empty_game_date,
             'skipped_empty_scores': self.skipped_empty_scores,
-            'duplicate_key_violations': self.duplicate_key_violations
+            'duplicate_key_violations': self.duplicate_key_violations,
+            'duplicate_links_backfilled': self.duplicate_links_backfilled
         }
 
 
@@ -559,11 +561,17 @@ class EnhancedETLPipeline:
                     existing_composite_keys = await self._check_duplicates_by_composite_key(games_with_existing_uid)
                     if existing_composite_keys:
                         logger.info(f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)")
+                        # Capture duplicates before filtering for backfill
+                        m11_composite_dupes = [g for g in games_with_existing_uid if self._make_composite_key(g) in existing_composite_keys]
                         # Filter out games with existing composite keys
                         games_with_existing_uid = [g for g in games_with_existing_uid if self._make_composite_key(g) not in existing_composite_keys]
                         batch_metrics.duplicates_found = len(existing_composite_keys)
                         self.metrics.duplicates_found += len(existing_composite_keys)
                         logger.info(f"[Pipeline] Filtered to {len(games_with_existing_uid)} games after composite key duplicate check")
+                        # Backfill missing master IDs on Modular11 composite-key duplicates
+                        bf = await self._backfill_duplicate_team_links(m11_composite_dupes)
+                        batch_metrics.duplicate_links_backfilled += bf
+                        self.metrics.duplicate_links_backfilled += bf
                 
                 # Combine: games with new game_uid (trust them) + games with existing game_uid that passed composite key check
                 game_records = games_with_new_uid + games_with_existing_uid
@@ -582,6 +590,7 @@ class EnhancedETLPipeline:
                 regen_existing_uids, regen_uid_master_ids = await self._check_duplicates(game_records)
                 if regen_existing_uids:
                     pre_count = len(game_records)
+                    regen_dupes_list = [g for g in game_records if g.get('game_uid') in regen_existing_uids]
                     game_records = [g for g in game_records if g.get('game_uid') not in regen_existing_uids]
                     regen_dupes = pre_count - len(game_records)
                     if regen_dupes > 0:
@@ -591,6 +600,10 @@ class EnhancedETLPipeline:
                             f"[Pipeline] Regenerated game_uid dedup: {regen_dupes} duplicates caught "
                             f"(master-ID UIDs matched existing records)"
                         )
+                        # Backfill missing master IDs on the duplicates we just filtered out
+                        bf = await self._backfill_duplicate_team_links(regen_dupes_list)
+                        batch_metrics.duplicate_links_backfilled += bf
+                        self.metrics.duplicate_links_backfilled += bf
                     # Merge for downstream use
                     existing_uids.update(regen_existing_uids)
                     game_uid_to_master_ids.update(regen_uid_master_ids)
@@ -599,12 +612,18 @@ class EnhancedETLPipeline:
                 existing_composite_keys = await self._check_duplicates_by_composite_key(game_records)
                 if existing_composite_keys:
                     logger.info(f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)")
+                    # Capture duplicates before filtering for backfill
+                    composite_dupes_list = [g for g in game_records if self._make_composite_key(g) in existing_composite_keys]
                     # Filter out games with existing composite keys
                     game_records = [g for g in game_records if self._make_composite_key(g) not in existing_composite_keys]
                     batch_metrics.duplicates_found = len(existing_composite_keys)  # Set (not +=) because this is the authoritative count
                     self.metrics.duplicates_found += len(existing_composite_keys)
                     logger.info(f"[Pipeline] Filtered to {len(game_records)} new games after composite key duplicate check")
-            
+                    # Backfill missing master IDs on composite-key duplicates
+                    bf = await self._backfill_duplicate_team_links(composite_dupes_list)
+                    batch_metrics.duplicate_links_backfilled += bf
+                    self.metrics.duplicate_links_backfilled += bf
+
             # Step 3b2: Master-level dedup — catch cross-scraper duplicates
             # The event scraper and team scraper may use different provider_team_ids
             # (registration IDs vs API team IDs) for the same physical team. Since
@@ -614,6 +633,7 @@ class EnhancedETLPipeline:
             master_dedup_removed = await self._check_duplicates_by_master_ids(game_records)
             if master_dedup_removed > 0:
                 pre_count = len(game_records)
+                master_dupes_list = [g for g in game_records if g.get('_master_dedup_skip')]
                 game_records = [g for g in game_records if not g.get('_master_dedup_skip')]
                 batch_metrics.duplicates_found = getattr(batch_metrics, 'duplicates_found', 0) + master_dedup_removed
                 self.metrics.duplicates_found += master_dedup_removed
@@ -621,6 +641,10 @@ class EnhancedETLPipeline:
                     f"[Pipeline] Master-level dedup: removed {master_dedup_removed} cross-scraper "
                     f"duplicates ({pre_count} -> {len(game_records)} games)"
                 )
+                # Backfill missing master IDs on master-level duplicates
+                bf = await self._backfill_duplicate_team_links(master_dupes_list)
+                batch_metrics.duplicate_links_backfilled += bf
+                self.metrics.duplicate_links_backfilled += bf
 
             # Step 3c: Handle games where game_uid exists but scores differ
             # Check if master team IDs match - if not, it's a different game (e.g., U13 vs U14)
@@ -826,6 +850,7 @@ class EnhancedETLPipeline:
                     f"  Accepted:        {self.metrics.games_accepted:,} games\n"
                     f"  Quarantined:     {self.metrics.games_quarantined:,} games\n"
                     f"  Duplicates:      {self.metrics.duplicates_found:,} games (already in DB)\n"
+                    f"  Links backfilled:{self.metrics.duplicate_links_backfilled:,} healed\n"
                     f"  Perspective dup: {self.metrics.duplicates_skipped:,} skipped\n"
                     f"  Processing rate: {games_per_sec:.1f} games/sec\n"
                     f"  Elapsed time:    {elapsed_time/60:.1f} minutes\n"
@@ -1304,6 +1329,102 @@ class EnhancedETLPipeline:
                 # Non-fatal: continue without this check rather than block the import
 
         return duplicates_found
+
+    async def _backfill_duplicate_team_links(self, duplicate_games: List[Dict]) -> int:
+        """
+        Backfill missing home_team_master_id / away_team_master_id on existing
+        DB rows that were identified as duplicates.
+
+        When a duplicate game is skipped, the existing row may have NULL master
+        IDs (partial match from an earlier import).  If the incoming candidate
+        has resolved master IDs, we UPDATE only the NULL columns — never
+        overwriting an existing non-null value.
+
+        Args:
+            duplicate_games: candidate game dicts that were filtered out as
+                duplicates.  Each must have at least ``game_uid`` or enough
+                composite-key fields to locate the DB row.
+
+        Returns:
+            Number of rows where at least one master ID was backfilled.
+        """
+        if not duplicate_games or self.dry_run:
+            return 0
+
+        backfilled = 0
+
+        for game in duplicate_games:
+            candidate_home = game.get('home_team_master_id')
+            candidate_away = game.get('away_team_master_id')
+
+            # Nothing to backfill if the candidate itself has no master IDs
+            if not candidate_home and not candidate_away:
+                continue
+
+            game_uid = game.get('game_uid')
+            existing_row = None
+
+            # --- locate existing row ---
+            # Try game_uid first (fast, indexed)
+            if game_uid:
+                try:
+                    result = self.supabase.table('games').select(
+                        'id, game_uid, home_team_master_id, away_team_master_id'
+                    ).eq('game_uid', game_uid).limit(1).execute()
+                    if result.data:
+                        existing_row = result.data[0]
+                except Exception as e:
+                    logger.warning(f"[Backfill] Error looking up game_uid {game_uid}: {e}")
+
+            # Fallback: composite key lookup
+            if not existing_row:
+                try:
+                    provider_id = game.get('provider_id') or self.provider_id
+                    game_date = game.get('game_date')
+                    home_pid = game.get('home_provider_id')
+                    away_pid = game.get('away_provider_id')
+                    if provider_id and game_date and home_pid and away_pid:
+                        result = self.supabase.table('games').select(
+                            'id, game_uid, home_team_master_id, away_team_master_id'
+                        ).eq('provider_id', provider_id).eq(
+                            'game_date', game_date
+                        ).eq('home_provider_id', home_pid).eq(
+                            'away_provider_id', away_pid
+                        ).limit(1).execute()
+                        if result.data:
+                            existing_row = result.data[0]
+                except Exception as e:
+                    logger.warning(f"[Backfill] Error in composite-key lookup: {e}")
+
+            if not existing_row:
+                continue
+
+            # --- determine which fields need backfill ---
+            updates = {}
+            if not existing_row.get('home_team_master_id') and candidate_home:
+                updates['home_team_master_id'] = candidate_home
+            if not existing_row.get('away_team_master_id') and candidate_away:
+                updates['away_team_master_id'] = candidate_away
+
+            if not updates:
+                continue
+
+            # --- apply update ---
+            row_id = existing_row.get('id')
+            row_uid = existing_row.get('game_uid') or game_uid or 'unknown'
+            try:
+                self.supabase.table('games').update(updates).eq('id', row_id).execute()
+                backfilled += 1
+                logger.info(
+                    f"[Backfill] Healed game {row_uid}: set {updates}"
+                )
+            except Exception as e:
+                logger.warning(f"[Backfill] Failed to update game {row_uid}: {e}")
+
+        if backfilled > 0:
+            logger.info(f"[Backfill] Backfilled missing master IDs on {backfilled} duplicate games")
+
+        return backfilled
 
     async def _update_games_with_scores(self, game_records: List[Dict]) -> int:
         """
@@ -1927,9 +2048,10 @@ class EnhancedETLPipeline:
         print(f"  Unique Games: {unique_games:,}")
         print(f"  Imported: {metrics.games_accepted:,}")
         print(f"  Already in Database: {metrics.duplicates_found:,}")
+        print(f"  Links Backfilled: {metrics.duplicate_links_backfilled:,}")
         print(f"  Duplicates Skipped: {metrics.duplicates_skipped:,}")
         print(f"  Quarantined: {metrics.games_quarantined:,}")
-        
+
         # Team Matching Statistics
         print("\nTEAM MATCHING:")
         print(f"  Total Teams Seen: {summary['processed']:,}")

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -1348,6 +1348,12 @@ class EnhancedETLPipeline:
         Returns:
             Number of rows where at least one master ID was backfilled.
         """
+        # Explicitly disable duplicate-link backfill for Modular11. Its identity
+        # model includes age_group/division and we do not want any healing writes
+        # on deduped Modular11 rows.
+        if self.provider_code and self.provider_code.lower() == 'modular11':
+            return 0
+
         if not duplicate_games or self.dry_run:
             return 0
 

--- a/tests/test_enhanced_pipeline.py
+++ b/tests/test_enhanced_pipeline.py
@@ -266,5 +266,187 @@ class TestEnhancedValidator:
         assert result['summary']['validation_rate'] == 0.5
 
 
+class TestBackfillDuplicateTeamLinks:
+    """Tests for _backfill_duplicate_team_links healing NULL master IDs."""
+
+    @pytest.fixture
+    def mock_supabase(self):
+        """Mock Supabase client sufficient for pipeline construction."""
+        supabase = Mock()
+
+        # Provider lookup
+        provider_result = Mock()
+        provider_result.data = {'id': 'test-provider-uuid'}
+        supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = provider_result
+
+        # General table mocks
+        supabase.table.return_value.insert.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.in_.return_value.execute.return_value.data = []
+        # Health check
+        supabase.table.return_value.select.return_value.limit.return_value.execute.return_value.data = []
+        # Range for alias cache pagination
+        supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.range.return_value.execute.return_value.data = []
+
+        return supabase
+
+    def _build_pipeline(self, supabase, dry_run=False):
+        return EnhancedETLPipeline(supabase, 'gotsport', dry_run=dry_run)
+
+    @pytest.mark.asyncio
+    async def test_backfill_heals_null_home_master_id(self, mock_supabase):
+        """Existing row has NULL home_team_master_id; candidate has it resolved."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=False)
+
+        existing_row = {
+            'id': 'row-1',
+            'game_uid': 'gs:2026-02-20:499398:123',
+            'home_team_master_id': None,
+            'away_team_master_id': 'away-master-1',
+        }
+
+        # Mock: lookup by game_uid returns the existing row
+        select_mock = Mock()
+        select_mock.data = [existing_row]
+        mock_supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = select_mock
+
+        update_mock = Mock()
+        update_mock.data = [{'id': 'row-1'}]
+        mock_supabase.table.return_value.update.return_value.eq.return_value.execute.return_value = update_mock
+
+        candidates = [{
+            'game_uid': 'gs:2026-02-20:499398:123',
+            'home_team_master_id': '9017bed1-af58-4303-abe9-f10d2551693f',
+            'away_team_master_id': 'away-master-1',
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 1
+        # Verify update was called with only the missing field
+        mock_supabase.table.return_value.update.assert_called_once_with(
+            {'home_team_master_id': '9017bed1-af58-4303-abe9-f10d2551693f'}
+        )
+
+    @pytest.mark.asyncio
+    async def test_backfill_heals_both_null_master_ids(self, mock_supabase):
+        """Existing row has both master IDs NULL; candidate has both resolved."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=False)
+
+        existing_row = {
+            'id': 'row-2',
+            'game_uid': 'gs:2026-02-21:499398:456',
+            'home_team_master_id': None,
+            'away_team_master_id': None,
+        }
+
+        select_mock = Mock()
+        select_mock.data = [existing_row]
+        mock_supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = select_mock
+
+        update_mock = Mock()
+        update_mock.data = [{'id': 'row-2'}]
+        mock_supabase.table.return_value.update.return_value.eq.return_value.execute.return_value = update_mock
+
+        candidates = [{
+            'game_uid': 'gs:2026-02-21:499398:456',
+            'home_team_master_id': 'home-master-2',
+            'away_team_master_id': 'away-master-2',
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 1
+        mock_supabase.table.return_value.update.assert_called_once_with(
+            {'home_team_master_id': 'home-master-2', 'away_team_master_id': 'away-master-2'}
+        )
+
+    @pytest.mark.asyncio
+    async def test_backfill_does_not_overwrite_existing_ids(self, mock_supabase):
+        """Existing row already has both master IDs — no update should occur."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=False)
+
+        existing_row = {
+            'id': 'row-3',
+            'game_uid': 'gs:2026-02-20:111:222',
+            'home_team_master_id': 'existing-home',
+            'away_team_master_id': 'existing-away',
+        }
+
+        select_mock = Mock()
+        select_mock.data = [existing_row]
+        mock_supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = select_mock
+
+        candidates = [{
+            'game_uid': 'gs:2026-02-20:111:222',
+            'home_team_master_id': 'different-home',
+            'away_team_master_id': 'different-away',
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 0
+        mock_supabase.table.return_value.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_skipped_in_dry_run(self, mock_supabase):
+        """Dry-run mode must not write anything."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=True)
+
+        candidates = [{
+            'game_uid': 'gs:2026-02-20:499398:123',
+            'home_team_master_id': 'some-master',
+            'away_team_master_id': None,
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 0
+        mock_supabase.table.return_value.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_no_insert_occurs(self, mock_supabase):
+        """Backfill must never insert new rows — only update existing ones."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=False)
+
+        existing_row = {
+            'id': 'row-4',
+            'game_uid': 'gs:2026-02-20:777:888',
+            'home_team_master_id': None,
+            'away_team_master_id': 'existing-away',
+        }
+
+        select_mock = Mock()
+        select_mock.data = [existing_row]
+        mock_supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = select_mock
+
+        update_mock = Mock()
+        update_mock.data = [{'id': 'row-4'}]
+        mock_supabase.table.return_value.update.return_value.eq.return_value.execute.return_value = update_mock
+
+        candidates = [{
+            'game_uid': 'gs:2026-02-20:777:888',
+            'home_team_master_id': 'new-home-master',
+            'away_team_master_id': 'different-away',  # should NOT overwrite existing
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 1
+        # Only home_team_master_id should be updated (away already exists)
+        mock_supabase.table.return_value.update.assert_called_once_with(
+            {'home_team_master_id': 'new-home-master'}
+        )
+        # Verify no insert was called
+        mock_supabase.table.return_value.insert.assert_not_called()
+
+    def test_metrics_includes_backfill_field(self):
+        """ImportMetrics.to_dict() must include duplicate_links_backfilled."""
+        metrics = ImportMetrics()
+        metrics.duplicate_links_backfilled = 5
+        result = metrics.to_dict()
+        assert result['duplicate_links_backfilled'] == 5
+
+
 # Run with: pytest tests/test_enhanced_pipeline.py -v
 

--- a/tests/test_enhanced_pipeline.py
+++ b/tests/test_enhanced_pipeline.py
@@ -405,6 +405,23 @@ class TestBackfillDuplicateTeamLinks:
         mock_supabase.table.return_value.update.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_backfill_skipped_for_modular11(self, mock_supabase):
+        """Modular11 must never run duplicate-link backfill writes."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=False)
+        pipeline.provider_code = 'modular11'
+
+        candidates = [{
+            'game_uid': 'modular11:2026-02-20:74:249:U14:HD',
+            'home_team_master_id': 'home-master',
+            'away_team_master_id': 'away-master',
+        }]
+
+        count = await pipeline._backfill_duplicate_team_links(candidates)
+
+        assert count == 0
+        mock_supabase.table.return_value.update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_backfill_no_insert_occurs(self, mock_supabase):
         """Backfill must never insert new rows — only update existing ones."""
         pipeline = self._build_pipeline(mock_supabase, dry_run=False)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 📦 PitchRank Pull Request

## 🔍 Overview

Introduces two new scripts to automate the resolution of "partial games" (games where one team's `master_id` is `NULL`), which currently hide them from team history.

1.  `export_unknown_opponents.py`: Exports games with unresolved opponents into aggregate and detailed CSVs.
2.  `auto_match_unknown_opponents.py`: Reads the export, uses existing fuzzy matching logic (`score_team_pair`) to suggest links, and can optionally execute the linking (create `team_alias_map` entries and backfill missing `home_team_master_id`/`away_team_master_id` in the `games` table).

This allows for automated data hygiene to improve game visibility on team pages.

---

## ✅ Changes Included

### New Scripts

-   [x] `scripts/export_unknown_opponents.py`:
    -   Identifies games with `NULL` `home_team_master_id` or `away_team_master_id` where the corresponding provider ID exists.
    -   Exports aggregated data (by unknown provider team ID) and detailed game-level data to CSV.
    -   Includes optional `--resolve-gotsport-details` for enriching unknown teams with names/clubs from the source API.
-   [x] `scripts/auto_match_unknown_opponents.py`:
    -   Reads the aggregate export from `export_unknown_opponents.py`.
    -   Reuses `score_team_pair` from `find_fuzzy_duplicate_teams.py` for fuzzy matching against existing master teams.
    -   Generates a report categorizing matches as `auto_link`, `review`, `no_match`, or `skip_protected_division`.
    -   Optional `--execute` mode to:
        -   Create `team_alias_map` entries for high-confidence matches.
        -   Backfill missing `home_team_master_id` or `away_team_master_id` in the `games` table.

---

## 🧪 Testing Checklist

-   [x] `export_unknown_opponents.py` runs successfully and generates CSVs.
-   [x] `auto_match_unknown_opponents.py` runs in dry-run mode and produces a match report.
-   [x] Fuzzy matching logic (`score_team_pair`) is correctly integrated and provides reasonable scores.
-   [x] `--execute` mode correctly creates `team_alias_map` entries.
-   [x] `--execute` mode correctly backfills `home_team_master_id`/`away_team_master_id` without overwriting existing non-NULL values.
-   [x] Sample output format matches expectations (as demonstrated in conversation).

---

## 📸 Screenshots (If UI Change)

_N/A - Backend scripts. Sample output format was demonstrated in the conversation._

---

## 📚 Documentation

-   [x] Script usage instructions are provided in the assistant's final response.

---

## 🚀 Deployment Notes

None.

---

## 📎 Related Issues / Tickets

Addresses the root cause of games being imported but not linked to master teams, leading to them being invisible in frontend team history.

---

## 🤝 Reviewer Notes

-   Pay attention to the logic in `auto_match_unknown_opponents.py` for safely backfilling `home_team_master_id`/`away_team_master_id` to ensure no data is inadvertently overwritten.
-   The `--resolve-gotsport-details` option in `export_unknown_opponents.py` can be slow due to per-team API calls; this is an expected trade-off for richer data.

---
<p><a href="https://cursor.com/agents/bc-c30c4648-0d8e-44c8-8dcd-3fcb736e408c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c30c4648-0d8e-44c8-8dcd-3fcb736e408c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->