### PR TITLE
Add RPC fallback for state rank when view times out

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -122,21 +122,32 @@ export const api = {
       console.warn('[api.getTeam] state_rankings_view error, continuing without state ranking data:', stateRankError.message);
     }
 
-    // Fallback: If either view returned no data, try querying rankings_full directly.
-    // This commonly happens when state_rankings_view times out (its ROW_NUMBER window
-    // function requires scanning all rows). rankings_full has pre-computed state_rank.
-    // Skip this fallback for deprecated teams — they are intentionally excluded from views.
+    // Fallback: If either view returned no data, try rankings_full and/or state rank RPC.
+    // state_rankings_view commonly times out because its ROW_NUMBER window function
+    // requires scanning all rows. The RPC computes state rank via COUNT on rankings_full
+    // using FLOAT8 > FLOAT8 comparison (no PostgREST FLOAT8→NUMERIC precision bug).
+    // Skip fallbacks for deprecated teams — they are intentionally excluded from views.
     let rankingsFullData = null;
-    if ((!rankingData || !stateRankData) && !teamData?.is_deprecated) {
-      const { data: rfData, error: rfError } = await supabase
-        .from('rankings_full')
-        .select('*')
-        .eq('team_id', id)
-        .maybeSingle();
+    let stateRankFallback: { state_rank: number; sos_rank_state: number } | null = null;
 
-      if (!rfError && rfData) {
-        rankingsFullData = rfData;
+    if (!teamData?.is_deprecated) {
+      const fallbackPromises: Promise<void>[] = [];
+
+      if (!rankingData || !stateRankData) {
+        fallbackPromises.push(
+          supabase.from('rankings_full').select('*').eq('team_id', id).maybeSingle()
+            .then(({ data, error }) => { if (!error && data) rankingsFullData = data; })
+        );
       }
+
+      if (!stateRankData) {
+        fallbackPromises.push(
+          supabase.rpc('get_team_state_rank', { p_team_id: id }).maybeSingle()
+            .then(({ data, error }) => { if (!error && data) stateRankFallback = data; })
+        );
+      }
+
+      await Promise.all(fallbackPromises);
     }
 
     // Resolve merged team IDs so total games include games from deprecated teams
@@ -263,8 +274,8 @@ export const api = {
     // comparison bug: PostgreSQL casts the FLOAT8 column to NUMERIC for comparison, revealing
     // hidden binary precision (e.g., 0.497134135753087 as FLOAT8 is actually 0.49713413575308703
     // in full precision). This caused teams to count against themselves, inflating their rank by 1.
-    const rankInStateFinal: number | null = stateRankData?.rank_in_state_final ?? stateRankData?.state_rank ?? rankingsFullData?.state_rank ?? null;
-    const sosRankState: number | null = stateRankData?.sos_rank_state ?? stateRankData?.state_sos_rank ?? rankingData?.sos_rank_state ?? rankingsFullData?.sos_rank_state ?? null;
+    const rankInStateFinal: number | null = stateRankData?.rank_in_state_final ?? stateRankData?.state_rank ?? stateRankFallback?.state_rank ?? null;
+    const sosRankState: number | null = stateRankData?.sos_rank_state ?? stateRankData?.state_sos_rank ?? rankingData?.sos_rank_state ?? stateRankFallback?.sos_rank_state ?? null;
 
     const gamesPlayed =
       rankingData?.games_played ??

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -131,7 +131,7 @@ export const api = {
     let stateRankFallback: { state_rank: number; sos_rank_state: number } | null = null;
 
     if (!teamData?.is_deprecated) {
-      const fallbackPromises: Promise<void>[] = [];
+      const fallbackPromises: PromiseLike<void>[] = [];
 
       if (!rankingData || !stateRankData) {
         fallbackPromises.push(

--- a/supabase/migrations/20260308000000_add_get_team_state_rank_function.sql
+++ b/supabase/migrations/20260308000000_add_get_team_state_rank_function.sql
@@ -1,0 +1,52 @@
+-- RPC function to compute a team's state rank from rankings_full.
+-- This avoids the state_rankings_view timeout (which requires ROW_NUMBER over all rows)
+-- and avoids the FLOAT8 vs NUMERIC precision bug in PostgREST .gt() filters.
+-- By using a subquery to get the team's score as FLOAT8, the comparison is FLOAT8 > FLOAT8.
+
+CREATE OR REPLACE FUNCTION get_team_state_rank(p_team_id UUID)
+RETURNS TABLE (
+    state_rank BIGINT,
+    sos_rank_state BIGINT
+) LANGUAGE sql STABLE AS $$
+    WITH team_info AS (
+        SELECT
+            team_id,
+            state_code,
+            age_group,
+            gender,
+            power_score_final,
+            sos_norm_state,
+            status
+        FROM rankings_full
+        WHERE team_id = p_team_id
+    )
+    SELECT
+        -- State rank: count teams with higher power_score_final in same state/age/gender + 1
+        (
+            SELECT COUNT(*) + 1
+            FROM rankings_full rf
+            WHERE rf.state_code = ti.state_code
+              AND rf.age_group = ti.age_group
+              AND rf.gender = ti.gender
+              AND rf.status IN ('Active', 'Not Enough Ranked Games')
+              AND rf.power_score_final > ti.power_score_final
+        )::BIGINT AS state_rank,
+        -- SOS state rank: count teams with higher sos_norm_state in same state/age/gender + 1
+        (
+            SELECT COUNT(*) + 1
+            FROM rankings_full rf
+            WHERE rf.state_code = ti.state_code
+              AND rf.age_group = ti.age_group
+              AND rf.gender = ti.gender
+              AND rf.status IN ('Active', 'Not Enough Ranked Games')
+              AND rf.sos_norm_state IS NOT NULL
+              AND ti.sos_norm_state IS NOT NULL
+              AND rf.sos_norm_state > ti.sos_norm_state
+        )::BIGINT AS sos_rank_state
+    FROM team_info ti
+    WHERE ti.status IN ('Active', 'Not Enough Ranked Games');
+$$;
+
+-- Grant access
+GRANT EXECUTE ON FUNCTION get_team_state_rank(UUID) TO anon;
+GRANT EXECUTE ON FUNCTION get_team_state_rank(UUID) TO authenticated;


### PR DESCRIPTION
The state_rankings_view query for a single team frequently times out because its ROW_NUMBER() window function must scan all rows before filtering. Added a get_team_state_rank() RPC function that computes state rank via COUNT on rankings_full (a regular indexed table, not a view). The RPC compares FLOAT8 > FLOAT8 within the same SQL context, avoiding the PostgREST FLOAT8-to-NUMERIC precision bug.

The fallback runs in parallel with the rankings_full table lookup when the state view returns no data.

https://claude.ai/code/session_012Gc51aBo46oaAP9zUuoNJ4

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

