### PR TITLE
fix: eliminate mobile column clipping in rankings table

### DIFF
--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -346,18 +346,17 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
           )}
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-2 sm:px-6">
         {sortedRankings.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-8">
             No rankings found for the selected filters
           </p>
         ) : (
           <div className="rounded-md border overflow-hidden">
-            {/* Mobile: Horizontal scroll wrapper with momentum scrolling */}
-            <div className="overflow-x-auto -mx-4 sm:mx-0 touch-pan-x">
-              <div className="inline-block min-w-full align-middle min-w-[400px] sm:min-w-[500px]">
+            {/* Table wrapper - no horizontal scroll on mobile, columns flex to fit */}
+            <div className="touch-pan-y">
                 {/* Table Header */}
-                <div data-testid="rankings-table-header" className="grid grid-cols-[52px_3fr_1fr_1fr] sm:grid-cols-[70px_2fr_1fr_1fr] border-b-2 border-primary bg-secondary/50 sticky top-0 z-10">
+                <div data-testid="rankings-table-header" className="grid grid-cols-[44px_1fr_58px_50px] sm:grid-cols-[70px_2fr_1fr_1fr] border-b-2 border-primary bg-secondary/50 sticky top-0 z-10">
                   <div className="px-1.5 sm:px-4 py-2 sm:py-4 font-semibold text-xs sm:text-sm uppercase tracking-wide min-w-0 overflow-hidden">
                     <SortButton field="rank" label="Rank" sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
                   </div>
@@ -417,7 +416,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                           data-testid={`rankings-row-${virtualRow.index}`}
                           ref={virtualizer.measureElement}
                           className={`
-                            grid grid-cols-[52px_3fr_1fr_1fr] sm:grid-cols-[70px_2fr_1fr_1fr] border-b group cursor-pointer
+                            grid grid-cols-[44px_1fr_58px_50px] sm:grid-cols-[70px_2fr_1fr_1fr] border-b group cursor-pointer
                             hover:bg-accent/70 hover:shadow-md
                             transition-[background-color,box-shadow] duration-200 ease-in-out
                             md:hover:scale-[1.01] hover:z-10
@@ -513,7 +512,6 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                   )}
                   </div>
                 </div>
-              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
The -mx-4 negative margin on the scroll wrapper was being clipped by the parent's overflow-hidden (border-radius), cutting off the left side of the Rank column and right side of SOS Rank. Additionally, min-w-[400px] forced horizontal scrolling on 375px screens.

Changes:
- Remove -mx-4 negative margin and the inner min-width wrapper that caused both left/right clipping and forced horizontal overflow
- Use fixed-width columns on mobile (44px rank, 58px PS, 50px SOS) with 1fr for team names — team now gets ~183px instead of ~157px
- Reduce CardContent horizontal padding on mobile (px-2 vs px-6) to maximize table width on small screens
- Desktop layout unchanged (70px 2fr 1fr 1fr)

https://claude.ai/code/session_01DawBzp5aMpiUnejr3dhrDc

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

