### PR TITLE
Fix state rank showing '—' by falling back to rankings_full

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -122,10 +122,12 @@ export const api = {
       console.warn('[api.getTeam] state_rankings_view error, continuing without state ranking data:', stateRankError.message);
     }
 
-    // Fallback: If views returned no data, try querying rankings_full directly
-    // Skip this fallback for deprecated teams — they are intentionally excluded from views
+    // Fallback: If either view returned no data, try querying rankings_full directly.
+    // This commonly happens when state_rankings_view times out (its ROW_NUMBER window
+    // function requires scanning all rows). rankings_full has pre-computed state_rank.
+    // Skip this fallback for deprecated teams — they are intentionally excluded from views.
     let rankingsFullData = null;
-    if (!rankingData && !stateRankData && !teamData?.is_deprecated) {
+    if ((!rankingData || !stateRankData) && !teamData?.is_deprecated) {
       const { data: rfData, error: rfError } = await supabase
         .from('rankings_full')
         .select('*')
@@ -253,7 +255,7 @@ export const api = {
       rankingsFullData?.rank_in_cohort_final ??
       null;
 
-    const sosNormState = stateRankData?.sos_norm_state ?? null;
+    const sosNormState = stateRankData?.sos_norm_state ?? rankingsFullData?.sos_norm ?? null;
 
     // Use rank_in_state_final and sos_rank_state directly from the view.
     // The view's ROW_NUMBER() compares FLOAT8 to FLOAT8 (same type, no precision issues).
@@ -261,8 +263,8 @@ export const api = {
     // comparison bug: PostgreSQL casts the FLOAT8 column to NUMERIC for comparison, revealing
     // hidden binary precision (e.g., 0.497134135753087 as FLOAT8 is actually 0.49713413575308703
     // in full precision). This caused teams to count against themselves, inflating their rank by 1.
-    const rankInStateFinal: number | null = stateRankData?.rank_in_state_final ?? stateRankData?.state_rank ?? null;
-    const sosRankState: number | null = stateRankData?.sos_rank_state ?? stateRankData?.state_sos_rank ?? rankingData?.sos_rank_state ?? null;
+    const rankInStateFinal: number | null = stateRankData?.rank_in_state_final ?? stateRankData?.state_rank ?? rankingsFullData?.state_rank ?? null;
+    const sosRankState: number | null = stateRankData?.sos_rank_state ?? stateRankData?.state_sos_rank ?? rankingData?.sos_rank_state ?? rankingsFullData?.sos_rank_state ?? null;
 
     const gamesPlayed =
       rankingData?.games_played ??


### PR DESCRIPTION
When state_rankings_view times out (its ROW_NUMBER window function requires scanning all rows), stateRankData is null and state rank displays as '—'. Now fetch rankings_full as fallback when either view returns no data (not just when both fail), and use its pre-computed state_rank in the fallback chain.

https://claude.ai/code/session_012Gc51aBo46oaAP9zUuoNJ4

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

