### PR TITLE
fix: harden rankings engine — 5 audit items

### DIFF
--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -685,14 +685,21 @@ async def main():
                 saved_count = filtered_teams  # Would-be saved count
 
         # Refresh precomputed total game stats used by rankings_view
+        backfill_status = "skipped"
         if not args.dry_run and saved_count > 0:
             with (timing_report.section("backfill_total_game_stats") if timing_report else nullcontext()):
                 try:
                     result = supabase.rpc('backfill_total_game_stats').execute()
                     backfill_count = result.data if result.data else 0
                     console.print(f"[dim]Backfilled total game stats for {backfill_count:,} teams[/dim]")
+                    backfill_status = "complete"
                 except Exception as e:
-                    console.print(f"[yellow]Warning: backfill_total_game_stats failed: {e}[/yellow]")
+                    backfill_status = "failed"
+                    console.print(f"[red]ERROR: backfill_total_game_stats failed: {e}[/red]")
+                    console.print("[red]Run status: PARTIAL — rankings saved but game stats stale[/red]")
+                    # Exit with code 2 to signal partial completion to CI
+                    # Rankings are saved, but downstream views may be stale
+                    sys.exit(2)
         
         # ----------------------------------------------------------------
         #  Summary Banner
@@ -704,7 +711,8 @@ async def main():
             f"• PowerScores out of bounds: [cyan]{out_of_bounds_count}[/cyan]\n"
             f"• Saved to Supabase: [green]{saved_count:,}[/green]\n"
             f"• Dry run mode: [yellow]{args.dry_run}[/yellow]\n"
-            f"• ML Layer: [yellow]{args.ml}[/yellow]"
+            f"• ML Layer: [yellow]{args.ml}[/yellow]\n"
+            f"• Backfill status: [{'green' if backfill_status == 'complete' else 'yellow'}]{backfill_status}[/{'green' if backfill_status == 'complete' else 'yellow'}]"
         )
         console.print("\n")
         console.print(Panel(summary_text, title="📊 Run Summary", border_style="bright_blue"))

--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -1244,11 +1244,11 @@ def compute_rankings(
         f"found={cross_age_found}, missing={cross_age_missing}"
     )
 
-    direct = (
-        g_sos.groupby("team_id", group_keys=False).apply(
-            lambda d: _avg_weighted(d, "opp_strength", "w_sos")
-        ).rename("sos_direct").reset_index()
-    )
+    # Vectorized weighted mean — avoids groupby.apply returning scalar (deprecated pandas pattern)
+    _ws = g_sos["opp_strength"] * g_sos["w_sos"]
+    _wsum = g_sos.groupby("team_id")["w_sos"].sum()
+    _vsum = g_sos.assign(_ws=_ws).groupby("team_id")["_ws"].sum()
+    direct = (_vsum / _wsum.replace(0, np.nan)).fillna(0.5).rename("sos_direct").reset_index()
     sos_curr = direct.rename(columns={"sos_direct": "sos"}).copy()
 
     # PageRank-style dampening on initial SOS (Pass 1)
