### PR TITLE
fix: replace unnest in RPC with plain CASE remap for age 18→19

### DIFF
--- a/supabase/migrations/20260325000000_merge_u18_into_u19_age_remap.sql
+++ b/supabase/migrations/20260325000000_merge_u18_into_u19_age_remap.sql
@@ -350,17 +350,25 @@ LANGUAGE sql STABLE AS $$
         CROSS JOIN gender_norm gn
         WHERE rf.state_code = UPPER(p_state)
           AND (
+              -- Extract numeric age, remap 18→19 (U18 merged into U19), then compare
               CASE
-                  WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
-                  WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
-                  WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
-                  ELSE NULL
+                  WHEN (
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
+                  ) = 18 THEN 19
+                  ELSE
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
               END
-          ) IN (
-              -- Match both 18 and 19 when target is 19 (U18 merged into U19)
-              SELECT CASE WHEN at.target_age = 19 THEN unnest(ARRAY[18, 19]) ELSE at.target_age END
-              FROM age_target at
-          )
+          ) = (SELECT at.target_age FROM age_target at)
           AND rf.gender = gn.gender_val
           AND rf.status IN ('Active', 'Not Enough Ranked Games')
           AND t.is_deprecated IS NOT TRUE
@@ -434,19 +442,25 @@ RETURNS BIGINT LANGUAGE sql STABLE AS $$
     JOIN teams t ON t.team_id_master = rf.team_id
     WHERE rf.state_code = UPPER(p_state)
       AND (
+          -- Extract numeric age, remap 18→19 (U18 merged into U19), then compare
           CASE
-              WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
-              WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
-              WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
-              ELSE NULL
+              WHEN (
+                  CASE
+                      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                      ELSE NULL
+                  END
+              ) = 18 THEN 19
+              ELSE
+                  CASE
+                      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                      ELSE NULL
+                  END
           END
-      ) IN (
-          -- Match both 18 and 19 when target is 19 (U18 merged into U19)
-          CASE WHEN p_age::INTEGER IN (18, 19) THEN 18
-               ELSE p_age::INTEGER END,
-          CASE WHEN p_age::INTEGER IN (18, 19) THEN 19
-               ELSE p_age::INTEGER END
-      )
+      ) = CASE WHEN p_age::INTEGER = 18 THEN 19 ELSE p_age::INTEGER END
       AND rf.gender = CASE
           WHEN p_gender IN ('M', 'B') THEN 'Male'
           WHEN p_gender IN ('F', 'G') THEN 'Female'


### PR DESCRIPTION
PostgreSQL doesn't allow set-returning functions (unnest) inside CASE. Replaced with the same pattern used in rankings_view: extract the age, remap 18→19 via nested CASE, then compare against the target age.

https://claude.ai/code/session_01VX4SdBZGWXpHLhk2S2oLEf

# 📦 PitchRank Pull Request

## 🔍 Overview

Provide a clear summary of the change.  

Example:

- Updated rankings UI to use ML-enhanced PowerScore

- Implemented SOS Index (sos_norm)

- Added formatting utilities and tooltips

- Synced frontend types with backend data contract

---

## ✅ Changes Included

### Frontend

- [ ] Updated all PowerScore displays to use `power_score_final`

- [ ] Updated all SOS displays to use `sos_norm`

- [ ] Implemented `formatPowerScore()` (0–100 scale, 2 decimals)

- [ ] Implemented `formatSOSIndex()` (0–100 scale, 1 decimal)

- [ ] Updated RankingsTable

- [ ] Updated TeamHeader

- [ ] Updated ComparePanel

- [ ] Updated HomeLeaderboard & test page

- [ ] Added tooltips ("PowerScore (ML Adjusted)" and "SOS Index")

- [ ] Updated column labels and sorting logic

### Backend / Shared Types

- [ ] Updated `@pitchrank/types` package

- [ ] Verified schema matches `rankings_view` fields

- [ ] Ensured `power_score_final` and `sos_norm` are present

- [ ] Added or reviewed OpenAPI schema

---

## 🧪 Testing Checklist

- [ ] Rankings tables load correctly for all age/gender/state filters

- [ ] Team detail page shows correct PowerScore & SOS Index

- [ ] Sorting by PowerScore works

- [ ] Sorting by SOS Index works

- [ ] No remaining references to `strength_of_schedule`, `power_score`, or `national_power_score`

- [ ] All numbers scale correctly (0–100)

- [ ] Tooltip text renders correctly on desktop/mobile

---

## 📸 Screenshots (If UI Change)

_Add before/after screenshots here._

---

## 📚 Documentation

- [ ] Data Contract updated (if needed)

- [ ] README updated (if needed)

---

## 🚀 Deployment Notes

_Add anything special devops should know (usually none)._

---

## 📎 Related Issues / Tickets

_Example: Closes #187_

---

## 🤝 Reviewer Notes

Anything the reviewer should pay close attention to.

