### PR TITLE
fix: resolve Playwright test failures and improve suite reliability

### DIFF
--- a/frontend/app/api/teams/search/route.ts
+++ b/frontend/app/api/teams/search/route.ts
@@ -27,8 +27,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ teams: [] });
     }
 
-    // Sanitize query: strip PostgREST filter-injection characters
-    const sanitizedQuery = query.replace(/[%_(),.*\\]/g, '');
+    // Sanitize query: whitelist alphanumeric, spaces, hyphens, apostrophes
+    const sanitizedQuery = query
+      .replace(/[^a-zA-Z0-9\s\-']/g, '')
+      .replace(/'/g, "''")  // Escape apostrophes for PostgREST
+      .trim();
     if (sanitizedQuery.length < 2) {
       return NextResponse.json({ teams: [] });
     }
@@ -57,7 +60,13 @@ export async function GET(request: NextRequest) {
     const { data: teams, error } = await teamsQuery;
 
     if (error) {
-      console.error('[teams/search] Error:', error);
+      console.error('[teams/search] Supabase query error:', {
+        message: error.message,
+        code: error.code,
+        details: error.details,
+        hint: error.hint,
+        query: sanitizedQuery,
+      });
       return NextResponse.json(
         { error: 'Failed to search teams' },
         { status: 500 }

--- a/frontend/app/rankings/layout.tsx
+++ b/frontend/app/rankings/layout.tsx
@@ -10,13 +10,13 @@ const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
  * NOTE: Uses absolute URLs for canonical/OG to avoid Google indexing issues
  */
 export const metadata: Metadata = {
-  title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams | PitchRank',
+  title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams',
   description: 'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from 726,730+ real game results. No fluff, just data.',
   alternates: {
     canonical: `${baseUrl}/rankings`,
   },
   openGraph: {
-    title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams | PitchRank',
+    title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams',
     description: 'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from real game results.',
     url: `${baseUrl}/rankings`,
     siteName: 'PitchRank',

--- a/frontend/e2e/rankings.spec.ts
+++ b/frontend/e2e/rankings.spec.ts
@@ -3,12 +3,12 @@ import { test, expect, type Page } from '@playwright/test';
 const RANKINGS_LOAD_TIMEOUT = 30_000;
 
 // Live rankings pages depend on external API responses that can be transiently slow.
-test.describe.configure({ timeout: 90_000, retries: 1 });
+test.describe.configure({ timeout: 90_000, retries: 2 });
 
 async function waitForRankingsTable(page: Page) {
   let lastError: unknown;
 
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < 3; attempt++) {
     try {
       const tableCard = page.locator('[data-testid="rankings-table-card"]');
       await expect(tableCard).toBeVisible({ timeout: RANKINGS_LOAD_TIMEOUT });
@@ -18,7 +18,8 @@ async function waitForRankingsTable(page: Page) {
       return tableCard;
     } catch (error) {
       lastError = error;
-      if (attempt === 0) {
+      if (attempt < 2) {
+        await page.waitForTimeout(2_000);
         await page.reload({ waitUntil: 'domcontentloaded' });
       }
     }
@@ -102,7 +103,7 @@ test.describe('Rankings Page', () => {
 
   test('page has correct metadata title', async ({ page }) => {
     await page.goto('/rankings');
-    await expect(page).toHaveTitle(/Rankings.*PitchRank|PitchRank.*Rankings/i);
+    await expect(page).toHaveTitle(/Ranks.*PitchRank|Youth Soccer Teams.*PitchRank/i);
   });
 });
 

--- a/frontend/hooks/useRankings.ts
+++ b/frontend/hooks/useRankings.ts
@@ -134,5 +134,7 @@ export function useRankings(
     }, { region, ageGroup, gender }),
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
+    retry: 2,
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
   });
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -41,10 +41,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: /api\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'mobile-chrome',
+      testIgnore: /api\.spec\.ts/,
       use: { ...devices['Pixel 5'] },
     },
     // API tests don't need a browser


### PR DESCRIPTION
## Summary

- **Restrict `api.spec.ts` to `api` project only** — Added `testIgnore: /api\.spec\.ts/` to `chromium` and `mobile-chrome` projects so API tests no longer run redundantly in browser projects
- **Fix doubled `/rankings` title** — Removed `| PitchRank` suffix from `rankings/layout.tsx` metadata since root layout template already appends it, eliminating the `"... | PitchRank | PitchRank"` duplication
- **Harden `/api/teams/search`** — Replaced blocklist sanitization with whitelist approach (`[^a-zA-Z0-9\s\-']`) and added structured error logging to help diagnose intermittent 500s under load
- **Improve rankings test resilience** — Increased `waitForRankingsTable` retries from 2→3 with 2s pause, bumped describe-level retries from 1→2, and added explicit React Query `retry`/`retryDelay` config to `useRankings` hook

## Test plan

- [ ] `npx playwright test --project=api` passes (API tests still run correctly)
- [ ] `npx playwright test --project=chromium --list` shows no `api.spec.ts` tests
- [ ] `npx playwright test e2e/rankings.spec.ts --grep "metadata title" --project=chromium` passes with corrected title
- [ ] Full suite run shows fewer failures than baseline (was 14 failed, 6 flaky)
- [ ] Verify `/rankings` page title in browser is `"See Where Your Team Ranks: 101,000+ Youth Soccer Teams | PitchRank"` (single suffix)

https://claude.ai/code/session_01YbvtcA1DVwh9bHjPibHW3C