### PR TITLE
fix: deduplicate Unknown opponent games when linked version exists

### DIFF
--- a/frontend/app/api/create-team/route.ts
+++ b/frontend/app/api/create-team/route.ts
@@ -135,22 +135,29 @@ export async function POST(request: NextRequest) {
     let gamesUpdated = 0;
     let homeUpdated = 0;
     let awayUpdated = 0;
+    const providerIdIsNull = game.provider_id === null;
 
     // Count games where opponent is HOME team first
-    const { count: homeCount } = await supabase
+    let homeCountQuery = supabase
       .from('games')
       .select('id', { count: 'exact', head: true })
       .eq('home_provider_id', providerTeamIdStr)
-      .eq('provider_id', game.provider_id)
       .is('home_team_master_id', null);
+    homeCountQuery = providerIdIsNull
+      ? homeCountQuery.is('provider_id', null)
+      : homeCountQuery.eq('provider_id', game.provider_id);
+    const { count: homeCount } = await homeCountQuery;
 
     // Update games where opponent is HOME team
-    const { error: homeUpdateError } = await supabase
+    let homeUpdateQuery = supabase
       .from('games')
       .update({ home_team_master_id: teamIdMaster })
       .eq('home_provider_id', providerTeamIdStr)
-      .eq('provider_id', game.provider_id)
       .is('home_team_master_id', null);
+    homeUpdateQuery = providerIdIsNull
+      ? homeUpdateQuery.is('provider_id', null)
+      : homeUpdateQuery.eq('provider_id', game.provider_id);
+    const { error: homeUpdateError } = await homeUpdateQuery;
 
     if (homeUpdateError) {
       console.error('[create-team] Failed to update home games:', homeUpdateError);
@@ -159,20 +166,26 @@ export async function POST(request: NextRequest) {
     }
 
     // Count games where opponent is AWAY team first
-    const { count: awayCount } = await supabase
+    let awayCountQuery = supabase
       .from('games')
       .select('id', { count: 'exact', head: true })
       .eq('away_provider_id', providerTeamIdStr)
-      .eq('provider_id', game.provider_id)
       .is('away_team_master_id', null);
+    awayCountQuery = providerIdIsNull
+      ? awayCountQuery.is('provider_id', null)
+      : awayCountQuery.eq('provider_id', game.provider_id);
+    const { count: awayCount } = await awayCountQuery;
 
     // Update games where opponent is AWAY team
-    const { error: awayUpdateError } = await supabase
+    let awayUpdateQuery = supabase
       .from('games')
       .update({ away_team_master_id: teamIdMaster })
       .eq('away_provider_id', providerTeamIdStr)
-      .eq('provider_id', game.provider_id)
       .is('away_team_master_id', null);
+    awayUpdateQuery = providerIdIsNull
+      ? awayUpdateQuery.is('provider_id', null)
+      : awayUpdateQuery.eq('provider_id', game.provider_id);
+    const { error: awayUpdateError } = await awayUpdateQuery;
 
     if (awayUpdateError) {
       console.error('[create-team] Failed to update away games:', awayUpdateError);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -616,8 +616,27 @@ export const api = {
       return true;
     });
 
+    // Second pass: remove games with Unknown (null) opponents when a linked version
+    // of the same game exists. This handles the case where a match is scraped from
+    // both teams' schedules with different provider IDs — after linking one copy,
+    // the other may still have a null opponent and generates a different dedup key.
+    const finalGames = deduplicatedGames.filter((game) => {
+      const hasNullOpponent = !game.home_team_master_id || !game.away_team_master_id;
+      if (!hasNullOpponent) return true;
+
+      // Check if a fully-linked version of this game exists in the list
+      const sortedScores = [game.home_score, game.away_score].sort((a, b) => (a ?? 0) - (b ?? 0)).join('-');
+      return !deduplicatedGames.some((other) => {
+        if (other === game) return false;
+        if (!other.home_team_master_id || !other.away_team_master_id) return false;
+        if (other.game_date !== game.game_date) return false;
+        const otherSortedScores = [other.home_score, other.away_score].sort((a, b) => (a ?? 0) - (b ?? 0)).join('-');
+        return sortedScores === otherSortedScores;
+      });
+    });
+
     return {
-      games: deduplicatedGames,
+      games: finalGames,
       lastScrapedAt: mostRecentScrapedAt,
     };
   },


### PR DESCRIPTION
After linking an Unknown opponent to a team (via create-team or link-opponent), both the old Unknown entry and the new linked entry could appear in game history. This happened because duplicate game records (scraped from both teams' schedules) generated different dedup keys when one had a null team_master_id.

Changes:
- Add second dedup pass in getTeamGames() to filter out Unknown opponent games when a fully-linked version of the same game exists (same date + same scores)
- Fix create-team API null provider_id handling: use .is() instead of .eq() for null comparisons, matching the existing fix in link-opponent API

https://claude.ai/code/session_01DBdM1Y34jiqzU28LQanVHt

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

