### PR TITLE
fix: normalize age_group in state rankings RPCs to handle u12/U12 for…

### DIFF
--- a/supabase/migrations/20260324100000_fix_state_rankings_rpc_age_normalization.sql
+++ b/supabase/migrations/20260324100000_fix_state_rankings_rpc_age_normalization.sql
@@ -1,0 +1,228 @@
+-- Fix age_group normalization in get_state_rankings and get_state_rankings_count RPCs.
+--
+-- Bug: The original RPCs (from PR #518) use exact text equality `rf.age_group = p_age`
+-- but rankings_full.age_group is not stored in a consistent format — values can be
+-- '12', 'u12', 'U12', or other text variants. The frontend sends normalized '12',
+-- so rows stored as 'u12' are silently filtered out, returning zero results.
+--
+-- Fix: Apply the same 3-tier regex normalization used by rankings_view
+-- (see 20260322000000_precompute_total_game_stats.sql lines 114-118).
+
+-- =====================================================
+-- Function 1: get_state_rankings (CREATE OR REPLACE)
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_state_rankings(
+    p_state TEXT,
+    p_age TEXT,
+    p_gender TEXT,
+    p_limit INT DEFAULT 1000,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    team_id_master UUID,
+    team_name TEXT,
+    club_name TEXT,
+    state TEXT,
+    age INT,
+    gender TEXT,
+    games_played INT,
+    wins INT,
+    losses INT,
+    draws INT,
+    total_games_played INT,
+    total_wins INT,
+    total_losses INT,
+    total_draws INT,
+    win_percentage NUMERIC,
+    power_score_final FLOAT8,
+    sos_norm FLOAT8,
+    sos_norm_state FLOAT8,
+    offense_norm FLOAT8,
+    defense_norm FLOAT8,
+    perf_centered FLOAT8,
+    rank_in_cohort_final INT,
+    rank_in_state_final BIGINT,
+    sos_rank_national INT,
+    sos_rank_state INT,
+    rank_change_7d INT,
+    rank_change_30d INT,
+    rank_change_state_7d INT,
+    rank_change_state_30d INT,
+    status TEXT,
+    last_game TIMESTAMPTZ,
+    last_calculated TIMESTAMPTZ
+) LANGUAGE sql STABLE AS $$
+    WITH
+    -- Normalize gender parameter to rankings_full format
+    gender_norm AS (
+        SELECT CASE
+            WHEN p_gender IN ('M', 'B') THEN 'Male'
+            WHEN p_gender IN ('F', 'G') THEN 'Female'
+            ELSE p_gender
+        END AS gender_val
+    ),
+    -- Filter to the specific cohort first (fast — uses indexes)
+    cohort AS (
+        SELECT
+            t.team_id_master,
+            t.team_name,
+            t.club_name,
+            rf.state_code,
+            rf.age_group,
+            rf.gender AS raw_gender,
+            COALESCE(rf.games_played, cr.games_played) AS games_played,
+            COALESCE(rf.wins, cr.wins) AS wins,
+            COALESCE(rf.losses, cr.losses) AS losses,
+            COALESCE(rf.draws, cr.draws) AS draws,
+            COALESCE(rf.total_games_played, 0) AS total_games_played,
+            COALESCE(rf.total_wins, 0) AS total_wins,
+            COALESCE(rf.total_losses, 0) AS total_losses,
+            COALESCE(rf.total_draws, 0) AS total_draws,
+            rf.power_score_final,
+            rf.sos_norm,
+            rf.sos_norm_state,
+            rf.off_norm,
+            rf.def_norm,
+            rf.perf_centered,
+            COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS rank_in_cohort_final,
+            rf.sos_rank_national,
+            rf.sos_rank_state,
+            rf.rank_change_7d,
+            rf.rank_change_30d,
+            rf.rank_change_state_7d,
+            rf.rank_change_state_30d,
+            rf.status,
+            rf.last_game,
+            rf.last_calculated
+        FROM teams t
+        JOIN rankings_full rf ON t.team_id_master = rf.team_id
+        LEFT JOIN current_rankings cr ON t.team_id_master = cr.team_id
+        CROSS JOIN gender_norm gn
+        WHERE rf.state_code = UPPER(p_state)
+          AND (
+              CASE
+                  WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                  WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                  WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                  ELSE NULL
+              END
+          ) = p_age::INTEGER
+          AND rf.gender = gn.gender_val
+          AND rf.status IN ('Active', 'Not Enough Ranked Games')
+          AND t.is_deprecated IS NOT TRUE
+          AND rf.power_score_final IS NOT NULL
+    ),
+    -- Compute state rank ONLY for Active teams within this cohort
+    active_ranked AS (
+        SELECT
+            c.team_id_master,
+            ROW_NUMBER() OVER (ORDER BY c.power_score_final DESC) AS rank_in_state
+        FROM cohort c
+        WHERE c.status = 'Active'
+    )
+    SELECT
+        c.team_id_master,
+        c.team_name,
+        c.club_name,
+        c.state_code AS state,
+        p_age::INT AS age,
+        CASE
+            WHEN c.raw_gender = 'Male' THEN 'M'
+            WHEN c.raw_gender = 'Female' THEN 'F'
+            WHEN c.raw_gender = 'Boys' THEN 'M'
+            WHEN c.raw_gender = 'Girls' THEN 'F'
+            WHEN c.raw_gender = 'M' THEN 'M'
+            WHEN c.raw_gender = 'F' THEN 'F'
+            ELSE c.raw_gender
+        END AS gender,
+        c.games_played,
+        c.wins,
+        c.losses,
+        c.draws,
+        c.total_games_played,
+        c.total_wins,
+        c.total_losses,
+        c.total_draws,
+        CASE
+            WHEN c.total_games_played > 0
+            THEN ((c.total_wins::NUMERIC + c.total_draws::NUMERIC * 0.5)
+                  / c.total_games_played::NUMERIC) * 100
+            ELSE NULL
+        END AS win_percentage,
+        c.power_score_final,
+        c.sos_norm,
+        c.sos_norm_state,
+        c.off_norm AS offense_norm,
+        c.def_norm AS defense_norm,
+        c.perf_centered,
+        c.rank_in_cohort_final,
+        ar.rank_in_state AS rank_in_state_final,
+        c.sos_rank_national,
+        c.sos_rank_state,
+        c.rank_change_7d,
+        c.rank_change_30d,
+        c.rank_change_state_7d,
+        c.rank_change_state_30d,
+        c.status,
+        c.last_game,
+        c.last_calculated
+    FROM cohort c
+    LEFT JOIN active_ranked ar ON c.team_id_master = ar.team_id_master
+    ORDER BY c.power_score_final DESC
+    LIMIT p_limit
+    OFFSET p_offset;
+$$;
+
+COMMENT ON FUNCTION get_state_rankings IS
+  'Fast state rankings RPC. Filters to (state, age, gender) cohort FIRST, '
+  'then computes ROW_NUMBER() only on the filtered set. Replaces querying '
+  'state_rankings_view which times out on large states due to unscoped window function. '
+  'Returns RankingRow-compatible shape with pagination support. '
+  'Age normalization handles 12, u12, U12 formats via regex (matches rankings_view logic).';
+
+-- =====================================================
+-- Function 2: get_state_rankings_count (CREATE OR REPLACE)
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_state_rankings_count(
+    p_state TEXT,
+    p_age TEXT,
+    p_gender TEXT
+)
+RETURNS BIGINT LANGUAGE sql STABLE AS $$
+    SELECT COUNT(*)
+    FROM rankings_full rf
+    JOIN teams t ON t.team_id_master = rf.team_id
+    WHERE rf.state_code = UPPER(p_state)
+      AND (
+          CASE
+              WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+              WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+              WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+              ELSE NULL
+          END
+      ) = p_age::INTEGER
+      AND rf.gender = CASE
+          WHEN p_gender IN ('M', 'B') THEN 'Male'
+          WHEN p_gender IN ('F', 'G') THEN 'Female'
+          ELSE p_gender
+      END
+      AND rf.status IN ('Active', 'Not Enough Ranked Games')
+      AND t.is_deprecated IS NOT TRUE
+      AND rf.power_score_final IS NOT NULL;
+$$;
+
+COMMENT ON FUNCTION get_state_rankings_count IS
+  'Fast count of teams in a (state, age, gender) cohort. '
+  'Uses same filters as get_state_rankings but without ROW_NUMBER overhead. '
+  'Age normalization handles 12, u12, U12 formats via regex (matches rankings_view logic).';
+
+-- =====================================================
+-- Grant permissions
+-- =====================================================
+
+GRANT EXECUTE ON FUNCTION get_state_rankings(TEXT, TEXT, TEXT, INT, INT) TO anon;
+GRANT EXECUTE ON FUNCTION get_state_rankings(TEXT, TEXT, TEXT, INT, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_state_rankings_count(TEXT, TEXT, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION get_state_rankings_count(TEXT, TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
…mats

The get_state_rankings and get_state_rankings_count RPCs used exact text equality (rf.age_group = p_age) but rankings_full.age_group is not stored in a consistent format — values can be '12', 'u12', 'U12', etc. The frontend sends normalized '12', so rows stored as 'u12' were silently filtered out, returning zero results ("No teams available").

Apply the same 3-tier regex normalization used by rankings_view:
- '^[0-9]+$' -> direct cast
- '^[uU][0-9]+$' -> strip prefix, cast
- '[0-9]+' -> extract digits, cast

Also fix the SELECT output to use p_age::INT instead of c.age_group::INT which would fail on non-numeric age_group values.

https://claude.ai/code/session_01DsbbRuTRDtmpxznGP7QDcd

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