@@ -1293,11 +1293,11 @@ def compute_rankings(
             return cfg.UNRANKED_SOS_BASE
 
         g_sos["opp_sos"] = g_sos["opp_id"].map(get_opponent_sos)
-        trans = (
-            g_sos.groupby("team_id", group_keys=False).apply(
-                lambda d: _avg_weighted(d, "opp_sos", "w_sos")
-            ).rename("sos_trans").reset_index()
-        )
+        # Vectorized weighted mean for transitive SOS (avoids deprecated groupby.apply scalar pattern)
+        _ws_t = g_sos["opp_sos"] * g_sos["w_sos"]
+        _wsum_t = g_sos.groupby("team_id")["w_sos"].sum()
+        _vsum_t = g_sos.assign(_ws_t=_ws_t).groupby("team_id")["_ws_t"].sum()
+        trans = (_vsum_t / _wsum_t.replace(0, np.nan)).fillna(0.5).rename("sos_trans").reset_index()
 
         # Blend direct (opponent OFF/DEF - fixed) and transitive (opponent SOS - iterates)
         # Direct stays fixed to prevent upward drift, transitive propagates schedule info
@@ -1516,6 +1516,25 @@ def compute_rankings(
             )
         else:
             logger.info(f"✅ GP-SOS correlation check passed: {gp_sos_corr:.3f} (within ±0.10)")
+
+        # Per-age-bucket GP-SOS correlation breakdown (ages 15-18 are highest concern)
+        if "age" in team.columns:
+            age_col = pd.to_numeric(team["age"], errors="coerce")
+            for age_val in sorted(age_col.dropna().unique()):
+                age_mask = age_col == age_val
+                age_subset = team.loc[age_mask, ["gp", "sos_norm"]].dropna()
+                if len(age_subset) < 10:
+                    continue
+                age_corr = age_subset.corr().iloc[0, 1]
+                if pd.isna(age_corr):
+                    continue
+                level = "WARNING" if abs(age_corr) > 0.10 else "OK"
+                flag = "⚠️" if level == "WARNING" else "✅"
+                median_gp = age_subset["gp"].median()
+                logger.info(
+                    f"  {flag} Age {int(age_val)}: GP-SOS corr={age_corr:.3f} "
+                    f"(n={len(age_subset)}, median_gp={median_gp:.0f}) [{level}]"
+                )
 
     # -------------------------
     # Layer 6: Performance

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -472,42 +472,6 @@ async def compute_all_cohorts(
         else:
             logger.warning("⚠️ No team IDs found for state metadata fetch - SCF will be disabled")
 
-    # ========== AGE-BUCKET VALIDATION ==========
-    # Reject/quarantine impossible ages before ranking.
-    # Valid ages for youth soccer: 8-19 (U8 through U19).
-    # Ages outside this range indicate data quality issues.
-    VALID_AGE_MIN = 8
-    VALID_AGE_MAX = 19
-    games_df["_age_num"] = pd.to_numeric(games_df["age"], errors="coerce")
-    invalid_age_mask = (
-        games_df["_age_num"].isna()
-        | (games_df["_age_num"] < VALID_AGE_MIN)
-        | (games_df["_age_num"] > VALID_AGE_MAX)
-    )
-    if invalid_age_mask.any():
-        invalid_games = games_df.loc[invalid_age_mask]
-        invalid_age_counts = invalid_games["age"].value_counts().to_dict()
-        logger.warning(
-            f"🚫 Quarantining {invalid_age_mask.sum():,} game rows with invalid ages: {invalid_age_counts}"
-        )
-        # Log sample source rows for each bad age bucket
-        for bad_age, count in sorted(invalid_age_counts.items(), key=lambda x: -x[1]):
-            sample = invalid_games[invalid_games["age"] == bad_age].head(3)
-            for _, row in sample.iterrows():
-                logger.warning(
-                    f"   Age {bad_age}: team={str(row.get('team_id', ''))[:12]}... "
-                    f"opp={str(row.get('opp_id', ''))[:12]}... "
-                    f"date={row.get('game_date', 'N/A')}, "
-                    f"provider={row.get('provider', 'N/A')}"
-                )
-        games_df = games_df.loc[~invalid_age_mask].copy()
-        logger.info(f"✅ After age validation: {len(games_df):,} game rows remain")
-    games_df.drop(columns=["_age_num"], inplace=True, errors="ignore")
-
-    if games_df.empty:
-        logger.error("❌ No valid games remain after age validation")
-        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
-
     # Group by (age, gender) cohorts
     cohorts = list(games_df.groupby(["age", "gender"]))
     logger.info(f"🔄 Two-pass SOS: Processing {len(cohorts)} cohorts")

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -472,6 +472,42 @@ async def compute_all_cohorts(
         else:
             logger.warning("⚠️ No team IDs found for state metadata fetch - SCF will be disabled")
 
+    # ========== AGE-BUCKET VALIDATION ==========
+    # Reject/quarantine ages outside PitchRank's supported range (U10–U18).
+    # Ages outside this range are data quality issues (u0, u3–u7) or
+    # unsupported age groups (u9, u19–u21). Based on production data:
+    #   u0: 3 teams, u3–u7: 54 teams, u8–u9: 2,373 teams, u20–u21: 39 teams
+    VALID_AGE_MIN = 10
+    VALID_AGE_MAX = 18
+    games_df["_age_num"] = pd.to_numeric(games_df["age"], errors="coerce")
+    invalid_age_mask = (
+        games_df["_age_num"].isna()
+        | (games_df["_age_num"] < VALID_AGE_MIN)
+        | (games_df["_age_num"] > VALID_AGE_MAX)
+    )
+    if invalid_age_mask.any():
+        invalid_games = games_df.loc[invalid_age_mask]
+        invalid_age_counts = invalid_games["age"].value_counts().to_dict()
+        logger.warning(
+            f"🚫 Quarantining {invalid_age_mask.sum():,} game rows with ages outside {VALID_AGE_MIN}–{VALID_AGE_MAX}: {invalid_age_counts}"
+        )
+        for bad_age, count in sorted(invalid_age_counts.items(), key=lambda x: -x[1]):
+            sample = invalid_games[invalid_games["age"] == bad_age].head(3)
+            for _, row in sample.iterrows():
+                logger.warning(
+                    f"   Age {bad_age}: team={str(row.get('team_id', ''))[:12]}... "
+                    f"opp={str(row.get('opp_id', ''))[:12]}... "
+                    f"date={row.get('game_date', 'N/A')}, "
+                    f"provider={row.get('provider', 'N/A')}"
+                )
+        games_df = games_df.loc[~invalid_age_mask].copy()
+        logger.info(f"✅ After age validation: {len(games_df):,} game rows remain")
+    games_df.drop(columns=["_age_num"], inplace=True, errors="ignore")
+
+    if games_df.empty:
+        logger.error("❌ No valid games remain after age validation")
+        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
+
     # Group by (age, gender) cohorts
     cohorts = list(games_df.groupby(["age", "gender"]))
     logger.info(f"🔄 Two-pass SOS: Processing {len(cohorts)} cohorts")

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -472,6 +472,42 @@ async def compute_all_cohorts(
         else:
             logger.warning("⚠️ No team IDs found for state metadata fetch - SCF will be disabled")
 
+    # ========== AGE-BUCKET VALIDATION ==========
+    # Reject/quarantine impossible ages before ranking.
+    # Valid ages for youth soccer: 8-19 (U8 through U19).
+    # Ages outside this range indicate data quality issues.
+    VALID_AGE_MIN = 8
+    VALID_AGE_MAX = 19
+    games_df["_age_num"] = pd.to_numeric(games_df["age"], errors="coerce")
+    invalid_age_mask = (
+        games_df["_age_num"].isna()
+        | (games_df["_age_num"] < VALID_AGE_MIN)
+        | (games_df["_age_num"] > VALID_AGE_MAX)
+    )
+    if invalid_age_mask.any():
+        invalid_games = games_df.loc[invalid_age_mask]
+        invalid_age_counts = invalid_games["age"].value_counts().to_dict()
+        logger.warning(
+            f"🚫 Quarantining {invalid_age_mask.sum():,} game rows with invalid ages: {invalid_age_counts}"
+        )
+        # Log sample source rows for each bad age bucket
+        for bad_age, count in sorted(invalid_age_counts.items(), key=lambda x: -x[1]):
+            sample = invalid_games[invalid_games["age"] == bad_age].head(3)
+            for _, row in sample.iterrows():
+                logger.warning(
+                    f"   Age {bad_age}: team={str(row.get('team_id', ''))[:12]}... "
+                    f"opp={str(row.get('opp_id', ''))[:12]}... "
+                    f"date={row.get('game_date', 'N/A')}, "
+                    f"provider={row.get('provider', 'N/A')}"
+                )
+        games_df = games_df.loc[~invalid_age_mask].copy()
+        logger.info(f"✅ After age validation: {len(games_df):,} game rows remain")
+    games_df.drop(columns=["_age_num"], inplace=True, errors="ignore")
+
+    if games_df.empty:
+        logger.error("❌ No valid games remain after age validation")
+        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
+
     # Group by (age, gender) cohorts
     cohorts = list(games_df.groupby(["age", "gender"]))
     logger.info(f"🔄 Two-pass SOS: Processing {len(cohorts)} cohorts")

--- a/src/rankings/ranking_history.py
+++ b/src/rankings/ranking_history.py
@@ -119,7 +119,8 @@ async def save_ranking_snapshot(
         # Batch size: 2000 records per batch (safe for Supabase upsert operations)
         batch_size = 2000
         saved_count = 0
-        
+        failed_batches = []
+
         for i in range(0, total_records, batch_size):
             batch = snapshot_records[i:i + batch_size]
             batch_num = (i // batch_size) + 1
@@ -139,10 +140,35 @@ async def save_ranking_snapshot(
                     logger.info(f"   Batch {batch_num}/{total_batches}: Saved {batch_saved:,} snapshots ({saved_count:,}/{total_records:,} total)")
                 
             except Exception as batch_error:
-                logger.error(f"❌ Error saving batch {batch_num}/{total_batches}: {batch_error}")
-                # Continue with next batch instead of failing completely
-                continue
-        
+                logger.error(f"❌ Error saving snapshot batch {batch_num}/{total_batches}: {batch_error}")
+                failed_batches.append(batch_num)
+                # Retry this batch once with backoff
+                import time
+                time.sleep(2)
+                try:
+                    response = supabase_client.table("ranking_history").upsert(
+                        batch,
+                        on_conflict="team_id,snapshot_date"
+                    ).execute()
+                    batch_saved = len(response.data) if response.data else len(batch)
+                    saved_count += batch_saved
+                    failed_batches.pop()  # Remove from failed list on success
+                    logger.info(f"   Batch {batch_num} succeeded on retry ({batch_saved:,} snapshots)")
+                except Exception as retry_error:
+                    logger.error(f"❌ Batch {batch_num} failed on retry: {retry_error}")
+
+        # Verify saved count matches expected count
+        if failed_batches:
+            raise RuntimeError(
+                f"Snapshot save incomplete: {len(failed_batches)} batch(es) failed "
+                f"(batches {failed_batches}). Saved {saved_count:,}/{total_records:,} records."
+            )
+
+        if saved_count < total_records:
+            logger.warning(
+                f"⚠️ Snapshot count mismatch: saved {saved_count:,} vs expected {total_records:,}"
+            )
+
         logger.info(f"✅ Saved {saved_count:,}/{total_records:,} ranking snapshots")
         return saved_count
 


### PR DESCRIPTION
## Summary

- **Snapshot failure now fatal**: failed batches retry once with backoff, then `raise RuntimeError` if any batch still fails — saved count verified against expected count
- **Backfill failure explicit**: `backfill_total_game_stats` failure exits with code 2 (partial completion) instead of silent warning; status shown in summary banner
- **GP-SOS bias investigation**: per-age-bucket correlation breakdown logged after global check — ages 15–18 flagged if corr > ±0.10, with sample size and median GP for triage
- **Age-bucket validation**: games with ages outside 8–19 quarantined before ranking, with source-row logging (team, opp, date, provider) for impossible ages like 0/3/4/5/6/7/21
- **groupby.apply patched**: scalar-returning `groupby.apply` replaced with vectorized `groupby.sum` division for both direct and transitive SOS — prevents breakage from upcoming pandas deprecation

## Files changed

| File | Change |
|------|--------|
| `src/rankings/ranking_history.py` | Snapshot batch retry + fatal on failure |
| `scripts/calculate_rankings.py` | Backfill exit code 2 + summary status |
| `src/etl/v53e.py` | Per-age GP-SOS correlation + vectorized SOS |
| `src/rankings/calculator.py` | Age-bucket validation gate |

## Test plan

- [ ] Run `python scripts/calculate_rankings.py --ml --dry-run` — verify age validation log output and no regressions
- [ ] Confirm impossible ages (0, 3, 4, 5, 6, 7, 21) are logged with source rows and quarantined
- [ ] Verify per-age GP-SOS correlation breakdown appears in logs for ages 15–18
- [ ] Simulate snapshot batch failure — confirm `RuntimeError` raised instead of silent continue
- [ ] Verify backfill failure returns exit code 2 (not 0)
- [ ] Confirm SOS values unchanged (vectorized groupby produces identical results to apply)

https://claude.ai/code/session_01AmTrUz4wnQ1xwNfiyGx2By