### PR TITLE
Filter biggest movers to exclude low-game teams and newly ranked teams

### DIFF
--- a/frontend/components/RecentMovers.tsx
+++ b/frontend/components/RecentMovers.tsx
@@ -81,7 +81,13 @@ export function RecentMovers({
     return rankings
       .filter(team => {
         const change = team[rankChangeField];
-        return change !== null && change !== undefined && Math.abs(change) > 0;
+        // Must have a non-zero rank change
+        if (change === null || change === undefined || Math.abs(change) === 0) return false;
+        // Filter out teams with very few games (unreliable rank swings)
+        if ((team.total_games_played ?? 0) < 8) return false;
+        // Exclude teams that just became ranked (status indicates not enough games)
+        if (team.status === 'Not Enough Ranked Games') return false;
+        return true;
       })
       .sort((a, b) => {
         const changeA = Math.abs(a[rankChangeField] ?? 0);

--- a/supabase/migrations/20260308000000_filter_biggest_movers_min_games.sql
+++ b/supabase/migrations/20260308000000_filter_biggest_movers_min_games.sql
@@ -1,0 +1,71 @@
+-- Filter biggest movers to exclude teams with fewer than 8 games
+-- and teams that just became ranked (status = 'Not Enough Ranked Games').
+-- This prevents unrealistic rank swings from appearing in the movers list.
+
+CREATE OR REPLACE FUNCTION get_biggest_movers(
+  p_days INT DEFAULT 7,
+  p_limit INT DEFAULT 5,
+  p_direction TEXT DEFAULT 'up',
+  p_age_group TEXT DEFAULT NULL,
+  p_gender TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  team_name TEXT,
+  club_name TEXT,
+  state_code TEXT,
+  rank_change INT,
+  current_rank INT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    t.team_name,
+    t.club_name,
+    t.state_code,
+    CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END AS rank_change,
+    COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS current_rank
+  FROM rankings_full rf
+  JOIN teams t ON t.team_id_master = rf.team_id
+  WHERE COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) IS NOT NULL
+    AND CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END IS NOT NULL
+    AND (
+      (p_direction = 'up' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END > 0)
+      OR
+      (p_direction = 'down' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END < 0)
+    )
+    AND (
+      p_age_group IS NULL
+      OR LOWER(rf.age_group) = LOWER(p_age_group)
+      OR rf.age_group = REPLACE(LOWER(p_age_group), 'u', '')
+    )
+    AND (
+      p_gender IS NULL
+      OR LOWER(rf.gender) = LOWER(p_gender)
+      OR (LOWER(p_gender) = 'male' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'female' AND rf.gender IN ('F', 'Female', 'Girls'))
+      OR (LOWER(p_gender) = 'm' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'f' AND rf.gender IN ('F', 'Female', 'Girls'))
+    )
+    AND t.is_deprecated IS NOT TRUE
+    -- Exclude teams with fewer than 8 games (unreliable rank swings)
+    AND COALESCE(rf.games_played, 0) >= 8
+    -- Exclude teams that just became ranked
+    AND COALESCE(rf.status, '') != 'Not Enough Ranked Games'
+  ORDER BY
+    CASE
+      WHEN p_direction = 'up' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END DESC NULLS LAST,
+    CASE
+      WHEN p_direction = 'down' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END ASC NULLS LAST
+  LIMIT p_limit;
+$$;


### PR DESCRIPTION
Teams with fewer than 8 games and those with "Not Enough Ranked Games" status produced unrealistic rank swings in the movers widget. Applied filters in both the frontend RecentMovers component and the Supabase get_biggest_movers RPC function.

https://claude.ai/code/session_01E6UcMSU1cMDyAVoQWRyPYQ

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

