### PR TITLE
fix: lower SOS shrinkage anchor from 0.5 to 0.35 for low-GP teams

### DIFF
--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -76,7 +76,8 @@ class V53EConfig:
     # because it caused games-played bias in sos_norm. Kept for backward compatibility only.
     SOS_SAMPLE_SIZE_THRESHOLD: int = 25  # DEPRECATED: no longer used
     OPPONENT_SAMPLE_SIZE_THRESHOLD: int = 20  # DEPRECATED: no longer used (opponent shrinkage removed)
-    MIN_GAMES_FOR_TOP_SOS: int = 10  # Post-percentile shrinkage threshold (teams < this shrink toward 0.5)
+    MIN_GAMES_FOR_TOP_SOS: int = 10  # Post-percentile shrinkage threshold (teams < this shrink toward anchor)
+    SOS_SHRINKAGE_ANCHOR: float = 0.35  # Low-sample teams shrink toward this (0.35 = below-average, not neutral)
     # NOTE: SOS_TOP_CAP_FOR_LOW_SAMPLE is DEPRECATED - hard caps were replaced with soft shrinkage
     SOS_TOP_CAP_FOR_LOW_SAMPLE: float = 0.70  # DEPRECATED: no longer used
 
@@ -1378,25 +1379,28 @@ def compute_rankings(
         "OK"
     )
 
-    # Soft shrinkage: blend toward neutral (0.5) based on sample size
+    # Soft shrinkage: blend toward anchor based on sample size
     # Using LINEAR shrinkage for proportional dampening of low-sample teams:
-    # - 0 games: shrink_factor = 0.0 (fully shrunk to 0.5)
+    # - 0 games: shrink_factor = 0.0 (fully shrunk to anchor)
     # - 5 games: shrink_factor = 0.50 (50% of raw SOS retained)
     # - 8 games: shrink_factor = 0.80 (80% of raw SOS retained)
     # - 10+ games: shrink_factor = 1.0 (no shrinkage)
+    # Anchor is 0.35 (below-average) to prevent low-GP teams from getting
+    # a free "neutral schedule" assumption.
     low_sample_mask = team["gp"] < cfg.MIN_GAMES_FOR_TOP_SOS
     gp_clipped = team["gp"].clip(lower=0)
     shrink_factor = (gp_clipped / cfg.MIN_GAMES_FOR_TOP_SOS).clip(0.0, 1.0)
+    anchor = cfg.SOS_SHRINKAGE_ANCHOR
 
-    # Apply shrinkage: sos_norm = 0.5 + shrink_factor * (sos_norm - 0.5)
+    # Apply shrinkage: sos_norm = anchor + shrink_factor * (sos_norm - anchor)
     team.loc[low_sample_mask, "sos_norm"] = (
-        0.5 + shrink_factor[low_sample_mask] * (team.loc[low_sample_mask, "sos_norm"] - 0.5)
+        anchor + shrink_factor[low_sample_mask] * (team.loc[low_sample_mask, "sos_norm"] - anchor)
     )
 
     low_sample_count = low_sample_mask.sum()
     if low_sample_count > 0:
         logger.info(
-            f"🏷️  Low sample handling: {low_sample_count} teams with soft SOS shrinkage toward 0.5"
+            f"🏷️  Low sample handling: {low_sample_count} teams with soft SOS shrinkage toward {anchor}"
         )
 
     # Correlation guardrail: detect if games-played is leaking into sos_norm
