### PR TITLE
fix: audit rankings engine — fix residual persistence and reduce log noise

### DIFF
--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -47,7 +47,7 @@ else:
     load_dotenv()
 
 
-async def save_rankings_to_supabase(supabase_client, teams_df, use_rankings_full=True, maintain_backward_compat=True, merge_resolver=None):
+async def save_rankings_to_supabase(supabase_client, teams_df, use_rankings_full=True, maintain_backward_compat=True, merge_resolver=None, verbose=False):
     """Save rankings to rankings_full table (and optionally current_rankings for backward compatibility)
 
     Args:
@@ -144,13 +144,14 @@ async def save_rankings_to_supabase(supabase_client, teams_df, use_rankings_full
                             age_samples[ag] = rec
                         if len(age_samples) >= 5:
                             break
-                    console.print(f"[bold]🔍 DIAG: Verifying power_score_final vs national_power_score in records (pre-upsert):[/bold]")
-                    for ag, rec in sorted(age_samples.items()):
-                        psf = rec.get('power_score_final')
-                        nps = rec.get('national_power_score')
-                        ps_adj = rec.get('powerscore_adj')
-                        match = "⚠️  IDENTICAL" if psf is not None and nps is not None and abs(psf - nps) < 0.001 else "✅ different"
-                        console.print(f"  {ag}: psf={psf}, nps={nps}, ps_adj={ps_adj} → {match}")
+                    if verbose:
+                        console.print(f"[bold]🔍 DIAG: Verifying power_score_final vs national_power_score in records (pre-upsert):[/bold]")
+                        for ag, rec in sorted(age_samples.items()):
+                            psf = rec.get('power_score_final')
+                            nps = rec.get('national_power_score')
+                            ps_adj = rec.get('powerscore_adj')
+                            match = "⚠️  IDENTICAL" if psf is not None and nps is not None and abs(psf - nps) < 0.001 else "✅ different"
+                            console.print(f"  {ag}: psf={psf}, nps={nps}, ps_adj={ps_adj} → {match}")
 
                 # Clean up records: convert numpy types to Python native types
                 for record in records_full:
@@ -388,7 +389,10 @@ async def _save_batch_with_retry(supabase_client, table_name, records, table_nam
             console.print(f"[yellow]Warning: stale row cleanup failed for {table_display}: {e}[/yellow]")
             console.print(f"[yellow]Old rankings for removed teams may persist until next run[/yellow]")
 
-        console.print(f"[green]Saved {total_inserted} rankings to {table_display} table[/green]")
+        if total_inserted > 0:
+            console.print(f"[green]Saved {total_inserted} rankings to {table_display} table[/green]")
+        else:
+            console.print(f"[yellow]⚠️ Saved 0 rankings to {table_display} table — check for errors above[/yellow]")
         return total_inserted
     except Exception as e:
         console.print(f"[red]Error saving rankings to {table_display}: {e}[/red]")
@@ -413,7 +417,12 @@ async def main():
         action='store_true',
         help='Enable performance profiling (prints timing report at the end)'
     )
-    
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose diagnostic output (PowerScore distribution, DIAG blocks)'
+    )
+
     args = parser.parse_args()
     
     # Initialize Supabase client
@@ -577,34 +586,28 @@ async def main():
                 else:
                     console.print(f"  [red]✗ {out_of_bounds_count} PowerScores out of bounds[/red]")
                 
-                # PowerScore Distribution Analysis
-                unique_scores = teams_df[power_col].nunique()
-                duplicate_count = len(teams_df) - unique_scores
-                value_counts = teams_df[power_col].value_counts()
-                
-                console.print(f"\n[bold]PowerScore Distribution:[/bold]")
-                console.print(f"  Unique PowerScores: {unique_scores:,}")
-                console.print(f"  Teams with duplicate scores: {duplicate_count:,}")
-                console.print(f"  Percentage with unique scores: {unique_scores / len(teams_df) * 100:.2f}%")
-                console.print(f"  Mean teams per unique score: {value_counts.mean():.2f}")
-                console.print(f"  Max teams with same score: {value_counts.max()}")
-                
-                if value_counts.max() > 10:
-                    console.print(f"\n  [yellow]Top 5 most common PowerScore values:[/yellow]")
-                    for score, count in value_counts.head(5).items():
-                        console.print(f"    {score:.6f}: {count} teams")
+                # PowerScore Distribution Analysis (verbose only)
+                if args.verbose:
+                    unique_scores = teams_df[power_col].nunique()
+                    duplicate_count = len(teams_df) - unique_scores
+                    value_counts = teams_df[power_col].value_counts()
+                    console.print(f"\n[bold]PowerScore Distribution:[/bold]")
+                    console.print(f"  Unique: {unique_scores:,}, Duplicates: {duplicate_count:,}, Max same score: {value_counts.max()}")
+                    if value_counts.max() > 10:
+                        for score, count in value_counts.head(5).items():
+                            console.print(f"    {score:.6f}: {count} teams")
         elif 'powerscore_adj' in teams_df.columns:
             console.print(f"  Using adjusted PowerScore")
             power_col = 'powerscore_adj'
             rank_col = 'rank_in_cohort'
-            
+
             # Validate PowerScore bounds
             if not teams_df.empty:
                 min_score = teams_df[power_col].min()
                 max_score = teams_df[power_col].max()
                 violations = teams_df[~teams_df[power_col].between(0.0, 1.0, inclusive="both")]
                 out_of_bounds_count = len(violations)
-                
+
                 console.print(f"\n[bold]PowerScore Validation:[/bold]")
                 console.print(f"  Min: {min_score:.6f}")
                 console.print(f"  Max: {max_score:.6f}")
@@ -612,18 +615,14 @@ async def main():
                     console.print(f"  [green]✓ All PowerScores within [0.0, 1.0] bounds[/green]")
                 else:
                     console.print(f"  [red]✗ {out_of_bounds_count} PowerScores out of bounds[/red]")
-                
-                # PowerScore Distribution Analysis
-                unique_scores = teams_df[power_col].nunique()
-                duplicate_count = len(teams_df) - unique_scores
-                value_counts = teams_df[power_col].value_counts()
-                
-                console.print(f"\n[bold]PowerScore Distribution:[/bold]")
-                console.print(f"  Unique PowerScores: {unique_scores:,}")
-                console.print(f"  Teams with duplicate scores: {duplicate_count:,}")
-                console.print(f"  Percentage with unique scores: {unique_scores / len(teams_df) * 100:.2f}%")
-                console.print(f"  Mean teams per unique score: {value_counts.mean():.2f}")
-                console.print(f"  Max teams with same score: {value_counts.max()}")
+
+                # PowerScore Distribution Analysis (verbose only)
+                if args.verbose:
+                    unique_scores = teams_df[power_col].nunique()
+                    duplicate_count = len(teams_df) - unique_scores
+                    value_counts = teams_df[power_col].value_counts()
+                    console.print(f"\n[bold]PowerScore Distribution:[/bold]")
+                    console.print(f"  Unique: {unique_scores:,}, Duplicates: {duplicate_count:,}, Max same score: {value_counts.max()}")
                 
                 if value_counts.max() > 10:
                     console.print(f"\n  [yellow]Top 5 most common PowerScore values:[/yellow]")
@@ -679,7 +678,7 @@ async def main():
         saved_count = 0
         with (timing_report.section("save_rankings") if timing_report else nullcontext()):
             if not args.dry_run:
-                saved_count = await save_rankings_to_supabase(supabase, teams_df, merge_resolver=merge_resolver)
+                saved_count = await save_rankings_to_supabase(supabase, teams_df, merge_resolver=merge_resolver, verbose=getattr(args, 'verbose', False))
             else:
                 console.print("\n[yellow]Dry run - rankings not saved to database[/yellow]")
                 saved_count = filtered_teams  # Would-be saved count

--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -771,6 +771,7 @@ def compute_rankings(
     cfg: Optional[V53EConfig] = None,
     global_strength_map: Optional[Dict[str, float]] = None,
     team_state_map: Optional[Dict[str, str]] = None,
+    pass_label: Optional[str] = None,
 ) -> Dict[str, pd.DataFrame]:
     """
     Returns:
