### PR TITLE
Club canonical overrides: 43 fixes from full merge history

### DIFF
--- a/scripts/club_name_fixes_male_all_states.sql
+++ b/scripts/club_name_fixes_male_all_states.sql
@@ -6,4 +6,171 @@
 
 BEGIN;
 
+-- ========== CA ==========
+-- [CANONICAL] "Beach FC (Ca)" → "Beach Futbol Club" (25 teams)
+UPDATE teams SET club_name = 'Beach Futbol Club' WHERE club_name = 'Beach FC (Ca)' AND state_code = 'CA';
+
+-- [CANONICAL] "Beach FC  (CA)" → "Beach Futbol Club" (24 teams)
+UPDATE teams SET club_name = 'Beach Futbol Club' WHERE club_name = 'Beach FC  (CA)' AND state_code = 'CA';
+
+-- [CANONICAL] "FC Golden State Force" → "FC Golden State" (20 teams)
+UPDATE teams SET club_name = 'FC Golden State' WHERE club_name = 'FC Golden State Force' AND state_code = 'CA';
+
+-- [CANONICAL] "Mustang SC" → "Mustang Soccer" (8 teams)
+UPDATE teams SET club_name = 'Mustang Soccer' WHERE club_name = 'Mustang SC' AND state_code = 'CA';
+
+
+-- ========== CT ==========
+-- [CANONICAL] "Beachside Soccer Club CT" → "Beachside of Connecticut" (14 teams)
+UPDATE teams SET club_name = 'Beachside of Connecticut' WHERE club_name = 'Beachside Soccer Club CT' AND state_code = 'CT';
+
+-- [CANONICAL] "AC Connecticut" → "A.C. Connecticut" (12 teams)
+UPDATE teams SET club_name = 'A.C. Connecticut' WHERE club_name = 'AC Connecticut' AND state_code = 'CT';
+
+
+-- ========== GA ==========
+-- [CANONICAL] "NTH NASA" → "NASA Tophat" (10 teams)
+UPDATE teams SET club_name = 'NASA Tophat' WHERE club_name = 'NTH NASA' AND state_code = 'GA';
+
+-- [CANONICAL] "Concord Fire" → "Concorde Fire" (1 teams)
+UPDATE teams SET club_name = 'Concorde Fire' WHERE club_name = 'Concord Fire' AND state_code = 'GA';
+
+
+-- ========== ID ==========
+-- [CANONICAL] "Boise Timbers | Thorns" → "Boise Timbers | Thorns FC" (60 teams)
+UPDATE teams SET club_name = 'Boise Timbers | Thorns FC' WHERE club_name = 'Boise Timbers | Thorns' AND state_code = 'ID';
+
+
+-- ========== MI ==========
+-- [CANONICAL] "Nationals SC" → "Nationals" (21 teams)
+UPDATE teams SET club_name = 'Nationals' WHERE club_name = 'Nationals SC' AND state_code = 'MI';
+
+
+-- ========== MN ==========
+-- [CANONICAL] "St Croix Soccer Club" → "St. Croix" (17 teams)
+UPDATE teams SET club_name = 'St. Croix' WHERE club_name = 'St Croix Soccer Club' AND state_code = 'MN';
+
+
+-- ========== MS ==========
+-- [CANONICAL] "MS Futbol Club" → "Mississippi Rush" (42 teams)
+UPDATE teams SET club_name = 'Mississippi Rush' WHERE club_name = 'MS Futbol Club' AND state_code = 'MS';
+
+
+-- ========== NJ ==========
+-- [CANONICAL] "Match Fit Surf" → "Match Fit Academy" (88 teams)
+UPDATE teams SET club_name = 'Match Fit Academy' WHERE club_name = 'Match Fit Surf' AND state_code = 'NJ';
+
+-- [CANONICAL] "Franklin Township Youth Soccer Association" → "Franklin Township SC" (9 teams)
+UPDATE teams SET club_name = 'Franklin Township SC' WHERE club_name = 'Franklin Township Youth Soccer Association' AND state_code = 'NJ';
+
+
+-- ========== NV ==========
+-- [CANONICAL] "LV Heat Surf SC" → "Las Vegas Heat Surf SC" (46 teams)
+UPDATE teams SET club_name = 'Las Vegas Heat Surf SC' WHERE club_name = 'LV Heat Surf SC' AND state_code = 'NV';
+
+
+-- ========== NY ==========
+-- [CANONICAL] "WNY Flash" → "Western New York Flash" (44 teams)
+UPDATE teams SET club_name = 'Western New York Flash' WHERE club_name = 'WNY Flash' AND state_code = 'NY';
+
+-- [CANONICAL] "East Coast Surf SC" → "East Coast Surf" (9 teams)
+UPDATE teams SET club_name = 'East Coast Surf' WHERE club_name = 'East Coast Surf SC' AND state_code = 'NY';
+
+
+-- ========== OH ==========
+-- [CANONICAL] "Cincinnati United" → "Cincinnati United Premier Soccer Club" (169 teams)
+UPDATE teams SET club_name = 'Cincinnati United Premier Soccer Club' WHERE club_name = 'Cincinnati United' AND state_code = 'OH';
+
+-- [CANONICAL] "Ohio Elite SA" → "Ohio Elite Soccer Academy" (44 teams)
+UPDATE teams SET club_name = 'Ohio Elite Soccer Academy' WHERE club_name = 'Ohio Elite SA' AND state_code = 'OH';
+
+-- [CANONICAL] "Canton Force" → "Canton Akron United Force" (11 teams)
+UPDATE teams SET club_name = 'Canton Akron United Force' WHERE club_name = 'Canton Force' AND state_code = 'OH';
+
+
+-- ========== OK ==========
+-- [CANONICAL] "Oklahoma Celtic Football Club" → "Oklahoma Celtic" (71 teams)
+UPDATE teams SET club_name = 'Oklahoma Celtic' WHERE club_name = 'Oklahoma Celtic Football Club' AND state_code = 'OK';
+
+-- [CANONICAL] "West Side Alliance" → "West Side Alliance SC" (30 teams)
+UPDATE teams SET club_name = 'West Side Alliance SC' WHERE club_name = 'West Side Alliance' AND state_code = 'OK';
+
+
+-- ========== OR ==========
+-- [CANONICAL] "Saints Soccer Academy" → "Saints Academy" (28 teams)
+UPDATE teams SET club_name = 'Saints Academy' WHERE club_name = 'Saints Soccer Academy' AND state_code = 'OR';
+
+-- [CANONICAL] "FC Portland" → "FC Portland Academy" (8 teams)
+UPDATE teams SET club_name = 'FC Portland Academy' WHERE club_name = 'FC Portland' AND state_code = 'OR';
+
+-- [CANONICAL] "Oregon Surf" → "Oregon Surf SC" (5 teams)
+UPDATE teams SET club_name = 'Oregon Surf SC' WHERE club_name = 'Oregon Surf' AND state_code = 'OR';
+
+
+-- ========== SC ==========
+-- [CANONICAL] "South Carolina United" → "South Carolina United FC" (9 teams)
+UPDATE teams SET club_name = 'South Carolina United FC' WHERE club_name = 'South Carolina United' AND state_code = 'SC';
+
+-- [CANONICAL] "South Carolina Surf" → "South Carolina Surf SC" (8 teams)
+UPDATE teams SET club_name = 'South Carolina Surf SC' WHERE club_name = 'South Carolina Surf' AND state_code = 'SC';
+
+-- [CANONICAL] "James Island Youth SC    (JIYSC)" → "James Island Youth SC" (2 teams)
+UPDATE teams SET club_name = 'James Island Youth SC' WHERE club_name = 'James Island Youth SC    (JIYSC)' AND state_code = 'SC';
+
+
+-- ========== TN ==========
+-- [CANONICAL] "FC Alliance" → "FC Alliance TN" (14 teams)
+UPDATE teams SET club_name = 'FC Alliance TN' WHERE club_name = 'FC Alliance' AND state_code = 'TN';
+
+
+-- ========== TX ==========
+-- [CANONICAL] "Atlético Dallas Youth" → "Atletico Dallas Youth" (56 teams)
+UPDATE teams SET club_name = 'Atletico Dallas Youth' WHERE club_name = 'Atlético Dallas Youth' AND state_code = 'TX';
+
+-- [CANONICAL] "Lonestar Soccer Club" → "Lonestar" (31 teams)
+UPDATE teams SET club_name = 'Lonestar' WHERE club_name = 'Lonestar Soccer Club' AND state_code = 'TX';
+
+-- [CANONICAL] "Cavalry FC" → "Cavalry Youth Soccer" (15 teams)
+UPDATE teams SET club_name = 'Cavalry Youth Soccer' WHERE club_name = 'Cavalry FC' AND state_code = 'TX';
+
+
+-- ========== UT ==========
+-- [CANONICAL] "Sparta United" → "Sparta United Soccer Club" (21 teams)
+UPDATE teams SET club_name = 'Sparta United Soccer Club' WHERE club_name = 'Sparta United' AND state_code = 'UT';
+
+-- [CANONICAL] "La Roca" → "La Roca FC" (12 teams)
+UPDATE teams SET club_name = 'La Roca FC' WHERE club_name = 'La Roca' AND state_code = 'UT';
+
+
+-- ========== VA ==========
+-- [CANONICAL] "Arlington Soccer Association" → "Arlington Soccer" (84 teams)
+UPDATE teams SET club_name = 'Arlington Soccer' WHERE club_name = 'Arlington Soccer Association' AND state_code = 'VA';
+
+-- [CANONICAL] "Springfield SYC Soccer" → "Springfield SYC" (62 teams)
+UPDATE teams SET club_name = 'Springfield SYC' WHERE club_name = 'Springfield SYC Soccer' AND state_code = 'VA';
+
+-- [CANONICAL] "PWSI Courage" → "Prince William Soccer Inc" (16 teams)
+UPDATE teams SET club_name = 'Prince William Soccer Inc' WHERE club_name = 'PWSI Courage' AND state_code = 'VA';
+
+-- [CANONICAL] "Beach FC  (VA)" → "Beach FC" (12 teams)
+UPDATE teams SET club_name = 'Beach FC' WHERE club_name = 'Beach FC  (VA)' AND state_code = 'VA';
+
+-- [CANONICAL] "Beach FC (Va)" → "Beach FC" (12 teams)
+UPDATE teams SET club_name = 'Beach FC' WHERE club_name = 'Beach FC (Va)' AND state_code = 'VA';
+
+-- [CANONICAL] "VA Reign FC" → "Virginia Reign" (11 teams)
+UPDATE teams SET club_name = 'Virginia Reign' WHERE club_name = 'VA Reign FC' AND state_code = 'VA';
+
+-- [CANONICAL] "Richmond Utd" → "Richmond United" (4 teams)
+UPDATE teams SET club_name = 'Richmond United' WHERE club_name = 'Richmond Utd' AND state_code = 'VA';
+
+
+-- ========== WA ==========
+-- [CANONICAL] "Eastside F.C" → "Eastside FC" (12 teams)
+UPDATE teams SET club_name = 'Eastside FC' WHERE club_name = 'Eastside F.C' AND state_code = 'WA';
+
+-- [CANONICAL] "Mount Rainier FC" → "Mt. Rainier Futbol Club" (8 teams)
+UPDATE teams SET club_name = 'Mt. Rainier Futbol Club' WHERE club_name = 'Mount Rainier FC' AND state_code = 'WA';
+
+
 COMMIT;

