### PR TITLE
fix: increase statement timeout for backfill_total_game_stats RPC

### DIFF
--- a/supabase/migrations/20260324200000_backfill_game_stats_increase_timeout.sql
+++ b/supabase/migrations/20260324200000_backfill_game_stats_increase_timeout.sql
@@ -1,0 +1,72 @@
+-- Fix statement timeout in backfill_total_game_stats RPC
+-- The bulk UPDATE on ~103K rankings_full rows exceeds Supabase's
+-- default PostgREST statement timeout. Since this function is
+-- SECURITY DEFINER, SET LOCAL applies only within the transaction.
+-- Date: 2026-03-24
+
+CREATE OR REPLACE FUNCTION backfill_total_game_stats()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  updated_count INTEGER;
+BEGIN
+  -- Allow up to 120s for the bulk UPDATE (default PostgREST timeout is 8-30s)
+  SET LOCAL statement_timeout = '120s';
+
+  WITH game_agg AS (
+    SELECT
+      team_id,
+      COUNT(*) AS total_games,
+      SUM(CASE WHEN is_win  THEN 1 ELSE 0 END) AS total_w,
+      SUM(CASE WHEN is_loss THEN 1 ELSE 0 END) AS total_l,
+      SUM(CASE WHEN is_draw THEN 1 ELSE 0 END) AS total_d
+    FROM (
+      -- Home games
+      SELECT
+        g.home_team_master_id AS team_id,
+        g.home_score > g.away_score AS is_win,
+        g.home_score < g.away_score AS is_loss,
+        g.home_score = g.away_score AS is_draw
+      FROM games g
+      WHERE g.home_score IS NOT NULL
+        AND g.away_score IS NOT NULL
+        AND g.is_excluded = FALSE
+
+      UNION ALL
+
+      -- Away games
+      SELECT
+        g.away_team_master_id AS team_id,
+        g.away_score > g.home_score AS is_win,
+        g.away_score < g.home_score AS is_loss,
+        g.away_score = g.home_score AS is_draw
+      FROM games g
+      WHERE g.home_score IS NOT NULL
+        AND g.away_score IS NOT NULL
+        AND g.is_excluded = FALSE
+    ) sub
+    GROUP BY team_id
+  )
+  UPDATE rankings_full rf
+  SET
+    total_games_played = ga.total_games,
+    total_wins         = ga.total_w,
+    total_losses       = ga.total_l,
+    total_draws        = ga.total_d
+  FROM game_agg ga
+  WHERE rf.team_id = ga.team_id;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+COMMENT ON FUNCTION backfill_total_game_stats IS
+  'Bulk-compute total_games_played/wins/losses/draws for every team in rankings_full. '
+  'Does NOT overwrite win_percentage (that stays as the v53e capped-games value). '
+  'rankings_view computes all-games win_percentage inline from the precomputed totals. '
+  'Single scan of games table via UNION ALL. '
+  'Uses SET LOCAL statement_timeout = 120s to avoid PostgREST timeout on bulk UPDATE. '
+  'Called after save_rankings_to_supabase in calculate_rankings.py.';


### PR DESCRIPTION
The bulk UPDATE on ~103K rankings_full rows was exceeding Supabase's default PostgREST statement timeout, causing the ranking workflow to exit with code 2 despite rankings being fully saved.

Adds SET LOCAL statement_timeout = '120s' inside the SECURITY DEFINER function so the timeout applies only within that transaction.

https://claude.ai/code/session_013qdYcjfhw7A46Nfkwpa7hR

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