@@ -1151,15 +1152,12 @@ def compute_rankings(
         n_components = team["component_id"].nunique()
         component_sizes = team.groupby("component_id")["team_id"].count()
         if n_components > 1:
+            top5 = sorted(component_sizes.values, reverse=True)[:5]
             logger.info(
-                f"🔗 Connected components detected: {n_components} components. "
-                f"Sizes: {sorted(component_sizes.values, reverse=True)[:10]}"
+                f"🔗 {n_components} connected components (top 5 sizes: {top5})"
             )
         else:
-            logger.info(
-                f"🔗 Game graph is fully connected (1 component, {len(team)} teams). "
-                f"Component-based SOS normalization is a no-op."
-            )
+            logger.debug(f"🔗 Fully connected graph ({len(team)} teams, 1 component)")
     else:
         # Disabled: all teams in one pseudo-component
         team["component_id"] = 0
@@ -1239,8 +1237,9 @@ def compute_rankings(
     g_sos["opp_strength"] = g_sos["opp_id"].map(get_opponent_strength)
 
     # Log cross-age lookup stats
+    _pass_tag = f"[{pass_label}] " if pass_label else ""
     logger.info(
-        f"🔍 Cross-age SOS lookups: global_map_size={len(global_strength_map) if global_strength_map else 0}, "
+        f"🔍 {_pass_tag}Cross-age SOS lookups: global_map_size={len(global_strength_map) if global_strength_map else 0}, "
         f"found={cross_age_found}, missing={cross_age_missing}"
     )
 
@@ -1459,13 +1458,13 @@ def compute_rankings(
                 f"small component(s) (< {min_size} teams)"
             )
 
-    # Log SOS norms by cohort to verify full range
-    logger.info("📊 SOS norms by cohort (should show ~0.0-1.0 range in each):")
+    # Log SOS norms summary (per-cohort detail at DEBUG)
+    logger.info(f"📊 SOS norms: overall min={team['sos_norm'].min():.3f}, max={team['sos_norm'].max():.3f}, mean={team['sos_norm'].mean():.3f}")
     for (age, gender), grp in team.groupby(['age', 'gender']):
         if len(grp) >= 5:
-            logger.info(f"    {age} {gender}: min={grp['sos_norm'].min():.3f}, "
-                       f"max={grp['sos_norm'].max():.3f}, "
-                       f"mean={grp['sos_norm'].mean():.3f}, n={len(grp)}")
+            logger.debug(f"  SOS {age} {gender}: min={grp['sos_norm'].min():.3f}, "
+                        f"max={grp['sos_norm'].max():.3f}, "
+                        f"mean={grp['sos_norm'].mean():.3f}, n={len(grp)}")
 
     # Low sample handling: smooth shrink toward 0.5 for teams with insufficient games
     # This prevents teams with few games from having extreme SOS values (high or low)
@@ -1517,7 +1516,7 @@ def compute_rankings(
         else:
             logger.info(f"✅ GP-SOS correlation check passed: {gp_sos_corr:.3f} (within ±0.10)")
 
-        # Per-age-bucket GP-SOS correlation breakdown (ages 15-18 are highest concern)
+        # Per-age-bucket GP-SOS correlation breakdown (only log warnings at INFO)
         if "age" in team.columns:
             age_col = pd.to_numeric(team["age"], errors="coerce")
             for age_val in sorted(age_col.dropna().unique()):
@@ -1528,13 +1527,17 @@ def compute_rankings(
                 age_corr = age_subset.corr().iloc[0, 1]
                 if pd.isna(age_corr):
                     continue
-                level = "WARNING" if abs(age_corr) > 0.10 else "OK"
-                flag = "⚠️" if level == "WARNING" else "✅"
                 median_gp = age_subset["gp"].median()
-                logger.info(
-                    f"  {flag} Age {int(age_val)}: GP-SOS corr={age_corr:.3f} "
-                    f"(n={len(age_subset)}, median_gp={median_gp:.0f}) [{level}]"
-                )
+                if abs(age_corr) > 0.10:
+                    logger.warning(
+                        f"  ⚠️ Age {int(age_val)}: GP-SOS corr={age_corr:.3f} "
+                        f"(n={len(age_subset)}, median_gp={median_gp:.0f})"
+                    )
+                else:
+                    logger.debug(
+                        f"  Age {int(age_val)}: GP-SOS corr={age_corr:.3f} "
+                        f"(n={len(age_subset)}, median_gp={median_gp:.0f})"
+                    )
 
     # -------------------------
     # Layer 6: Performance
@@ -1723,8 +1726,9 @@ def compute_rankings(
             sos_change = np.abs(team["sos"].values - prev_sos).mean()
             power_change = np.abs(team["powerscore_adj"].values - prev_power).mean()
 
-            logger.info(
-                f"  📊 Power-SOS iteration {power_iter + 1}/{cfg.SOS_POWER_ITERATIONS}: "
+            _iter_log = logger.info if power_iter == cfg.SOS_POWER_ITERATIONS - 1 else logger.debug
+            _iter_log(
+                f"  Power-SOS iter {power_iter + 1}/{cfg.SOS_POWER_ITERATIONS}: "
                 f"sos_change={sos_change:.6f}, power_change={power_change:.6f}, "
                 f"sos_range=[{team['sos'].min():.4f}, {team['sos'].max():.4f}]"
             )
@@ -1768,6 +1772,13 @@ def compute_rankings(
             "Active"
         )
     )
+
+    # Log status distribution summary
+    status_counts = team["status"].value_counts().to_dict()
+    logger.info(f"📊 Team status distribution: {status_counts}")
+    nan_ps = team["powerscore_adj"].isna().sum()
+    if nan_ps > 0:
+        logger.warning(f"⚠️ {nan_ps} teams have NaN powerscore_adj")
 
     # Initialize rank_in_cohort as NULL for all teams
     team["rank_in_cohort"] = None

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import Optional, Dict, Tuple, TYPE_CHECKING
 from contextlib import nullcontext
 from datetime import datetime
 import hashlib
@@ -33,7 +33,7 @@ def _section(timing_report: Optional["TimingReport"], name: str, **metadata):
     return nullcontext()
 
 
-async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame) -> None:
+async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame) -> Tuple[int, int]:
     """
     Persist per-game ML residuals to the games table using batch RPC.
 
@@ -42,9 +42,12 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
     Args:
         supabase_client: Supabase client instance
         game_residuals: DataFrame with columns [game_id, ml_overperformance]
+
+    Returns:
+        Tuple of (total_updated, failed_count)
     """
     if game_residuals.empty:
-        return
+        return (0, 0)
 
     # Use moderate batch size to avoid statement timeouts
     batch_size = 1000
@@ -84,10 +87,14 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
         if (i // batch_size) % 10 == 0 and i > 0:
             logger.info(f"  Progress: {total_updated:,} / {len(game_residuals):,} games updated...")
 
-    if failed_count > 0:
-        logger.warning(f"⚠️ Failed to update {failed_count} games")
+    if failed_count > 0 and total_updated == 0:
+        logger.error(f"❌ Residual persistence failed: 0/{len(game_residuals):,} games updated, {failed_count:,} failed")
+    elif failed_count > 0:
+        logger.warning(f"⚠️ Residual persistence partial: {total_updated:,} updated, {failed_count:,} failed out of {len(game_residuals):,}")
+    else:
+        logger.info(f"✅ Successfully updated {total_updated:,} games with ML residuals")
 
-    logger.info(f"✅ Successfully updated {total_updated:,} games with ML residuals")
+    return (total_updated, failed_count)
 
 
 async def compute_rankings_with_ml(
@@ -105,6 +112,7 @@ async def compute_rankings_with_ml(
     merge_version: Optional[str] = None,  # For cache invalidation when merges change
     team_state_map: Optional[Dict[str, str]] = None,  # For SCF regional bubble detection
     timing_report: Optional["TimingReport"] = None,
+    pass_label: Optional[str] = None,  # "Pass1" or "Pass2" for log disambiguation
 ) -> Dict[str, pd.DataFrame]:
     """
     Runs your deterministic v53E engine, then applies the Supabase-aware ML adjustment.
@@ -199,6 +207,7 @@ async def compute_rankings_with_ml(
                 cfg=v53_cfg,
                 global_strength_map=global_strength_map,
                 team_state_map=team_state_map,  # For SCF regional bubble detection
+                pass_label=pass_label,
             )
         logger.info(f"✅ v53e engine completed: {len(base['teams']):,} teams ranked")
 
@@ -226,30 +235,14 @@ async def compute_rankings_with_ml(
             "games_used": games_used if not getattr(games_used, "empty", True) else pd.DataFrame()
         }
 
-    # Diagnostic: Log PowerScore max before ML layer
+    # Log PowerScore summary before ML layer
     if not teams_base.empty and "powerscore_adj" in teams_base.columns:
-        logger.info("📊 PowerScore max BEFORE ML layer (per age/gender):")
-        ps_max_before = teams_base.groupby(["age", "gender"])["powerscore_adj"].max().round(3)
-        for (age, gender), ps_max in ps_max_before.items():
-            logger.info(f"    {age} {gender}: max_powerscore_adj={ps_max:.3f}")
-
-        # Log team counts per cohort for completeness
-        team_counts = teams_base.groupby(["age", "gender"]).size()
-        logger.info("  Team counts per cohort: %s", team_counts.to_dict())
+        ps_stats = teams_base["powerscore_adj"]
+        logger.info(f"📊 Pre-ML PowerScore: min={ps_stats.min():.3f}, max={ps_stats.max():.3f}, mean={ps_stats.mean():.3f}, n={len(teams_base)}")
 
     # 3) Apply ML predictive adjustment
     logger.info("🤖 Applying ML predictive adjustment layer...")
-
-    # DIAGNOSTIC: Check if required columns for game residuals exist
-    logger.info(f"[DIAG] games_df columns: {list(games_df.columns)}")
-    logger.info(f"[DIAG] games_df has 'id': {'id' in games_df.columns}")
-    logger.info(f"[DIAG] games_df has 'home_team_master_id': {'home_team_master_id' in games_df.columns}")
-    if 'id' in games_df.columns:
-        logger.info(f"[DIAG] Sample 'id' values: {games_df['id'].head(3).tolist()}")
-    if 'home_team_master_id' in games_df.columns:
-        logger.info(f"[DIAG] Sample 'home_team_master_id' values: {games_df['home_team_master_id'].head(3).tolist()}")
-    if 'team_id' in games_df.columns:
-        logger.info(f"[DIAG] Sample 'team_id' values: {games_df['team_id'].head(3).tolist()}")
+    logger.debug(f"games_df: {len(games_df)} rows, has_id={'id' in games_df.columns}, has_home_master={'home_team_master_id' in games_df.columns}")
 
     ml_cfg = layer13_cfg or Layer13Config(
         lookback_days=v53_cfg.WINDOW_DAYS,
@@ -275,30 +268,30 @@ async def compute_rankings_with_ml(
     with _section(timing_report, "persist_game_residuals"):
         if not game_residuals.empty:
             logger.info(f"💾 Persisting {len(game_residuals):,} game residuals to database...")
-            await _persist_game_residuals(supabase_client, game_residuals)
-            logger.info("✅ Game residuals persisted successfully")
+            updated, failed = await _persist_game_residuals(supabase_client, game_residuals)
+            if failed > 0:
+                logger.warning(f"⚠️ Game residuals: {updated:,} persisted, {failed:,} failed")
+            elif updated == 0:
+                logger.warning("⚠️ Game residuals: 0 records persisted despite non-empty input")
+            else:
+                logger.info(f"✅ Game residuals persisted: {updated:,} records")
         else:
-            logger.warning("⚠️ No game residuals to persist - check DEBUG output above to see why extraction failed")
+            logger.warning("⚠️ No game residuals to persist — check extraction logs above")
             logger.warning("   Common causes: missing columns (id, home_team_master_id), empty feats, or filter issues")
 
-    # Diagnostic: Log PowerScore max after ML layer
+    # Log PowerScore summary after ML layer
     if not teams_with_ml.empty and "powerscore_ml" in teams_with_ml.columns:
-        logger.info("📊 PowerScore max AFTER ML layer (per age/gender):")
-        ps_max_after = teams_with_ml.groupby(["age", "gender"])["powerscore_ml"].max().round(3)
-        for (age, gender), ps_max in ps_max_after.items():
-            logger.info(f"    {age} {gender}: max_powerscore_ml={ps_max:.3f}")
+        ps_ml = teams_with_ml["powerscore_ml"]
+        logger.info(f"📊 Post-ML PowerScore: min={ps_ml.min():.3f}, max={ps_ml.max():.3f}, mean={ps_ml.mean():.3f}")
 
-        # Compare before/after to detect flattening
+        # Per-cohort detail at DEBUG
         if "powerscore_adj" in teams_with_ml.columns:
-            logger.info("📈 Anchor scaling preservation check:")
             ps_max_before_ml = teams_with_ml.groupby(["age", "gender"])["powerscore_adj"].max().round(3)
             ps_max_after_ml = teams_with_ml.groupby(["age", "gender"])["powerscore_ml"].max().round(3)
-
             for (age, gender) in ps_max_before_ml.index:
                 before = ps_max_before_ml[(age, gender)]
                 after = ps_max_after_ml.get((age, gender), 0)
-                diff = after - before
-                logger.info(f"    {age} {gender}: before={before:.3f}, after={after:.3f}, diff={diff:+.3f}")
+                logger.debug(f"  {age} {gender}: pre-ML={before:.3f}, post-ML={after:.3f}, diff={after - before:+.3f}")
 
     # Calculate rank changes using historical snapshots (7d and 30d)
     logger.info("📊 Calculating rank changes from historical data...")
@@ -530,6 +523,7 @@ async def compute_all_cohorts(
             global_strength_map=None,  # No global map yet
             merge_version=merge_version,  # For cache invalidation
             team_state_map=team_state_map,  # For SCF regional bubble detection
+            pass_label="Pass1",
         )
         pass1_tasks.append(task)
 
@@ -566,6 +560,7 @@ async def compute_all_cohorts(
             global_strength_map=global_strength_map,  # Now with cross-age strengths
             merge_version=merge_version,  # For cache invalidation
             team_state_map=team_state_map,  # For SCF regional bubble detection
+            pass_label="Pass2",
         )
         pass2_tasks.append(task)
 

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -403,18 +403,20 @@ async def fetch_games_for_rankings(
         dep_rows_before = team_id_strs.isin(deprecated_in_merge).sum()
         logger.info(f"  [MERGE-DIAG] Pre-merge: {dep_rows_before:,} perspective rows have deprecated team_id")
 
-        v53e_df = merge_resolver.resolve_dataframe(v53e_df, ['team_id', 'opp_id'])
+        v53e_df = merge_resolver.resolve_dataframe(v53e_df, ['team_id', 'opp_id', 'home_team_master_id'])
 
-        # DIAGNOSTIC: Verify merge resolution worked
+        # DIAGNOSTIC: Verify merge resolution worked (team_id, opp_id, home_team_master_id)
         team_id_strs_after = v53e_df['team_id'].astype(str)
         dep_rows_after = team_id_strs_after.isin(deprecated_in_merge).sum()
-        if dep_rows_after > 0:
+        home_master_strs_after = v53e_df['home_team_master_id'].astype(str)
+        dep_home_after = home_master_strs_after.isin(deprecated_in_merge).sum()
+        if dep_rows_after > 0 or dep_home_after > 0:
             logger.warning(
-                f"  [MERGE-DIAG] ⚠️ Post-merge: {dep_rows_after:,} rows STILL have deprecated team_id! "
-                f"Merge resolution may be incomplete."
+                f"  [MERGE-DIAG] ⚠️ Post-merge: {dep_rows_after:,} rows with deprecated team_id, "
+                f"{dep_home_after:,} with deprecated home_team_master_id"
             )
         else:
-            logger.info(f"  [MERGE-DIAG] Post-merge: All deprecated team_ids resolved successfully")
+            logger.info(f"  [MERGE-DIAG] Post-merge: All deprecated IDs resolved (team_id, opp_id, home_team_master_id)")
 
         # After merge resolution, team_id/opp_id point to canonical teams but
         # age/gender still reflect the deprecated team's metadata.  Re-map them

--- a/src/rankings/layer13_predictive_adjustment.py
+++ b/src/rankings/layer13_predictive_adjustment.py
@@ -194,17 +194,17 @@ def _extract_game_residuals(feats: pd.DataFrame, games_df: pd.DataFrame, cfg: La
     import logging
     logger = logging.getLogger(__name__)
 
-    logger.info(f"[DEBUG _extract_game_residuals] Input feats: {len(feats)} rows, columns: {list(feats.columns)}")
+    logger.debug(f"_extract_game_residuals: {len(feats)} rows, columns: {list(feats.columns)}")
 
     if feats.empty or 'residual' not in feats.columns:
-        logger.warning("[DEBUG _extract_game_residuals] Feats empty or missing 'residual' column")
+        logger.warning("_extract_game_residuals: feats empty or missing 'residual' column")
         return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
 
     # Check if v53e format has the required fields (id, team_id, home_team_master_id)
     required_cols = {'id', 'team_id', 'home_team_master_id', 'residual'}
     if not required_cols.issubset(feats.columns):
         missing = required_cols - set(feats.columns)
-        logger.warning(f"[DEBUG _extract_game_residuals] ❌ Missing required columns: {missing}")
+        logger.warning(f"_extract_game_residuals: missing required columns: {missing}")
         return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
 
     # Filter to home team perspective only (where team_id == home_team_master_id)
@@ -212,16 +212,18 @@ def _extract_game_residuals(feats: pd.DataFrame, games_df: pd.DataFrame, cfg: La
     feats['team_id_str'] = feats['team_id'].astype(str).str.strip().str.lower()
     feats['home_team_master_id_str'] = feats['home_team_master_id'].astype(str).str.strip().str.lower()
     home_perspective = feats[feats['team_id_str'] == feats['home_team_master_id_str']].copy()
-    logger.info(f"[DEBUG _extract_game_residuals] Home perspective after filter: {len(home_perspective)} rows")
-    
-    # Debug: show why rows might be filtered out
+    logger.debug(f"_extract_game_residuals: home perspective={len(home_perspective)} rows from {len(feats)} total")
+
+    # Warn if home perspective filter eliminates all rows (likely a merge resolution issue)
     if len(home_perspective) == 0 and len(feats) > 0:
-        logger.warning(f"[DEBUG _extract_game_residuals] ⚠️ All rows filtered out! Sample team_id values: {feats['team_id_str'].head(5).tolist()}")
-        logger.warning(f"[DEBUG _extract_game_residuals] Sample home_team_master_id values: {feats['home_team_master_id_str'].head(5).tolist()}")
-        logger.warning(f"[DEBUG _extract_game_residuals] Matching count: {(feats['team_id_str'] == feats['home_team_master_id_str']).sum()}")
-    
+        match_count = (feats['team_id_str'] == feats['home_team_master_id_str']).sum()
+        logger.warning(
+            f"_extract_game_residuals: all {len(feats)} rows filtered out (0 home perspective matches). "
+            f"This likely means home_team_master_id was not resolved through MergeResolver."
+        )
+        logger.debug(f"  Sample team_id: {feats['team_id_str'].head(3).tolist()}, home_master: {feats['home_team_master_id_str'].head(3).tolist()}")
+
     if home_perspective.empty:
-        logger.warning("[DEBUG _extract_game_residuals] Home perspective is empty after filtering")
         return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
 
     # Extract game_id (UUID) and residual
@@ -235,7 +237,7 @@ def _extract_game_residuals(feats: pd.DataFrame, games_df: pd.DataFrame, cfg: La
     # Remove duplicates (shouldn't happen, but safety check)
     result_df = result_df.drop_duplicates(subset=['game_id'], keep='first')
 
-    logger.info(f"[DEBUG _extract_game_residuals] ✅ Extracted {len(result_df)} game residuals")
+    logger.info(f"✅ Extracted {len(result_df):,} game residuals from {len(feats):,} feature rows")
 
     return result_df
 
@@ -437,18 +439,9 @@ async def apply_predictive_adjustment(
     if return_game_residuals:
         import logging
         logger = logging.getLogger(__name__)
-        logger.info("[DEBUG apply_predictive_adjustment] About to extract game residuals...")
-        logger.info(f"[DEBUG apply_predictive_adjustment] feats shape: {feats.shape}, columns: {list(feats.columns)}")
-        logger.info(f"[DEBUG apply_predictive_adjustment] feats has 'residual': {'residual' in feats.columns}")
-        logger.info(f"[DEBUG apply_predictive_adjustment] feats has 'id': {'id' in feats.columns}")
-        logger.info(f"[DEBUG apply_predictive_adjustment] feats has 'team_id': {'team_id' in feats.columns}")
-        logger.info(f"[DEBUG apply_predictive_adjustment] feats has 'home_team_master_id': {'home_team_master_id' in feats.columns}")
-        if not feats.empty and 'residual' in feats.columns:
-            logger.info(f"[DEBUG apply_predictive_adjustment] Residual stats: min={feats['residual'].min():.3f}, max={feats['residual'].max():.3f}, mean={feats['residual'].mean():.3f}")
+        logger.debug(f"Extracting game residuals from feats: {feats.shape}, has_residual={'residual' in feats.columns}")
         game_residuals = _extract_game_residuals(feats, games_df, cfg)
-        logger.info(f"[DEBUG apply_predictive_adjustment] Extracted game_residuals: shape={game_residuals.shape}, empty={game_residuals.empty}")
-        if not game_residuals.empty:
-            logger.info(f"[DEBUG apply_predictive_adjustment] Sample residuals: {game_residuals.head().to_dict()}")
+        logger.debug(f"Game residuals extracted: {game_residuals.shape}, empty={game_residuals.empty}")
         return out, game_residuals
 
     return out
@@ -576,18 +569,15 @@ def _build_features(
         if col in f.columns:
             needed.append(col)
 
-    # Debug logging
     import logging
     logger = logging.getLogger(__name__)
-    logger.info(f"[DEBUG _build_features] Input columns: {list(f.columns)}")
-    logger.info(f"[DEBUG _build_features] Has 'id': {'id' in f.columns}, Has 'home_team_master_id': {'home_team_master_id' in f.columns}")
-    logger.info(f"[_build_features] Needed columns: {needed}")
+    logger.debug(f"_build_features: {len(f)} rows, needed_cols={len(needed)}, has_id={'id' in f.columns}")
 
     # Only keep columns that exist
     needed = [col for col in needed if col in f.columns]
     f = f[needed].dropna(subset=["goal_margin", "team_power", "opp_power"])
 
-    logger.info(f"[DEBUG _build_features] Output columns: {list(f.columns)}, rows: {len(f)}")
+    logger.debug(f"_build_features: {len(f)} rows after dropna")
 
     return f.reset_index(drop=True)
 

--- a/src/rankings/ranking_history.py
+++ b/src/rankings/ranking_history.py
@@ -68,7 +68,11 @@ async def save_ranking_snapshot(
         df['rank_in_state'] = pd.array([pd.NA] * len(df), dtype='Int64')
 
         # Only rank Active teams (8+ games) to match ranking engine behavior
-        active_mask = df['status'] == 'Active' if 'status' in df.columns else pd.Series(True, index=df.index)
+        if 'status' in df.columns:
+            active_mask = df['status'] == 'Active'
+        else:
+            logger.warning("⚠️ 'status' column missing in snapshot — all teams treated as Active for state ranking")
+            active_mask = pd.Series(True, index=df.index)
         if active_mask.any():
             active_ranks = df.loc[active_mask].groupby(['state_code', 'age_group', 'gender'])[score_col].rank(
                 method='min', ascending=False, na_option='bottom'
@@ -236,7 +240,7 @@ async def get_historical_ranks(
                 continue
 
         if not all_records:
-            logger.debug(f"No historical rankings found for {len(team_ids)} teams around {target_date}")
+            logger.info(f"📍 No historical national rankings found for {len(team_ids)} teams around {target_date} ({days_ago}d ago)")
             return {team_id: None for team_id in team_ids}
 
         # Build mapping of team_id -> rank (prefer ML rank, fallback to cohort rank)
@@ -337,7 +341,7 @@ async def get_historical_state_ranks(
                 continue
 
         if not all_records:
-            logger.debug(f"No historical state rankings found for {len(team_ids)} teams around {target_date}")
+            logger.info(f"📍 No historical state rankings found for {len(team_ids)} teams around {target_date} ({days_ago}d ago)")
             return {team_id: None for team_id in team_ids}
 
         # Build mapping of team_id -> state rank
@@ -459,7 +463,11 @@ async def calculate_rank_changes(
 
         # Calculate current rank within state for each cohort — Active teams only
         current_rankings_df['current_state_rank'] = pd.array([pd.NA] * len(current_rankings_df), dtype='Int64')
-        active_mask = df['status'] == 'Active' if 'status' in df.columns else pd.Series(True, index=df.index)
+        if 'status' in df.columns:
+            active_mask = df['status'] == 'Active'
+        else:
+            logger.warning("⚠️ 'status' column missing — all teams treated as Active for state rank changes")
+            active_mask = pd.Series(True, index=df.index)
         if active_mask.any():
             active_ranks = df.loc[active_mask].groupby(['state_code', 'age_group', 'gender'])[score_col].rank(
                 method='min', ascending=False, na_option='bottom'
@@ -521,13 +529,12 @@ async def calculate_rank_changes(
     teams_with_state_7d = current_rankings_df["rank_change_state_7d"].notna().sum()
     teams_with_state_30d = current_rankings_df["rank_change_state_30d"].notna().sum()
 
-    logger.info(f"✅ Rank changes calculated:")
-    logger.info(f"   National:")
-    logger.info(f"   - Teams with 7-day data: {teams_with_7d:,}/{total_teams:,} ({teams_with_7d/total_teams*100:.1f}%)")
-    logger.info(f"   - Teams with 30-day data: {teams_with_30d:,}/{total_teams:,} ({teams_with_30d/total_teams*100:.1f}%)")
-    logger.info(f"   State:")
-    logger.info(f"   - Teams with 7-day data: {teams_with_state_7d:,}/{total_teams:,} ({teams_with_state_7d/total_teams*100:.1f}%)")
-    logger.info(f"   - Teams with 30-day data: {teams_with_state_30d:,}/{total_teams:,} ({teams_with_state_30d/total_teams*100:.1f}%)")
+    logger.info(
+        f"✅ Rank changes: national 7d={teams_with_7d:,}/{total_teams:,} ({teams_with_7d/total_teams*100:.0f}%), "
+        f"30d={teams_with_30d:,}/{total_teams:,} ({teams_with_30d/total_teams*100:.0f}%) | "
+        f"state 7d={teams_with_state_7d:,}/{total_teams:,} ({teams_with_state_7d/total_teams*100:.0f}%), "
+        f"30d={teams_with_state_30d:,}/{total_teams:,} ({teams_with_state_30d/total_teams*100:.0f}%)"
+    )
 
     # Show examples of big movers (only if we have data)
     if teams_with_7d > 0:


### PR DESCRIPTION
## Summary

Deep audit of the rankings engine identified a **root cause bug** where ML game residuals were silently dropped for all merged teams, plus several misleading log patterns.

### Root Cause Fix
- `home_team_master_id` was **not** resolved through `MergeResolver` in `data_adapter.py` (only `team_id` and `opp_id` were). After merge resolution, `team_id` = canonical but `home_team_master_id` = deprecated original. The residual extractor's home-perspective filter (`team_id == home_team_master_id`) then failed for every merged team → empty residuals → false success log.

### Behavioral Fixes
- **Residual persistence** now returns `(updated, failed)` counts — caller logs accurate success/partial/failure status instead of unconditional "✅ persisted successfully"
- **Green-on-zero**: `Saved 0 rankings` no longer shows as green success — displays yellow warning instead

### Observability Improvements
- **Pass labels**: Cross-age SOS logs now prefixed with `[Pass1]`/`[Pass2]` to disambiguate interleaved asyncio output (the `global_map_size=0` entries for 16M/17F/18F were Pass 1 logs, not a bug)
- **Status distribution**: v53e now logs `Active/Inactive/Not Enough Games` team counts after status assignment
- **State rank coverage**: Explicit warning when `status` column missing; historical snapshot not-found upgraded from DEBUG to INFO
- **`--verbose` flag**: PowerScore distribution analysis and DIAG blocks gated behind new CLI flag

### Log Noise Reduction
- 14 `[DEBUG ...]` prefixed lines in layer13 moved to `logger.debug()`
- Per-cohort SOS norms, GP-SOS correlation (OK results), Power-SOS iteration stats → moved to DEBUG
- Connected component sizes capped to top 5
- Pre/post-ML PowerScore logs consolidated from per-cohort to single summary line

### Files Changed (6)
- `src/rankings/data_adapter.py` — Root cause fix (1 line + diagnostic)
- `src/rankings/calculator.py` — Residual return type, pass_label, log consolidation
- `src/rankings/layer13_predictive_adjustment.py` — Debug log cleanup
- `src/rankings/ranking_history.py` — Status validation, coverage metrics
- `src/etl/v53e.py` — Pass label, status summary, log consolidation
- `scripts/calculate_rankings.py` — Green-on-zero, --verbose flag

### Audited and Found Correct (No Fix Needed)
- GP-SOS bias (already fixed with post-percentile shrinkage + ±0.10 guardrail)
- Cross-age map lifecycle (two-pass architecture is sound)
- Component shrinkage logic (small → more pull toward 0.5, correct)
- PageRank NaN propagation (`.fillna(0.5)` runs before dampening)
- asyncio.gather fail-fast behavior (correct, better than silent skip)

## Test plan
- [ ] Run `python scripts/calculate_rankings.py --ml --dry-run` and verify:
  - Pass labels appear on cross-age SOS logs (`[Pass1]`, `[Pass2]`)
  - Status distribution summary logged after v53e
  - No `[DEBUG ...]` prefixed lines at INFO level
  - No false "✅" on zero-record operations
- [ ] Run with `--verbose` to verify distribution analysis still works
- [ ] Verify merged teams' game residuals are now persisted (check `ml_overperformance` column in games table)
- [ ] Grep for regressions: `home_team_master_id` usage in other code paths

https://claude.ai/code/session_013qdYcjfhw7A46Nfkwpa7hR