--- a/scripts/export_merge_history.py
+++ b/scripts/export_merge_history.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Export merge history with club names for trend analysis.
+
+Outputs a CSV with deprecated team, canonical team, club names, and merge metadata.
+Run and share the CSV to analyze club name patterns in manual merges.
+
+Usage:
+    python scripts/export_merge_history.py
+    python scripts/export_merge_history.py --output data/exports/merge_history.csv
+"""
+import argparse
+import csv
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from supabase import create_client
+
+env_local = Path('.env.local')
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+supabase_url = os.getenv('SUPABASE_URL') or os.getenv('NEXT_PUBLIC_SUPABASE_URL')
+supabase_key = os.getenv('SUPABASE_SERVICE_ROLE_KEY') or os.getenv('SUPABASE_KEY')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Export merge history with club names')
+    parser.add_argument('--output', '-o', default='data/exports/merge_history.csv',
+                        help='Output CSV path')
+    parser.add_argument('--limit', '-n', type=int, default=500,
+                        help='Max merges to export (default 500). Use 0 for all.')
+    args = parser.parse_args()
+
+    if not supabase_url or not supabase_key:
+        print("Error: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set")
+        return 1
+
+    db = create_client(supabase_url, supabase_key)
+
+    print("Fetching merge history...")
+    merges = []
+    page_size = 1000
+    offset = 0
+    while True:
+        result = db.table('team_merge_map').select(
+            'id, deprecated_team_id, canonical_team_id, merged_at, merged_by, merge_reason'
+        ).order('merged_at', desc=True).range(offset, offset + page_size - 1).execute()
+        batch = result.data or []
+        if not batch:
+            break
+        merges.extend(batch)
+        if args.limit and len(merges) >= args.limit:
+            merges = merges[:args.limit]
+            break
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    if not merges:
+        print("No merges found.")
+        return 0
+
+    # Fetch team details (name, club_name) for all deprecated and canonical IDs
+    dep_ids = list({m['deprecated_team_id'] for m in merges})
+    can_ids = list({m['canonical_team_id'] for m in merges})
+    all_ids = list(set(dep_ids + can_ids))
+
+    teams = {}
+    batch_size = 100
+    for i in range(0, len(all_ids), batch_size):
+        batch = all_ids[i:i + batch_size]
+        r = db.table('teams').select('team_id_master, team_name, club_name, state_code').in_(
+            'team_id_master', batch
+        ).execute()
+        for t in (r.data or []):
+            teams[t['team_id_master']] = t
+
+    # Build output rows
+    rows = []
+    for m in merges:
+        dep = teams.get(m['deprecated_team_id'], {})
+        can = teams.get(m['canonical_team_id'], {})
+        rows.append({
+            'merged_at': m.get('merged_at', ''),
+            'merged_by': m.get('merged_by', ''),
+            'merge_reason': (m.get('merge_reason') or '')[:100],
+            'deprecated_team_name': dep.get('team_name', ''),
+            'deprecated_club_name': dep.get('club_name', ''),
+            'deprecated_state': dep.get('state_code', ''),
+            'canonical_team_name': can.get('team_name', ''),
+            'canonical_club_name': can.get('club_name', ''),
+            'canonical_state': can.get('state_code', ''),
+        })
+
+    # Write CSV
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, 'w', newline='', encoding='utf-8') as f:
+        w = csv.DictWriter(f, fieldnames=[
+            'merged_at', 'merged_by', 'merge_reason',
+            'deprecated_team_name', 'deprecated_club_name', 'deprecated_state',
+            'canonical_team_name', 'canonical_club_name', 'canonical_state',
+        ])
+        w.writeheader()
+        w.writerows(rows)
+
+    print(f"Exported {len(rows)} merges to {out_path}")
+    print()
+    print("Sample (first 5):")
+    print("-" * 100)
+    for i, r in enumerate(rows[:5], 1):
+        print(f"{i}. {r['deprecated_team_name'][:35]:<35} | {r['deprecated_club_name'][:25]:<25} → {r['canonical_club_name'][:25]}")
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/scripts/full_club_analysis.py
+++ b/scripts/full_club_analysis.py
@@ -39,6 +39,11 @@ CLUB_CANONICAL_OVERRIDES = [
     ("WA", "regex", r"Eastside FC\s*\(wa\)\s*$", "Eastside FC"),
     ("WA", "regex", r"Atletico\s*\(wa\)\s*$", "Atletico FC"),
     ("WA", "prefix", "NW United", "Northwest United FC"),
+    ("WA", "exact", "Eastside F.C", "Eastside FC"),
+    ("WA", "exact", "Mount Rainier FC", "Mt. Rainier Futbol Club"),
+    # Oklahoma (from full merge history - 4x prefers short form)
+    ("OK", "exact", "Oklahoma Celtic Football Club", "Oklahoma Celtic"),
+    ("OK", "exact", "West Side Alliance", "West Side Alliance SC"),
     # North Carolina
     ("NC", "exact", "CESA", "Carolina Elite Soccer Academy"),
     ("NC", "regex", r"Charlotte Soccer Academy\s*\(CSA\)\s*$", "Charlotte Soccer Academy"),
@@ -59,6 +64,60 @@ CLUB_CANONICAL_OVERRIDES = [
     ("TX", "exact", "Soccer Central/AC River/SA Athenians", "AC River"),
     ("TX", "exact", "Valencia Academy Houston", "Valencia CF"),
     ("TX", "regex", r"Juventus Academy Houston\s*\(JA\)\s*$", "Juventus Academy Houston"),
+    ("TX", "exact", "Lonestar Soccer Club", "Lonestar"),
+    ("TX", "exact", "Cavalry FC", "Cavalry Youth Soccer"),
+    ("TX", "exact", "Atlético Dallas Youth", "Atletico Dallas Youth"),
+    # Nevada (from full merge history)
+    ("NV", "exact", "LV Heat Surf SC", "Las Vegas Heat Surf SC"),
+    # New York
+    ("NY", "exact", "WNY Flash", "Western New York Flash"),
+    ("NY", "exact", "East Coast Surf SC", "East Coast Surf"),
+    # Idaho
+    ("ID", "exact", "Boise Timbers | Thorns", "Boise Timbers | Thorns FC"),
+    # Oregon
+    ("OR", "exact", "Oregon Surf", "Oregon Surf SC"),
+    ("OR", "exact", "FC Portland", "FC Portland Academy"),
+    ("OR", "exact", "Saints Soccer Academy", "Saints Academy"),
+    # Utah
+    ("UT", "exact", "Sparta United", "Sparta United Soccer Club"),
+    ("UT", "exact", "La Roca", "La Roca FC"),
+    # South Carolina
+    ("SC", "exact", "South Carolina United", "South Carolina United FC"),
+    ("SC", "exact", "South Carolina Surf", "South Carolina Surf SC"),
+    ("SC", "regex", r"James Island Youth SC\s+\(JIYSC\)\s*$", "James Island Youth SC"),
+    ("SC", "exact", "Coast Futbol Alliance", "Coast FA"),
+    # Tennessee
+    ("TN", "exact", "FC Alliance", "FC Alliance TN"),
+    # Minnesota (4x each direction - pick St. Croix as canonical)
+    ("MN", "exact", "St Croix Soccer Club", "St. Croix"),
+    # Michigan
+    ("MI", "exact", "Nationals SC", "Nationals"),
+    # Connecticut
+    ("CT", "exact", "Beachside Soccer Club CT", "Beachside of Connecticut"),
+    ("CT", "exact", "AC Connecticut", "A.C. Connecticut"),
+    # Georgia
+    ("GA", "exact", "NTH NASA", "NASA Tophat"),
+    ("GA", "exact", "Concord Fire", "Concorde Fire"),
+    # Virginia
+    ("VA", "exact", "Springfield SYC Soccer", "Springfield SYC"),
+    ("VA", "exact", "PWSI Courage", "Prince William Soccer Inc"),
+    ("VA", "exact", "Arlington Soccer Association", "Arlington Soccer"),
+    ("VA", "regex", r"Beach FC\s+\(VA\)\s*$", "Beach FC"),
+    ("VA", "exact", "VA Reign FC", "Virginia Reign"),
+    ("VA", "exact", "Richmond Utd", "Richmond United"),
+    # New Jersey
+    ("NJ", "exact", "Match Fit Surf", "Match Fit Academy"),
+    ("NJ", "exact", "Franklin Township Youth Soccer Association", "Franklin Township SC"),
+    # Ohio
+    ("OH", "exact", "Canton Force", "Canton Akron United Force"),
+    ("OH", "exact", "Ohio Elite SA", "Ohio Elite Soccer Academy"),
+    ("OH", "exact", "Cincinnati United", "Cincinnati United Premier Soccer Club"),
+    # California
+    ("CA", "exact", "Mustang SC", "Mustang Soccer"),
+    ("CA", "exact", "FC Golden State Force", "FC Golden State"),
+    ("CA", "regex", r"Beach FC\s+\(CA\)\s*$", "Beach Futbol Club"),
+    # Mississippi
+    ("MS", "exact", "MS Futbol Club", "Mississippi Rush"),
 ]
 
 # Acronyms to keep uppercase


### PR DESCRIPTION
## Summary
- **43 canonical overrides** across 18 states
- **1,205 teams** updated (executed)
- Derived from analysis of full merge history (5,101 merges)

## Changes
- Added overrides for CA, CT, GA, ID, MI, MN, MS, NJ, NV, NY, OH, OK, OR, SC, TN, TX, UT, VA, WA
- Removed CA City SC and AZ RSL Arizona (risky - could merge different branches)
- Added GA Concord Fire â†’ Concorde Fire (typo fix - correct spelling per concordefire.com)
- Added \scripts/export_merge_history.py\ for full merge analysis (\--limit 0\ for all merges)

## States affected
CA, CT, GA, ID, MI, MN, MS, NJ, NV, NY, OH, OK, OR, SC, TN, TX, UT, VA, WA

Made with [Cursor](https://cursor.com)