@@ -1577,12 +1581,13 @@ def compute_rankings(
                 sos_norm_values = team['sos_norm'].values
                 team['sos_norm'] = 0.5 + comp_shrink * (sos_norm_values - 0.5)
 
-            # Step 6: Apply low-sample shrinkage (vectorized) - LINEAR for proportional dampening
+            # Step 6: Apply low-sample shrinkage (vectorized) - LINEAR toward anchor
             low_sample_mask = gps < cfg.MIN_GAMES_FOR_TOP_SOS
             shrink_factor = np.clip(gps / cfg.MIN_GAMES_FOR_TOP_SOS, 0.0, 1.0)
             sos_norm_values = team['sos_norm'].values.copy()
+            anchor = cfg.SOS_SHRINKAGE_ANCHOR
             sos_norm_values[low_sample_mask] = (
-                0.5 + shrink_factor[low_sample_mask] * (sos_norm_values[low_sample_mask] - 0.5)
+                anchor + shrink_factor[low_sample_mask] * (sos_norm_values[low_sample_mask] - anchor)
             )
             team['sos_norm'] = sos_norm_values
 

--- a/tests/unit/test_bad_sos_ranking_diagnosis.py
+++ b/tests/unit/test_bad_sos_ranking_diagnosis.py
@@ -13,9 +13,9 @@ Root cause analysis of the PowerScore formula and SOS mechanics:
    A team beating weak opponents gets LOW off_norm (good, opponent-adjusted)
    but their 60% SOS weight still dominates the score.
 
-3. NEUTRAL ANCHOR = 0.5: The shrinkage anchor is 0.5 (median). For weak-SOS
-   teams, this is generous. A more appropriate anchor might be lower (e.g., 0.35)
-   to avoid rewarding teams that haven't proven their schedule quality.
+3. ANCHOR (NOW 0.35): The shrinkage anchor was changed from 0.5 to 0.35 via
+   SOS_SHRINKAGE_ANCHOR config. This prevents rewarding teams that haven't
+   proven their schedule quality with a free "neutral" assumption.
 
 These tests quantify each mechanism and test potential fixes.
 """
@@ -267,39 +267,34 @@ class TestPotentialFixes:
 
     def test_fix_lower_shrinkage_anchor(self):
         """
-        Fix #1: Change shrinkage anchor from 0.5 to 0.35.
-        Weak-SOS teams with few games shrink toward 0.35 instead of 0.5,
+        Fix #1 (IMPLEMENTED): Shrinkage anchor is now 0.35 (via SOS_SHRINKAGE_ANCHOR).
+        Weak-SOS teams with few games shrink toward 0.35 instead of 0.50,
         preventing free SOS inflation.
         """
+        from src.etl.v53e import V53EConfig
+        cfg = V53EConfig()
         games, elite, mid, weak = _build_tiered_league()
 
-        # Baseline
+        # Run with the now-default 0.35 anchor
         team_baseline = _run_rankings(games)
 
-        # Modified: manually apply lower shrinkage anchor
-        # We can't easily change the anchor in v53e without modifying the code,
-        # so we'll compute the effect analytically
         weak_base = team_baseline[team_baseline["team_id"].isin(weak)]
         mid_base = team_baseline[team_baseline["team_id"].isin(mid)]
 
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         print(f"\n{'='*70}")
-        print(f"FIX #1: Lower shrinkage anchor (0.5 → 0.35)")
+        print(f"FIX #1 (ACTIVE): Shrinkage anchor = {anchor}")
         print(f"{'='*70}")
         print(f"\n  Current state:")
         print(f"    Weak avg sos_norm: {weak_base['sos_norm'].mean():.4f}")
         print(f"    Mid avg sos_norm:  {mid_base['sos_norm'].mean():.4f}")
         print(f"    Gap:               {mid_base['sos_norm'].mean() - weak_base['sos_norm'].mean():.4f}")
 
-        # Simulate what would happen with 0.35 anchor
-        # new_sos = 0.35 + shrink_factor * (raw_sos - 0.35)
-        # vs current: 0.5 + shrink_factor * (raw_sos - 0.5)
-        # For a team with raw_sos=0.1, 5 games:
-        #   Current:  0.5 + 0.5*(0.1 - 0.5) = 0.30
-        #   Proposed: 0.35 + 0.5*(0.1 - 0.35) = 0.225
+        # Show the formula with the active anchor
         print(f"\n  Example: team with raw_sos_norm=0.10, 5 games (shrink=0.5):")
-        print(f"    Current (anchor=0.5):  {0.5 + 0.5*(0.1 - 0.5):.3f}")
-        print(f"    Proposed (anchor=0.35): {0.35 + 0.5*(0.1 - 0.35):.3f}")
-        print(f"    Improvement: {(0.5 + 0.5*(0.1 - 0.5)) - (0.35 + 0.5*(0.1 - 0.35)):.3f} lower")
+        print(f"    Anchor={anchor}: {anchor + 0.5*(0.1 - anchor):.3f}")
+        print(f"    (Old anchor=0.5 would have given: {0.5 + 0.5*(0.1 - 0.5):.3f})")
+        print(f"    Improvement: {(0.5 + 0.5*(0.1 - 0.5)) - (anchor + 0.5*(0.1 - anchor)):.3f} lower")
 
     def test_fix_sos_weight_reduction(self):
         """

--- a/tests/unit/test_linear_shrinkage_regression.py
+++ b/tests/unit/test_linear_shrinkage_regression.py
@@ -3,13 +3,13 @@ Regression tests ensuring linear shrinkage stays linear.
 
 The low-sample SOS shrinkage formula is:
   shrink_factor = min(gp / MIN_GAMES_FOR_TOP_SOS, 1.0)
-  sos_norm = 0.5 + shrink_factor * (sos_norm_raw - 0.5)
+  sos_norm = anchor + shrink_factor * (sos_norm_raw - anchor)
 
-This must be LINEAR (proportional to gp), not exponential, sigmoid, or
-step-function. These tests guard against regressions that could introduce
-games-played bias.
+Where anchor = SOS_SHRINKAGE_ANCHOR (default 0.35). This must be LINEAR
+(proportional to gp), not exponential, sigmoid, or step-function. These
+tests guard against regressions that could introduce games-played bias.
 
-Also tests component-size shrinkage:
+Also tests component-size shrinkage (still anchored at 0.5):
   component_shrink = min(component_size / MIN_COMPONENT_SIZE_FOR_FULL_SOS, 1.0)
   sos_norm = 0.5 + component_shrink * (sos_norm_raw - 0.5)
 """
@@ -32,36 +32,39 @@ class TestLinearShrinkageFormula:
     def cfg(self):
         return V53EConfig()
 
-    def _shrink(self, gp, raw_sos_norm, threshold):
+    def _shrink(self, gp, raw_sos_norm, threshold, anchor=0.35):
         """Replicate the shrinkage formula from v53e.py."""
         shrink_factor = min(gp / threshold, 1.0)
-        return 0.5 + shrink_factor * (raw_sos_norm - 0.5)
+        return anchor + shrink_factor * (raw_sos_norm - anchor)
 
     def test_zero_games_fully_shrunk(self, cfg):
-        """0 games → sos_norm = 0.5 regardless of raw value."""
-        assert self._shrink(0, 1.0, cfg.MIN_GAMES_FOR_TOP_SOS) == 0.5
-        assert self._shrink(0, 0.0, cfg.MIN_GAMES_FOR_TOP_SOS) == 0.5
-        assert self._shrink(0, 0.9, cfg.MIN_GAMES_FOR_TOP_SOS) == 0.5
+        """0 games → sos_norm = anchor regardless of raw value."""
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
+        assert self._shrink(0, 1.0, cfg.MIN_GAMES_FOR_TOP_SOS, anchor) == anchor
+        assert self._shrink(0, 0.0, cfg.MIN_GAMES_FOR_TOP_SOS, anchor) == anchor
+        assert self._shrink(0, 0.9, cfg.MIN_GAMES_FOR_TOP_SOS, anchor) == anchor
 
     def test_half_threshold_half_deviation(self, cfg):
-        """5 games with threshold=10 → retain 50% of deviation from 0.5."""
+        """5 games with threshold=10 → retain 50% of deviation from anchor."""
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS  # 10
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR  # 0.35
         raw = 0.9
-        result = self._shrink(5, raw, threshold)
-        expected = 0.5 + 0.5 * (0.9 - 0.5)  # = 0.7
+        result = self._shrink(5, raw, threshold, anchor)
+        expected = anchor + 0.5 * (0.9 - anchor)  # = 0.35 + 0.5*0.55 = 0.625
         assert abs(result - expected) < 1e-10
 
     def test_at_threshold_no_shrinkage(self, cfg):
         """At threshold → factor=1.0, no shrinkage."""
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         raw = 0.9
-        result = self._shrink(threshold, raw, threshold)
+        result = self._shrink(threshold, raw, threshold, anchor)
         assert abs(result - raw) < 1e-10
 
     def test_above_threshold_no_shrinkage(self, cfg):
         """Above threshold → capped at 1.0, no shrinkage."""
-        threshold = cfg.MIN_GAMES_FOR_TOP_SOS
-        result = self._shrink(100, 0.9, threshold)
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
+        result = self._shrink(100, 0.9, cfg.MIN_GAMES_FOR_TOP_SOS, anchor)
         assert abs(result - 0.9) < 1e-10
 
     def test_linearity_property(self, cfg):
@@ -69,42 +72,45 @@ class TestLinearShrinkageFormula:
         The key property: shrinkage must be LINEAR in gp.
         For any two game counts g1, g2 below threshold, the shrunk values
         must satisfy:
-          shrunk(g2) - shrunk(g1) = (g2 - g1)/threshold * (raw - 0.5)
+          shrunk(g2) - shrunk(g1) = (g2 - g1)/threshold * (raw - anchor)
         """
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         raw = 0.85
 
         for g1 in range(0, threshold):
             for g2 in range(g1 + 1, threshold + 1):
-                s1 = self._shrink(g1, raw, threshold)
-                s2 = self._shrink(g2, raw, threshold)
-                expected_diff = (g2 - g1) / threshold * (raw - 0.5)
+                s1 = self._shrink(g1, raw, threshold, anchor)
+                s2 = self._shrink(g2, raw, threshold, anchor)
+                expected_diff = (g2 - g1) / threshold * (raw - anchor)
                 actual_diff = s2 - s1
                 assert abs(actual_diff - expected_diff) < 1e-10, (
                     f"Non-linear shrinkage at g1={g1}, g2={g2}: "
                     f"diff={actual_diff:.6f}, expected={expected_diff:.6f}"
                 )
 
-    def test_symmetry_around_half(self, cfg):
-        """Shrinkage should be symmetric: teams above AND below 0.5 are
-        pulled equally toward 0.5."""
+    def test_symmetry_around_anchor(self, cfg):
+        """Shrinkage should be symmetric: teams above AND below anchor are
+        pulled equally toward anchor."""
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         gp = 5
 
-        high = self._shrink(gp, 0.9, threshold)  # pulled down
-        low = self._shrink(gp, 0.1, threshold)   # pulled up
+        high = self._shrink(gp, anchor + 0.4, threshold, anchor)  # pulled down
+        low = self._shrink(gp, anchor - 0.4, threshold, anchor)   # pulled up
 
-        # Distance from 0.5 should be equal
-        assert abs((high - 0.5) - (0.5 - low)) < 1e-10
+        # Distance from anchor should be equal
+        assert abs((high - anchor) - (anchor - low)) < 1e-10
 
     def test_monotonic_in_games(self, cfg):
         """More games → closer to raw value (less shrinkage)."""
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         raw = 0.85
 
-        prev = self._shrink(0, raw, threshold)
+        prev = self._shrink(0, raw, threshold, anchor)
         for gp in range(1, threshold + 5):
-            curr = self._shrink(gp, raw, threshold)
+            curr = self._shrink(gp, raw, threshold, anchor)
             assert curr >= prev - 1e-10, (
                 f"Non-monotonic: shrink({gp}) = {curr:.6f} < shrink({gp-1}) = {prev:.6f}"
             )
@@ -116,12 +122,13 @@ class TestLinearShrinkageFormula:
         We check that equal gp increments produce equal sos_norm increments.
         """
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         raw = 0.9
 
         increments = []
         for gp in range(threshold):
-            s_curr = self._shrink(gp, raw, threshold)
-            s_next = self._shrink(gp + 1, raw, threshold)
+            s_curr = self._shrink(gp, raw, threshold, anchor)
+            s_next = self._shrink(gp + 1, raw, threshold, anchor)
             increments.append(s_next - s_curr)
 
         # All increments should be identical (linear property)
@@ -133,15 +140,16 @@ class TestLinearShrinkageFormula:
 
     def test_not_step_function(self, cfg):
         """Guard against regression to hard cap / step function.
-        Step: sos_norm = 0.5 if gp < threshold, else raw → NOT linear.
+        Step: sos_norm = anchor if gp < threshold, else raw → NOT linear.
         """
         threshold = cfg.MIN_GAMES_FOR_TOP_SOS
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         raw = 0.9
 
-        # Mid-range gp should produce values between 0.5 and raw
+        # Mid-range gp should produce values between anchor and raw
         mid_gp = threshold // 2
-        result = self._shrink(mid_gp, raw, threshold)
-        assert result > 0.5 + 0.01, f"Step-function detected: shrink({mid_gp}) = {result:.6f}"
+        result = self._shrink(mid_gp, raw, threshold, anchor)
+        assert result > anchor + 0.01, f"Step-function detected: shrink({mid_gp}) = {result:.6f}"
         assert result < raw - 0.01, f"No shrinkage at mid: shrink({mid_gp}) = {result:.6f}"
 
 
@@ -240,9 +248,10 @@ class TestShrinkageInPipeline:
         low_team = teams[teams["team_id"] == "low_gp"]
         if not low_team.empty:
             low_sos_norm = low_team["sos_norm"].values[0]
-            # Should be closer to 0.5 than the extremes
-            assert abs(low_sos_norm - 0.5) < 0.35, (
-                f"Low-gp team sos_norm ({low_sos_norm:.3f}) not sufficiently shrunk"
+            anchor = cfg.SOS_SHRINKAGE_ANCHOR
+            # Should be closer to anchor than the extremes
+            assert abs(low_sos_norm - anchor) < 0.40, (
+                f"Low-gp team sos_norm ({low_sos_norm:.3f}) not sufficiently shrunk toward {anchor}"
             )
 
 

--- a/tests/unit/test_minmax_vs_percentile_sos.py
+++ b/tests/unit/test_minmax_vs_percentile_sos.py
@@ -100,8 +100,9 @@ def _run_with_normalization(games, cfg, norm_fn, today="2025-07-01"):
     # Re-apply low-sample shrinkage
     low_mask = teams["gp"] < cfg.MIN_GAMES_FOR_TOP_SOS
     shrink = (teams["gp"] / cfg.MIN_GAMES_FOR_TOP_SOS).clip(0.0, 1.0)
+    anchor = cfg.SOS_SHRINKAGE_ANCHOR
     teams.loc[low_mask, "sos_norm"] = (
-        0.5 + shrink[low_mask] * (teams.loc[low_mask, "sos_norm"] - 0.5)
+        anchor + shrink[low_mask] * (teams.loc[low_mask, "sos_norm"] - anchor)
     )
 
     # Recompute PowerScore

--- a/tests/unit/test_provisional_sos_shrinkage.py
+++ b/tests/unit/test_provisional_sos_shrinkage.py
@@ -3,7 +3,7 @@ Tests for provisional multiplier + SOS shrinkage compounding.
 
 Verifies:
 - Provisional multiplier thresholds (0.85 / 0.95 / 1.00) at game-count boundaries
-- SOS low-sample shrinkage toward 0.5
+- SOS low-sample shrinkage toward anchor (default 0.35)
 - The compound effect: provisional_mult * powerscore_core where sos_norm is
   already shrunk for low-game-count teams
 - Boundary conditions at the thresholds (gp=7→8, gp=14→15)
@@ -143,29 +143,32 @@ class TestProvisionalMultInPipeline:
 # ===========================================================================
 
 class TestSOSShrinkage:
-    """Verify SOS low-sample shrinkage toward 0.5."""
+    """Verify SOS low-sample shrinkage toward anchor."""
 
     def test_shrinkage_formula_linear(self):
         """
         For teams with gp < MIN_GAMES_FOR_TOP_SOS (10), sos_norm should be
-        shrunk toward 0.5: sos_norm = 0.5 + (gp/10) * (raw - 0.5).
+        shrunk toward anchor: sos_norm = anchor + (gp/10) * (raw - anchor).
         """
         cfg = V53EConfig()
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR  # 0.35
         # A team with 5 games out of threshold 10 should retain 50% of the
-        # deviation from 0.5
+        # deviation from anchor
         gp = 5
         raw_sos_norm = 0.9
         shrink_factor = min(gp / cfg.MIN_GAMES_FOR_TOP_SOS, 1.0)
-        expected = 0.5 + shrink_factor * (raw_sos_norm - 0.5)
-        assert abs(expected - 0.7) < 0.01  # 0.5 + 0.5*(0.9-0.5) = 0.7
+        expected = anchor + shrink_factor * (raw_sos_norm - anchor)
+        # 0.35 + 0.5*(0.9-0.35) = 0.35 + 0.275 = 0.625
+        assert abs(expected - 0.625) < 0.01
 
     def test_full_games_no_shrinkage(self):
         """Teams with >= MIN_GAMES_FOR_TOP_SOS games should have no shrinkage."""
         cfg = V53EConfig()
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
         gp = 10
         raw_sos_norm = 0.9
         shrink_factor = min(gp / cfg.MIN_GAMES_FOR_TOP_SOS, 1.0)
-        expected = 0.5 + shrink_factor * (raw_sos_norm - 0.5)
+        expected = anchor + shrink_factor * (raw_sos_norm - anchor)
         assert abs(expected - 0.9) < 0.01  # factor=1.0 → no change
 
 
@@ -179,7 +182,7 @@ class TestCompoundEffect:
     def test_low_games_double_penalty(self):
         """
         A team with 5 games gets:
-        1. SOS shrinkage: sos_norm pulled toward 0.5 (factor=0.5)
+        1. SOS shrinkage: sos_norm pulled toward anchor (factor=0.5)
         2. Provisional: powerscore_adj = powerscore_core * 0.85
 
         The compound effect should be strictly less than a team with 20 games
@@ -187,6 +190,7 @@ class TestCompoundEffect:
         """
         # This is a formula-level test
         cfg = V53EConfig()
+        anchor = cfg.SOS_SHRINKAGE_ANCHOR
 
         # Simulate two teams with same off/def norms but different gp
         off_norm = 0.8
@@ -195,7 +199,7 @@ class TestCompoundEffect:
 
         # Team A: 5 games
         shrink_a = min(5 / cfg.MIN_GAMES_FOR_TOP_SOS, 1.0)  # 0.5
-        sos_norm_a = 0.5 + shrink_a * (raw_sos_norm - 0.5)  # 0.7
+        sos_norm_a = anchor + shrink_a * (raw_sos_norm - anchor)  # 0.35 + 0.5*0.55 = 0.625
         core_a = cfg.OFF_WEIGHT * off_norm + cfg.DEF_WEIGHT * def_norm + cfg.SOS_WEIGHT * sos_norm_a
         adj_a = core_a * _provisional_multiplier(5, cfg.MIN_GAMES_PROVISIONAL)  # * 0.85
 


### PR DESCRIPTION
Teams with <10 games had their SOS shrunk toward 0.5 (neutral), giving weak-schedule teams a free boost. Now shrinks toward 0.35 (below-average) via configurable SOS_SHRINKAGE_ANCHOR in V53EConfig.

Effect: a 5-game team with raw sos_norm=0.10 now gets 0.225 instead of 0.300 — eliminating the "shrinkage beneficiary" pattern found in U9/U19 cohorts. Teams with 10+ games are completely unaffected.

https://claude.ai/code/session_01RUU6Mb93u5QpmTtKxEdu3P

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

