### PR TITLE
fix: remove engagement CTA from infographic image, keep in caption only

### DIFF
--- a/frontend/components/infographics/Top10Infographic.tsx
+++ b/frontend/components/infographics/Top10Infographic.tsx
@@ -131,19 +131,6 @@ export const Top10Infographic = forwardRef<HTMLDivElement, Top10InfographicProps
               Rankings as of {formatDate(generatedDate)}
             </div>
 
-            {/* Engagement CTA */}
-            <div
-              style={{
-                fontFamily: "'DM Sans', Arial, sans-serif",
-                fontSize: `${ctaSize}px`,
-                fontWeight: 600,
-                color: BRAND_COLORS.brightWhite,
-                marginTop: 12,
-                textDecoration: 'none',
-              }}
-            >
-              Did we get it right? Tag your team {'\u{1F447}'}
-            </div>
           </div>
 
           {/* Rankings List */}

--- a/frontend/components/infographics/canvasRenderer.ts
+++ b/frontend/components/infographics/canvasRenderer.ts
@@ -124,14 +124,7 @@ export async function renderInfographicToCanvas(options: RenderOptions): Promise
   ctx.font = `400 ${statsSize}px "DM Sans", Arial, sans-serif`;
   ctx.fillText(`Rankings as of ${formatDate(generatedDate)}`, dimensions.width / 2, currentY + statsSize / 2);
 
-  currentY += statsSize + 12;
-
-  // Engagement CTA
-  ctx.fillStyle = BRAND_COLORS.brightWhite;
-  ctx.font = `600 ${ctaSize}px "DM Sans", Arial, sans-serif`;
-  ctx.fillText('Did we get it right? Tag your team \u{1F447}', dimensions.width / 2, currentY + ctaSize / 2);
-
-  currentY += ctaSize + (isVertical ? 36 : 20);
+  currentY += statsSize + (isVertical ? 48 : 32);
 
   // ===== RANKINGS LIST =====
   const top10 = teams.slice(0, 10);


### PR DESCRIPTION
https://claude.ai/code/session_013ZGYoHbPCyds6oHkmPx9d3

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

