### PR TITLE
fix: rankings filter navigates to dynamic route when user changes fil…

### DIFF
--- a/frontend/components/RankingsFilter.tsx
+++ b/frontend/components/RankingsFilter.tsx
@@ -25,6 +25,8 @@ export function RankingsFilter({ onFilterChange }: RankingsFilterProps) {
   const isNavigatingRef = useRef(false);
   // Track the target path we're navigating to
   const targetPathRef = useRef<string | null>(null);
+  // Track if the user has interacted with the filters (prevents auto-redirect on initial load)
+  const hasUserInteractedRef = useRef(false);
 
   // Extract current URL parts → /rankings/[region]/[ageGroup]/[gender]
   const pathParts = pathname.split("/").filter(Boolean);
@@ -38,16 +40,19 @@ export function RankingsFilter({ onFilterChange }: RankingsFilterProps) {
 
   // Handlers that track filter changes
   const handleRegionChange = (newRegion: string) => {
+    hasUserInteractedRef.current = true;
     setRegion(newRegion);
     trackFilterApplied({ region: newRegion, age_group: ageGroup, gender });
   };
 
   const handleAgeGroupChange = (newAgeGroup: string) => {
+    hasUserInteractedRef.current = true;
     setAgeGroup(newAgeGroup);
     trackFilterApplied({ region, age_group: newAgeGroup, gender });
   };
 
   const handleGenderChange = (newGender: string) => {
+    hasUserInteractedRef.current = true;
     setGender(newGender);
     trackFilterApplied({ region, age_group: ageGroup, gender: newGender });
   };
@@ -86,17 +91,22 @@ export function RankingsFilter({ onFilterChange }: RankingsFilterProps) {
 
   // Handle filter changes
   useEffect(() => {
-    // If on home rankings page, use callback immediately
+    // If on home rankings page with callback, use it
     if (pathname === '/rankings' && onFilterChange) {
       onFilterChange(region, ageGroup, gender);
       return;
     }
 
-    // Otherwise, navigate to filtered route
-    if (!pathname.startsWith('/rankings/')) {
+    // Navigate to filtered route from /rankings or /rankings/...
+    if (!pathname.startsWith('/rankings')) {
       return;
     }
-    
+
+    // On the base /rankings page, only navigate when the user changes a filter
+    if (pathname === '/rankings' && !hasUserInteractedRef.current) {
+      return;
+    }
+
     const targetPath = `/rankings/${region}/${ageGroup}/${gender}`;
     const currentPath = pathname;
     


### PR DESCRIPTION
…ters

The /rankings base page wasn't responding to filter changes because the navigation effect skipped paths not starting with '/rankings/'. Now it navigates to /rankings/{region}/{ageGroup}/{gender} on filter interaction while still avoiding auto-redirect on initial page load (for SEO).

https://claude.ai/code/session_018GWFANaa29MdxkWgLKTjCw

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

