### PR TITLE
fix: replace state_rankings_view with RPC to fix timeout on large states

### DIFF
--- a/frontend/app/api/rankings/state/route.ts
+++ b/frontend/app/api/rankings/state/route.ts
@@ -1,0 +1,83 @@
+import { createServerSupabase } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { normalizeAgeGroup } from "@/lib/utils";
+
+/**
+ * GET /api/rankings/state?state=TX&age=u12&gender=M&limit=1000&offset=0
+ *
+ * Returns state rankings for a specific (state, age, gender) cohort.
+ * Uses the get_state_rankings RPC which filters BEFORE computing ROW_NUMBER(),
+ * avoiding the timeout that state_rankings_view causes on large states.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const state = searchParams.get("state");
+  const ageParam = searchParams.get("age");
+  const gender = searchParams.get("gender");
+  const limit = parseInt(searchParams.get("limit") || "1000", 10);
+  const offset = parseInt(searchParams.get("offset") || "0", 10);
+
+  // Validate required params
+  if (!state || !ageParam || !gender) {
+    return NextResponse.json(
+      { error: "Missing required parameters: state, age, gender" },
+      { status: 400 }
+    );
+  }
+
+  // Normalize age group (e.g., "u12" -> 12)
+  const normalizedAge = normalizeAgeGroup(ageParam);
+  if (normalizedAge === null) {
+    return NextResponse.json(
+      { error: `Invalid age group: ${ageParam}` },
+      { status: 400 }
+    );
+  }
+
+  // Validate limit/offset
+  if (isNaN(limit) || limit < 1 || limit > 5000) {
+    return NextResponse.json(
+      { error: "limit must be between 1 and 5000" },
+      { status: 400 }
+    );
+  }
+  if (isNaN(offset) || offset < 0) {
+    return NextResponse.json(
+      { error: "offset must be >= 0" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const supabase = await createServerSupabase();
+
+    const { data, error } = await supabase.rpc("get_state_rankings", {
+      p_state: state.toUpperCase(),
+      p_age: String(normalizedAge),
+      p_gender: gender,
+      p_limit: limit,
+      p_offset: offset,
+    });
+
+    if (error) {
+      console.error("[API /rankings/state] RPC error:", error.message);
+      return NextResponse.json(
+        { error: "Failed to fetch state rankings" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data || [], {
+      headers: {
+        "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300",
+      },
+    });
+  } catch (err) {
+    console.error("[API /rankings/state] Unexpected error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/hooks/useRankings.ts
+++ b/frontend/hooks/useRankings.ts
@@ -5,6 +5,113 @@ import { apiTimer } from '@/lib/performance';
 import type { RankingRow } from '@/types/RankingRow';
 
 /**
+ * Fetch state rankings via the /api/rankings/state route, which uses the
+ * get_state_rankings RPC (filters before ROW_NUMBER — no timeout).
+ */
+async function fetchStateRankings(
+  region: string,
+  ageGroup: string | undefined,
+  gender: 'M' | 'F' | 'B' | 'G' | null | undefined
+): Promise<RankingRow[]> {
+  const BATCH_SIZE = 1000;
+  const allResults: RankingRow[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  const normalizedAge = ageGroup ? normalizeAgeGroup(ageGroup) : null;
+
+  while (hasMore) {
+    const params = new URLSearchParams({
+      state: region,
+      ...(normalizedAge !== null && { age: String(normalizedAge) }),
+      ...(gender && { gender }),
+      limit: String(BATCH_SIZE),
+      offset: String(offset),
+    });
+
+    const res = await fetch(`/api/rankings/state?${params.toString()}`);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      console.error('[useRankings] State rankings API error:', body.error || res.statusText);
+      throw new Error(body.error || `State rankings request failed: ${res.status}`);
+    }
+
+    const data: RankingRow[] = await res.json();
+
+    if (!data || data.length === 0) {
+      hasMore = false;
+    } else {
+      allResults.push(...data);
+      if (data.length < BATCH_SIZE) {
+        hasMore = false;
+      } else {
+        offset += BATCH_SIZE;
+      }
+    }
+  }
+
+  return allResults;
+}
+
+/**
+ * Fetch national rankings directly from Supabase rankings_view.
+ */
+async function fetchNationalRankings(
+  ageGroup: string | undefined,
+  gender: 'M' | 'F' | 'B' | 'G' | null | undefined
+): Promise<RankingRow[]> {
+  const BATCH_SIZE = 1000;
+  const allResults: RankingRow[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  let normalizedAge: number | null = null;
+  if (ageGroup) {
+    normalizedAge = normalizeAgeGroup(ageGroup);
+  }
+
+  while (hasMore) {
+    let query = supabase
+      .from('rankings_view')
+      .select('*')
+      .in('status', ['Active', 'Not Enough Ranked Games']);
+
+    if (normalizedAge !== null) {
+      query = query.eq('age', normalizedAge);
+    }
+
+    if (gender) {
+      query = query.eq('gender', gender);
+    }
+
+    query = query
+      .order('power_score_final', { ascending: false })
+      .range(offset, offset + BATCH_SIZE - 1);
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('[useRankings] Error fetching national rankings:', error.message);
+      throw error;
+    }
+
+    if (!data || data.length === 0) {
+      hasMore = false;
+    } else {
+      allResults.push(...(data as RankingRow[]));
+      if (data.length < BATCH_SIZE) {
+        hasMore = false;
+      } else {
+        offset += BATCH_SIZE;
+      }
+    }
+  }
+
+  return allResults;
+}
+
+/**
  * Get rankings filtered by region, age group, and gender
  * @param region - State code (2 letters) or null/undefined for national rankings
  * @param ageGroup - Age group filter (e.g., 'u10', 'u11') - will be normalized to integer
@@ -20,61 +127,10 @@ export function useRankings(
     queryKey: ['rankings', region, ageGroup, gender],
     enabled: true,
     queryFn: () => apiTimer('rankings:list', async () => {
-      const BATCH_SIZE = 1000;
-      const allResults: RankingRow[] = [];
-      let offset = 0;
-      let hasMore = true;
-
-      const table = region ? 'state_rankings_view' : 'rankings_view';
-      const normalizedRegion = region?.toUpperCase();
-      let normalizedAge: number | null = null;
-
-      if (ageGroup) {
-        normalizedAge = normalizeAgeGroup(ageGroup);
+      if (region) {
+        return fetchStateRankings(region, ageGroup, gender);
       }
-
-      while (hasMore) {
-        let query = supabase
-          .from(table)
-          .select('*')
-          .in('status', ['Active', 'Not Enough Ranked Games']);
-
-        if (region) {
-          query = query.eq('state', normalizedRegion);
-        }
-
-        if (normalizedAge !== null) {
-          query = query.eq('age', normalizedAge);
-        }
-
-        if (gender) {
-          query = query.eq('gender', gender);
-        }
-
-        query = query
-          .order('power_score_final', { ascending: false })
-          .range(offset, offset + BATCH_SIZE - 1);
-
-        const { data, error } = await query;
-
-        if (error) {
-          console.error(`[useRankings] Error fetching ${region ? 'state' : 'national'} rankings:`, error.message);
-          throw error;
-        }
-
-        if (!data || data.length === 0) {
-          hasMore = false;
-        } else {
-          allResults.push(...(data as RankingRow[]));
-          if (data.length < BATCH_SIZE) {
-            hasMore = false;
-          } else {
-            offset += BATCH_SIZE;
-          }
-        }
-      }
-
-      return allResults;
+      return fetchNationalRankings(ageGroup, gender);
     }, { region, ageGroup, gender }),
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -36,20 +36,52 @@ export const api = {
     let offset = 0;
     let hasMore = true;
 
-    const table = region ? 'state_rankings_view' : 'rankings_view';
-    const normalizedRegion = region?.toUpperCase();
     let normalizedAge: number | null = null;
-
     if (ageGroup) {
       normalizedAge = normalizeAgeGroup(ageGroup);
     }
 
     const fetchLimit = options?.limit;
 
+    // State rankings: use get_state_rankings RPC (filters before ROW_NUMBER — no timeout)
+    if (region) {
+      while (hasMore) {
+        const batchSize = fetchLimit ? Math.min(fetchLimit - allResults.length, BATCH_SIZE) : BATCH_SIZE;
+
+        const { data, error } = await supabase.rpc('get_state_rankings', {
+          p_state: region.toUpperCase(),
+          p_age: normalizedAge !== null ? String(normalizedAge) : '',
+          p_gender: gender || '',
+          p_limit: batchSize,
+          p_offset: offset,
+        });
+
+        if (error) {
+          console.error('Error fetching state rankings via RPC:', error);
+          throw error;
+        }
+
+        if (!data || data.length === 0) {
+          hasMore = false;
+        } else {
+          allResults.push(...(data as RankingWithTeam[]));
+          if (data.length < batchSize) {
+            hasMore = false;
+          } else if (fetchLimit && allResults.length >= fetchLimit) {
+            hasMore = false;
+          } else {
+            offset += batchSize;
+          }
+        }
+      }
+      return allResults;
+    }
+
+    // National rankings: use rankings_view directly (no ROW_NUMBER — fast)
     while (hasMore) {
       const batchSize = fetchLimit ? Math.min(fetchLimit - allResults.length, BATCH_SIZE) : BATCH_SIZE;
 
-      let query = supabase.from(table).select('*')
+      let query = supabase.from('rankings_view').select('*')
         .in('status', ['Active', 'Not Enough Ranked Games']);
 
       if (normalizedAge !== null) {
@@ -60,10 +92,6 @@ export const api = {
         query = query.eq('gender', gender);
       }
 
-      if (region) {
-        query = query.eq('state', normalizedRegion);
-      }
-
       query = query
         .order('power_score_final', { ascending: false })
         .range(offset, offset + batchSize - 1);
@@ -71,7 +99,7 @@ export const api = {
       const { data, error } = await query;
 
       if (error) {
-        console.error(`Error fetching rankings from ${table}:`, error);
+        console.error('Error fetching rankings from rankings_view:', error);
         throw error;
       }
 
@@ -100,15 +128,28 @@ export const api = {
     ageGroup?: string,
     gender?: 'M' | 'F' | 'B' | 'G' | null
   ): Promise<number> {
-    const table = region ? 'state_rankings_view' : 'rankings_view';
-    const normalizedRegion = region?.toUpperCase();
     let normalizedAge: number | null = null;
-
     if (ageGroup) {
       normalizedAge = normalizeAgeGroup(ageGroup);
     }
 
-    let query = supabase.from(table).select('*', { count: 'exact', head: true })
+    // State rankings: use get_state_rankings_count RPC (avoids state_rankings_view timeout)
+    if (region) {
+      const { data, error } = await supabase.rpc('get_state_rankings_count', {
+        p_state: region.toUpperCase(),
+        p_age: normalizedAge !== null ? String(normalizedAge) : '',
+        p_gender: gender || '',
+      });
+
+      if (error) {
+        console.error('Error fetching state rankings count via RPC:', error);
+        return 0;
+      }
+      return (data as number) ?? 0;
+    }
+
+    // National rankings: use rankings_view directly
+    let query = supabase.from('rankings_view').select('*', { count: 'exact', head: true })
       .in('status', ['Active', 'Not Enough Ranked Games']);
 
     if (normalizedAge !== null) {
@@ -117,14 +158,11 @@ export const api = {
     if (gender) {
       query = query.eq('gender', gender);
     }
-    if (region) {
-      query = query.eq('state', normalizedRegion);
-    }
 
     const { count, error } = await query;
 
     if (error) {
-      console.error(`Error fetching rankings count from ${table}:`, error);
+      console.error('Error fetching rankings count from rankings_view:', error);
       return 0;
     }
     return count ?? 0;

--- a/supabase/migrations/20260324000000_add_get_state_rankings_rpc.sql
+++ b/supabase/migrations/20260324000000_add_get_state_rankings_rpc.sql
@@ -1,0 +1,210 @@
+-- RPC function to return state rankings for a specific (state, age, gender) cohort.
+-- This replaces querying state_rankings_view which times out on large states (TX, CA, NY, WA)
+-- because its ROW_NUMBER() window function scans ALL rows across ALL states before
+-- PostgREST filters are applied.
+--
+-- This RPC filters FIRST to the specific cohort, then computes ROW_NUMBER() only
+-- on that small set (typically <500 rows), making it fast and reliable.
+
+-- =====================================================
+-- Function 1: get_state_rankings — paginated state rankings list
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_state_rankings(
+    p_state TEXT,
+    p_age TEXT,
+    p_gender TEXT,
+    p_limit INT DEFAULT 1000,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    team_id_master UUID,
+    team_name TEXT,
+    club_name TEXT,
+    state TEXT,
+    age INT,
+    gender TEXT,
+    games_played INT,
+    wins INT,
+    losses INT,
+    draws INT,
+    total_games_played INT,
+    total_wins INT,
+    total_losses INT,
+    total_draws INT,
+    win_percentage NUMERIC,
+    power_score_final FLOAT8,
+    sos_norm FLOAT8,
+    sos_norm_state FLOAT8,
+    offense_norm FLOAT8,
+    defense_norm FLOAT8,
+    perf_centered FLOAT8,
+    rank_in_cohort_final INT,
+    rank_in_state_final BIGINT,
+    sos_rank_national INT,
+    sos_rank_state INT,
+    rank_change_7d INT,
+    rank_change_30d INT,
+    rank_change_state_7d INT,
+    rank_change_state_30d INT,
+    status TEXT,
+    last_game TIMESTAMPTZ,
+    last_calculated TIMESTAMPTZ
+) LANGUAGE sql STABLE AS $$
+    WITH
+    -- Normalize gender parameter to rankings_full format
+    gender_norm AS (
+        SELECT CASE
+            WHEN p_gender IN ('M', 'B') THEN 'Male'
+            WHEN p_gender IN ('F', 'G') THEN 'Female'
+            ELSE p_gender
+        END AS gender_val
+    ),
+    -- Filter to the specific cohort first (fast — uses indexes)
+    cohort AS (
+        SELECT
+            t.team_id_master,
+            t.team_name,
+            t.club_name,
+            rf.state_code,
+            rf.age_group,
+            rf.gender AS raw_gender,
+            COALESCE(rf.games_played, cr.games_played) AS games_played,
+            COALESCE(rf.wins, cr.wins) AS wins,
+            COALESCE(rf.losses, cr.losses) AS losses,
+            COALESCE(rf.draws, cr.draws) AS draws,
+            COALESCE(rf.total_games_played, 0) AS total_games_played,
+            COALESCE(rf.total_wins, 0) AS total_wins,
+            COALESCE(rf.total_losses, 0) AS total_losses,
+            COALESCE(rf.total_draws, 0) AS total_draws,
+            rf.power_score_final,
+            rf.sos_norm,
+            rf.sos_norm_state,
+            rf.off_norm,
+            rf.def_norm,
+            rf.perf_centered,
+            COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS rank_in_cohort_final,
+            rf.sos_rank_national,
+            rf.sos_rank_state,
+            rf.rank_change_7d,
+            rf.rank_change_30d,
+            rf.rank_change_state_7d,
+            rf.rank_change_state_30d,
+            rf.status,
+            rf.last_game,
+            rf.last_calculated
+        FROM teams t
+        JOIN rankings_full rf ON t.team_id_master = rf.team_id
+        LEFT JOIN current_rankings cr ON t.team_id_master = cr.team_id
+        CROSS JOIN gender_norm gn
+        WHERE rf.state_code = UPPER(p_state)
+          AND rf.age_group = p_age
+          AND rf.gender = gn.gender_val
+          AND rf.status IN ('Active', 'Not Enough Ranked Games')
+          AND t.is_deprecated IS NOT TRUE
+          AND rf.power_score_final IS NOT NULL
+    ),
+    -- Compute state rank ONLY for Active teams within this cohort
+    active_ranked AS (
+        SELECT
+            c.team_id_master,
+            ROW_NUMBER() OVER (ORDER BY c.power_score_final DESC) AS rank_in_state
+        FROM cohort c
+        WHERE c.status = 'Active'
+    )
+    SELECT
+        c.team_id_master,
+        c.team_name,
+        c.club_name,
+        c.state_code AS state,
+        c.age_group::INT AS age,
+        CASE
+            WHEN c.raw_gender = 'Male' THEN 'M'
+            WHEN c.raw_gender = 'Female' THEN 'F'
+            WHEN c.raw_gender = 'Boys' THEN 'M'
+            WHEN c.raw_gender = 'Girls' THEN 'F'
+            WHEN c.raw_gender = 'M' THEN 'M'
+            WHEN c.raw_gender = 'F' THEN 'F'
+            ELSE c.raw_gender
+        END AS gender,
+        c.games_played,
+        c.wins,
+        c.losses,
+        c.draws,
+        c.total_games_played,
+        c.total_wins,
+        c.total_losses,
+        c.total_draws,
+        CASE
+            WHEN c.total_games_played > 0
+            THEN ((c.total_wins::NUMERIC + c.total_draws::NUMERIC * 0.5)
+                  / c.total_games_played::NUMERIC) * 100
+            ELSE NULL
+        END AS win_percentage,
+        c.power_score_final,
+        c.sos_norm,
+        c.sos_norm_state,
+        c.off_norm AS offense_norm,
+        c.def_norm AS defense_norm,
+        c.perf_centered,
+        c.rank_in_cohort_final,
+        ar.rank_in_state AS rank_in_state_final,
+        c.sos_rank_national,
+        c.sos_rank_state,
+        c.rank_change_7d,
+        c.rank_change_30d,
+        c.rank_change_state_7d,
+        c.rank_change_state_30d,
+        c.status,
+        c.last_game,
+        c.last_calculated
+    FROM cohort c
+    LEFT JOIN active_ranked ar ON c.team_id_master = ar.team_id_master
+    ORDER BY c.power_score_final DESC
+    LIMIT p_limit
+    OFFSET p_offset;
+$$;
+
+COMMENT ON FUNCTION get_state_rankings IS
+  'Fast state rankings RPC. Filters to (state, age, gender) cohort FIRST, '
+  'then computes ROW_NUMBER() only on the filtered set. Replaces querying '
+  'state_rankings_view which times out on large states due to unscoped window function. '
+  'Returns RankingRow-compatible shape with pagination support.';
+
+-- =====================================================
+-- Function 2: get_state_rankings_count — fast count
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_state_rankings_count(
+    p_state TEXT,
+    p_age TEXT,
+    p_gender TEXT
+)
+RETURNS BIGINT LANGUAGE sql STABLE AS $$
+    SELECT COUNT(*)
+    FROM rankings_full rf
+    JOIN teams t ON t.team_id_master = rf.team_id
+    WHERE rf.state_code = UPPER(p_state)
+      AND rf.age_group = p_age
+      AND rf.gender = CASE
+          WHEN p_gender IN ('M', 'B') THEN 'Male'
+          WHEN p_gender IN ('F', 'G') THEN 'Female'
+          ELSE p_gender
+      END
+      AND rf.status IN ('Active', 'Not Enough Ranked Games')
+      AND t.is_deprecated IS NOT TRUE
+      AND rf.power_score_final IS NOT NULL;
+$$;
+
+COMMENT ON FUNCTION get_state_rankings_count IS
+  'Fast count of teams in a (state, age, gender) cohort. '
+  'Uses same filters as get_state_rankings but without ROW_NUMBER overhead.';
+
+-- =====================================================
+-- Grant permissions
+-- =====================================================
+
+GRANT EXECUTE ON FUNCTION get_state_rankings(TEXT, TEXT, TEXT, INT, INT) TO anon;
+GRANT EXECUTE ON FUNCTION get_state_rankings(TEXT, TEXT, TEXT, INT, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_state_rankings_count(TEXT, TEXT, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION get_state_rankings_count(TEXT, TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary

- **Root cause**: `state_rankings_view` uses `ROW_NUMBER() OVER (PARTITION BY state, age, gender ...)` which scans ALL rows across ALL states before PostgREST WHERE filters are applied, causing statement timeouts on large cohorts (TX, CA, NY, WA)
- **Fix**: New `get_state_rankings` RPC that filters to the specific (state, age, gender) cohort FIRST, then computes `ROW_NUMBER()` only on the small filtered set (typically <500 rows)
- New `/api/rankings/state` Next.js API route as the server-side entry point for state rankings
- `useRankings` hook and `api.ts` updated to use the new safe path for state queries
- National rankings path unchanged (`rankings_view` has no `ROW_NUMBER`)
- `state_rankings_view` left in place for backward compatibility (watchlist, getTeam fallback)
- `RankingRow` contract fully preserved — no frontend component changes needed

## Test plan

- [ ] Deploy migration to Supabase (`get_state_rankings` + `get_state_rankings_count` RPCs)
- [ ] Verify previously-failing routes no longer timeout:
  - `/rankings/TX/u12/male`
  - `/rankings/CA/u14/female`
  - `/rankings/NY/u12/male`
  - `/rankings/WA/u17/male`
- [ ] Verify small states still work: `/rankings/AL/u12/female`
- [ ] Verify national rankings unchanged: `/rankings/national/u12/male`
- [ ] Confirm no "Connection Error" state on previously failing routes
- [ ] Verify team detail page still shows state rank
- [ ] Verify watchlist still shows state rankings
- [ ] Run Playwright rankings tests

https://claude.ai/code/session_01DsbbRuTRDtmpxznGP7QDcd