### PR TITLE
fix: widen rank column and give team names more room on mobile

### DIFF
--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -357,7 +357,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
             <div className="overflow-x-auto -mx-4 sm:mx-0 touch-pan-x">
               <div className="inline-block min-w-full align-middle min-w-[400px] sm:min-w-[500px]">
                 {/* Table Header */}
-                <div data-testid="rankings-table-header" className="grid border-b-2 border-primary bg-secondary/50 sticky top-0 z-10" style={{ gridTemplateColumns: '60px 2fr 1fr 1fr' }}>
+                <div data-testid="rankings-table-header" className="grid grid-cols-[52px_3fr_1fr_1fr] sm:grid-cols-[70px_2fr_1fr_1fr] border-b-2 border-primary bg-secondary/50 sticky top-0 z-10">
                   <div className="px-1.5 sm:px-4 py-2 sm:py-4 font-semibold text-xs sm:text-sm uppercase tracking-wide min-w-0 overflow-hidden">
                     <SortButton field="rank" label="Rank" sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
                   </div>
@@ -417,14 +417,13 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                           data-testid={`rankings-row-${virtualRow.index}`}
                           ref={virtualizer.measureElement}
                           className={`
-                            grid border-b group cursor-pointer
+                            grid grid-cols-[52px_3fr_1fr_1fr] sm:grid-cols-[70px_2fr_1fr_1fr] border-b group cursor-pointer
                             hover:bg-accent/70 hover:shadow-md
                             transition-[background-color,box-shadow] duration-200 ease-in-out
                             md:hover:scale-[1.01] hover:z-10
                             ${borderClass}
                           `}
                           style={{
-                            gridTemplateColumns: '60px 2fr 1fr 1fr',
                             position: 'absolute',
                             top: 0,
                             left: 0,


### PR DESCRIPTION
The rankings table grid used a fixed `60px 2fr 1fr 1fr` at all screen sizes. On mobile (375px), team names only got ~157px — causing heavy truncation on names like "B2014 Pre-ECNL (Martinez)". The rank column also clipped when rank-change arrows appeared next to 3-digit ranks.

Mobile grid:  52px 3fr 1fr 1fr — team gets ~60% of remaining space
Desktop grid: 70px 2fr 1fr 1fr — balanced layout with wider rank column

Replaced inline style gridTemplateColumns with responsive Tailwind classes so header and rows stay in sync at all breakpoints.

https://claude.ai/code/session_01DawBzp5aMpiUnejr3dhrDc

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

