### PR TITLE
Extract shared ranking constants, vectorize ML lookups, document MD5

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,8 +1,12 @@
 """PitchRank Configuration Settings - Scalable Version"""
-from pathlib import Path
-from dotenv import load_dotenv
+
 import os
 from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from src.rankings.constants import AGE_TO_ANCHOR
 
 # Load environment variables
 load_dotenv()
@@ -44,217 +48,217 @@ else:
 
 # Providers
 PROVIDERS = {
-    'gotsport': {
-        'code': 'gotsport',
-        'name': 'GotSport',
-        'base_url': 'https://www.gotsport.com',
-        'adapter': 'src.scrapers.gotsport'
+    "gotsport": {
+        "code": "gotsport",
+        "name": "GotSport",
+        "base_url": "https://www.gotsport.com",
+        "adapter": "src.scrapers.gotsport",
     },
-    'tgs': {
-        'code': 'tgs',
-        'name': 'Total Global Sports',
-        'base_url': 'https://www.totalglobalsports.com',
-        'adapter': 'src.scrapers.tgs'
+    "tgs": {
+        "code": "tgs",
+        "name": "Total Global Sports",
+        "base_url": "https://www.totalglobalsports.com",
+        "adapter": "src.scrapers.tgs",
     },
-    'usclub': {
-        'code': 'usclub',
-        'name': 'US Club Soccer',
-        'base_url': 'https://www.usclubsoccer.org',
-        'adapter': 'src.scrapers.usclub'
+    "usclub": {
+        "code": "usclub",
+        "name": "US Club Soccer",
+        "base_url": "https://www.usclubsoccer.org",
+        "adapter": "src.scrapers.usclub",
     },
-    'sincsports': {
-        'code': 'sincsports',
-        'name': 'SincSports',
-        'base_url': 'https://soccer.sincsports.com',
-        'adapter': 'src.scrapers.sincsports'
+    "sincsports": {
+        "code": "sincsports",
+        "name": "SincSports",
+        "base_url": "https://soccer.sincsports.com",
+        "adapter": "src.scrapers.sincsports",
     },
-    'athleteone': {
-        'code': 'athleteone',
-        'name': 'AthleteOne / TGS',
-        'base_url': 'https://api.athleteone.com',
-        'adapter': 'src.scrapers.athleteone'
-    }
+    "athleteone": {
+        "code": "athleteone",
+        "name": "AthleteOne / TGS",
+        "base_url": "https://api.athleteone.com",
+        "adapter": "src.scrapers.athleteone",
+    },
 }
 
 # Age Groups with metadata
-# NOTE: anchor_score values are aligned with v53e.py AGE_TO_ANCHOR mapping
-# These provide linear progression from U10 (0.40) to U19 (1.00)
+# anchor_score derived from AGE_TO_ANCHOR (src/rankings/constants.py) — single source of truth
 # U19 encompasses both birth years 2007 and 2008 (formerly U18+U19)
-AGE_GROUPS = {
-    'u10': {'birth_year': 2016, 'anchor_score': 0.400},
-    'u11': {'birth_year': 2015, 'anchor_score': 0.475},
-    'u12': {'birth_year': 2014, 'anchor_score': 0.550},
-    'u13': {'birth_year': 2013, 'anchor_score': 0.625},
-    'u14': {'birth_year': 2012, 'anchor_score': 0.700},
-    'u15': {'birth_year': 2011, 'anchor_score': 0.775},
-    'u16': {'birth_year': 2010, 'anchor_score': 0.850},
-    'u17': {'birth_year': 2009, 'anchor_score': 0.925},
-    'u19': {'birth_year': 2007, 'anchor_score': 1.000}
+_BIRTH_YEARS = {
+    10: 2016,
+    11: 2015,
+    12: 2014,
+    13: 2013,
+    14: 2012,
+    15: 2011,
+    16: 2010,
+    17: 2009,
+    19: 2007,
 }
+AGE_GROUPS = {f"u{age}": {"birth_year": by, "anchor_score": AGE_TO_ANCHOR[age]} for age, by in _BIRTH_YEARS.items()}
 
 # Ranking Configuration (aligned with v53e V53EConfig)
 RANKING_CONFIG = {
     # Layer 1
-    'window_days': int(os.getenv("RANKING_WINDOW_DAYS", 365)),  # V53EConfig.WINDOW_DAYS
-    'inactive_hide_days': int(os.getenv("INACTIVE_HIDE_DAYS", 365)),  # V53EConfig.INACTIVE_HIDE_DAYS
-    
+    "window_days": int(os.getenv("RANKING_WINDOW_DAYS", 365)),  # V53EConfig.WINDOW_DAYS
+    "inactive_hide_days": int(os.getenv("INACTIVE_HIDE_DAYS", 365)),  # V53EConfig.INACTIVE_HIDE_DAYS
     # Layer 2
-    'max_games': int(os.getenv("MAX_GAMES_PER_TEAM", 30)),  # V53EConfig.MAX_GAMES_FOR_RANK
-    'goal_diff_cap': int(os.getenv("GOAL_DIFF_CAP", 6)),  # V53EConfig.GOAL_DIFF_CAP
-    'outlier_guard_zscore': float(os.getenv("OUTLIER_GUARD_ZSCORE", 2.5)),  # V53EConfig.OUTLIER_GUARD_ZSCORE
-    
+    "max_games": int(os.getenv("MAX_GAMES_PER_TEAM", 30)),  # V53EConfig.MAX_GAMES_FOR_RANK
+    "goal_diff_cap": int(os.getenv("GOAL_DIFF_CAP", 6)),  # V53EConfig.GOAL_DIFF_CAP
+    "outlier_guard_zscore": float(os.getenv("OUTLIER_GUARD_ZSCORE", 2.5)),  # V53EConfig.OUTLIER_GUARD_ZSCORE
     # Layer 3 (recency)
-    'recent_k': int(os.getenv("RECENT_K", 15)),  # V53EConfig.RECENT_K
-    'recent_share': float(os.getenv("RECENT_SHARE", 0.65)),  # V53EConfig.RECENT_SHARE
-    'dampen_tail_start': int(os.getenv("DAMPEN_TAIL_START", 26)),  # V53EConfig.DAMPEN_TAIL_START
-    'dampen_tail_end': int(os.getenv("DAMPEN_TAIL_END", 30)),  # V53EConfig.DAMPEN_TAIL_END
-    'dampen_tail_start_weight': float(os.getenv("DAMPEN_TAIL_START_WEIGHT", 0.8)),  # V53EConfig.DAMPEN_TAIL_START_WEIGHT
-    'dampen_tail_end_weight': float(os.getenv("DAMPEN_TAIL_END_WEIGHT", 0.4)),  # V53EConfig.DAMPEN_TAIL_END_WEIGHT
-    
+    "recent_k": int(os.getenv("RECENT_K", 15)),  # V53EConfig.RECENT_K
+    "recent_share": float(os.getenv("RECENT_SHARE", 0.65)),  # V53EConfig.RECENT_SHARE
+    "dampen_tail_start": int(os.getenv("DAMPEN_TAIL_START", 26)),  # V53EConfig.DAMPEN_TAIL_START
+    "dampen_tail_end": int(os.getenv("DAMPEN_TAIL_END", 30)),  # V53EConfig.DAMPEN_TAIL_END
+    "dampen_tail_start_weight": float(
+        os.getenv("DAMPEN_TAIL_START_WEIGHT", 0.8)
+    ),  # V53EConfig.DAMPEN_TAIL_START_WEIGHT
+    "dampen_tail_end_weight": float(os.getenv("DAMPEN_TAIL_END_WEIGHT", 0.4)),  # V53EConfig.DAMPEN_TAIL_END_WEIGHT
     # Layer 4 (defense ridge)
-    'ridge_ga': float(os.getenv("RIDGE_GA", 0.25)),  # V53EConfig.RIDGE_GA
-    
+    "ridge_ga": float(os.getenv("RIDGE_GA", 0.25)),  # V53EConfig.RIDGE_GA
     # Layer 5 (Adaptive K)
-    'adaptive_k_alpha': float(os.getenv("ADAPTIVE_K_ALPHA", 0.5)),  # V53EConfig.ADAPTIVE_K_ALPHA
-    'adaptive_k_beta': float(os.getenv("ADAPTIVE_K_BETA", 0.6)),  # V53EConfig.ADAPTIVE_K_BETA
-    'team_outlier_guard_zscore': float(os.getenv("TEAM_OUTLIER_GUARD_ZSCORE", 2.5)),  # V53EConfig.TEAM_OUTLIER_GUARD_ZSCORE
-    
+    "adaptive_k_alpha": float(os.getenv("ADAPTIVE_K_ALPHA", 0.5)),  # V53EConfig.ADAPTIVE_K_ALPHA
+    "adaptive_k_beta": float(os.getenv("ADAPTIVE_K_BETA", 0.6)),  # V53EConfig.ADAPTIVE_K_BETA
+    "team_outlier_guard_zscore": float(
+        os.getenv("TEAM_OUTLIER_GUARD_ZSCORE", 2.5)
+    ),  # V53EConfig.TEAM_OUTLIER_GUARD_ZSCORE
     # Layer 6 (Performance)
-    'performance_k': float(os.getenv("PERFORMANCE_K", 0.15)),  # V53EConfig.PERFORMANCE_K (legacy, use perf_* instead)
-    'perf_game_scale': float(os.getenv("PERF_GAME_SCALE", 0.15)),  # V53EConfig.PERF_GAME_SCALE - scales per-game residual
-    'perf_blend_weight': float(os.getenv("PERF_BLEND_WEIGHT", 0.00)),  # V53EConfig.PERF_BLEND_WEIGHT - weight in powerscore (was 0.15, reduced to 0.00 — stat-padding bias fix)
-    'perf_cap': float(os.getenv("PERF_CAP", 0.15)),  # V53EConfig.PERF_CAP - symmetric cap on perf_centered before blending
-    'performance_decay_rate': float(os.getenv("PERFORMANCE_DECAY_RATE", 0.08)),  # V53EConfig.PERFORMANCE_DECAY_RATE
-    'performance_threshold': float(os.getenv("PERFORMANCE_THRESHOLD", 0.5)),  # V53EConfig.PERFORMANCE_THRESHOLD – lowered from 2.0
-    'performance_goal_scale': float(os.getenv("PERFORMANCE_GOAL_SCALE", 5.0)),  # V53EConfig.PERFORMANCE_GOAL_SCALE
-    
+    "performance_k": float(os.getenv("PERFORMANCE_K", 0.15)),  # V53EConfig.PERFORMANCE_K (legacy, use perf_* instead)
+    "perf_game_scale": float(
+        os.getenv("PERF_GAME_SCALE", 0.15)
+    ),  # V53EConfig.PERF_GAME_SCALE - scales per-game residual
+    "perf_blend_weight": float(
+        os.getenv("PERF_BLEND_WEIGHT", 0.00)
+    ),  # V53EConfig.PERF_BLEND_WEIGHT - weight in powerscore (was 0.15, reduced to 0.00 — stat-padding bias fix)
+    "perf_cap": float(
+        os.getenv("PERF_CAP", 0.15)
+    ),  # V53EConfig.PERF_CAP - symmetric cap on perf_centered before blending
+    "performance_decay_rate": float(os.getenv("PERFORMANCE_DECAY_RATE", 0.08)),  # V53EConfig.PERFORMANCE_DECAY_RATE
+    "performance_threshold": float(
+        os.getenv("PERFORMANCE_THRESHOLD", 0.5)
+    ),  # V53EConfig.PERFORMANCE_THRESHOLD – lowered from 2.0
+    "performance_goal_scale": float(os.getenv("PERFORMANCE_GOAL_SCALE", 5.0)),  # V53EConfig.PERFORMANCE_GOAL_SCALE
     # Layer 7 (Bayesian shrink)
-    'shrink_tau': float(os.getenv("SHRINK_TAU", 8.0)),  # V53EConfig.SHRINK_TAU
-    
+    "shrink_tau": float(os.getenv("SHRINK_TAU", 8.0)),  # V53EConfig.SHRINK_TAU
     # Layer 8 (SOS)
-    'unranked_sos_base': float(os.getenv("UNRANKED_SOS_BASE", 0.35)),  # V53EConfig.UNRANKED_SOS_BASE
-    'sos_repeat_cap': int(os.getenv("SOS_REPEAT_CAP", 2)),  # V53EConfig.SOS_REPEAT_CAP (reduced from 4)
-    'sos_iterations': int(os.getenv("SOS_ITERATIONS", 1)),  # V53EConfig.SOS_ITERATIONS (single-pass, no transitive)
-    'sos_transitivity_lambda': float(os.getenv("SOS_TRANSITIVITY_LAMBDA", 0.0)),  # V53EConfig.SOS_TRANSITIVITY_LAMBDA (disabled)
-
+    "unranked_sos_base": float(os.getenv("UNRANKED_SOS_BASE", 0.35)),  # V53EConfig.UNRANKED_SOS_BASE
+    "sos_repeat_cap": int(os.getenv("SOS_REPEAT_CAP", 2)),  # V53EConfig.SOS_REPEAT_CAP (reduced from 4)
+    "sos_iterations": int(os.getenv("SOS_ITERATIONS", 1)),  # V53EConfig.SOS_ITERATIONS (single-pass, no transitive)
+    "sos_transitivity_lambda": float(
+        os.getenv("SOS_TRANSITIVITY_LAMBDA", 0.0)
+    ),  # V53EConfig.SOS_TRANSITIVITY_LAMBDA (disabled)
     # Opponent-adjusted offense/defense (fixes double-counting problem)
-    'opponent_adjust_enabled': os.getenv("OPPONENT_ADJUST_ENABLED", "true").lower() in ("true", "1", "yes"),  # V53EConfig.OPPONENT_ADJUST_ENABLED
-    'opponent_adjust_baseline': float(os.getenv("OPPONENT_ADJUST_BASELINE", 0.5)),  # V53EConfig.OPPONENT_ADJUST_BASELINE
-    'opponent_adjust_clip_min': float(os.getenv("OPPONENT_ADJUST_CLIP_MIN", 0.4)),  # V53EConfig.OPPONENT_ADJUST_CLIP_MIN
-    'opponent_adjust_clip_max': float(os.getenv("OPPONENT_ADJUST_CLIP_MAX", 1.6)),  # V53EConfig.OPPONENT_ADJUST_CLIP_MAX
-
+    "opponent_adjust_enabled": (
+        os.getenv("OPPONENT_ADJUST_ENABLED", "true").lower() in ("true", "1", "yes")
+    ),  # V53EConfig.OPPONENT_ADJUST_ENABLED
+    "opponent_adjust_baseline": float(
+        os.getenv("OPPONENT_ADJUST_BASELINE", 0.5)
+    ),  # V53EConfig.OPPONENT_ADJUST_BASELINE
+    "opponent_adjust_clip_min": float(
+        os.getenv("OPPONENT_ADJUST_CLIP_MIN", 0.4)
+    ),  # V53EConfig.OPPONENT_ADJUST_CLIP_MIN
+    "opponent_adjust_clip_max": float(
+        os.getenv("OPPONENT_ADJUST_CLIP_MAX", 1.6)
+    ),  # V53EConfig.OPPONENT_ADJUST_CLIP_MAX
     # Layer 10 weights (tuned via weight simulator — SOS boosted for schedule-strength emphasis)
-    'off_weight': float(os.getenv("OFF_WEIGHT", 0.20)),  # V53EConfig.OFF_WEIGHT (was 0.25)
-    'def_weight': float(os.getenv("DEF_WEIGHT", 0.20)),  # V53EConfig.DEF_WEIGHT (was 0.25)
-    'sos_weight': float(os.getenv("SOS_WEIGHT", 0.60)),  # V53EConfig.SOS_WEIGHT (was 0.50)
-    
+    "off_weight": float(os.getenv("OFF_WEIGHT", 0.20)),  # V53EConfig.OFF_WEIGHT (was 0.25)
+    "def_weight": float(os.getenv("DEF_WEIGHT", 0.20)),  # V53EConfig.DEF_WEIGHT (was 0.25)
+    "sos_weight": float(os.getenv("SOS_WEIGHT", 0.60)),  # V53EConfig.SOS_WEIGHT (was 0.50)
     # Provisional
-    'min_games_for_ranking': int(os.getenv("MIN_GAMES_FOR_RANKING", 6)),  # V53EConfig.MIN_GAMES_PROVISIONAL
-
+    "min_games_for_ranking": int(os.getenv("MIN_GAMES_FOR_RANKING", 6)),  # V53EConfig.MIN_GAMES_PROVISIONAL
     # Cross-age anchors
-    'anchor_percentile': float(os.getenv("ANCHOR_PERCENTILE", 0.98)),  # V53EConfig.ANCHOR_PERCENTILE
-    
+    "anchor_percentile": float(os.getenv("ANCHOR_PERCENTILE", 0.98)),  # V53EConfig.ANCHOR_PERCENTILE
     # Normalization mode
-    'norm_mode': os.getenv("NORM_MODE", "percentile"),  # V53EConfig.NORM_MODE
-    
+    "norm_mode": os.getenv("NORM_MODE", "percentile"),  # V53EConfig.NORM_MODE
     # Legacy fields (for backward compatibility)
-    'recent_games': 15,
-    'middle_games': 10,
-    'oldest_games': 5,
-    'recent_weight': 0.50,
-    'middle_weight': 0.35,
-    'oldest_weight': 0.15,
-    'default_opponent_strength': 0.35,
-    'win_points': 1.0,
-    'draw_points': 0.35,
-    'loss_points': 0.0,
+    "recent_games": 15,
+    "middle_games": 10,
+    "oldest_games": 5,
+    "recent_weight": 0.50,
+    "middle_weight": 0.35,
+    "oldest_weight": 0.15,
+    "default_opponent_strength": 0.35,
+    "win_points": 1.0,
+    "draw_points": 0.35,
+    "loss_points": 0.0,
 }
 
 # Matching Configuration
 MATCHING_CONFIG = {
-    'fuzzy_threshold': 0.75,
-    'auto_approve_threshold': 0.9,
-    'review_threshold': 0.75,
-    'max_age_diff': 2,
-    'weights': {
-        'team': 0.35,
-        'club': 0.35,
-        'age': 0.10,
-        'location': 0.10
-    },
-    'club_boost_identical': 0.10,
-    'club_min_similarity': 0.8,
-    'club_variant_match_boost': 0.15,
-    'fuzzy_confidence_ceiling': 0.99,
-    'connection_refresh_interval': 1000,
-    'affinity_variant_gate_required': True,
-    'affinity_rcl_strict': True,
-    'affinity_club_similarity_threshold': 0.9,
-    'affinity_debug_match_reasons': False,
+    "fuzzy_threshold": 0.75,
+    "auto_approve_threshold": 0.9,
+    "review_threshold": 0.75,
+    "max_age_diff": 2,
+    "weights": {"team": 0.35, "club": 0.35, "age": 0.10, "location": 0.10},
+    "club_boost_identical": 0.10,
+    "club_min_similarity": 0.8,
+    "club_variant_match_boost": 0.15,
+    "fuzzy_confidence_ceiling": 0.99,
+    "connection_refresh_interval": 1000,
+    "affinity_variant_gate_required": True,
+    "affinity_rcl_strict": True,
+    "affinity_club_similarity_threshold": 0.9,
+    "affinity_debug_match_reasons": False,
 }
 
 # ETL Configuration
-ETL_CONFIG = {
-    'batch_size': 500,
-    'max_retries': 3,
-    'retry_delay': 5,
-    'incremental_days': 7,
-    'validation_enabled': True
-}
+ETL_CONFIG = {"batch_size": 500, "max_retries": 3, "retry_delay": 5, "incremental_days": 7, "validation_enabled": True}
 
 # ML Layer Configuration (Layer 13)
 ML_CONFIG = {
-    'enabled': os.getenv("ML_LAYER_ENABLED", "true").lower() == "true",
-    'alpha': float(os.getenv("ML_ALPHA", 0.08)),  # Blend weight for ML adjustment (tuned via weight simulator: 0.08 optimal)
-    'recency_decay_lambda': float(os.getenv("ML_RECENCY_DECAY_LAMBDA", 0.06)),
-    'min_team_games_for_residual': int(os.getenv("ML_MIN_TEAM_GAMES", 6)),
-    'residual_clip_goals': float(os.getenv("ML_RESIDUAL_CLIP", 3.5)),
-    'norm_mode': os.getenv("ML_NORM_MODE", "percentile"),  # "percentile" or "zscore"
-    'lookback_days': int(os.getenv("ML_LOOKBACK_DAYS", 365)),
-    'xgb_params': {
-        'n_estimators': int(os.getenv("ML_XGB_N_ESTIMATORS", 220)),
-        'max_depth': int(os.getenv("ML_XGB_MAX_DEPTH", 5)),
-        'learning_rate': float(os.getenv("ML_XGB_LEARNING_RATE", 0.08)),
-        'subsample': float(os.getenv("ML_XGB_SUBSAMPLE", 0.9)),
-        'colsample_bytree': float(os.getenv("ML_XGB_COLSAMPLE_BYTREE", 0.9)),
-        'reg_lambda': float(os.getenv("ML_XGB_REG_LAMBDA", 1.0)),
-        'n_jobs': int(os.getenv("ML_XGB_N_JOBS", -1)),
-        'random_state': 42,
+    "enabled": os.getenv("ML_LAYER_ENABLED", "true").lower() == "true",
+    "alpha": float(
+        os.getenv("ML_ALPHA", 0.08)
+    ),  # Blend weight for ML adjustment (tuned via weight simulator: 0.08 optimal)
+    "recency_decay_lambda": float(os.getenv("ML_RECENCY_DECAY_LAMBDA", 0.06)),
+    "min_team_games_for_residual": int(os.getenv("ML_MIN_TEAM_GAMES", 6)),
+    "residual_clip_goals": float(os.getenv("ML_RESIDUAL_CLIP", 3.5)),
+    "norm_mode": os.getenv("ML_NORM_MODE", "percentile"),  # "percentile" or "zscore"
+    "lookback_days": int(os.getenv("ML_LOOKBACK_DAYS", 365)),
+    "xgb_params": {
+        "n_estimators": int(os.getenv("ML_XGB_N_ESTIMATORS", 220)),
+        "max_depth": int(os.getenv("ML_XGB_MAX_DEPTH", 5)),
+        "learning_rate": float(os.getenv("ML_XGB_LEARNING_RATE", 0.08)),
+        "subsample": float(os.getenv("ML_XGB_SUBSAMPLE", 0.9)),
+        "colsample_bytree": float(os.getenv("ML_XGB_COLSAMPLE_BYTREE", 0.9)),
+        "reg_lambda": float(os.getenv("ML_XGB_REG_LAMBDA", 1.0)),
+        "n_jobs": int(os.getenv("ML_XGB_N_JOBS", -1)),
+        "random_state": 42,
     },
-    'rf_params': {
-        'n_estimators': int(os.getenv("ML_RF_N_ESTIMATORS", 240)),
-        'max_depth': int(os.getenv("ML_RF_MAX_DEPTH", 18)),
-        'min_samples_leaf': int(os.getenv("ML_RF_MIN_SAMPLES_LEAF", 2)),
-        'n_jobs': int(os.getenv("ML_RF_N_JOBS", -1)),
-        'random_state': 42,
+    "rf_params": {
+        "n_estimators": int(os.getenv("ML_RF_N_ESTIMATORS", 240)),
+        "max_depth": int(os.getenv("ML_RF_MAX_DEPTH", 18)),
+        "min_samples_leaf": int(os.getenv("ML_RF_MIN_SAMPLES_LEAF", 2)),
+        "n_jobs": int(os.getenv("ML_RF_N_JOBS", -1)),
+        "random_state": 42,
     },
 }
 
 # Data Adapter Configuration (Supabase ↔ v53e mapping)
 DATA_ADAPTER_CONFIG = {
-    'games_table': 'games',
-    'teams_table': 'teams',
-    'column_mappings': {
+    "games_table": "games",
+    "teams_table": "teams",
+    "column_mappings": {
         # Supabase → v53e
-        'game_date': 'date',
-        'home_team_master_id': 'team_id',  # for home perspective
-        'away_team_master_id': 'opp_id',    # for home perspective
-        'home_score': 'gf',
-        'away_score': 'ga',
-        'age_group': 'age',  # converted via age_group_to_age()
-        'gender': 'gender',  # kept as-is
+        "game_date": "date",
+        "home_team_master_id": "team_id",  # for home perspective
+        "away_team_master_id": "opp_id",  # for home perspective
+        "home_score": "gf",
+        "away_score": "ga",
+        "age_group": "age",  # converted via age_group_to_age()
+        "gender": "gender",  # kept as-is
     },
-    'age_group_conversion': {
+    "age_group_conversion": {
         # Maps 'u10' → '10', 'u11' → '11', etc.
-        'enabled': True,
+        "enabled": True,
     },
-    'perspective_based': True,  # Each game appears twice (home/away perspectives)
+    "perspective_based": True,  # Each game appears twice (home/away perspectives)
 }
 
 # Cache Configuration
 CACHE_CONFIG = {
-    'ttl_seconds': 3600,  # 1 hour
-    'max_size_mb': 100
+    "ttl_seconds": 3600,  # 1 hour
+    "max_size_mb": 100,
 }
 
 # Logging
@@ -269,6 +273,7 @@ DEBUG_MODE = os.getenv("DEBUG_MODE", "false").lower() == "true"
 
 # Validate critical configuration at startup
 import logging as _logging
+
 _settings_logger = _logging.getLogger(__name__)
 if not USE_LOCAL_SUPABASE:
     if not SUPABASE_URL:
@@ -280,7 +285,7 @@ if not USE_LOCAL_SUPABASE:
 # Note: PERF_BLEND_WEIGHT is applied additively on top of this sum,
 # making the theoretical max 1.0 + 0.5 * PERF_BLEND_WEIGHT = 1.075.
 # The ranking engine normalizes by this max (see v53e.py MAX_POWERSCORE_THEORETICAL).
-_weight_sum = RANKING_CONFIG['off_weight'] + RANKING_CONFIG['def_weight'] + RANKING_CONFIG['sos_weight']
+_weight_sum = RANKING_CONFIG["off_weight"] + RANKING_CONFIG["def_weight"] + RANKING_CONFIG["sos_weight"]
 if abs(_weight_sum - 1.0) > 0.01:
     raise ValueError(
         f"Ranking weights must sum to 1.0, got {_weight_sum:.3f} "

--- a/scripts/diagnose_ranking.py
+++ b/scripts/diagnose_ranking.py
@@ -11,71 +11,104 @@ Usage:
 Example:
     python scripts/diagnose_ranking.py 691eb36d-95b2-4a08-bd59-13c1b0e830bb
 """
-import sys
-import os
+
 import argparse
-from pathlib import Path
+import os
+import sys
 from datetime import datetime
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
 
 from dotenv import load_dotenv
-from supabase import create_client
-from rich.console import Console
-from rich.table import Table
-from rich.panel import Panel
 from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from src.rankings.constants import AGE_TO_ANCHOR, SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
+from src.rankings.shared import sos_ml_blend
+from supabase import create_client
 
 load_dotenv()
 console = Console()
 
 # ─── Algorithm constants (from V53EConfig + Layer13Config) ───────────────────
-# These must match the actual config. If they drift, the validation is wrong.
+# Shared constants imported from src.rankings.constants; local values are
+# script-specific and not duplicated elsewhere.
 ALGORITHM = {
     "OFF_WEIGHT": 0.20,
     "DEF_WEIGHT": 0.20,
     "SOS_WEIGHT": 0.60,
     "GOAL_DIFF_CAP": 6,
     "ML_ALPHA": 0.08,
-    "SOS_ML_THRESHOLD_LOW": 0.45,
-    "SOS_ML_THRESHOLD_HIGH": 0.60,
+    "SOS_ML_THRESHOLD_LOW": SOS_ML_THRESHOLD_LOW,
+    "SOS_ML_THRESHOLD_HIGH": SOS_ML_THRESHOLD_HIGH,
     "MIN_GAMES_PROVISIONAL": 6,
     "PERF_BLEND_WEIGHT": 0.00,  # Performance layer disabled in final score
     "SHRINK_TAU": 8.0,
     "RECENCY_DECAY_RATE": 0.08,
     "UNRANKED_SOS_BASE": 0.35,
-    "ANCHORS": {
-        10: 0.400, 11: 0.475, 12: 0.550, 13: 0.625, 14: 0.700,
-        15: 0.775, 16: 0.850, 17: 0.925, 18: 1.000, 19: 1.000,
-    },
+    "ANCHORS": AGE_TO_ANCHOR,
 }
 
 # Metric columns to fetch from rankings_full
 METRIC_COLS = [
-    "team_id", "age_group", "gender", "state_code", "status",
-    "games_played", "wins", "losses", "draws",
-    "goals_for", "goals_against", "win_percentage",
-    "games_last_180_days", "last_game", "sample_flag",
+    "team_id",
+    "age_group",
+    "gender",
+    "state_code",
+    "status",
+    "games_played",
+    "wins",
+    "losses",
+    "draws",
+    "goals_for",
+    "goals_against",
+    "win_percentage",
+    "games_last_180_days",
+    "last_game",
+    "sample_flag",
     # Offense/Defense
-    "off_raw", "sad_raw", "off_shrunk", "sad_shrunk", "def_shrunk",
-    "off_norm", "def_norm",
+    "off_raw",
+    "sad_raw",
+    "off_shrunk",
+    "sad_shrunk",
+    "def_shrunk",
+    "off_norm",
+    "def_norm",
     # SOS
-    "sos", "sos_norm", "sos_raw",
-    "sos_norm_national", "sos_norm_state",
-    "sos_rank_national", "sos_rank_state",
+    "sos",
+    "sos_norm",
+    "sos_raw",
+    "sos_norm_national",
+    "sos_norm_state",
+    "sos_rank_national",
+    "sos_rank_state",
     # Performance
-    "perf_raw", "perf_centered",
+    "perf_raw",
+    "perf_centered",
     # Power scores (layer by layer)
-    "power_presos", "powerscore_core", "provisional_mult",
-    "powerscore_adj", "anchor", "abs_strength",
+    "power_presos",
+    "powerscore_core",
+    "provisional_mult",
+    "powerscore_adj",
+    "anchor",
+    "abs_strength",
     # ML Layer
-    "ml_overperf", "ml_norm", "powerscore_ml",
+    "ml_overperf",
+    "ml_norm",
+    "powerscore_ml",
     # Final scores
-    "national_power_score", "power_score_final",
+    "national_power_score",
+    "power_score_final",
     # Ranks
-    "rank_in_cohort", "rank_in_cohort_ml",
-    "national_rank", "state_rank",
-    "rank_change_7d", "rank_change_30d",
+    "rank_in_cohort",
+    "rank_in_cohort_ml",
+    "national_rank",
+    "state_rank",
+    "rank_change_7d",
+    "rank_change_30d",
     "last_calculated",
 ]
 
@@ -101,9 +134,12 @@ def get_supabase():
 
 
 def fetch_team_name(supabase, team_id: str) -> str:
-    result = supabase.table("teams").select(
-        "team_name, club_name, age_group, gender, state_code"
-    ).eq("team_id_master", team_id).execute()
+    result = (
+        supabase.table("teams")
+        .select("team_name, club_name, age_group, gender, state_code")
+        .eq("team_id_master", team_id)
+        .execute()
+    )
     if result.data:
         r = result.data[0]
         return f"{r.get('team_name', '?')} ({r.get('club_name', '')}) — {r.get('age_group', '?')} {r.get('gender', '?')}, {r.get('state_code', '?')}"
@@ -118,19 +154,29 @@ def fetch_team_ranking(supabase, team_id: str) -> dict | None:
 
 def fetch_cohort_top(supabase, age_group: str, gender: str, limit: int = 10) -> list:
     cols = ", ".join(METRIC_COLS)
-    result = supabase.table("rankings_full").select(cols).eq(
-        "age_group", age_group
-    ).eq("gender", gender).eq("status", "Active").order(
-        "power_score_final", desc=True
-    ).limit(limit).execute()
+    result = (
+        supabase.table("rankings_full")
+        .select(cols)
+        .eq("age_group", age_group)
+        .eq("gender", gender)
+        .eq("status", "Active")
+        .order("power_score_final", desc=True)
+        .limit(limit)
+        .execute()
+    )
     return result.data or []
 
 
 def fetch_cohort_stats(supabase, age_group: str, gender: str) -> dict:
     """Fetch cohort-wide stats for context (total teams, score ranges)."""
-    result = supabase.table("rankings_full").select(
-        "team_id, power_score_final, powerscore_adj, sos_norm, status"
-    ).eq("age_group", age_group).eq("gender", gender).eq("status", "Active").execute()
+    result = (
+        supabase.table("rankings_full")
+        .select("team_id, power_score_final, powerscore_adj, sos_norm, status")
+        .eq("age_group", age_group)
+        .eq("gender", gender)
+        .eq("status", "Active")
+        .execute()
+    )
     rows = result.data or []
     if not rows:
         return {}
@@ -146,11 +192,14 @@ def fetch_cohort_stats(supabase, age_group: str, gender: str) -> dict:
 
 
 def fetch_team_games(supabase, team_id: str, limit: int = 15) -> list:
-    result = supabase.table("games").select(
-        "game_date, home_team_master_id, away_team_master_id, home_score, away_score"
-    ).or_(
-        f"home_team_master_id.eq.{team_id},away_team_master_id.eq.{team_id}"
-    ).order("game_date", desc=True).limit(limit).execute()
+    result = (
+        supabase.table("games")
+        .select("game_date, home_team_master_id, away_team_master_id, home_score, away_score")
+        .or_(f"home_team_master_id.eq.{team_id},away_team_master_id.eq.{team_id}")
+        .order("game_date", desc=True)
+        .limit(limit)
+        .execute()
+    )
     return result.data or []
 
 
@@ -161,11 +210,14 @@ def fetch_opponent_rankings(supabase, opponent_ids: list) -> dict:
     rankings = {}
     batch_size = 100
     for i in range(0, len(opponent_ids), batch_size):
-        batch = opponent_ids[i:i + batch_size]
-        result = supabase.table("rankings_full").select(
-            "team_id, power_score_final, powerscore_adj, status, national_rank, age_group, gender"
-        ).in_("team_id", batch).execute()
-        for r in (result.data or []):
+        batch = opponent_ids[i : i + batch_size]
+        result = (
+            supabase.table("rankings_full")
+            .select("team_id, power_score_final, powerscore_adj, status, national_rank, age_group, gender")
+            .in_("team_id", batch)
+            .execute()
+        )
+        for r in result.data or []:
             rankings[r["team_id"]] = r
     return rankings
 
@@ -191,6 +243,7 @@ def arrow(team_val, top_val) -> str:
 
 
 # ─── Algorithm Validation ────────────────────────────────────────────────────
+
 
 def validate_algorithm(team: dict, cohort_stats: dict) -> list:
     """
@@ -228,16 +281,18 @@ def validate_algorithm(team: dict, cohort_stats: dict) -> list:
     ps_core = team.get("powerscore_core")
     if all(v is not None for v in [off_n, def_n, sos_n, ps_core]):
         expected_core = (
-            off_n * ALGORITHM["OFF_WEIGHT"]
-            + def_n * ALGORITHM["DEF_WEIGHT"]
-            + sos_n * ALGORITHM["SOS_WEIGHT"]
+            off_n * ALGORITHM["OFF_WEIGHT"] + def_n * ALGORITHM["DEF_WEIGHT"] + sos_n * ALGORITHM["SOS_WEIGHT"]
         )
         diff = abs(ps_core - expected_core)
         if diff > 0.05:
-            checks.append(("WARN",
-                f"powerscore_core ({ps_core:.4f}) differs from expected "
-                f"OFF*0.20 + DEF*0.20 + SOS*0.60 = {expected_core:.4f} by {diff:.4f}. "
-                f"May indicate hybrid SOS norm or rounding."))
+            checks.append(
+                (
+                    "WARN",
+                    f"powerscore_core ({ps_core:.4f}) differs from expected "
+                    f"OFF*0.20 + DEF*0.20 + SOS*0.60 = {expected_core:.4f} by {diff:.4f}. "
+                    f"May indicate hybrid SOS norm or rounding.",
+                )
+            )
         else:
             checks.append(("OK", f"PowerScore blend verified: {ps_core:.4f} ≈ {expected_core:.4f} (diff {diff:.4f})"))
 
@@ -260,29 +315,35 @@ def validate_algorithm(team: dict, cohort_stats: dict) -> list:
         expected_ml = min(1.0, max(0.0, ps_adj + ALGORITHM["ML_ALPHA"] * ml_norm))
         diff = abs(ps_ml - expected_ml)
         if diff > 0.02:
-            checks.append(("WARN",
-                f"powerscore_ml ({ps_ml:.4f}) differs from expected "
-                f"adj + 0.08 * ml_norm = {expected_ml:.4f} by {diff:.4f}. "
-                f"May be SOS-conditioned scaling (weak SOS dampens ML authority)."))
+            checks.append(
+                (
+                    "WARN",
+                    f"powerscore_ml ({ps_ml:.4f}) differs from expected "
+                    f"adj + 0.08 * ml_norm = {expected_ml:.4f} by {diff:.4f}. "
+                    f"May be SOS-conditioned scaling (weak SOS dampens ML authority).",
+                )
+            )
         else:
             checks.append(("OK", f"ML blend verified: {ps_ml:.4f} ≈ {expected_ml:.4f}"))
 
     # --- SOS-conditioned ML scaling ---
     if sos_n is not None and ml_norm is not None and ps_adj is not None and ps_ml is not None:
-        if sos_n < ALGORITHM["SOS_ML_THRESHOLD_LOW"]:
+        if sos_n < SOS_ML_THRESHOLD_LOW:
             # ML should have NO authority — powerscore_ml should equal powerscore_adj
             if abs(ps_ml - ps_adj) > 0.005:
-                checks.append(("WARN",
-                    f"SOS={sos_n:.3f} is below {ALGORITHM['SOS_ML_THRESHOLD_LOW']} threshold — "
-                    f"ML should have no authority, but ps_ml ({ps_ml:.4f}) ≠ ps_adj ({ps_adj:.4f})"))
+                checks.append(
+                    (
+                        "WARN",
+                        f"SOS={sos_n:.3f} is below {SOS_ML_THRESHOLD_LOW} threshold — "
+                        f"ML should have no authority, but ps_ml ({ps_ml:.4f}) ≠ ps_adj ({ps_adj:.4f})",
+                    )
+                )
             else:
                 checks.append(("OK", f"ML correctly suppressed for weak SOS ({sos_n:.3f})"))
-        elif sos_n >= ALGORITHM["SOS_ML_THRESHOLD_HIGH"]:
+        elif sos_n >= SOS_ML_THRESHOLD_HIGH:
             checks.append(("OK", f"ML has full authority — SOS ({sos_n:.3f}) above threshold"))
         else:
-            scale = (sos_n - ALGORITHM["SOS_ML_THRESHOLD_LOW"]) / (
-                ALGORITHM["SOS_ML_THRESHOLD_HIGH"] - ALGORITHM["SOS_ML_THRESHOLD_LOW"]
-            )
+            scale = (sos_n - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)
             checks.append(("OK", f"ML partial authority ({scale:.0%}) — SOS ({sos_n:.3f}) in transition zone"))
 
     # --- Age anchor scaling ---
@@ -295,17 +356,20 @@ def validate_algorithm(team: dict, cohort_stats: dict) -> list:
         expected_anchor = ALGORITHM["ANCHORS"][age_num]
         ps_final = team.get("power_score_final")
         if ps_final is not None and ps_final > expected_anchor + 0.001:
-            checks.append(("FAIL",
-                f"power_score_final ({ps_final:.4f}) exceeds age anchor ceiling "
-                f"({expected_anchor:.3f} for {age_str})"))
+            checks.append(
+                (
+                    "FAIL",
+                    f"power_score_final ({ps_final:.4f}) exceeds age anchor ceiling "
+                    f"({expected_anchor:.3f} for {age_str})",
+                )
+            )
         elif ps_final is not None:
             checks.append(("OK", f"Final score ({ps_final:.4f}) within anchor ceiling ({expected_anchor:.3f})"))
 
     # --- Performance layer should be disabled (PERF_BLEND_WEIGHT = 0.00) ---
     perf = team.get("perf_centered")
     if perf is not None and abs(perf) > 0.001:
-        checks.append(("OK",
-            f"perf_centered = {perf:.4f} (computed but NOT blended — PERF_BLEND_WEIGHT=0.00)"))
+        checks.append(("OK", f"perf_centered = {perf:.4f} (computed but NOT blended — PERF_BLEND_WEIGHT=0.00)"))
 
     # --- Bayesian shrinkage: low-sample teams should have shrunk offense/defense ---
     if gp is not None and gp < ALGORITHM["SHRINK_TAU"]:
@@ -313,13 +377,21 @@ def validate_algorithm(team: dict, cohort_stats: dict) -> list:
         off_shrunk = team.get("off_shrunk")
         if off_raw is not None and off_shrunk is not None:
             if abs(off_raw - off_shrunk) < 0.001:
-                checks.append(("WARN",
-                    f"Team has only {gp} games but off_raw ≈ off_shrunk — "
-                    f"Bayesian shrinkage may not be applying (tau={ALGORITHM['SHRINK_TAU']})"))
+                checks.append(
+                    (
+                        "WARN",
+                        f"Team has only {gp} games but off_raw ≈ off_shrunk — "
+                        f"Bayesian shrinkage may not be applying (tau={ALGORITHM['SHRINK_TAU']})",
+                    )
+                )
             else:
-                checks.append(("OK",
-                    f"Bayesian shrinkage active: off_raw={off_raw:.3f} → off_shrunk={off_shrunk:.3f} "
-                    f"({gp} games, tau={ALGORITHM['SHRINK_TAU']})"))
+                checks.append(
+                    (
+                        "OK",
+                        f"Bayesian shrinkage active: off_raw={off_raw:.3f} → off_shrunk={off_shrunk:.3f} "
+                        f"({gp} games, tau={ALGORITHM['SHRINK_TAU']})",
+                    )
+                )
 
     # --- Win percentage sanity ---
     wins = team.get("wins") or 0
@@ -334,15 +406,19 @@ def validate_algorithm(team: dict, cohort_stats: dict) -> list:
     # --- Status consistency ---
     if status := team.get("status"):
         if status == "Active" and gp < ALGORITHM["MIN_GAMES_PROVISIONAL"]:
-            checks.append(("WARN", f"Status is 'Active' but only {gp} games (threshold={ALGORITHM['MIN_GAMES_PROVISIONAL']})"))
+            checks.append(
+                ("WARN", f"Status is 'Active' but only {gp} games (threshold={ALGORITHM['MIN_GAMES_PROVISIONAL']})")
+            )
 
     return checks
 
 
 # ─── Accurate Simulator (mirrors v53e + Layer 13 exactly) ────────────────────
 
-def simulate_powerscore(off_norm: float, def_norm: float, sos_norm: float,
-                        games_played: int, ml_norm: float, age_num: int) -> dict:
+
+def simulate_powerscore(
+    off_norm: float, def_norm: float, sos_norm: float, games_played: int, ml_norm: float, age_num: int
+) -> dict:
     """
     Reproduce the full v53e → ML → anchor pipeline from normalized components.
     This matches the actual engine — no shortcuts, no display multipliers.
@@ -352,9 +428,7 @@ def simulate_powerscore(off_norm: float, def_norm: float, sos_norm: float,
     # Layer 10: PowerScore blend (OFF:0.20, DEF:0.20, SOS:0.60)
     # Note: PERF_BLEND_WEIGHT = 0.00, so performance is NOT in the blend
     ps_core = (
-        off_norm * ALGORITHM["OFF_WEIGHT"]
-        + def_norm * ALGORITHM["DEF_WEIGHT"]
-        + sos_norm * ALGORITHM["SOS_WEIGHT"]
+        off_norm * ALGORITHM["OFF_WEIGHT"] + def_norm * ALGORITHM["DEF_WEIGHT"] + sos_norm * ALGORITHM["SOS_WEIGHT"]
     )
 
     # Provisional multiplier: linear ramp 0.85 → 1.0 over 0-15 games
@@ -369,20 +443,13 @@ def simulate_powerscore(off_norm: float, def_norm: float, sos_norm: float,
     ps_adj = min(1.0, max(0.0, ps_core * prov))
 
     # ML Layer 13: additive blend with SOS-conditioned scaling
-    # Step 1: compute ML delta
     ml_delta = ALGORITHM["ML_ALPHA"] * ml_norm
-
-    # Step 2: scale by SOS authority
-    if sos_norm < ALGORITHM["SOS_ML_THRESHOLD_LOW"]:
-        ml_scale = 0.0
-    elif sos_norm >= ALGORITHM["SOS_ML_THRESHOLD_HIGH"]:
-        ml_scale = 1.0
-    else:
-        ml_scale = (sos_norm - ALGORITHM["SOS_ML_THRESHOLD_LOW"]) / (
-            ALGORITHM["SOS_ML_THRESHOLD_HIGH"] - ALGORITHM["SOS_ML_THRESHOLD_LOW"]
-        )
-
-    ps_ml = min(1.0, max(0.0, ps_adj + ml_delta * ml_scale))
+    ps_ml_raw = ps_adj + ml_delta
+    ps_ml = sos_ml_blend(ps_adj, ps_ml_raw, sos_norm)
+    ml_scale = max(
+        0.0,
+        min(1.0, (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)),
+    )
 
     # Age anchor scaling: final = ps_ml * anchor, capped at anchor
     anchor = ALGORITHM["ANCHORS"].get(age_num, 1.0)
@@ -439,31 +506,25 @@ def simulate_what_if(team: dict, top1: dict, cohort_top: list) -> list:
 
     # Scenario 1: Current (baseline)
     current = simulate_powerscore(team_off, team_def, team_sos, team_gp, team_ml, age_num)
-    scenarios.append((
-        "Current", "No changes",
-        current["ps_final"], sim_rank(current["ps_final"])
-    ))
+    scenarios.append(("Current", "No changes", current["ps_final"], sim_rank(current["ps_final"])))
 
     # Scenario 2: Max out SOS (play the toughest schedule possible)
     s = simulate_powerscore(team_off, team_def, 1.0, team_gp, team_ml, age_num)
-    scenarios.append((
-        "Max SOS", "sos_norm → 1.000 (hardest schedule in cohort)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        ("Max SOS", "sos_norm → 1.000 (hardest schedule in cohort)", s["ps_final"], sim_rank(s["ps_final"]))
+    )
 
     # Scenario 3: Max out offense
     s = simulate_powerscore(1.0, team_def, team_sos, team_gp, team_ml, age_num)
-    scenarios.append((
-        "Max Offense", "off_norm → 1.000 (best scoring in cohort)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        ("Max Offense", "off_norm → 1.000 (best scoring in cohort)", s["ps_final"], sim_rank(s["ps_final"]))
+    )
 
     # Scenario 4: Max out defense
     s = simulate_powerscore(team_off, 1.0, team_sos, team_gp, team_ml, age_num)
-    scenarios.append((
-        "Max Defense", "def_norm → 1.000 (best defense in cohort)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        ("Max Defense", "def_norm → 1.000 (best defense in cohort)", s["ps_final"], sim_rank(s["ps_final"]))
+    )
 
     # Scenario 5: Match #1's exact metrics
     top_off = top1.get("off_norm") or 0.5
@@ -472,49 +533,55 @@ def simulate_what_if(team: dict, top1: dict, cohort_top: list) -> list:
     top_gp = top1.get("games_played") or 30
     top_ml = top1.get("ml_norm") or 0.0
     s = simulate_powerscore(top_off, top_def, top_sos, top_gp, top_ml, age_num)
-    scenarios.append((
-        "Clone #1's metrics", f"Copy all normalized values from #1",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        ("Clone #1's metrics", f"Copy all normalized values from #1", s["ps_final"], sim_rank(s["ps_final"]))
+    )
 
     # Scenario 6: Improve SOS to match #1's SOS only
     s = simulate_powerscore(team_off, team_def, top_sos, team_gp, team_ml, age_num)
-    scenarios.append((
-        "Match #1's SOS", f"sos_norm → {top_sos:.3f} (keep everything else)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        ("Match #1's SOS", f"sos_norm → {top_sos:.3f} (keep everything else)", s["ps_final"], sim_rank(s["ps_final"]))
+    )
 
     # Scenario 7: Best realistic improvement (+10% on weakest metric)
-    weakest_metric = min(
-        [("off", team_off), ("def", team_def), ("sos", team_sos)],
-        key=lambda x: x[1]
-    )
+    weakest_metric = min([("off", team_off), ("def", team_def), ("sos", team_sos)], key=lambda x: x[1])
     boosted = min(1.0, weakest_metric[1] + 0.10)
     off_b = boosted if weakest_metric[0] == "off" else team_off
     def_b = boosted if weakest_metric[0] == "def" else team_def
     sos_b = boosted if weakest_metric[0] == "sos" else team_sos
     s = simulate_powerscore(off_b, def_b, sos_b, team_gp, team_ml, age_num)
-    scenarios.append((
-        f"Boost weakest ({weakest_metric[0]})",
-        f"{weakest_metric[0]}_norm {weakest_metric[1]:.3f} → {boosted:.3f} (+0.100)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        (
+            f"Boost weakest ({weakest_metric[0]})",
+            f"{weakest_metric[0]}_norm {weakest_metric[1]:.3f} → {boosted:.3f} (+0.100)",
+            s["ps_final"],
+            sim_rank(s["ps_final"]),
+        )
+    )
 
     # Scenario 8: More games (if provisional penalty applies)
     if team_gp < 15:
         s = simulate_powerscore(team_off, team_def, team_sos, 30, team_ml, age_num)
-        scenarios.append((
-            "Full season (30 GP)", f"games_played {team_gp} → 30 (removes provisional penalty)",
-            s["ps_final"], sim_rank(s["ps_final"])
-        ))
+        scenarios.append(
+            (
+                "Full season (30 GP)",
+                f"games_played {team_gp} → 30 (removes provisional penalty)",
+                s["ps_final"],
+                sim_rank(s["ps_final"]),
+            )
+        )
 
     # Scenario 9: ML boost (strong recent form)
     better_ml = min(0.5, team_ml + 0.20)
     s = simulate_powerscore(team_off, team_def, team_sos, team_gp, better_ml, age_num)
-    scenarios.append((
-        "Strong ML form", f"ml_norm {team_ml:+.3f} → {better_ml:+.3f} (beat expectations recently)",
-        s["ps_final"], sim_rank(s["ps_final"])
-    ))
+    scenarios.append(
+        (
+            "Strong ML form",
+            f"ml_norm {team_ml:+.3f} → {better_ml:+.3f} (beat expectations recently)",
+            s["ps_final"],
+            sim_rank(s["ps_final"]),
+        )
+    )
 
     # Scenario 10: Find minimum SOS needed to reach #1
     # Binary search for the SOS that makes ps_final >= target
@@ -530,16 +597,24 @@ def simulate_what_if(team: dict, top1: dict, cohort_top: list) -> list:
             lo = mid
     if needed_sos is not None and needed_sos <= 1.0:
         s = simulate_powerscore(team_off, team_def, needed_sos, team_gp, team_ml, age_num)
-        scenarios.append((
-            "Min SOS for #1", f"sos_norm needs to reach {needed_sos:.3f} (currently {team_sos:.3f})",
-            s["ps_final"], sim_rank(s["ps_final"])
-        ))
+        scenarios.append(
+            (
+                "Min SOS for #1",
+                f"sos_norm needs to reach {needed_sos:.3f} (currently {team_sos:.3f})",
+                s["ps_final"],
+                sim_rank(s["ps_final"]),
+            )
+        )
     else:
         # SOS alone can't do it — find combo
-        scenarios.append((
-            "Min SOS for #1", "SOS alone cannot close the gap — need offense/defense improvement too",
-            current["ps_final"], sim_rank(current["ps_final"])
-        ))
+        scenarios.append(
+            (
+                "Min SOS for #1",
+                "SOS alone cannot close the gap — need offense/defense improvement too",
+                current["ps_final"],
+                sim_rank(current["ps_final"]),
+            )
+        )
 
     return scenarios
 
@@ -605,8 +680,8 @@ def explain_ranking_position(team: dict, top1: dict, cohort_stats: dict) -> list
     prov_top = top1.get("provisional_mult") or 1.0
     if prov_team < prov_top:
         explanations.append(
-            f"  Provisional penalty: your mult={prov_team:.3f} vs #1={prov_top:.3f} "
-            f"(you have fewer games)")
+            f"  Provisional penalty: your mult={prov_team:.3f} vs #1={prov_top:.3f} (you have fewer games)"
+        )
 
     # The biggest factor
     explanations.append("")
@@ -621,17 +696,19 @@ def explain_ranking_position(team: dict, top1: dict, cohort_stats: dict) -> list
     if sos_contrib > 0.01:
         explanations.append(
             "💡 INSIGHT: SOS is the biggest drag. The algorithm weights schedule strength at 60%. "
-            "Playing stronger opponents (tournament teams, out-of-state competition) would help.")
+            "Playing stronger opponents (tournament teams, out-of-state competition) would help."
+        )
     elif off_contrib > 0.01:
         explanations.append(
-            "💡 INSIGHT: Offense is the gap. More decisive wins (larger margins) against similar opponents.")
+            "💡 INSIGHT: Offense is the gap. More decisive wins (larger margins) against similar opponents."
+        )
     elif def_contrib > 0.01:
-        explanations.append(
-            "💡 INSIGHT: Defense is the gap. Allowing fewer goals would improve the ranking.")
+        explanations.append("💡 INSIGHT: Defense is the gap. Allowing fewer goals would improve the ranking.")
     elif ml_gap > 0.005:
         explanations.append(
             "💡 INSIGHT: The ML model favors #1 based on patterns in game features (power diff, recency). "
-            "Recent form and beating higher-ranked opponents matter here.")
+            "Recent form and beating higher-ranked opponents matter here."
+        )
 
     return explanations
 
@@ -651,10 +728,12 @@ def diagnose_team(supabase, team_id: str):
     status = team.get("status", "Unknown")
     current_rank = team.get("national_rank") or team.get("rank_in_cohort_ml") or "?"
 
-    console.print(f"  Cohort: [cyan]{age_group} {gender}[/cyan]  |  "
-                  f"Status: [cyan]{status}[/cyan]  |  "
-                  f"Rank: [bold yellow]#{current_rank}[/bold yellow]  |  "
-                  f"State: [cyan]{team.get('state_code', '?')}[/cyan]")
+    console.print(
+        f"  Cohort: [cyan]{age_group} {gender}[/cyan]  |  "
+        f"Status: [cyan]{status}[/cyan]  |  "
+        f"Rank: [bold yellow]#{current_rank}[/bold yellow]  |  "
+        f"State: [cyan]{team.get('state_code', '?')}[/cyan]"
+    )
     console.print(f"  Last calculated: {team.get('last_calculated', '?')}")
     console.print()
 
@@ -673,9 +752,11 @@ def diagnose_team(supabase, team_id: str):
     console.print()
 
     if cohort_stats:
-        console.print(f"  Cohort: {cohort_stats.get('total_active', '?')} active teams  |  "
-                      f"Score range: [{fmt(cohort_stats.get('score_min'), 4)} – {fmt(cohort_stats.get('score_max'), 4)}]  |  "
-                      f"Mean: {fmt(cohort_stats.get('score_mean'), 4)}")
+        console.print(
+            f"  Cohort: {cohort_stats.get('total_active', '?')} active teams  |  "
+            f"Score range: [{fmt(cohort_stats.get('score_min'), 4)} – {fmt(cohort_stats.get('score_max'), 4)}]  |  "
+            f"Mean: {fmt(cohort_stats.get('score_mean'), 4)}"
+        )
         console.print()
 
     # ── Cohort Top 10 ────────────────────────────────────────────────────
@@ -755,8 +836,11 @@ def diagnose_team(supabase, team_id: str):
 
         wld = f"{t.get('wins', 0)}-{t.get('losses', 0)}-{t.get('draws', 0)}"
         lb.add_row(
-            str(i), name, t.get("state_code", "?"),
-            str(t.get("games_played", 0)), wld,
+            str(i),
+            name,
+            t.get("state_code", "?"),
+            str(t.get("games_played", 0)),
+            wld,
             fmt(t.get("sos_norm"), 3),
             fmt(t.get("powerscore_adj"), 4),
             fmt(t.get("powerscore_ml"), 4),
@@ -791,12 +875,16 @@ def diagnose_team(supabase, team_id: str):
         actual_final = team.get("power_score_final") or 0
         sim_diff = abs(current_sim["ps_final"] - actual_final)
         if sim_diff > 0.01:
-            console.print(f"  [yellow]⚠ Simulator drift: simulated {current_sim['ps_final']:.4f} vs "
-                         f"actual {actual_final:.4f} (diff {sim_diff:.4f}). "
-                         f"Hybrid SOS norm or rounding may cause small differences.[/yellow]")
+            console.print(
+                f"  [yellow]⚠ Simulator drift: simulated {current_sim['ps_final']:.4f} vs "
+                f"actual {actual_final:.4f} (diff {sim_diff:.4f}). "
+                f"Hybrid SOS norm or rounding may cause small differences.[/yellow]"
+            )
         else:
-            console.print(f"  [green]✓ Simulator accuracy: {current_sim['ps_final']:.4f} vs actual "
-                         f"{actual_final:.4f} (diff {sim_diff:.4f})[/green]")
+            console.print(
+                f"  [green]✓ Simulator accuracy: {current_sim['ps_final']:.4f} vs actual "
+                f"{actual_final:.4f} (diff {sim_diff:.4f})[/green]"
+            )
         console.print()
 
         scenarios = simulate_what_if(team, top1, top)
@@ -836,9 +924,12 @@ def diagnose_team(supabase, team_id: str):
         console.print("[bold underline]Biggest Gaps vs #1[/bold underline]")
         gaps = []
         key_metrics = [
-            ("off_norm", "Offense"), ("def_norm", "Defense"),
-            ("sos_norm", "SOS"), ("perf_centered", "Performance"),
-            ("ml_norm", "ML Adjustment"), ("powerscore_adj", "PowerScore (pre-ML)"),
+            ("off_norm", "Offense"),
+            ("def_norm", "Defense"),
+            ("sos_norm", "SOS"),
+            ("perf_centered", "Performance"),
+            ("ml_norm", "ML Adjustment"),
+            ("powerscore_adj", "PowerScore (pre-ML)"),
             ("power_score_final", "Final Score"),
         ]
         for col, label in key_metrics:
@@ -852,8 +943,9 @@ def diagnose_team(supabase, team_id: str):
         for label, col, diff, tv, cv in gaps:
             color = "green" if diff > 0 else "red"
             direction = "ahead" if diff > 0 else "behind"
-            console.print(f"  [{color}]{label}: {diff:+.4f} ({direction})[/{color}]  "
-                         f"(you: {fmt(tv, 4)}, #1: {fmt(cv, 4)})")
+            console.print(
+                f"  [{color}]{label}: {diff:+.4f} ({direction})[/{color}]  (you: {fmt(tv, 4)}, #1: {fmt(cv, 4)})"
+            )
         console.print()
 
     # ── Recent Games with Opponent Strength ───────────────────────────────
@@ -911,12 +1003,16 @@ def diagnose_team(supabase, team_id: str):
         console.print(gt)
 
         # Schedule quality summary
-        ranked_opps = [opp_rankings[oid] for oid in opp_ids if oid in opp_rankings and opp_rankings[oid].get("power_score_final")]
+        ranked_opps = [
+            opp_rankings[oid] for oid in opp_ids if oid in opp_rankings and opp_rankings[oid].get("power_score_final")
+        ]
         if ranked_opps:
             avg_opp = sum(r["power_score_final"] for r in ranked_opps) / len(ranked_opps)
             top_opps = sum(1 for r in ranked_opps if (r.get("national_rank") or 999) <= 20)
-            console.print(f"\n  Schedule quality: avg opponent score = {avg_opp:.3f} | "
-                         f"top-20 opponents: {top_opps}/{len(ranked_opps)}")
+            console.print(
+                f"\n  Schedule quality: avg opponent score = {avg_opp:.3f} | "
+                f"top-20 opponents: {top_opps}/{len(ranked_opps)}"
+            )
     else:
         console.print("  No recent games found.")
 
@@ -928,22 +1024,24 @@ def diagnose_team(supabase, team_id: str):
 def main():
     parser = argparse.ArgumentParser(
         description="Diagnose why a team is or isn't #1 in their cohort. "
-                    "Cross-references ranking output against v53e algorithm design."
+        "Cross-references ranking output against v53e algorithm design."
     )
     parser.add_argument("team_ids", nargs="+", help="One or more team UUIDs to diagnose")
     args = parser.parse_args()
 
     supabase = get_supabase()
 
-    console.print(Panel(
-        f"[bold]PitchRank Ranking Diagnostic[/bold]\n"
-        f"Teams: {len(args.team_ids)}  |  "
-        f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n"
-        f"[dim]Algorithm: v53e (OFF:20% DEF:20% SOS:60%) + ML Layer 13 (α=0.08)\n"
-        f"SOS-conditioned ML: suppressed below SOS 0.45, full above 0.60\n"
-        f"Age anchors: U10=0.40 → U19=1.00[/dim]",
-        title="🔍 Ranking Diagnostic",
-    ))
+    console.print(
+        Panel(
+            f"[bold]PitchRank Ranking Diagnostic[/bold]\n"
+            f"Teams: {len(args.team_ids)}  |  "
+            f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n"
+            f"[dim]Algorithm: v53e (OFF:20% DEF:20% SOS:60%) + ML Layer 13 (α=0.08)\n"
+            f"SOS-conditioned ML: suppressed below SOS 0.45, full above 0.60\n"
+            f"Age anchors: U10=0.40 → U19=1.00[/dim]",
+            title="🔍 Ranking Diagnostic",
+        )
+    )
     console.print()
 
     for team_id in args.team_ids:

--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import logging
@@ -38,16 +37,22 @@ class V53EConfig:
     # Layer 5 (Adaptive K + team-level outlier guard)
     ADAPTIVE_K_ALPHA: float = 0.5
     ADAPTIVE_K_BETA: float = 0.6
-    TEAM_OUTLIER_GUARD_ZSCORE: float = 3.0  # clip aggregated OFF/DEF extremes (tightened from 3.5 — fewer teams hit ceiling, reducing tie compression)
+    TEAM_OUTLIER_GUARD_ZSCORE: float = (
+        3.0  # clip aggregated OFF/DEF extremes (tightened from 3.5 — fewer teams hit ceiling, reducing tie compression)
+    )
 
     # Layer 6 (Performance)
     PERFORMANCE_K: float = 0.15  # Legacy: kept for backward compatibility, use PERF_* instead
     PERF_GAME_SCALE: float = 0.15  # Scales per-game performance residual
-    PERF_BLEND_WEIGHT: float = 0.00  # Weight of perf_centered in final powerscore (was 0.15, set to 0.00 — stat-padding bias fix)
+    PERF_BLEND_WEIGHT: float = (
+        0.00  # Weight of perf_centered in final powerscore (was 0.15, set to 0.00 — stat-padding bias fix)
+    )
     PERF_CAP: float = 0.15  # Symmetric cap on perf_centered [-cap, +cap] before blending (clips outlier overperformers)
-    PERFORMANCE_DECAY_RATE: float = 0.08   # decay per recency index step
-    PERFORMANCE_THRESHOLD: float = 0.5     # goals – lowered from 2.0 to fix asymmetric filtering bias against defensive teams
-    PERFORMANCE_GOAL_SCALE: float = 5.0    # goals per 1.0 power diff
+    PERFORMANCE_DECAY_RATE: float = 0.08  # decay per recency index step
+    PERFORMANCE_THRESHOLD: float = (
+        0.5  # goals – lowered from 2.0 to fix asymmetric filtering bias against defensive teams
+    )
+    PERFORMANCE_GOAL_SCALE: float = 5.0  # goals per 1.0 power diff
 
     # Layer 7 (Bayesian shrink)
     SHRINK_TAU: float = 8.0
@@ -81,7 +86,9 @@ class V53EConfig:
     # threshold among ranked teams (>= MIN_GAMES_PROVISIONAL), sos_norm is
     # residualized against GP via OLS to remove the linear relationship.
     GP_SOS_DECORRELATION_ENABLED: bool = True
-    GP_SOS_DECORRELATION_THRESHOLD: float = 0.15  # Correlation threshold to trigger (above 0.10 guardrail, conservative)
+    GP_SOS_DECORRELATION_THRESHOLD: float = (
+        0.15  # Correlation threshold to trigger (above 0.10 guardrail, conservative)
+    )
 
     # NOTE: MIN_GAMES_FOR_SOS_RANK was removed — SOS rank eligibility is now
     # derived from team status ("Active"), which itself uses MIN_GAMES_PROVISIONAL.
@@ -91,7 +98,7 @@ class V53EConfig:
     OPPONENT_ADJUST_ENABLED: bool = True
     OPPONENT_ADJUST_BASELINE: float = 0.5  # Reference strength for adjustment
     OPPONENT_ADJUST_CLIP_MIN: float = 0.25  # Min multiplier (widened to preserve signal from elite matchups)
-    OPPONENT_ADJUST_CLIP_MAX: float = 2.0   # Max multiplier (widened — old 1.6 clipped wins vs top-10 opponents)
+    OPPONENT_ADJUST_CLIP_MAX: float = 2.0  # Max multiplier (widened — old 1.6 clipped wins vs top-10 opponents)
 
     # Layer 10 weights (tuned via weight simulator — SOS boosted for schedule-strength emphasis)
     OFF_WEIGHT: float = 0.20  # was 0.25
@@ -141,7 +148,7 @@ class V53EConfig:
     # play in regional conferences but face elite competition — NOT a bubble.
     SCF_QUALITY_OVERRIDE_ENABLED: bool = True
     SCF_QUALITY_PERCENTILE: float = 0.65  # Opponents avg power above this percentile → boost SCF
-    SCF_QUALITY_BOOST_MIN: float = 0.85   # Minimum SCF after quality boost (overrides geographic calc)
+    SCF_QUALITY_BOOST_MIN: float = 0.85  # Minimum SCF after quality boost (overrides geographic calc)
 
     # Isolation Penalty via Bridge Games
     # Bridge games = games against teams from outside your state cluster
@@ -191,38 +198,80 @@ class V53EConfig:
 # =========================
 STATE_TO_REGION = {
     # Pacific
-    'CA': 'pacific', 'OR': 'pacific', 'WA': 'pacific', 'AK': 'pacific', 'HI': 'pacific',
+    "CA": "pacific",
+    "OR": "pacific",
+    "WA": "pacific",
+    "AK": "pacific",
+    "HI": "pacific",
     # Mountain
-    'MT': 'mountain', 'ID': 'mountain', 'WY': 'mountain', 'NV': 'mountain',
-    'UT': 'mountain', 'CO': 'mountain', 'AZ': 'mountain', 'NM': 'mountain',
+    "MT": "mountain",
+    "ID": "mountain",
+    "WY": "mountain",
+    "NV": "mountain",
+    "UT": "mountain",
+    "CO": "mountain",
+    "AZ": "mountain",
+    "NM": "mountain",
     # West North Central
-    'ND': 'west_north_central', 'SD': 'west_north_central', 'NE': 'west_north_central',
-    'KS': 'west_north_central', 'MN': 'west_north_central', 'IA': 'west_north_central', 'MO': 'west_north_central',
+    "ND": "west_north_central",
+    "SD": "west_north_central",
+    "NE": "west_north_central",
+    "KS": "west_north_central",
+    "MN": "west_north_central",
+    "IA": "west_north_central",
+    "MO": "west_north_central",
     # West South Central
-    'TX': 'west_south_central', 'OK': 'west_south_central', 'AR': 'west_south_central', 'LA': 'west_south_central',
+    "TX": "west_south_central",
+    "OK": "west_south_central",
+    "AR": "west_south_central",
+    "LA": "west_south_central",
     # East North Central
-    'WI': 'east_north_central', 'MI': 'east_north_central', 'IL': 'east_north_central',
-    'IN': 'east_north_central', 'OH': 'east_north_central',
+    "WI": "east_north_central",
+    "MI": "east_north_central",
+    "IL": "east_north_central",
+    "IN": "east_north_central",
+    "OH": "east_north_central",
     # East South Central
-    'KY': 'east_south_central', 'TN': 'east_south_central', 'MS': 'east_south_central', 'AL': 'east_south_central',
+    "KY": "east_south_central",
+    "TN": "east_south_central",
+    "MS": "east_south_central",
+    "AL": "east_south_central",
     # South Atlantic
-    'WV': 'south_atlantic', 'VA': 'south_atlantic', 'MD': 'south_atlantic', 'DE': 'south_atlantic',
-    'DC': 'south_atlantic', 'NC': 'south_atlantic', 'SC': 'south_atlantic', 'GA': 'south_atlantic', 'FL': 'south_atlantic',
+    "WV": "south_atlantic",
+    "VA": "south_atlantic",
+    "MD": "south_atlantic",
+    "DE": "south_atlantic",
+    "DC": "south_atlantic",
+    "NC": "south_atlantic",
+    "SC": "south_atlantic",
+    "GA": "south_atlantic",
+    "FL": "south_atlantic",
     # Middle Atlantic
-    'NY': 'middle_atlantic', 'PA': 'middle_atlantic', 'NJ': 'middle_atlantic',
+    "NY": "middle_atlantic",
+    "PA": "middle_atlantic",
+    "NJ": "middle_atlantic",
     # New England
-    'CT': 'new_england', 'RI': 'new_england', 'MA': 'new_england',
-    'VT': 'new_england', 'NH': 'new_england', 'ME': 'new_england',
+    "CT": "new_england",
+    "RI": "new_england",
+    "MA": "new_england",
+    "VT": "new_england",
+    "NH": "new_england",
+    "ME": "new_england",
 }
 
 
 # Required team-centric columns (one row per team per game)
 REQUIRED_COLUMNS = [
-    "game_id", "date",
-    "team_id", "opp_id",
-    "age", "gender",
-    "opp_age", "opp_gender",
-    "gf", "ga",
+    "game_id",
+    "date",
+    "team_id",
+    "opp_id",
+    "age",
+    "gender",
+    "opp_age",
+    "opp_gender",
+    "gf",
+    "ga",
 ]
 
 
@@ -339,7 +388,7 @@ def _hybrid_sos_norm(x: pd.Series, zscore_blend: float = 0.30) -> pd.Series:
 
     # Percentile component (same as existing)
     x_rounded = x.round(10)
-    ranks = x_rounded.rank(method='average')
+    ranks = x_rounded.rank(method="average")
     pct = (ranks - 1) / (len(x) - 1)
 
     # Sigmoid z-score component (use rounded values to match percentile noise suppression)
@@ -509,15 +558,15 @@ def compute_schedule_connectivity(
 
     if not cfg.SCF_ENABLED:
         # If disabled, return SCF=1.0 for all teams (no dampening)
-        for team_id in games_df['team_id'].unique():
+        for team_id in games_df["team_id"].unique():
             result[team_id] = {
-                'scf': 1.0,
-                'unique_states': 0,
-                'unique_regions': 0,
-                'bridge_games': 0,
-                'home_state': team_state_map.get(str(team_id), 'UNKNOWN'),
-                'is_isolated': False,
-                'quality_boosted': False,
+                "scf": 1.0,
+                "unique_states": 0,
+                "unique_regions": 0,
+                "bridge_games": 0,
+                "home_state": team_state_map.get(str(team_id), "UNKNOWN"),
+                "is_isolated": False,
+                "quality_boosted": False,
             }
         return result
 
@@ -529,37 +578,37 @@ def compute_schedule_connectivity(
             quality_threshold = float(np.percentile(all_strengths, cfg.SCF_QUALITY_PERCENTILE * 100))
             logger.info(
                 f"🔗 SCF quality override: threshold={quality_threshold:.4f} "
-                f"(p{cfg.SCF_QUALITY_PERCENTILE*100:.0f} of {len(all_strengths)} teams)"
+                f"(p{cfg.SCF_QUALITY_PERCENTILE * 100:.0f} of {len(all_strengths)} teams)"
             )
 
     quality_boosted_count = 0
 
     # Group games by team to analyze each team's schedule
-    for team_id, team_games in games_df.groupby('team_id'):
+    for team_id, team_games in games_df.groupby("team_id"):
         team_id_str = str(team_id)
-        home_state = team_state_map.get(team_id_str, 'UNKNOWN')
-        home_region = STATE_TO_REGION.get(home_state, 'unknown')
+        home_state = team_state_map.get(team_id_str, "UNKNOWN")
+        home_region = STATE_TO_REGION.get(home_state, "unknown")
 
         # Get all opponent states
-        opp_ids = team_games['opp_id'].unique()
+        opp_ids = team_games["opp_id"].unique()
         opp_states = set()
         opp_regions = set()
         bridge_games = 0
 
         for opp_id in opp_ids:
-            opp_state = team_state_map.get(str(opp_id), 'UNKNOWN')
-            opp_region = STATE_TO_REGION.get(opp_state, 'unknown')
+            opp_state = team_state_map.get(str(opp_id), "UNKNOWN")
+            opp_region = STATE_TO_REGION.get(opp_state, "unknown")
 
-            if opp_state != 'UNKNOWN':
+            if opp_state != "UNKNOWN":
                 opp_states.add(opp_state)
 
-            if opp_region != 'unknown':
+            if opp_region != "unknown":
                 opp_regions.add(opp_region)
 
             # Count bridge games (games vs teams from different states)
-            if opp_state != home_state and opp_state != 'UNKNOWN':
+            if opp_state != home_state and opp_state != "UNKNOWN":
                 # Count how many games against this out-of-state opponent
-                games_vs_opp = len(team_games[team_games['opp_id'] == opp_id])
+                games_vs_opp = len(team_games[team_games["opp_id"] == opp_id])
                 bridge_games += games_vs_opp
 
         # Calculate SCF based on schedule diversity
@@ -584,10 +633,7 @@ def compute_schedule_connectivity(
         # Geographic isolation ≠ quality isolation.
         quality_boosted = False
         if quality_threshold is not None and strength_map and len(opp_ids) >= 3:
-            opp_strengths = [
-                strength_map.get(str(oid), 0.0) for oid in opp_ids
-                if str(oid) in strength_map
-            ]
+            opp_strengths = [strength_map.get(str(oid), 0.0) for oid in opp_ids if str(oid) in strength_map]
             if opp_strengths:
                 avg_opp_strength = float(np.mean(opp_strengths))
                 if avg_opp_strength >= quality_threshold:
@@ -597,37 +643,30 @@ def compute_schedule_connectivity(
 
         # Determine if team is isolated (no bridge games or very few unique states)
         # Quality-boosted teams are NOT considered isolated
-        is_isolated = (
-            not quality_boosted and (
-                bridge_games < cfg.MIN_BRIDGE_GAMES or
-                unique_states < cfg.SCF_MIN_UNIQUE_STATES
-            )
+        is_isolated = not quality_boosted and (
+            bridge_games < cfg.MIN_BRIDGE_GAMES or unique_states < cfg.SCF_MIN_UNIQUE_STATES
         )
 
         result[team_id_str] = {
-            'scf': scf,
-            'unique_states': unique_states,
-            'unique_regions': unique_regions,
-            'bridge_games': bridge_games,
-            'home_state': home_state,
-            'is_isolated': is_isolated,
-            'quality_boosted': quality_boosted,
+            "scf": scf,
+            "unique_states": unique_states,
+            "unique_regions": unique_regions,
+            "bridge_games": bridge_games,
+            "home_state": home_state,
+            "is_isolated": is_isolated,
+            "quality_boosted": quality_boosted,
         }
 
     if quality_boosted_count > 0:
         logger.info(
             f"🔗 SCF quality override applied to {quality_boosted_count} teams "
-            f"(opponents avg power >= p{cfg.SCF_QUALITY_PERCENTILE*100:.0f})"
+            f"(opponents avg power >= p{cfg.SCF_QUALITY_PERCENTILE * 100:.0f})"
         )
 
     return result
 
 
-def apply_scf_to_sos(
-    team_df: pd.DataFrame,
-    scf_data: Dict[str, Dict],
-    cfg: V53EConfig
-) -> pd.DataFrame:
+def apply_scf_to_sos(team_df: pd.DataFrame, scf_data: Dict[str, Dict], cfg: V53EConfig) -> pd.DataFrame:
     """
     Apply Schedule Connectivity Factor to dampen SOS for isolated teams.
 
@@ -643,49 +682,38 @@ def apply_scf_to_sos(
     team_df = team_df.copy()
 
     # Add SCF columns
-    team_df['scf'] = team_df['team_id'].map(
-        lambda tid: scf_data.get(str(tid), {}).get('scf', 1.0)
-    )
-    team_df['bridge_games'] = team_df['team_id'].map(
-        lambda tid: scf_data.get(str(tid), {}).get('bridge_games', 0)
-    )
-    team_df['is_isolated'] = team_df['team_id'].map(
-        lambda tid: scf_data.get(str(tid), {}).get('is_isolated', False)
-    )
-    team_df['unique_opp_states'] = team_df['team_id'].map(
-        lambda tid: scf_data.get(str(tid), {}).get('unique_states', 0)
+    team_df["scf"] = team_df["team_id"].map(lambda tid: scf_data.get(str(tid), {}).get("scf", 1.0))
+    team_df["bridge_games"] = team_df["team_id"].map(lambda tid: scf_data.get(str(tid), {}).get("bridge_games", 0))
+    team_df["is_isolated"] = team_df["team_id"].map(lambda tid: scf_data.get(str(tid), {}).get("is_isolated", False))
+    team_df["unique_opp_states"] = team_df["team_id"].map(
+        lambda tid: scf_data.get(str(tid), {}).get("unique_states", 0)
     )
 
     # Store original SOS before adjustment
-    team_df['sos_raw_before_scf'] = team_df['sos'].copy()
+    team_df["sos_raw_before_scf"] = team_df["sos"].copy()
 
     # Apply SCF dampening to raw SOS
     # Formula: sos_adjusted = neutral + SCF * (sos_raw - neutral)
     neutral = cfg.SCF_NEUTRAL_SOS
-    team_df['sos'] = neutral + team_df['scf'] * (team_df['sos'] - neutral)
+    team_df["sos"] = neutral + team_df["scf"] * (team_df["sos"] - neutral)
 
     # Track quality-boosted teams
-    team_df['quality_boosted'] = team_df['team_id'].map(
-        lambda tid: scf_data.get(str(tid), {}).get('quality_boosted', False)
+    team_df["quality_boosted"] = team_df["team_id"].map(
+        lambda tid: scf_data.get(str(tid), {}).get("quality_boosted", False)
     )
 
     # Apply isolation penalty cap if enabled — but NOT for quality-boosted teams
     if cfg.ISOLATION_PENALTY_ENABLED:
         # Teams with insufficient bridge games get SOS capped
         # Quality-boosted teams are exempt (they play elite opponents, not a bubble)
-        isolation_mask = (
-            (team_df['bridge_games'] < cfg.MIN_BRIDGE_GAMES) &
-            (~team_df['quality_boosted'])
-        )
-        team_df.loc[isolation_mask, 'sos'] = team_df.loc[isolation_mask, 'sos'].clip(
-            upper=cfg.ISOLATION_SOS_CAP
-        )
+        isolation_mask = (team_df["bridge_games"] < cfg.MIN_BRIDGE_GAMES) & (~team_df["quality_boosted"])
+        team_df.loc[isolation_mask, "sos"] = team_df.loc[isolation_mask, "sos"].clip(upper=cfg.ISOLATION_SOS_CAP)
 
     # Log statistics
-    isolated_count = team_df['is_isolated'].sum()
-    avg_scf = team_df['scf'].mean()
-    low_scf_count = (team_df['scf'] < 0.7).sum()
-    quality_boosted_count = team_df['quality_boosted'].sum()
+    isolated_count = team_df["is_isolated"].sum()
+    avg_scf = team_df["scf"].mean()
+    low_scf_count = (team_df["scf"] < 0.7).sum()
+    quality_boosted_count = team_df["quality_boosted"].sum()
 
     logger.info(
         f"🔗 Schedule Connectivity Factor applied: "
@@ -695,7 +723,7 @@ def apply_scf_to_sos(
 
     # Log some examples of isolated teams (for debugging)
     if isolated_count > 0 and isolated_count <= 10:
-        isolated_teams = team_df[team_df['is_isolated']].head(5)
+        isolated_teams = team_df[team_df["is_isolated"]].head(5)
         for _, row in isolated_teams.iterrows():
             logger.info(
                 f"  📍 Isolated: team={row['team_id'][:8]}... "
@@ -707,10 +735,7 @@ def apply_scf_to_sos(
 
 
 def _adjust_for_opponent_strength(
-    games: pd.DataFrame,
-    strength_map: Dict[str, float],
-    cfg: V53EConfig,
-    baseline: Optional[float] = None
+    games: pd.DataFrame, strength_map: Dict[str, float], cfg: V53EConfig, baseline: Optional[float] = None
 ) -> pd.DataFrame:
     """
     Adjust goals for/against based on opponent strength to fix double-counting problem.
@@ -734,9 +759,9 @@ def _adjust_for_opponent_strength(
         baseline = cfg.OPPONENT_ADJUST_BASELINE
 
     # Get opponent strength for each game, floor at UNRANKED_SOS_BASE to prevent division by zero
-    g["opp_strength"] = g["opp_id"].map(
-        lambda o: strength_map.get(o, cfg.UNRANKED_SOS_BASE)
-    ).clip(lower=cfg.UNRANKED_SOS_BASE)
+    g["opp_strength"] = (
+        g["opp_id"].map(lambda o: strength_map.get(o, cfg.UNRANKED_SOS_BASE)).clip(lower=cfg.UNRANKED_SOS_BASE)
+    )
 
     # Calculate adjustment multipliers
     # Offense: score against strong opponent = more credit
@@ -744,8 +769,7 @@ def _adjust_for_opponent_strength(
     # Example: opp_strength=0.8, baseline=0.7 → multiplier=1.14 (14% more credit)
     #          opp_strength=0.6, baseline=0.7 → multiplier=0.86 (14% less credit)
     g["off_multiplier"] = (g["opp_strength"] / baseline).clip(
-        cfg.OPPONENT_ADJUST_CLIP_MIN,
-        cfg.OPPONENT_ADJUST_CLIP_MAX
+        cfg.OPPONENT_ADJUST_CLIP_MIN, cfg.OPPONENT_ADJUST_CLIP_MAX
     )
 
     # Defense: allow goals to strong opponent = less penalty
@@ -753,8 +777,7 @@ def _adjust_for_opponent_strength(
     # Example: opp_strength=0.8, baseline=0.7 → multiplier=0.875 (12.5% less penalty)
     #          opp_strength=0.6, baseline=0.7 → multiplier=1.17 (17% more penalty)
     g["def_multiplier"] = (baseline / g["opp_strength"]).clip(
-        cfg.OPPONENT_ADJUST_CLIP_MIN,
-        cfg.OPPONENT_ADJUST_CLIP_MAX
+        cfg.OPPONENT_ADJUST_CLIP_MIN, cfg.OPPONENT_ADJUST_CLIP_MAX
     )
 
     # Apply adjustments
@@ -792,7 +815,7 @@ def compute_rankings(
                        Factor (SCF) calculation. If not provided, SCF is disabled.
     """
     cfg = cfg or V53EConfig()
-    
+
     # Error handling: check for required columns
     try:
         _require_columns(games_df, REQUIRED_COLUMNS)
@@ -803,7 +826,7 @@ def compute_rankings(
     g = games_df.copy()
     g["date"] = pd.to_datetime(g["date"], errors="coerce")
     if today is None:
-        today = pd.Timestamp(pd.Timestamp.now('UTC').date())
+        today = pd.Timestamp(pd.Timestamp.now("UTC").date())
 
     # Defensive check: NaN age/gender would silently bypass cohort groupby operations
     # (groupby defaults to dropna=True). The import filter in data_adapter.py should
@@ -878,28 +901,26 @@ def compute_rankings(
     # Vectorized aggregation: compute weighted averages and simple aggregations
     g["gf_weighted"] = g["gf"] * g["w_game"]
     g["ga_weighted"] = g["ga"] * g["w_game"]
-    
+
     # Aggregate using vectorized operations
-    team = g.groupby(["team_id", "age", "gender"], as_index=False).agg({
-        "gf_weighted": "sum",
-        "ga_weighted": "sum",
-        "w_game": "sum",  # w_sum for weighted average calculation
-        "date": "max",    # last_game
-    }).rename(columns={"date": "last_game"})
-    
+    team = (
+        g.groupby(["team_id", "age", "gender"], as_index=False)
+        .agg(
+            {
+                "gf_weighted": "sum",
+                "ga_weighted": "sum",
+                "w_game": "sum",  # w_sum for weighted average calculation
+                "date": "max",  # last_game
+            }
+        )
+        .rename(columns={"date": "last_game"})
+    )
+
     # Calculate weighted averages (vectorized)
     w_sum = team["w_game"]
-    team["off_raw"] = np.where(
-        w_sum > 0,
-        team["gf_weighted"] / w_sum,
-        0.0
-    ).astype(float)
-    team["sad_raw"] = np.where(
-        w_sum > 0,
-        team["ga_weighted"] / w_sum,
-        0.0
-    ).astype(float)
-    
+    team["off_raw"] = np.where(w_sum > 0, team["gf_weighted"] / w_sum, 0.0).astype(float)
+    team["sad_raw"] = np.where(w_sum > 0, team["ga_weighted"] / w_sum, 0.0).astype(float)
+
     # Add gp (game count) using vectorized count
     gp_counts = g.groupby(["team_id", "age", "gender"], as_index=False).size().rename(columns={"size": "gp"})
     team = team.merge(gp_counts, on=["team_id", "age", "gender"], how="left")
@@ -915,7 +936,9 @@ def compute_rankings(
     # Calculate games in activity window (INACTIVE_HIDE_DAYS) for status filtering
     inactive_cutoff = today - pd.Timedelta(days=cfg.INACTIVE_HIDE_DAYS)
     g_recent = g[g["date"] >= inactive_cutoff].copy()
-    gp_recent_counts = g_recent.groupby(["team_id", "age", "gender"], as_index=False).size().rename(columns={"size": "gp_last_window"})
+    gp_recent_counts = (
+        g_recent.groupby(["team_id", "age", "gender"], as_index=False).size().rename(columns={"size": "gp_last_window"})
+    )
     team = team.merge(gp_recent_counts, on=["team_id", "age", "gender"], how="left")
     team["gp_last_window"] = team["gp_last_window"].fillna(0).astype(int)
 
@@ -948,8 +971,7 @@ def compute_rankings(
                 mu, sd = s.mean(), s.std(ddof=0)
                 # Save pre-clip values for tie-breaking in normalization
                 out[f"{col}_preclip"] = s
-                out[col] = s.clip(mu - cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd,
-                                  mu + cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd)
+                out[col] = s.clip(mu - cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd, mu + cfg.TEAM_OUTLIER_GUARD_ZSCORE * sd)
         return out
 
     team = pd.concat([_shrink_cohort(grp) for _, grp in team.groupby(["age", "gender"])]).reset_index(drop=True)
@@ -970,26 +992,9 @@ def compute_rankings(
     # -------------------------
     # power_presos uses only OFF/DEF (50% each) to avoid circular dependency with SOS.
     # This provides a stable base strength for opponent adjustment and cross-age SOS lookups.
-    team["power_presos"] = (
-        0.5 * team["off_norm"]
-        + 0.5 * team["def_norm"]
-    )
+    team["power_presos"] = 0.5 * team["off_norm"] + 0.5 * team["def_norm"]
 
-    # Static age → anchor mapping for U10–U19
-    # This ensures consistent scaling across ages regardless of cohort splitting
-    # Younger teams have lower max PowerScore, older teams can reach 1.0
-    AGE_TO_ANCHOR = {
-        10: 0.400,
-        11: 0.475,
-        12: 0.550,
-        13: 0.625,
-        14: 0.700,
-        15: 0.775,
-        16: 0.850,
-        17: 0.925,
-        18: 1.000,  # Legacy: kept for safety if u18 data reaches v53e unremappe
-        19: 1.000,  # U19 encompasses birth years 2007+2008 (formerly U18+U19)
-    }
+    from src.rankings.constants import AGE_TO_ANCHOR
 
     def compute_anchor(age_val):
         """Map age to static anchor value"""
@@ -1023,8 +1028,10 @@ def compute_rankings(
         # Floor at UNRANKED_SOS_BASE to prevent division by zero in opponent adjustment
         strength_values = list(strength_map.values())
         actual_mean_strength = max(np.mean(strength_values) if strength_values else 0.5, cfg.UNRANKED_SOS_BASE)
-        logger.info(f"📊 Strength distribution: mean={actual_mean_strength:.3f}, "
-                   f"min={min(strength_values):.3f}, max={max(strength_values):.3f}")
+        logger.info(
+            f"📊 Strength distribution: mean={actual_mean_strength:.3f}, "
+            f"min={min(strength_values):.3f}, max={max(strength_values):.3f}"
+        )
 
         # Use actual mean as baseline for opponent adjustment
         baseline = actual_mean_strength
@@ -1036,31 +1043,23 @@ def compute_rankings(
         g_adjusted["gf_weighted_adj"] = g_adjusted["gf_adjusted"] * g_adjusted["w_game"]
         g_adjusted["ga_weighted_adj"] = g_adjusted["ga_adjusted"] * g_adjusted["w_game"]
 
-        team_adj = g_adjusted.groupby(["team_id", "age", "gender"], as_index=False).agg({
-            "gf_weighted_adj": "sum",
-            "ga_weighted_adj": "sum",
-            "w_game": "sum",
-        })
+        team_adj = g_adjusted.groupby(["team_id", "age", "gender"], as_index=False).agg(
+            {
+                "gf_weighted_adj": "sum",
+                "ga_weighted_adj": "sum",
+                "w_game": "sum",
+            }
+        )
 
         # Calculate adjusted weighted averages
         w_sum = team_adj["w_game"]
-        team_adj["off_raw"] = np.where(
-            w_sum > 0,
-            team_adj["gf_weighted_adj"] / w_sum,
-            0.0
-        ).astype(float)
-        team_adj["sad_raw"] = np.where(
-            w_sum > 0,
-            team_adj["ga_weighted_adj"] / w_sum,
-            0.0
-        ).astype(float)
+        team_adj["off_raw"] = np.where(w_sum > 0, team_adj["gf_weighted_adj"] / w_sum, 0.0).astype(float)
+        team_adj["sad_raw"] = np.where(w_sum > 0, team_adj["ga_weighted_adj"] / w_sum, 0.0).astype(float)
 
         # Merge back to team DataFrame (replace old off_raw, sad_raw)
         team = team.drop(columns=["off_raw", "sad_raw"])
         team = team.merge(
-            team_adj[["team_id", "age", "gender", "off_raw", "sad_raw"]],
-            on=["team_id", "age", "gender"],
-            how="left"
+            team_adj[["team_id", "age", "gender", "off_raw", "sad_raw"]], on=["team_id", "age", "gender"], how="left"
         )
 
         # Re-apply defense ridge
@@ -1077,10 +1076,7 @@ def compute_rankings(
         team = _normalize_by_cohort(team, "def_shrunk", "def_norm", cfg.NORM_MODE)
 
         # Recalculate power_presos with adjusted OFF/DEF (50% each, no SOS to avoid circularity)
-        team["power_presos"] = (
-            0.5 * team["off_norm"]
-            + 0.5 * team["def_norm"]
-        )
+        team["power_presos"] = 0.5 * team["off_norm"] + 0.5 * team["def_norm"]
 
         # Update strength_map and power_map with adjusted power
         team["abs_strength"] = (team["power_presos"] * team["anchor"]).clip(cfg.UNRANKED_SOS_BASE, 1.0)
@@ -1108,17 +1104,12 @@ def compute_rankings(
     #
     # Pipeline for g_365:
     #   recency weights → w_game → adaptive K → w_sos
-    g_365 = pd.concat(
-        [apply_recency(grp) for _, grp in g_365.groupby("team_id")]
-    ).reset_index(drop=True)
+    g_365 = pd.concat([apply_recency(grp) for _, grp in g_365.groupby("team_id")]).reset_index(drop=True)
     g_365["w_game"] = g_365["w_base"]
     g_365["k_adapt"] = g_365.apply(adaptive_k, axis=1)
     g_365["w_sos"] = g_365["w_game"] * g_365["k_adapt"]
 
-    logger.info(
-        f"📊 SOS 365-day window: {len(g_365)} game-rows "
-        f"(vs {len(g)} in 30-game OFF/DEF window)"
-    )
+    logger.info(f"📊 SOS 365-day window: {len(g_365)} game-rows (vs {len(g)} in 30-game OFF/DEF window)")
 
     g_365 = g_365.sort_values(["team_id", "opp_id", "w_sos"], ascending=[True, True, False])
     g_365["repeat_rank"] = g_365.groupby(["team_id", "opp_id"])["w_sos"].rank(ascending=False, method="first")
@@ -1143,18 +1134,14 @@ def compute_rankings(
         team["component_id"] = team["team_id"].map(component_map).fillna(-1).astype(int)
 
         # Compute component size WITHIN this cohort (for shrinkage decisions)
-        team["component_size"] = team.groupby(
-            ["age", "gender", "component_id"]
-        )["team_id"].transform("count")
+        team["component_size"] = team.groupby(["age", "gender", "component_id"])["team_id"].transform("count")
 
         # Log component statistics
         n_components = team["component_id"].nunique()
         component_sizes = team.groupby("component_id")["team_id"].count()
         if n_components > 1:
             top5 = sorted(component_sizes.values, reverse=True)[:5]
-            logger.info(
-                f"🔗 {n_components} connected components (top 5 sizes: {top5})"
-            )
+            logger.info(f"🔗 {n_components} connected components (top 5 sizes: {top5})")
         else:
             logger.debug(f"🔗 Fully connected graph ({len(team)} teams, 1 component)")
     else:
@@ -1188,10 +1175,7 @@ def compute_rankings(
         cohort_avg_strength[(age, gender)] = float((grp_base_power * grp_anchor).mean())
 
     # Map team_id to cohort for quick lookup
-    team_cohort_map = dict(zip(
-        team["team_id"],
-        list(zip(team["age"], team["gender"]))
-    ))
+    team_cohort_map = dict(zip(team["team_id"], list(zip(team["age"], team["gender"]))))
 
     # Calculate BASE strength for each team (OFF/DEF only, normalized to avoid drift)
     # This represents opponent quality independent of their schedule
@@ -1201,10 +1185,7 @@ def compute_rankings(
     base_strength_map = {}
     for tid in team["team_id"]:
         # Base power uses only OFF and DEF (50% each of the non-SOS weight)
-        base_power = (
-            0.5 * team_off_norm_map.get(tid, 0.5) +
-            0.5 * team_def_norm_map.get(tid, 0.5)
-        )
+        base_power = 0.5 * team_off_norm_map.get(tid, 0.5) + 0.5 * team_def_norm_map.get(tid, 0.5)
         # Apply anchor to match global_strength_map scale
         # Raw strength is already anchored and bounded [0, 1]
         anchor = team_anchor_map.get(tid, 0.7)
@@ -1252,13 +1233,8 @@ def compute_rankings(
     # PageRank-style dampening on initial SOS (Pass 1)
     # This anchors even the first pass toward baseline, preventing inflated bubbles
     if cfg.PAGERANK_DAMPENING_ENABLED:
-        sos_curr["sos"] = (
-            (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE
-            + cfg.PAGERANK_ALPHA * sos_curr["sos"]
-        )
-        logger.info(
-            f"📌 PageRank dampening applied: alpha={cfg.PAGERANK_ALPHA}, baseline={cfg.PAGERANK_BASELINE}"
-        )
+        sos_curr["sos"] = (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE + cfg.PAGERANK_ALPHA * sos_curr["sos"]
+        logger.info(f"📌 PageRank dampening applied: alpha={cfg.PAGERANK_ALPHA}, baseline={cfg.PAGERANK_BASELINE}")
 
     # Log initial SOS (Pass 1: Direct)
     logger.info(
@@ -1300,27 +1276,26 @@ def compute_rankings(
         # Blend direct (opponent OFF/DEF - fixed) and transitive (opponent SOS - iterates)
         # Direct stays fixed to prevent upward drift, transitive propagates schedule info
         merged = direct.merge(trans, on="team_id", how="outer").fillna(0.5)
-        merged["sos"] = (
-            (1 - cfg.SOS_TRANSITIVITY_LAMBDA) * merged["sos_direct"]
-            + cfg.SOS_TRANSITIVITY_LAMBDA * merged["sos_trans"]
-        )
+        merged["sos"] = (1 - cfg.SOS_TRANSITIVITY_LAMBDA) * merged["sos_direct"] + cfg.SOS_TRANSITIVITY_LAMBDA * merged[
+            "sos_trans"
+        ]
 
         # PageRank-style dampening: anchor SOS toward baseline to prevent infinite drift
         # Formula: SOS_final = (1 - alpha) * baseline + alpha * SOS_calculated
         # This ensures isolated clusters can't inflate SOS beyond a certain point
         if cfg.PAGERANK_DAMPENING_ENABLED:
-            merged["sos"] = (
-                (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE
-                + cfg.PAGERANK_ALPHA * merged["sos"]
-            )
+            merged["sos"] = (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE + cfg.PAGERANK_ALPHA * merged["sos"]
 
         # SOS stability guard: clip values between 0.0 and 1.0
         merged["sos"] = merged["sos"].clip(0.0, 1.0)
         sos_curr = merged[["team_id", "sos"]]
 
         # Calculate convergence: mean absolute change from previous iteration
-        sos_changes = [abs(sos_curr[sos_curr["team_id"] == tid]["sos"].iloc[0] - prev_sos_map.get(tid, 0.5))
-                      for tid in sos_curr["team_id"] if tid in prev_sos_map]
+        sos_changes = [
+            abs(sos_curr[sos_curr["team_id"] == tid]["sos"].iloc[0] - prev_sos_map.get(tid, 0.5))
+            for tid in sos_curr["team_id"]
+            if tid in prev_sos_map
+        ]
         mean_change = np.mean(sos_changes) if sos_changes else 0.0
 
         # Log convergence metrics with change tracking
@@ -1374,8 +1349,7 @@ def compute_rankings(
         )
     elif cfg.SCF_ENABLED and team_state_map is None:
         logger.warning(
-            "⚠️  SCF enabled but team_state_map not provided. "
-            "Regional bubble detection disabled for this run."
+            "⚠️  SCF enabled but team_state_map not provided. Regional bubble detection disabled for this run."
         )
 
     # NOTE: Pre-percentile SOS shrinkage was REMOVED (was buggy)
@@ -1402,9 +1376,9 @@ def compute_rankings(
     # SOS contribution to ~10% instead of 50%.
 
     # Determine groupby columns based on whether component normalization is enabled
-    sos_group_cols = ['age', 'gender']
+    sos_group_cols = ["age", "gender"]
     if cfg.COMPONENT_SOS_ENABLED:
-        sos_group_cols = ['age', 'gender', 'component_id']
+        sos_group_cols = ["age", "gender", "component_id"]
         logger.info("🔄 Computing SOS normalization (percentile within connected components)")
     else:
         logger.info("🔄 Computing per-cohort SOS normalization (percentile within age+gender)")
@@ -1419,26 +1393,23 @@ def compute_rankings(
         # epsilon) get spread across the full [0, 1] range, creating up to 0.40
         # PowerScore gaps from pure noise.
         x_rounded = x.round(10)
-        ranks = x_rounded.rank(method='average')
+        ranks = x_rounded.rank(method="average")
         return (ranks - 1) / (len(x) - 1) if len(x) > 1 else pd.Series([0.5], index=x.index)
 
     # Select normalization function: hybrid (percentile+zscore blend) or pure percentile
     if cfg.SOS_NORM_HYBRID_ENABLED:
         _sos_norm_fn = lambda x: _hybrid_sos_norm(x, zscore_blend=cfg.SOS_NORM_HYBRID_ZSCORE_BLEND)
-        logger.info(
-            f"🔀 Using HYBRID SOS normalization "
-            f"(zscore_blend={cfg.SOS_NORM_HYBRID_ZSCORE_BLEND:.0%})"
-        )
+        logger.info(f"🔀 Using HYBRID SOS normalization (zscore_blend={cfg.SOS_NORM_HYBRID_ZSCORE_BLEND:.0%})")
     else:
         _sos_norm_fn = percentile_within_group
 
-    team['sos_norm'] = team.groupby(sos_group_cols)['sos'].transform(_sos_norm_fn)
+    team["sos_norm"] = team.groupby(sos_group_cols)["sos"].transform(_sos_norm_fn)
 
     # Handle edge cases (NaN from single-team cohorts/components)
-    team['sos_norm'] = team['sos_norm'].fillna(0.5)
+    team["sos_norm"] = team["sos_norm"].fillna(0.5)
 
     # Ensure values are clipped to [0, 1]
-    team['sos_norm'] = team['sos_norm'].clip(0.0, 1.0)
+    team["sos_norm"] = team["sos_norm"].clip(0.0, 1.0)
 
     # Component-size shrinkage: small disconnected components get their sos_norm
     # shrunk toward 0.5 because percentile normalization over a handful of teams
@@ -1453,26 +1424,25 @@ def compute_rankings(
         shrunk_components = team[team["component_size"] < min_size]["component_id"].nunique()
         if shrunk_components > 0:
             logger.info(
-                f"📉 Component-size shrinkage applied to {shrunk_components} "
-                f"small component(s) (< {min_size} teams)"
+                f"📉 Component-size shrinkage applied to {shrunk_components} small component(s) (< {min_size} teams)"
             )
 
     # Log SOS norms summary (per-cohort detail at DEBUG)
-    logger.info(f"📊 SOS norms: overall min={team['sos_norm'].min():.3f}, max={team['sos_norm'].max():.3f}, mean={team['sos_norm'].mean():.3f}")
-    for (age, gender), grp in team.groupby(['age', 'gender']):
+    logger.info(
+        f"📊 SOS norms: overall min={team['sos_norm'].min():.3f}, max={team['sos_norm'].max():.3f}, mean={team['sos_norm'].mean():.3f}"
+    )
+    for (age, gender), grp in team.groupby(["age", "gender"]):
         if len(grp) >= 5:
-            logger.debug(f"  SOS {age} {gender}: min={grp['sos_norm'].min():.3f}, "
-                        f"max={grp['sos_norm'].max():.3f}, "
-                        f"mean={grp['sos_norm'].mean():.3f}, n={len(grp)}")
+            logger.debug(
+                f"  SOS {age} {gender}: min={grp['sos_norm'].min():.3f}, "
+                f"max={grp['sos_norm'].max():.3f}, "
+                f"mean={grp['sos_norm'].mean():.3f}, n={len(grp)}"
+            )
 
     # Low sample handling: smooth shrink toward 0.5 for teams with insufficient games
     # This prevents teams with few games from having extreme SOS values (high or low)
     # while avoiding hard caps that create discontinuities.
-    team["sample_flag"] = np.where(
-        team["gp"] < cfg.MIN_GAMES_FOR_TOP_SOS,
-        "LOW_SAMPLE",
-        "OK"
-    )
+    team["sample_flag"] = np.where(team["gp"] < cfg.MIN_GAMES_FOR_TOP_SOS, "LOW_SAMPLE", "OK")
 
     # Soft shrinkage: blend toward anchor based on sample size
     # Using LINEAR shrinkage for proportional dampening of low-sample teams:
@@ -1488,15 +1458,13 @@ def compute_rankings(
     anchor = cfg.SOS_SHRINKAGE_ANCHOR
 
     # Apply shrinkage: sos_norm = anchor + shrink_factor * (sos_norm - anchor)
-    team.loc[low_sample_mask, "sos_norm"] = (
-        anchor + shrink_factor[low_sample_mask] * (team.loc[low_sample_mask, "sos_norm"] - anchor)
+    team.loc[low_sample_mask, "sos_norm"] = anchor + shrink_factor[low_sample_mask] * (
+        team.loc[low_sample_mask, "sos_norm"] - anchor
     )
 
     low_sample_count = low_sample_mask.sum()
     if low_sample_count > 0:
-        logger.info(
-            f"🏷️  Low sample handling: {low_sample_count} teams with soft SOS shrinkage toward {anchor}"
-        )
+        logger.info(f"🏷️  Low sample handling: {low_sample_count} teams with soft SOS shrinkage toward {anchor}")
 
     # Correlation guardrail + GP-SOS decorrelation
     # Detects if games-played is leaking into sos_norm, and for age buckets
@@ -1543,8 +1511,7 @@ def compute_rankings(
                 # GP-SOS decorrelation: only for ranked teams in biased age buckets
                 # We only fix the problem for teams that actually get ranked (>= MIN_GAMES_PROVISIONAL)
                 # since unranked teams' SOS doesn't affect displayed rankings.
-                if (cfg.GP_SOS_DECORRELATION_ENABLED
-                        and abs(age_corr) > cfg.GP_SOS_DECORRELATION_THRESHOLD):
+                if cfg.GP_SOS_DECORRELATION_ENABLED and abs(age_corr) > cfg.GP_SOS_DECORRELATION_THRESHOLD:
                     # Target: ranked teams in this age bucket
                     ranked_mask = age_mask & (team["gp"] >= cfg.MIN_GAMES_PROVISIONAL)
                     ranked_idx = team.index[ranked_mask]
@@ -1578,16 +1545,14 @@ def compute_rankings(
                         )
 
         if decorrelation_applied > 0:
-            logger.info(
-                f"📊 GP-SOS decorrelation applied to {decorrelation_applied} age bucket(s)"
-            )
+            logger.info(f"📊 GP-SOS decorrelation applied to {decorrelation_applied} age bucket(s)")
 
     # -------------------------
     # Layer 6: Performance
     # -------------------------
     g_perf = g.copy()
     g_perf["team_power"] = g_perf["team_id"].map(lambda t: power_map.get(t, 0.5))
-    g_perf["opp_power"]  = g_perf["opp_id"].map(lambda t: power_map.get(t, 0.5))
+    g_perf["opp_power"] = g_perf["opp_id"].map(lambda t: power_map.get(t, 0.5))
     g_perf["exp_margin"] = cfg.PERFORMANCE_GOAL_SCALE * (g_perf["team_power"] - g_perf["opp_power"])
     g_perf["perf_delta"] = (g_perf["gd"] - g_perf["exp_margin"]).astype(float)
 
@@ -1601,11 +1566,7 @@ def compute_rankings(
     # per-game performance contribution (symmetric)
     # Uses PERF_GAME_SCALE to scale individual game residuals
     g_perf["perf_contrib"] = (
-        cfg.PERF_GAME_SCALE
-        * g_perf["perf_delta"]
-        * g_perf["recency_decay"]
-        * g_perf["k_adapt"]
-        * g_perf["w_game"]
+        cfg.PERF_GAME_SCALE * g_perf["perf_delta"] * g_perf["recency_decay"] * g_perf["k_adapt"] * g_perf["w_game"]
     )
 
     perf_team = (
@@ -1644,9 +1605,7 @@ def compute_rankings(
         + team["perf_centered"] * cfg.PERF_BLEND_WEIGHT
     ) / MAX_POWERSCORE_THEORETICAL
 
-    team["provisional_mult"] = team["gp"].apply(
-        lambda gp: _provisional_multiplier(int(gp), cfg.MIN_GAMES_PROVISIONAL)
-    )
+    team["provisional_mult"] = team["gp"].apply(lambda gp: _provisional_multiplier(int(gp), cfg.MIN_GAMES_PROVISIONAL))
     team["powerscore_adj"] = team["powerscore_core"] * team["provisional_mult"]
 
     # -------------------------
@@ -1749,27 +1708,27 @@ def compute_rankings(
             # Step 5: Re-normalize SOS within connected components (or cohort if disabled)
             # Uses the same groupby columns and normalization function as the initial
             # normalization to ensure disconnected ecosystems are normalized independently.
-            team['sos_norm'] = team.groupby(sos_group_cols)['sos'].transform(_sos_norm_fn)
-            team['sos_norm'] = team['sos_norm'].fillna(0.5).clip(0.0, 1.0)
+            team["sos_norm"] = team.groupby(sos_group_cols)["sos"].transform(_sos_norm_fn)
+            team["sos_norm"] = team["sos_norm"].fillna(0.5).clip(0.0, 1.0)
 
             # Step 5b: Apply component-size shrinkage (same as initial normalization)
             if cfg.COMPONENT_SOS_ENABLED:
                 min_size = cfg.MIN_COMPONENT_SIZE_FOR_FULL_SOS
                 comp_shrink = (team["component_size"].values / min_size).clip(0.0, 1.0)
-                sos_norm_values = team['sos_norm'].values
-                team['sos_norm'] = 0.5 + comp_shrink * (sos_norm_values - 0.5)
+                sos_norm_values = team["sos_norm"].values
+                team["sos_norm"] = 0.5 + comp_shrink * (sos_norm_values - 0.5)
 
             # Step 6: Apply low-sample shrinkage (vectorized) - LINEAR toward anchor
             # NOTE: This is NOT compounding — each iteration recalculates sos_norm fresh
             # from scratch (step 5 above), so this shrinks a fresh value each time.
             low_sample_mask = gps < cfg.MIN_GAMES_FOR_TOP_SOS
             shrink_factor = np.clip(gps / cfg.MIN_GAMES_FOR_TOP_SOS, 0.0, 1.0)
-            sos_norm_values = team['sos_norm'].values.copy()
+            sos_norm_values = team["sos_norm"].values.copy()
             anchor = cfg.SOS_SHRINKAGE_ANCHOR
-            sos_norm_values[low_sample_mask] = (
-                anchor + shrink_factor[low_sample_mask] * (sos_norm_values[low_sample_mask] - anchor)
+            sos_norm_values[low_sample_mask] = anchor + shrink_factor[low_sample_mask] * (
+                sos_norm_values[low_sample_mask] - anchor
             )
-            team['sos_norm'] = sos_norm_values
+            team["sos_norm"] = sos_norm_values
 
             # Step 6b: GP-SOS decorrelation (same as initial pass)
             # Re-apply per iteration since sos_norm is recalculated fresh each time.
@@ -1790,17 +1749,12 @@ def compute_rankings(
                     gp_var = np.var(gp_c)
                     if gp_var > 0:
                         beta = np.cov(gp_c, sos_r)[0, 1] / gp_var
-                        team.loc[ranked_idx, "sos_norm"] = np.clip(
-                            sos_r - beta * gp_c, 0.0, 1.0
-                        )
+                        team.loc[ranked_idx, "sos_norm"] = np.clip(sos_r - beta * gp_c, 0.0, 1.0)
 
             # Step 7: Recalculate power score with new SOS (vectorized)
-            sos_norm_arr = team['sos_norm'].values
+            sos_norm_arr = team["sos_norm"].values
             powerscore_core = (
-                w_off * off_norms
-                + w_def * def_norms
-                + w_sos * sos_norm_arr
-                + perf_centereds * w_perf
+                w_off * off_norms + w_def * def_norms + w_sos * sos_norm_arr + perf_centereds * w_perf
             ) / MAX_POWERSCORE_THEORETICAL
 
             team["powerscore_core"] = powerscore_core
@@ -1835,10 +1789,8 @@ def compute_rankings(
     # Layer 11: Rank & status
     # -------------------------
     # Calculate days since last game (handle NULL last_game)
-    team["days_since_last"] = (
-        pd.Timestamp(today) - pd.to_datetime(team["last_game"], errors='coerce')
-    ).dt.days
-    
+    team["days_since_last"] = (pd.Timestamp(today) - pd.to_datetime(team["last_game"], errors="coerce")).dt.days
+
     # Filter teams based on games in activity window (INACTIVE_HIDE_DAYS, aligned with WINDOW_DAYS=365)
     # Status priority:
     # 1. "Inactive" - No games in activity window (gp_last_window == 0) OR last_game is NULL OR days_since_last >= INACTIVE_HIDE_DAYS
@@ -1846,15 +1798,11 @@ def compute_rankings(
     # 2. "Not Enough Ranked Games" - Has games in activity window but < MIN_GAMES_PROVISIONAL (6 games)
     # 3. "Active" - Has >= MIN_GAMES_PROVISIONAL games in activity window
     team["status"] = np.where(
-        (team["gp_last_window"] == 0) |
-        (team["last_game"].isna()) |
-        (team["days_since_last"].fillna(999) >= cfg.INACTIVE_HIDE_DAYS),
+        (team["gp_last_window"] == 0)
+        | (team["last_game"].isna())
+        | (team["days_since_last"].fillna(999) >= cfg.INACTIVE_HIDE_DAYS),
         "Inactive",
-        np.where(
-            team["gp_last_window"] < cfg.MIN_GAMES_PROVISIONAL,
-            "Not Enough Ranked Games",
-            "Active"
-        )
+        np.where(team["gp_last_window"] < cfg.MIN_GAMES_PROVISIONAL, "Not Enough Ranked Games", "Active"),
     )
 
     # Log status distribution summary
@@ -1876,8 +1824,7 @@ def compute_rankings(
         # Sort active teams for ranking: powerscore DESC, then SOS DESC (tiebreaker)
         # This ensures teams with same PowerScore are differentiated by schedule strength
         active_teams = active_teams.sort_values(
-            ["gender", "age", "powerscore_adj", "sos"],
-            ascending=[True, True, False, False]
+            ["gender", "age", "powerscore_adj", "sos"], ascending=[True, True, False, False]
         ).reset_index(drop=True)
 
         # Calculate unique ranks based on sort order (no ties)
@@ -1889,27 +1836,62 @@ def compute_rankings(
         team.loc[active_mask, "rank_in_cohort"] = team.loc[active_mask, "team_id"].map(rank_map)
 
     # Sort full team DataFrame for consistent output order (with SOS tiebreaker)
-    team = team.sort_values(["gender", "age", "powerscore_adj", "sos"], ascending=[True, True, False, False]).reset_index(drop=True)
+    team = team.sort_values(
+        ["gender", "age", "powerscore_adj", "sos"], ascending=[True, True, False, False]
+    ).reset_index(drop=True)
 
     # outputs
     games_used_cols = [
-        "game_id", "date", "team_id", "opp_id",
-        "age", "gender", "opp_age", "opp_gender",
-        "gf", "ga", "gd",
-        "w_base", "k_adapt", "w_game", "w_sos", "rank_recency"
+        "game_id",
+        "date",
+        "team_id",
+        "opp_id",
+        "age",
+        "gender",
+        "opp_age",
+        "opp_gender",
+        "gf",
+        "ga",
+        "gd",
+        "w_base",
+        "k_adapt",
+        "w_game",
+        "w_sos",
+        "rank_recency",
     ]
     # Return the 365-day SOS games (after repeat-cap) that actually fed SOS.
     games_used = g_sos[[c for c in games_used_cols if c in g_sos.columns]].copy()
 
     keep_cols = [
-        "team_id", "age", "gender", "gp", "gp_last_window", "last_game", "status", "rank_in_cohort",
-        "wins", "losses", "draws",
-        "off_raw", "sad_raw", "off_shrunk", "sad_shrunk", "def_shrunk",
-        "off_norm", "def_norm",
-        "sos", "sos_norm", "sample_flag",
-        "power_presos", "anchor", "abs_strength",
-        "perf_raw", "perf_centered",
-        "powerscore_core", "provisional_mult", "powerscore_adj"
+        "team_id",
+        "age",
+        "gender",
+        "gp",
+        "gp_last_window",
+        "last_game",
+        "status",
+        "rank_in_cohort",
+        "wins",
+        "losses",
+        "draws",
+        "off_raw",
+        "sad_raw",
+        "off_shrunk",
+        "sad_shrunk",
+        "def_shrunk",
+        "off_norm",
+        "def_norm",
+        "sos",
+        "sos_norm",
+        "sample_flag",
+        "power_presos",
+        "anchor",
+        "abs_strength",
+        "perf_raw",
+        "perf_centered",
+        "powerscore_core",
+        "provisional_mult",
+        "powerscore_adj",
     ]
     # Add SCF columns if they exist (from regional bubble detection)
     scf_cols = ["scf", "bridge_games", "is_isolated", "unique_opp_states", "quality_boosted"]
@@ -1929,7 +1911,7 @@ def compute_rankings(
 
     # Map rank_in_cohort to rank_in_cohort_final (convert to float, handle None)
     # Use pd.to_numeric to handle None values properly (converts None to NaN, which becomes NULL in DB)
-    teams["rank_in_cohort_final"] = pd.to_numeric(teams["rank_in_cohort"], errors='coerce')
+    teams["rank_in_cohort_final"] = pd.to_numeric(teams["rank_in_cohort"], errors="coerce")
 
     # State rank must be computed — fallback to cohort rank for now
     # (State information is not available in v53e output, will be computed later in pipeline)
@@ -1972,7 +1954,7 @@ def compute_rankings(
     teams["defense_norm"] = teams["def_norm"]
 
     # For data freshness
-    teams["last_calculated"] = pd.Timestamp.now('UTC')
+    teams["last_calculated"] = pd.Timestamp.now("UTC")
 
     # Games played summary for the frontend
     teams["games_played"] = teams["gp"]

--- a/src/models/affinity_wa_matcher.py
+++ b/src/models/affinity_wa_matcher.py
@@ -11,6 +11,7 @@ Affinity-specific overrides (do not affect other providers):
 - Broader club filter: "Eastside FC" matches "Eastside FC (WA)"
 - Club+variant boost: when club same and variant same, strong match (e.g. "B14 Red" vs "Eastside FC 2014 Red")
 """
+
 import logging
 import re
 import uuid
@@ -70,7 +71,7 @@ def _extract_rcl_number(name: str) -> Optional[str]:
     """Extract RCL division from team name, e.g. 'XF B14 RCL 3' -> '3', 'Crossfire 2014 RCL 2' -> '2'."""
     if not name:
         return None
-    m = re.search(r'\bRCL\s*(\d+)\b', name, re.IGNORECASE)
+    m = re.search(r"\bRCL\s*(\d+)\b", name, re.IGNORECASE)
     return m.group(1) if m else None
 
 
@@ -98,17 +99,13 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
     def __init__(self, supabase, provider_id=None, alias_cache=None):
         super().__init__(supabase, provider_id=provider_id, alias_cache=alias_cache)
         self.default_state_code = STATE_CODE
-        self._affinity_variant_gate_required = MATCHING_CONFIG.get('affinity_variant_gate_required', True)
-        self._affinity_rcl_strict = MATCHING_CONFIG.get('affinity_rcl_strict', True)
-        self._affinity_club_similarity_threshold = MATCHING_CONFIG.get('affinity_club_similarity_threshold', 0.9)
-        self._affinity_debug_match_reasons = MATCHING_CONFIG.get('affinity_debug_match_reasons', False)
+        self._affinity_variant_gate_required = MATCHING_CONFIG.get("affinity_variant_gate_required", True)
+        self._affinity_rcl_strict = MATCHING_CONFIG.get("affinity_rcl_strict", True)
+        self._affinity_club_similarity_threshold = MATCHING_CONFIG.get("affinity_club_similarity_threshold", 0.9)
+        self._affinity_debug_match_reasons = MATCHING_CONFIG.get("affinity_debug_match_reasons", False)
 
     def _fuzzy_match_team(
-        self,
-        team_name: str,
-        age_group: str,
-        gender: str,
-        club_name: Optional[str] = None
+        self, team_name: str, age_group: str, gender: str, club_name: Optional[str] = None
     ) -> Optional[Dict]:
         """Affinity-only fuzzy matching with gated candidate selection."""
         try:
@@ -128,36 +125,43 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
             provider_year = re.search(r"\b(20\d{2})\b", provider_team_name)
             provider_year_token = provider_year.group(1) if provider_year else None
 
-            name_lower = provider_team_name.lower() if provider_team_name else ''
-            provider_has_rl = (' rl' in name_lower or '-rl' in name_lower or 'ecnl rl' in name_lower or 'ecnl-rl' in name_lower)
-            provider_has_ecnl = 'ecnl' in name_lower and not provider_has_rl
+            name_lower = provider_team_name.lower() if provider_team_name else ""
+            provider_has_rl = (
+                " rl" in name_lower or "-rl" in name_lower or "ecnl rl" in name_lower or "ecnl-rl" in name_lower
+            )
+            provider_has_ecnl = "ecnl" in name_lower and not provider_has_rl
 
             # Affinity teams are WA-only; filter candidates to WA to avoid cross-state club noise.
-            result = self.db.table('teams').select(
-                'team_id_master, team_name, club_name, age_group, gender, state_code'
-            ).eq('age_group', age_group_normalized).eq('gender', gender).eq('state_code', STATE_CODE).execute()
+            result = (
+                self.db.table("teams")
+                .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                .eq("age_group", age_group_normalized)
+                .eq("gender", gender)
+                .eq("state_code", STATE_CODE)
+                .execute()
+            )
 
             if not result or not result.data:
                 return None
 
-            reject_counts = {'club_mismatch': 0, 'variant_mismatch': 0, 'rcl_mismatch': 0}
+            reject_counts = {"club_mismatch": 0, "variant_mismatch": 0, "rcl_mismatch": 0}
             best_match = None
             best_score = 0.0
             best_tiebreak = (0, 0, 0)
             provider_team = {
-                'team_name': provider_team_name,
-                'club_name': provider_club_name,
-                'age_group': age_group,
-                'state_code': 'WA',
+                "team_name": provider_team_name,
+                "club_name": provider_club_name,
+                "age_group": age_group,
+                "state_code": "WA",
             }
 
             candidate_count_before_gate = len(result.data)
             candidate_count_after_gate = 0
 
             for team in result.data:
-                candidate_name_raw = team.get('team_name', '')
+                candidate_name_raw = team.get("team_name", "")
                 candidate_name_norm = _normalize_for_affinity_wa(candidate_name_raw)
-                candidate_club_raw = team.get('club_name')
+                candidate_club_raw = team.get("club_name")
                 candidate_club_norm = _normalize_club_for_affinity(candidate_club_raw)
 
                 # Stage 1 gate: canonical same-club (or very high similarity).
@@ -167,32 +171,34 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
                         candidate_club_norm,
                         threshold=self._affinity_club_similarity_threshold,
                     ):
-                        reject_counts['club_mismatch'] += 1
+                        reject_counts["club_mismatch"] += 1
                         continue
 
                 # Stage 2 gate: variant compatibility.
                 candidate_variant = extract_team_variant(candidate_name_norm)
                 if self._affinity_variant_gate_required and provider_variant != candidate_variant:
-                    reject_counts['variant_mismatch'] += 1
+                    reject_counts["variant_mismatch"] += 1
                     continue
 
                 # Stage 2b gate: strict RCL lane separation.
                 candidate_rcl = _extract_rcl_number(candidate_name_norm)
                 if self._affinity_rcl_strict and provider_rcl and candidate_rcl and provider_rcl != candidate_rcl:
-                    reject_counts['rcl_mismatch'] += 1
+                    reject_counts["rcl_mismatch"] += 1
                     continue
 
                 candidate_count_after_gate += 1
                 candidate = {
-                    'team_name': candidate_name_norm,
-                    'club_name': candidate_club_norm or candidate_club_raw,
-                    'age_group': team.get('age_group'),
-                    'state_code': team.get('state_code')
+                    "team_name": candidate_name_norm,
+                    "club_name": candidate_club_norm or candidate_club_raw,
+                    "age_group": team.get("age_group"),
+                    "state_code": team.get("state_code"),
                 }
                 score = self._calculate_match_score(provider_team, candidate)
                 cand_lower = candidate_name_norm.lower()
-                cand_has_rl = (' rl' in cand_lower or '-rl' in cand_lower or 'ecnl rl' in cand_lower or 'ecnl-rl' in cand_lower)
-                cand_has_ecnl = 'ecnl' in cand_lower and not cand_has_rl
+                cand_has_rl = (
+                    " rl" in cand_lower or "-rl" in cand_lower or "ecnl rl" in cand_lower or "ecnl-rl" in cand_lower
+                )
+                cand_has_ecnl = "ecnl" in cand_lower and not cand_has_rl
                 if provider_has_rl and cand_has_rl:
                     score = min(1.0, score + 0.05)
                 elif provider_has_ecnl and cand_has_ecnl and not cand_has_rl:
@@ -205,23 +211,35 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
                 candidate_year_token = candidate_year.group(1) if candidate_year else None
                 tiebreak = (
                     1 if provider_variant == candidate_variant else 0,
-                    1 if provider_year_token and candidate_year_token and provider_year_token == candidate_year_token else 0,
-                    1 if provider_club_name and candidate_club_norm and are_same_club(provider_club_name, candidate_club_norm, threshold=0.95) else 0,
+                    1
+                    if provider_year_token and candidate_year_token and provider_year_token == candidate_year_token
+                    else 0,
+                    1
+                    if provider_club_name
+                    and candidate_club_norm
+                    and are_same_club(provider_club_name, candidate_club_norm, threshold=0.95)
+                    else 0,
                 )
 
-                if score >= self.fuzzy_threshold and (score > best_score or (score == best_score and tiebreak > best_tiebreak)):
+                if score >= self.fuzzy_threshold and (
+                    score > best_score or (score == best_score and tiebreak > best_tiebreak)
+                ):
                     best_score = score
                     best_tiebreak = tiebreak
-                    best_match = {'team_id': team['team_id_master'], 'team_name': candidate_name_raw, 'confidence': round(score, 3)}
+                    best_match = {
+                        "team_id": team["team_id_master"],
+                        "team_name": candidate_name_raw,
+                        "confidence": round(score, 3),
+                    }
 
             if self._affinity_debug_match_reasons:
                 logger.info(
                     "[AffinityWA] Candidate gate stats: before=%s after=%s rejected(club=%s, variant=%s, rcl=%s) for '%s'",
                     candidate_count_before_gate,
                     candidate_count_after_gate,
-                    reject_counts['club_mismatch'],
-                    reject_counts['variant_mismatch'],
-                    reject_counts['rcl_mismatch'],
+                    reject_counts["club_mismatch"],
+                    reject_counts["variant_mismatch"],
+                    reject_counts["rcl_mismatch"],
                     team_name,
                 )
             return best_match
@@ -232,11 +250,11 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
     def _calculate_match_score(self, provider_team: Dict, candidate: Dict) -> float:
         """Override: add club+variant boost for Affinity (e.g. 'B14 Red' vs 'Eastside FC 2014 Red')."""
         score = super()._calculate_match_score(provider_team, candidate)
-        provider_club = provider_team.get('club_name')
-        candidate_club = candidate.get('club_name')
+        provider_club = provider_team.get("club_name")
+        candidate_club = candidate.get("club_name")
         if provider_club and candidate_club:
             if are_same_club(provider_club, candidate_club, threshold=0.9):
-                boost = MATCHING_CONFIG.get('club_variant_match_boost', 0.35)
+                boost = MATCHING_CONFIG.get("club_variant_match_boost", 0.35)
                 score = min(1.0, score + boost)  # Club+variant match boost (caller filters by variant)
         return score
 
@@ -252,39 +270,39 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
         team_name: Optional[str],
         age_group: Optional[str],
         gender: Optional[str],
-        club_name: Optional[str] = None
+        club_name: Optional[str] = None,
     ) -> Dict:
         """Override: create new team when no match found. Reject fuzzy matches when RCL differs."""
-        base_result = super()._match_team(
-            provider_id, provider_team_id, team_name, age_group, gender, club_name
-        )
-        if base_result.get('matched'):
+        base_result = super()._match_team(provider_id, provider_team_id, team_name, age_group, gender, club_name)
+        if base_result.get("matched"):
             # Reject fuzzy matches when RCL number differs (RCL 2 vs RCL 3 are different teams)
-            method = base_result.get('method', '')
-            if 'fuzzy' in str(method).lower() and team_name and 'RCL' in team_name.upper():
+            method = base_result.get("method", "")
+            if "fuzzy" in str(method).lower() and team_name and "RCL" in team_name.upper():
                 provider_rcl = _extract_rcl_number(team_name)
                 if provider_rcl:
                     try:
-                        row = self.db.table('teams').select('team_name').eq(
-                            'team_id_master', base_result['team_id']
-                        ).single().execute()
+                        row = (
+                            self.db.table("teams")
+                            .select("team_name")
+                            .eq("team_id_master", base_result["team_id"])
+                            .single()
+                            .execute()
+                        )
                         if row.data:
-                            matched_rcl = _extract_rcl_number(row.data.get('team_name', ''))
+                            matched_rcl = _extract_rcl_number(row.data.get("team_name", ""))
                             if matched_rcl and provider_rcl != matched_rcl:
                                 logger.info(
                                     f"[AffinityWA] Rejecting fuzzy match: '{team_name}' RCL {provider_rcl} "
                                     f"!= matched RCL {matched_rcl}, creating new team"
                                 )
-                                base_result = {'matched': False}
+                                base_result = {"matched": False}
                     except Exception as e:
                         logger.debug(f"[AffinityWA] RCL check failed: {e}")
-            if base_result.get('matched'):
+            if base_result.get("matched"):
                 return base_result
 
         if team_name and age_group and gender:
-            logger.info(
-                f"[AffinityWA] No match for '{team_name}' ({age_group}, {gender}), creating new team"
-            )
+            logger.info(f"[AffinityWA] No match for '{team_name}' ({age_group}, {gender}), creating new team")
             try:
                 new_team_id = self._create_new_affinity_wa_team(
                     team_name=team_name,
@@ -292,9 +310,9 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
                     age_group=age_group,
                     gender=gender,
                     provider_id=provider_id,
-                    provider_team_id=provider_team_id
+                    provider_team_id=provider_team_id,
                 )
-                match_method = 'direct_id' if provider_team_id else 'import'
+                match_method = "direct_id" if provider_team_id else "import"
                 self._create_alias(
                     provider_id=provider_id,
                     provider_team_id=provider_team_id,
@@ -304,17 +322,15 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
                     confidence=1.0,
                     age_group=age_group,
                     gender=gender,
-                    review_status='approved'
+                    review_status="approved",
                 )
-                logger.info(
-                    f"[AffinityWA] Created: {team_name} ({age_group}, {gender}) -> {new_team_id}"
-                )
+                logger.info(f"[AffinityWA] Created: {team_name} ({age_group}, {gender}) -> {new_team_id}")
                 return {
-                    'matched': True,
-                    'team_id': new_team_id,
-                    'method': match_method,
-                    'confidence': 1.0,
-                    'created': True,  # Signal to pipeline for teams_created metrics
+                    "matched": True,
+                    "team_id": new_team_id,
+                    "method": match_method,
+                    "confidence": 1.0,
+                    "created": True,  # Signal to pipeline for teams_created metrics
                 }
             except Exception as e:
                 logger.error(f"[AffinityWA] Error creating team for {team_name}: {e}")
@@ -328,45 +344,50 @@ class AffinityWAGameMatcher(GameHistoryMatcher):
         age_group: str,
         gender: str,
         provider_id: Optional[str],
-        provider_team_id: Optional[str] = None
+        provider_team_id: Optional[str] = None,
     ) -> str:
         """Create new team in teams table. All affinity_wa teams are WA."""
         if not provider_team_id:
             import hashlib
-            provider_team_id = hashlib.md5(
-                f"{team_name}_{age_group}_{gender}".encode()
-            ).hexdigest()[:16]
+
+            # MD5 for deterministic ID generation (not security)
+            provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}".encode()).hexdigest()[:16]
 
         if provider_id:
             try:
-                existing = self.db.table('teams').select('team_id_master').eq(
-                    'provider_id', provider_id
-                ).eq('provider_team_id', provider_team_id).single().execute()
+                existing = (
+                    self.db.table("teams")
+                    .select("team_id_master")
+                    .eq("provider_id", provider_id)
+                    .eq("provider_team_id", provider_team_id)
+                    .single()
+                    .execute()
+                )
                 if existing.data:
-                    return existing.data['team_id_master']
+                    return existing.data["team_id_master"]
             except Exception:
                 pass
 
         team_id_master = str(uuid.uuid4())
         age_group_normalized = age_group.lower() if age_group else age_group
-        gender_normalized = 'Male' if gender.upper() in ('M', 'MALE', 'BOYS', 'B') else 'Female'
+        gender_normalized = "Male" if gender.upper() in ("M", "MALE", "BOYS", "B") else "Female"
         clean_team_name = team_name
         if club_name and team_name.startswith(club_name):
-            remaining = team_name[len(club_name):].strip()
-            if remaining and not remaining.startswith(('-', '–', '—')):
+            remaining = team_name[len(club_name) :].strip()
+            if remaining and not remaining.startswith(("-", "–", "—")):
                 clean_team_name = remaining
             elif remaining:
-                clean_team_name = remaining.lstrip('-–—').strip() or team_name
+                clean_team_name = remaining.lstrip("-–—").strip() or team_name
 
         team_data = {
-            'team_id_master': team_id_master,
-            'team_name': clean_team_name,
-            'club_name': club_name or clean_team_name,
-            'age_group': age_group_normalized,
-            'gender': gender_normalized,
-            'state_code': STATE_CODE,
-            'provider_id': provider_id,
-            'provider_team_id': provider_team_id,
+            "team_id_master": team_id_master,
+            "team_name": clean_team_name,
+            "club_name": club_name or clean_team_name,
+            "age_group": age_group_normalized,
+            "gender": gender_normalized,
+            "state_code": STATE_CODE,
+            "provider_id": provider_id,
+            "provider_team_id": provider_team_id,
         }
-        self.db.table('teams').insert(team_data).execute()
+        self.db.table("teams").insert(team_data).execute()
         return team_id_master

--- a/src/models/modular11_matcher.py
+++ b/src/models/modular11_matcher.py
@@ -12,6 +12,7 @@ Key features:
 - Token overlap requirement
 - Creates new teams when no confident match found
 """
+
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from difflib import SequenceMatcher
@@ -39,16 +40,42 @@ MODULAR11_DIVISION_MISMATCH_PENALTY = 0.10
 
 # Major tokens for token overlap requirement
 MAJOR_TOKENS = {
-    'galaxy', 'strikers', 'ideasport', 'flames', 'rsl', 'rapids', 'united',
-    'city', 'fc', 'sc', 'academy', 'mutiny', 'chargers', 'surf', 'revolution',
-    'fire', 'dynamo', 'timbers', 'sounders', 'whitecaps', 'impact', 'crew',
-    'union', 'redbulls', 'republic', 'real', 'athletic', 'sporting', 'inter'
+    "galaxy",
+    "strikers",
+    "ideasport",
+    "flames",
+    "rsl",
+    "rapids",
+    "united",
+    "city",
+    "fc",
+    "sc",
+    "academy",
+    "mutiny",
+    "chargers",
+    "surf",
+    "revolution",
+    "fire",
+    "dynamo",
+    "timbers",
+    "sounders",
+    "whitecaps",
+    "impact",
+    "crew",
+    "union",
+    "redbulls",
+    "republic",
+    "real",
+    "athletic",
+    "sporting",
+    "inter",
 }
 
 
 @dataclass
 class Modular11MatchResult:
     """Result from Modular11 fuzzy matching"""
+
     team_id_master: str
     confidence: float
     division_match: bool
@@ -58,7 +85,7 @@ class Modular11MatchResult:
 class Modular11GameMatcher(GameHistoryMatcher):
     """
     Modular11-specific team matcher with ultra-conservative fuzzy matching.
-    
+
     Key differences from base matcher:
     1. ALWAYS validates age_group before accepting any match
     2. Alias-first: If alias exists, return immediately (no fuzzy)
@@ -67,8 +94,15 @@ class Modular11GameMatcher(GameHistoryMatcher):
     5. Token overlap requirement
     6. Creates new teams when no confident match found
     """
-    
-    def __init__(self, supabase: Client, provider_id: Optional[str] = None, alias_cache: Optional[Dict] = None, debug: bool = False, summary_only: bool = False):
+
+    def __init__(
+        self,
+        supabase: Client,
+        provider_id: Optional[str] = None,
+        alias_cache: Optional[Dict] = None,
+        debug: bool = False,
+        summary_only: bool = False,
+    ):
         """Initialize Modular11 matcher with same interface as base matcher"""
         super().__init__(supabase, provider_id=provider_id, alias_cache=alias_cache)
         self.debug = debug
@@ -81,13 +115,13 @@ class Modular11GameMatcher(GameHistoryMatcher):
             "new_teams": 0,
             "review_queue": 0,
             "by_age": {},  # example: {"u16": {"matched": 5, "new": 3}}
-            "fuzzy_details": [],   # list of dicts containing accepted fuzzy matches
+            "fuzzy_details": [],  # list of dicts containing accepted fuzzy matches
             "fuzzy_reject_details": [],  # list of dicts for rejected matches
             "new_team_details": [],  # list of dicts
-            "review_entries": []  # list of dicts
+            "review_entries": [],  # list of dicts
         }
         logger.info("Initialized Modular11GameMatcher with ultra-conservative fuzzy matching")
-        
+
         # Club name synonym dictionary for improved token matching
         self.CLUB_SYNONYMS = {
             "sc": ["soccer club", "soccerclub", "sc"],
@@ -100,22 +134,22 @@ class Modular11GameMatcher(GameHistoryMatcher):
             "surf": ["surf sc", "surf soccer"],
             "united": ["utd", "united"],
         }
-    
+
     def _dlog(self, message: str):
         """Debug logging helper - prints only when self.debug=True and summary_only=False"""
         if self.debug and not self.summary_only:
             logger.info(f"[MOD11 DEBUG] {message}")
-    
+
     def _init_age_tracking(self, age_group: str):
         """Initialize age-group tracking if not exists"""
-        age_key = age_group.lower() if age_group else 'unknown'
+        age_key = age_group.lower() if age_group else "unknown"
         if age_key not in self.summary["by_age"]:
             self.summary["by_age"][age_key] = {"matched": 0, "new": 0}
-    
+
     def _birth_year_from_age_group(self, age_group: str) -> Optional[int]:
         """
         Convert age group (e.g., 'u16', 'U14') to birth year.
-        
+
         Birth year mapping (as used in team names):
         - U13 → 2013
         - U14 → 2012
@@ -123,179 +157,172 @@ class Modular11GameMatcher(GameHistoryMatcher):
         - U16 → 2010
         - U17 → 2009
         - U18 → 2008
-        
+
         Returns None if age_group is invalid or out of range.
         """
         if not age_group:
             return None
-        
+
         # Extract numeric age from age_group (e.g., 'u16' -> 16, 'U14' -> 14)
-        age_str = age_group.lower().replace('u', '').strip()
+        age_str = age_group.lower().replace("u", "").strip()
         try:
             age = int(age_str)
         except (ValueError, TypeError):
             return None
-        
+
         # Validate age range (U13-U18)
         if age < 13 or age > 18:
             return None
-        
+
         # Map age to birth year (as used in team names)
         # U13 = 2013, U14 = 2012, U15 = 2011, U16 = 2010, U17 = 2009, U18 = 2008
-        birth_year_map = {
-            13: 2013,
-            14: 2012,
-            15: 2011,
-            16: 2010,
-            17: 2009,
-            18: 2008
-        }
-        
+        birth_year_map = {13: 2013, 14: 2012, 15: 2011, 16: 2010, 17: 2009, 18: 2008}
+
         return birth_year_map.get(age)
-    
+
     def _candidate_birth_year_tokens(self, birth_year: int) -> List[str]:
         """
         Generate list of acceptable birth year tokens for matching.
-        
+
         Examples for birth_year=2009:
         ['2009', '09', 'b09', '09b', '(09)', '-09', '_09', ' 09 ']
-        
+
         Returns list of lowercase tokens to search for in team names.
         """
         if not birth_year or birth_year < 2000 or birth_year > 2015:
             return []
-        
+
         # Extract 2-digit year (e.g., 2009 -> '09')
         year_2digit = str(birth_year)[-2:]
         year_4digit = str(birth_year)
-        
+
         tokens = [
-            year_4digit,           # '2009'
-            year_2digit,           # '09'
-            f'b{year_2digit}',     # 'b09'
-            f'{year_2digit}b',     # '09b'
-            f'({year_2digit})',    # '(09)'
-            f'-{year_2digit}',     # '-09'
-            f'_{year_2digit}',     # '_09'
-            f' {year_2digit} ',    # ' 09 '
-            f' {year_2digit}',     # ' 09'
-            f'{year_2digit} ',     # '09 '
+            year_4digit,  # '2009'
+            year_2digit,  # '09'
+            f"b{year_2digit}",  # 'b09'
+            f"{year_2digit}b",  # '09b'
+            f"({year_2digit})",  # '(09)'
+            f"-{year_2digit}",  # '-09'
+            f"_{year_2digit}",  # '_09'
+            f" {year_2digit} ",  # ' 09 '
+            f" {year_2digit}",  # ' 09'
+            f"{year_2digit} ",  # '09 '
         ]
-        
+
         return [token.lower() for token in tokens]
-    
+
     def _contains_birth_year(self, name: str, tokens: List[str]) -> bool:
         """
         Check if team name contains any of the birth year tokens.
-        
+
         Args:
             name: Team name to search
             tokens: List of birth year tokens to look for
-        
+
         Returns:
             True if any token is found in the name (case-insensitive)
         """
         if not name or not tokens:
             return False
-        
+
         name_lower = name.lower()
         return any(token in name_lower for token in tokens)
-    
+
     def _expand_synonyms(self, name: str) -> List[str]:
         """
         Takes an input team name and returns an expanded token set
         including synonyms. Improves fuzzy match token overlap.
-        
+
         Args:
             name: Team name to expand
-        
+
         Returns:
             List of tokens including original tokens and synonyms
         """
         if not name:
             return []
-        
+
         # Split name into tokens (lowercase)
         tokens = re.split(r"[ \-_.,()]+", name.lower())
         tokens = [t.strip() for t in tokens if t.strip()]  # Remove empty tokens
-        
+
         # Start with original tokens
         expanded = set(tokens)
-        
+
         # Add synonyms for each token
         for token in tokens:
             if token in self.CLUB_SYNONYMS:
                 for syn in self.CLUB_SYNONYMS[token]:
                     expanded.add(syn)
-        
+
         return list(expanded)
-    
+
     def _normalize_club_terms(self, name: str) -> str:
         """
         Normalize club terms in team names before similarity scoring.
-        
+
         Replaces abbreviations with full terms:
         - ' sc ' → ' soccer club '
         - ' fc ' → ' football club '
         - ' sa ' → ' soccer academy '
-        
+
         Args:
             name: Team name to normalize
-        
+
         Returns:
             Normalized name string
         """
         if not name:
             return ""
-        
+
         lower = name.lower()
         replacements = {
             " sc ": " soccer club ",
             " fc ": " football club ",
             " sa ": " soccer academy ",
         }
-        
+
         for k, v in replacements.items():
             lower = lower.replace(k, v)
-        
+
         return lower
-    
+
     def _contains_wrong_birth_year(self, name: str, correct_birth_year: int) -> bool:
         """
         Check if team name contains a birth year that's different from the expected one.
-        
+
         This is used for HARD FILTER - reject candidates with wrong birth years.
-        
+
         Args:
             name: Team name to search
             correct_birth_year: The expected birth year (e.g., 2009 for U16)
-        
+
         Returns:
             True if name contains a different birth year (2008, 2010, 2011, 2012, etc.)
         """
         if not name or not correct_birth_year:
             return False
-        
+
         name_lower = name.lower()
-        
+
         # Check for any 4-digit year between 2000-2015 (reasonable range)
-        year_pattern = r'\b(20[0-1][0-9])\b'
+        year_pattern = r"\b(20[0-1][0-9])\b"
         found_years = re.findall(year_pattern, name_lower)
-        
+
         if found_years:
             for year_str in found_years:
                 year = int(year_str)
                 if year != correct_birth_year and 2000 <= year <= 2015:
                     return True  # Found a different birth year
-        
+
         # Also check for 2-digit years (e.g., '08', '10', '11', '12')
         # Extract 2-digit from correct birth year
         correct_2digit = str(correct_birth_year)[-2:]
         # Look for 2-digit years that could be birth years (avoid matching random numbers)
         # Pattern: b08, 08b, (08), -08, _08, or standalone 08 in context
-        year_2digit_pattern = r'\b([0-9]{2})\b'
+        year_2digit_pattern = r"\b([0-9]{2})\b"
         found_2digit = re.findall(year_2digit_pattern, name_lower)
-        
+
         if found_2digit:
             for digit_str in found_2digit:
                 # Check if it's a reasonable birth year (08-15 for 2008-2015)
@@ -306,16 +333,16 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         potential_year = 2000 + digit_int
                         if potential_year != correct_birth_year:
                             return True  # Found a different birth year
-        
+
         return False  # No wrong birth year found
-    
+
     def print_summary(self):
         """Print clean summary of match decisions (only when debug=True or summary_only=True)"""
         # Always print summary if we have data, regardless of debug mode
         # (summary_only mode suppresses per-team logs but still shows summary)
         if not self.debug and not self.summary_only:
             return
-        
+
         print("\n" + "=" * 60)
         print("MODULAR11 MATCH SUMMARY")
         print("=" * 60)
@@ -325,65 +352,67 @@ class Modular11GameMatcher(GameHistoryMatcher):
         print(f"Fuzzy Matches Rejected: {self.summary['fuzzy_rejected']}")
         print(f"New Teams Created: {self.summary['new_teams']}")
         print(f"Review Queue Entries: {self.summary['review_queue']}")
-        
-        if self.summary['by_age']:
+
+        if self.summary["by_age"]:
             print("\nAGE BREAKDOWN:")
-            for age in sorted(self.summary['by_age'].keys()):
-                stats = self.summary['by_age'][age]
+            for age in sorted(self.summary["by_age"].keys()):
+                stats = self.summary["by_age"][age]
                 print(f"  {age}: {stats['matched']} matched, {stats['new']} new")
-        
-        if self.summary['fuzzy_details']:
+
+        if self.summary["fuzzy_details"]:
             print("\n" + "=" * 60)
             print("FUZZY MATCHES (Accepted) - Detailed Breakdown")
             print("=" * 60)
-            for i, detail in enumerate(self.summary['fuzzy_details'], 1):
+            for i, detail in enumerate(self.summary["fuzzy_details"], 1):
                 print(f"\n{i}. {detail['incoming']} → {detail['matched_team']}")
                 print(f"   Age: {detail['age']}, Division: {detail['division'] or 'N/A'}")
                 print(f"   Score: {detail['score']:.4f} (threshold: 0.93) ✅")
                 print(f"   Gap: {detail['gap']:.4f} (threshold: 0.07) ✅")
                 print(f"   ─" * 30)
-        
-        if self.summary['fuzzy_reject_details']:
+
+        if self.summary["fuzzy_reject_details"]:
             print("\n" + "=" * 60)
             print("FUZZY MATCHES (Rejected) - Detailed Breakdown")
             print("=" * 60)
-            for i, detail in enumerate(self.summary['fuzzy_reject_details'], 1):
+            for i, detail in enumerate(self.summary["fuzzy_reject_details"], 1):
                 print(f"\n{i}. {detail['incoming']}")
                 print(f"   Age: {detail['age']}, Division: {detail['division'] or 'N/A'}")
                 print(f"   Rejection Reason: {detail['reason']}")
                 print(f"\n   Top Candidates:")
-                if detail.get('top_candidates'):
-                    for idx, candidate in enumerate(detail['top_candidates'][:3], 1):
-                        div_info = f" (div: {candidate.get('division', 'N/A')})" if candidate.get('division') else ""
+                if detail.get("top_candidates"):
+                    for idx, candidate in enumerate(detail["top_candidates"][:3], 1):
+                        div_info = f" (div: {candidate.get('division', 'N/A')})" if candidate.get("division") else ""
                         print(f"   {idx}. {candidate['team_name']}{div_info}")
-                        score_status = "PASS" if candidate['score'] >= 0.93 else "FAIL"
+                        score_status = "PASS" if candidate["score"] >= 0.93 else "FAIL"
                         print(f"       Score: {candidate['score']:.4f} [{score_status}] (need >= 0.93)")
-                        div_status = "PASS" if candidate['division_match'] else "FAIL"
+                        div_status = "PASS" if candidate["division_match"] else "FAIL"
                         print(f"       Division Match: [{div_status}]")
-                        token_status = "PASS" if candidate['token_overlap'] else "FAIL"
+                        token_status = "PASS" if candidate["token_overlap"] else "FAIL"
                         print(f"       Token Overlap: [{token_status}]")
-                        if idx == 1 and detail.get('second_team'):
-                            gap_status = "PASS" if detail['score_gap'] >= 0.07 else "FAIL"
+                        if idx == 1 and detail.get("second_team"):
+                            gap_status = "PASS" if detail["score_gap"] >= 0.07 else "FAIL"
                             print(f"       Gap to 2nd: {detail['score_gap']:.4f} [{gap_status}] (need >= 0.07)")
                         print()
                 print(f"   ─" * 30)
-        
-        if self.summary['new_team_details']:
+
+        if self.summary["new_team_details"]:
             print("\nNEW TEAMS CREATED:")
-            for detail in self.summary['new_team_details']:
-                print(f"  {detail['incoming']} -> {detail['clean_name']} "
-                      f"(id: {detail['team_id']}, age: {detail['age']}, div: {detail['division'] or 'N/A'})")
-        
-        if self.summary['review_entries']:
+            for detail in self.summary["new_team_details"]:
+                print(
+                    f"  {detail['incoming']} -> {detail['clean_name']} "
+                    f"(id: {detail['team_id']}, age: {detail['age']}, div: {detail['division'] or 'N/A'})"
+                )
+
+        if self.summary["review_entries"]:
             print("\nREVIEW QUEUE ENTRIES:")
-            for entry in self.summary['review_entries']:
-                suggestions_str = ", ".join(entry['suggestions'][:3]) if entry['suggestions'] else "none"
+            for entry in self.summary["review_entries"]:
+                suggestions_str = ", ".join(entry["suggestions"][:3]) if entry["suggestions"] else "none"
                 print(f"  {entry['incoming']} (age: {entry['age']}, div: {entry['division'] or 'N/A'})")
                 if suggestions_str:
                     print(f"    Suggestions: {suggestions_str}")
-        
+
         print("=" * 60 + "\n")
-    
+
     def _match_team(
         self,
         provider_id: str,
@@ -392,16 +421,16 @@ class Modular11GameMatcher(GameHistoryMatcher):
         age_group: Optional[str],
         gender: Optional[str],
         club_name: Optional[str] = None,
-        division: Optional[str] = None  # NEW: HD or AD
+        division: Optional[str] = None,  # NEW: HD or AD
     ) -> Dict:
         """
         Match a team using Modular11-specific ultra-conservative logic.
-        
+
         Strategy:
         1. Alias lookup (ALWAYS FIRST) - if alias exists, return immediately
         2. Modular11 fuzzy match (if no alias) - ultra-conservative thresholds
         3. Create new team (if no confident match)
-        
+
         Returns:
             Dict with:
             - matched: bool
@@ -414,32 +443,44 @@ class Modular11GameMatcher(GameHistoryMatcher):
             # Try to extract from team_name if it ends with HD/AD
             if team_name:
                 division = self._extract_division_from_name(team_name)
-        
+
         # Log incoming team info
-        self._dlog(f"Incoming team: {team_name} (age={age_group}, gender={gender}, division={division}, provider_team_id={provider_team_id})")
-        
+        self._dlog(
+            f"Incoming team: {team_name} (age={age_group}, gender={gender}, division={division}, provider_team_id={provider_team_id})"
+        )
+
         # Track processed teams
         self.summary["processed"] += 1
         if age_group:
             self._init_age_tracking(age_group)
-        
+
         # Strategy 1: Alias lookup (ALWAYS FIRST - no fuzzy if alias exists)
         if provider_team_id:
             self._dlog(f"Checking alias for provider_team_id={provider_team_id}, division={division}")
             alias_match = self._match_by_provider_id(provider_id, provider_team_id, age_group, gender, division)
             if alias_match:
                 # Get team details for logging
-                team_id_master = alias_match['team_id_master']
+                team_id_master = alias_match["team_id_master"]
                 try:
-                    team_result = self.db.table('teams').select('team_name, age_group, gender').eq('team_id_master', team_id_master).single().execute()
+                    team_result = (
+                        self.db.table("teams")
+                        .select("team_name, age_group, gender")
+                        .eq("team_id_master", team_id_master)
+                        .single()
+                        .execute()
+                    )
                     if team_result.data:
-                        team_name_db = team_result.data.get('team_name', 'Unknown')
-                        team_age = team_result.data.get('age_group', 'Unknown')
-                        team_gender = team_result.data.get('gender', 'Unknown')
-                        match_type = alias_match.get('match_method', 'provider_id')
-                        self._dlog(f"Alias found: provider_team_id={provider_team_id} maps to team_id_master={team_id_master}")
-                        self._dlog(f"Alias info: team_name={team_name_db}, age={team_age}, gender={team_gender}, match_method={match_type}")
-                        
+                        team_name_db = team_result.data.get("team_name", "Unknown")
+                        team_age = team_result.data.get("age_group", "Unknown")
+                        team_gender = team_result.data.get("gender", "Unknown")
+                        match_type = alias_match.get("match_method", "provider_id")
+                        self._dlog(
+                            f"Alias found: provider_team_id={provider_team_id} maps to team_id_master={team_id_master}"
+                        )
+                        self._dlog(
+                            f"Alias info: team_name={team_name_db}, age={team_age}, gender={team_gender}, match_method={match_type}"
+                        )
+
                         # Validate age group
                         if age_group and team_age:
                             age_normalized = age_group.lower()
@@ -451,80 +492,94 @@ class Modular11GameMatcher(GameHistoryMatcher):
                                 self._dlog(f"Alias accepted: age match confirmed ({age_group})")
                 except Exception as e:
                     self._dlog(f"Error fetching team details for alias validation: {e}")
-                
+
                 if alias_match:
                     # Alias found and validated - return immediately (NO fuzzy matching)
-                    match_type = alias_match.get('match_method', 'provider_id')
-                    team_id_master = alias_match['team_id_master']
+                    match_type = alias_match.get("match_method", "provider_id")
+                    team_id_master = alias_match["team_id_master"]
                     try:
-                        team_result = self.db.table('teams').select('team_name').eq('team_id_master', team_id_master).single().execute()
-                        final_team_name = team_result.data.get('team_name', 'Unknown') if team_result.data else 'Unknown'
+                        team_result = (
+                            self.db.table("teams")
+                            .select("team_name")
+                            .eq("team_id_master", team_id_master)
+                            .single()
+                            .execute()
+                        )
+                        final_team_name = (
+                            team_result.data.get("team_name", "Unknown") if team_result.data else "Unknown"
+                        )
                     except:
-                        final_team_name = 'Unknown'
+                        final_team_name = "Unknown"
                     self._dlog(f"FINAL DECISION: alias -> {final_team_name} ({team_id_master})")
-                    
+
                     # Track alias match in summary
                     self.summary["alias_matches"] += 1
                     if age_group:
                         age_key = age_group.lower()
                         self._init_age_tracking(age_group)
                         self.summary["by_age"][age_key]["matched"] += 1
-                    
+
                     return {
-                        'matched': True,
-                        'team_id': team_id_master,
-                        'method': 'alias' if match_type != 'direct_id' else 'direct_id',
-                        'confidence': 1.0
+                        "matched": True,
+                        "team_id": team_id_master,
+                        "method": "alias" if match_type != "direct_id" else "direct_id",
+                        "confidence": 1.0,
                     }
             else:
                 self._dlog(f"No alias found for provider_team_id={provider_team_id}")
-        
+
         # Strategy 2: Modular11-specific fuzzy match (only if no alias)
         fuzzy_match = None
         if team_name and age_group and gender:
             fuzzy_match = self.fuzzy_match_modular11_team(
-                incoming_name=team_name,
-                age_group=age_group,
-                gender=gender,
-                division=division,
-                club_name=club_name
+                incoming_name=team_name, age_group=age_group, gender=gender, division=division, club_name=club_name
             )
-            
+
             if fuzzy_match:
                 # High-confidence match found - create alias and return
                 self._create_modular11_alias(
                     provider_id=provider_id,
                     provider_team_id=provider_team_id,
                     team_id_master=fuzzy_match.team_id_master,
-                    match_method='fuzzy_auto',
+                    match_method="fuzzy_auto",
                     confidence=fuzzy_match.confidence,
                     division=division,
-                    age_group=age_group
+                    age_group=age_group,
                 )
                 try:
-                    team_result = self.db.table('teams').select('team_name').eq('team_id_master', fuzzy_match.team_id_master).single().execute()
-                    final_team_name = team_result.data.get('team_name', 'Unknown') if team_result.data else 'Unknown'
+                    team_result = (
+                        self.db.table("teams")
+                        .select("team_name")
+                        .eq("team_id_master", fuzzy_match.team_id_master)
+                        .single()
+                        .execute()
+                    )
+                    final_team_name = team_result.data.get("team_name", "Unknown") if team_result.data else "Unknown"
                 except:
-                    final_team_name = 'Unknown'
+                    final_team_name = "Unknown"
                 self._dlog(f"FINAL DECISION: fuzzy_auto -> matched {final_team_name} ({fuzzy_match.team_id_master})")
                 return {
-                    'matched': True,
-                    'team_id': fuzzy_match.team_id_master,
-                    'method': 'fuzzy_auto',
-                    'confidence': fuzzy_match.confidence
+                    "matched": True,
+                    "team_id": fuzzy_match.team_id_master,
+                    "method": "fuzzy_auto",
+                    "confidence": fuzzy_match.confidence,
                 }
             else:
                 self._dlog("Fuzzy match did not find confident match")
-        
+
         # Strategy 3: No confident match - create new team
         if team_name and age_group and gender:
             # Generate provider_team_id if not provided (for teams table requirement)
             # Include division in hash to prevent HD/AD collisions
             if not provider_team_id:
                 import hashlib
-                division_str = division or ''
-                provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[:16]
-            
+
+                division_str = division or ""
+                # MD5 for deterministic ID generation (not security)
+                provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[
+                    :16
+                ]
+
             new_team_id = self._create_new_modular11_team(
                 team_name=team_name,
                 club_name=club_name,
@@ -532,39 +587,41 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 gender=gender,
                 provider_id=provider_id,
                 provider_team_id=provider_team_id,
-                division=division
+                division=division,
             )
-            
+
             # Get clean name for tracking (from _create_new_modular11_team logic)
-            clean_name = team_name or 'Unknown'
+            clean_name = team_name or "Unknown"
             if team_name:
                 # Normalize similar to _create_new_modular11_team
                 clean_name = team_name.strip()
-                if clean_name.upper().endswith(' HD') or clean_name.upper().endswith(' AD'):
+                if clean_name.upper().endswith(" HD") or clean_name.upper().endswith(" AD"):
                     clean_name = clean_name[:-3].strip()
-            
+
             # Track new team creation (only if this is actually a new team, not a duplicate)
             # Check if we've already tracked this team_id to avoid double-counting
             if not any(detail.get("team_id") == new_team_id for detail in self.summary["new_team_details"]):
                 self.summary["new_teams"] += 1
-                self.summary["new_team_details"].append({
-                    "incoming": team_name or 'Unknown',
-                    "clean_name": clean_name,
-                    "team_id": new_team_id,
-                    "age": age_group,
-                    "division": division
-                })
+                self.summary["new_team_details"].append(
+                    {
+                        "incoming": team_name or "Unknown",
+                        "clean_name": clean_name,
+                        "team_id": new_team_id,
+                        "age": age_group,
+                        "division": division,
+                    }
+                )
                 if age_group:
                     age_key = age_group.lower()
                     self._init_age_tracking(age_group)
                     self.summary["by_age"][age_key]["new"] += 1
-            
+
             # Create alias for new team
             # NOTE: Pass base provider_team_id (raw club_id) - alias creation will build aliased format
             # Use 'direct_id' if provider_team_id exists (like TGS/GotSport) for fast Tier 1 matching
             # This ensures consistent matching behavior across providers
-            match_method = 'direct_id' if provider_team_id else 'import'
-            
+            match_method = "direct_id" if provider_team_id else "import"
+
             self._create_modular11_alias(
                 provider_id=provider_id,
                 provider_team_id=provider_team_id,  # Base club_id - alias will build {club_id}_{age}_{division}
@@ -572,34 +629,38 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 match_method=match_method,
                 confidence=1.0,  # New team = 100% confidence
                 division=division,
-                age_group=age_group
+                age_group=age_group,
             )
 
             # NOTE: Successfully created teams should NOT be added to review queue
             # Review queue is only for teams that couldn't be matched/created automatically
-            
-            clean_name = team_name or 'Unknown'
+
+            clean_name = team_name or "Unknown"
             self._dlog(f"FINAL DECISION: new team created -> {clean_name} ({new_team_id})")
             return {
-                'matched': True,
-                'team_id': new_team_id,
-                'method': match_method,  # Use same method as alias creation (direct_id or import)
-                'confidence': 1.0
+                "matched": True,
+                "team_id": new_team_id,
+                "method": match_method,  # Use same method as alias creation (direct_id or import)
+                "confidence": 1.0,
             }
-        
+
         # Fallback: ALWAYS create team (never return None)
         # This should rarely be hit, but ensures no blocking
         if team_name and age_group and gender:
             # Track if provider_team_id was originally provided (not generated)
             original_provider_team_id = provider_team_id
-            
+
             # Generate provider_team_id if not provided
             # Include division in hash to prevent HD/AD collisions
             if not provider_team_id:
                 import hashlib
-                division_str = division or ''
-                provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[:16]
-            
+
+                division_str = division or ""
+                # MD5 for deterministic ID generation (not security)
+                provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[
+                    :16
+                ]
+
             new_team_id = self._create_new_modular11_team(
                 team_name=team_name,
                 club_name=club_name,
@@ -607,16 +668,16 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 gender=gender,
                 provider_id=provider_id,
                 provider_team_id=provider_team_id,
-                division=division
+                division=division,
             )
-            
+
             # Create alias with age_group for unique identification
             # NOTE: Pass base provider_team_id (raw club_id) - alias creation will build aliased format
             # Use 'direct_id' if provider_team_id was originally provided (real provider ID)
             # Use 'import' if provider_team_id was generated (hash-based, not real provider ID)
             # This ensures consistent matching behavior across providers
-            match_method = 'direct_id' if original_provider_team_id else 'import'
-            
+            match_method = "direct_id" if original_provider_team_id else "import"
+
             self._create_modular11_alias(
                 provider_id=provider_id,
                 provider_team_id=provider_team_id,  # Base club_id - alias will build {club_id}_{age}_{division}
@@ -624,157 +685,156 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 match_method=match_method,
                 confidence=1.0,
                 division=division,
-                age_group=age_group
+                age_group=age_group,
             )
-            
+
             # Track in summary (only if this is actually a new team, not a duplicate)
             # Check if we've already tracked this team_id to avoid double-counting
-            clean_name = team_name or 'Unknown'
+            clean_name = team_name or "Unknown"
             if team_name:
                 clean_name = team_name.strip()
-                if clean_name.upper().endswith(' HD') or clean_name.upper().endswith(' AD'):
+                if clean_name.upper().endswith(" HD") or clean_name.upper().endswith(" AD"):
                     clean_name = clean_name[:-3].strip()
-            
+
             if not any(detail.get("team_id") == new_team_id for detail in self.summary["new_team_details"]):
                 self.summary["new_teams"] += 1
-                self.summary["new_team_details"].append({
-                    "incoming": team_name or 'Unknown',
-                    "clean_name": clean_name,
-                    "team_id": new_team_id,
-                    "age": age_group,
-                    "division": division
-                })
+                self.summary["new_team_details"].append(
+                    {
+                        "incoming": team_name or "Unknown",
+                        "clean_name": clean_name,
+                        "team_id": new_team_id,
+                        "age": age_group,
+                        "division": division,
+                    }
+                )
                 if age_group:
                     age_key = age_group.lower()
                     self._init_age_tracking(age_group)
                     self.summary["by_age"][age_key]["new"] += 1
-            
+
             # NOTE: Successfully created teams should NOT be added to review queue
             # Review queue is only for teams that couldn't be matched/created automatically
-            
-            clean_name = team_name or 'Unknown'
+
+            clean_name = team_name or "Unknown"
             self._dlog(f"FINAL DECISION: new team created (fallback) -> {clean_name} ({new_team_id})")
             return {
-                'matched': True,
-                'team_id': new_team_id,
-                'method': match_method,  # Use same method as alias creation (direct_id or import)
-                'confidence': 1.0
+                "matched": True,
+                "team_id": new_team_id,
+                "method": match_method,  # Use same method as alias creation (direct_id or import)
+                "confidence": 1.0,
             }
         else:
             # Only return None if we truly can't create (missing required fields)
-            logger.warning(f"[Modular11] Cannot create team - missing required fields: name={team_name}, age={age_group}, gender={gender}")
-            return {
-                'matched': False,
-                'team_id': None,
-                'method': None,
-                'confidence': 0.0
-            }
-    
+            logger.warning(
+                f"[Modular11] Cannot create team - missing required fields: name={team_name}, age={age_group}, gender={gender}"
+            )
+            return {"matched": False, "team_id": None, "method": None, "confidence": 0.0}
+
     def fuzzy_match_modular11_team(
-        self,
-        incoming_name: str,
-        age_group: str,
-        gender: str,
-        division: Optional[str],
-        club_name: Optional[str] = None
+        self, incoming_name: str, age_group: str, gender: str, division: Optional[str], club_name: Optional[str] = None
     ) -> Optional[Modular11MatchResult]:
         """
         Ultra-conservative fuzzy matching for Modular11 teams.
-        
+
         Requirements:
         - best_score >= 0.93
         - (best_score - second_best_score) >= 0.07
         - Token overlap exists
         - Division matches or absent (not conflicting)
-        
+
         Returns Modular11MatchResult if confident match found, None otherwise.
         """
         try:
             # Normalize age_group to lowercase (DB uses 'u13', source may have 'U13')
             age_group_normalized = age_group.lower() if age_group else age_group
-            
+
             self._dlog(f"Running fuzzy match for: {incoming_name}")
-            
+
             # Compute birth year from age group
             birth_year = self._birth_year_from_age_group(age_group)
             birth_year_tokens = []
             if birth_year:
                 birth_year_tokens = self._candidate_birth_year_tokens(birth_year)
-                self._dlog(f"[BY] Incoming {incoming_name} expects birth year {birth_year} (tokens: {birth_year_tokens[:3]}...)")
+                self._dlog(
+                    f"[BY] Incoming {incoming_name} expects birth year {birth_year} (tokens: {birth_year_tokens[:3]}...)"
+                )
             else:
                 self._dlog(f"[BY] Could not determine birth year from age_group={age_group}")
-            
+
             # Get candidate teams (strict age/gender filter)
-            result = self.db.table('teams').select(
-                'team_id_master, team_name, club_name, age_group, gender, state_code'
-            ).eq('age_group', age_group_normalized).eq('gender', gender).execute()
-            
+            result = (
+                self.db.table("teams")
+                .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                .eq("age_group", age_group_normalized)
+                .eq("gender", gender)
+                .execute()
+            )
+
             if not result.data:
                 self._dlog(f"No candidates found for {incoming_name} ({age_group}, {gender})")
                 logger.debug(f"[Modular11] No candidates found for {incoming_name} ({age_group}, {gender})")
                 return None
-            
+
             self._dlog(f"Found {len(result.data)} candidate teams (age={age_group_normalized}, gender={gender})")
-            
+
             # Get division info from aliases for candidates
             # Use the provider_id from initialization (Modular11 provider UUID)
-            provider_id_for_division = self._cached_provider_id or self._get_provider_id('modular11')
+            provider_id_for_division = self._cached_provider_id or self._get_provider_id("modular11")
             candidate_divisions = self._get_candidate_divisions(
-                [t['team_id_master'] for t in result.data],
-                provider_id_for_division
+                [t["team_id_master"] for t in result.data], provider_id_for_division
             )
-            
+
             # Score all candidates
             scored_candidates = []
             for team in result.data:
-                team_id = team['team_id_master']
+                team_id = team["team_id_master"]
                 candidate_division = candidate_divisions.get(team_id)
-                cand_name = team.get('team_name', '')
-                cand_age = team.get('age_group', '')
-                cand_gender = team.get('gender', '')
-                
+                cand_name = team.get("team_name", "")
+                cand_age = team.get("age_group", "")
+                cand_gender = team.get("gender", "")
+
                 # Normalize names for similarity scoring (expand abbreviations)
                 normalized_incoming = self._normalize_club_terms(incoming_name)
                 normalized_candidate = self._normalize_club_terms(cand_name)
-                
+
                 # Calculate base similarity using normalized names
                 provider_team = {
-                    'team_name': normalized_incoming,
-                    'club_name': club_name,
-                    'age_group': age_group,
-                    'state_code': None
+                    "team_name": normalized_incoming,
+                    "club_name": club_name,
+                    "age_group": age_group,
+                    "state_code": None,
                 }
                 candidate = {
-                    'team_name': normalized_candidate,
-                    'club_name': team.get('club_name'),
-                    'age_group': cand_age,
-                    'state_code': team.get('state_code')
+                    "team_name": normalized_candidate,
+                    "club_name": team.get("club_name"),
+                    "age_group": cand_age,
+                    "state_code": team.get("state_code"),
                 }
-                
+
                 base_score = self._calculate_match_score(provider_team, candidate)
-                
+
                 # Check token overlap with synonym expansion
                 incoming_tokens = self._expand_synonyms(incoming_name)
                 candidate_tokens = self._expand_synonyms(cand_name)
                 token_intersection = set(incoming_tokens) & set(candidate_tokens)
                 has_overlap = len(token_intersection) > 0
-                
+
                 self._dlog(f"[SYN] Tokens for incoming '{incoming_name}': {incoming_tokens[:10]}")
                 self._dlog(f"[SYN] Tokens for candidate '{cand_name}': {candidate_tokens[:10]}")
                 self._dlog(f"[SYN] Overlap={has_overlap} (intersection: {list(token_intersection)[:5]})")
-                
+
                 if not has_overlap:
-                    self._dlog(f"Candidate: {cand_name} | Age={cand_age} | Score={base_score:.4f} | TokenOverlap=False (REJECTED)")
-                    logger.debug(
-                        f"[Modular11] No token overlap: '{incoming_name}' vs '{cand_name}'"
+                    self._dlog(
+                        f"Candidate: {cand_name} | Age={cand_age} | Score={base_score:.4f} | TokenOverlap=False (REJECTED)"
                     )
+                    logger.debug(f"[Modular11] No token overlap: '{incoming_name}' vs '{cand_name}'")
                     continue  # Skip candidates without token overlap
-                
+
                 # Add small bonus for synonym overlap
                 if has_overlap:
                     base_score += 0.03  # Small safe boost for synonym overlap
                     self._dlog(f"[SYN] Synonym overlap bonus: +0.03")
-                
+
                 # Apply birth year scoring (HARD FILTER for wrong birth years)
                 birth_year_match = False
                 birth_year_adjustment = 0.0
@@ -782,16 +842,18 @@ class Modular11GameMatcher(GameHistoryMatcher):
                     # HARD FILTER: Reject candidates with WRONG birth year (e.g., 2010 when expecting 2009)
                     contains_wrong_birth_year = self._contains_wrong_birth_year(cand_name, birth_year)
                     if contains_wrong_birth_year:
-                        self._dlog(f"[BY] Candidate {cand_name} contains WRONG birth year (expecting {birth_year}), REJECTED")
+                        self._dlog(
+                            f"[BY] Candidate {cand_name} contains WRONG birth year (expecting {birth_year}), REJECTED"
+                        )
                         logger.debug(
                             f"[Modular11] Wrong birth year: '{incoming_name}' (expects {birth_year}) vs '{cand_name}'"
                         )
                         continue  # Skip candidate - wrong birth year
-                    
+
                     # Check if candidate contains CORRECT birth year
                     contains_birth_year = self._contains_birth_year(cand_name, birth_year_tokens)
                     birth_year_match = contains_birth_year
-                    
+
                     if contains_birth_year:
                         birth_year_adjustment = 0.05  # Bonus for correct birth year
                         base_score += birth_year_adjustment
@@ -800,11 +862,13 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         # Candidate has no birth year - apply penalty but still consider
                         birth_year_adjustment = -0.10  # Penalty for missing birth year
                         base_score += birth_year_adjustment
-                        self._dlog(f"[BY] Candidate {cand_name} MISSING birth year {birth_year} tokens, score_adj=-0.10")
+                        self._dlog(
+                            f"[BY] Candidate {cand_name} MISSING birth year {birth_year} tokens, score_adj=-0.10"
+                        )
                 elif birth_year and not birth_year_tokens:
                     # Birth year determined but no tokens generated (shouldn't happen, but safe)
                     self._dlog(f"[BY] Warning: birth_year={birth_year} but no tokens generated")
-                
+
                 # Apply division bonus/penalty
                 division_match = False
                 division_adjustment = 0.0
@@ -823,10 +887,10 @@ class Modular11GameMatcher(GameHistoryMatcher):
                     # One has division, other doesn't - slight penalty but not fatal
                     division_adjustment = -0.02
                     base_score += division_adjustment
-                
+
                 # Clamp score to [0, 1]
                 final_score = max(0.0, min(1.0, base_score))
-                
+
                 self._dlog(
                     f"Candidate: {cand_name} | Age={cand_age} | Gender={cand_gender} | "
                     f"RawScore={base_score - division_adjustment - birth_year_adjustment:.4f} | "
@@ -835,255 +899,260 @@ class Modular11GameMatcher(GameHistoryMatcher):
                     f"DivisionAdjustment={division_adjustment:+.4f} | ScoreAfterAdjustments={final_score:.4f} | "
                     f"DivisionMatch={division_match}"
                 )
-                
-                scored_candidates.append({
-                    'team_id_master': team_id,
-                    'team_name': cand_name,
-                    'score': final_score,
-                    'division_match': division_match,
-                    'token_overlap': has_overlap,
-                    'birth_year_match': birth_year_match
-                })
-            
+
+                scored_candidates.append(
+                    {
+                        "team_id_master": team_id,
+                        "team_name": cand_name,
+                        "score": final_score,
+                        "division_match": division_match,
+                        "token_overlap": has_overlap,
+                        "birth_year_match": birth_year_match,
+                    }
+                )
+
             if not scored_candidates:
                 self._dlog(f"No candidates with token overlap for {incoming_name}")
                 logger.debug(f"[Modular11] No candidates with token overlap for {incoming_name}")
                 return None
-            
+
             # Sort by score (descending)
-            scored_candidates.sort(key=lambda x: x['score'], reverse=True)
-            
+            scored_candidates.sort(key=lambda x: x["score"], reverse=True)
+
             best = scored_candidates[0]
-            second_best_score = scored_candidates[1]['score'] if len(scored_candidates) > 1 else 0.0
-            score_gap = best['score'] - second_best_score
-            
-            self._dlog(f"Best match score={best['score']:.4f}, second best={second_best_score:.4f}, gap={score_gap:.4f}")
-            
+            second_best_score = scored_candidates[1]["score"] if len(scored_candidates) > 1 else 0.0
+            score_gap = best["score"] - second_best_score
+
+            self._dlog(
+                f"Best match score={best['score']:.4f}, second best={second_best_score:.4f}, gap={score_gap:.4f}"
+            )
+
             # Apply ultra-conservative thresholds
             # Auto-approve if score >= 0.93, gap >= 0.07, and token overlap exists
             # Division mismatch is no longer a hard requirement (still affects scoring via bonus/penalty)
-            if (best['score'] >= MODULAR11_MIN_CONFIDENCE and
-                score_gap >= MODULAR11_MIN_GAP and
-                best['token_overlap']):
-                
-                self._dlog(f"Fuzzy match ACCEPTED: {incoming_name} -> {best['team_name']} (score: {best['score']:.4f}, gap: {score_gap:.4f})")
+            if best["score"] >= MODULAR11_MIN_CONFIDENCE and score_gap >= MODULAR11_MIN_GAP and best["token_overlap"]:
+                self._dlog(
+                    f"Fuzzy match ACCEPTED: {incoming_name} -> {best['team_name']} (score: {best['score']:.4f}, gap: {score_gap:.4f})"
+                )
                 logger.info(
                     f"[Modular11] High-confidence match: {incoming_name} → {best['team_name']} "
                     f"(score: {best['score']:.3f}, gap: {score_gap:.3f})"
                 )
-                
+
                 # Track fuzzy match accepted
                 self.summary["fuzzy_matches"] += 1
-                self.summary["fuzzy_details"].append({
-                    "incoming": incoming_name,
-                    "matched_team": best['team_name'],
-                    "score": best['score'],
-                    "gap": score_gap,
-                    "age": age_group,
-                    "division": division
-                })
+                self.summary["fuzzy_details"].append(
+                    {
+                        "incoming": incoming_name,
+                        "matched_team": best["team_name"],
+                        "score": best["score"],
+                        "gap": score_gap,
+                        "age": age_group,
+                        "division": division,
+                    }
+                )
                 if age_group:
                     age_key = age_group.lower()
                     self._init_age_tracking(age_group)
                     self.summary["by_age"][age_key]["matched"] += 1
-                
+
                 return Modular11MatchResult(
-                    team_id_master=best['team_id_master'],
-                    confidence=best['score'],
-                    division_match=best['division_match'],
-                    token_overlap=best['token_overlap']
+                    team_id_master=best["team_id_master"],
+                    confidence=best["score"],
+                    division_match=best["division_match"],
+                    token_overlap=best["token_overlap"],
                 )
             else:
                 # Log exact rejection reason
                 reasons = []
-                if best['score'] < MODULAR11_MIN_CONFIDENCE:
+                if best["score"] < MODULAR11_MIN_CONFIDENCE:
                     reasons.append(f"score < {MODULAR11_MIN_CONFIDENCE} required minimum (got {best['score']:.4f})")
                 if score_gap < MODULAR11_MIN_GAP:
                     reasons.append(f"score gap too small (need >= {MODULAR11_MIN_GAP}, got {score_gap:.4f})")
-                if not best['token_overlap']:
+                if not best["token_overlap"]:
                     reasons.append("no token overlap")
                 # Division mismatch is no longer a rejection reason - it only affects scoring
-                
+
                 rejection_reason = " | ".join(reasons) if reasons else "unknown reason"
                 self._dlog(f"Reject fuzzy match: {rejection_reason}")
-                
+
                 # Track fuzzy match rejected
                 self.summary["fuzzy_rejected"] += 1
-                
+
                 # Get top 3 candidates for detailed reporting
                 # Use existing candidate_divisions data (already fetched above)
                 top_candidates = []
                 for i, candidate in enumerate(scored_candidates[:3]):
-                    candidate_division = candidate_divisions.get(candidate['team_id_master'])
-                    
-                    top_candidates.append({
-                        "team_name": candidate['team_name'],
-                        "score": candidate['score'],
-                        "division": candidate_division,
-                        "division_match": candidate.get('division_match', False),
-                        "token_overlap": candidate.get('token_overlap', False)
-                    })
-                
-                self.summary["fuzzy_reject_details"].append({
-                    "incoming": incoming_name,
-                    "reason": rejection_reason,
-                    "best_score": best['score'],
-                    "best_team": best['team_name'],
-                    "best_division_match": best.get('division_match', False),
-                    "best_token_overlap": best.get('token_overlap', False),
-                    "second_score": second_best_score,
-                    "second_team": scored_candidates[1]['team_name'] if len(scored_candidates) > 1 else None,
-                    "score_gap": score_gap,
-                    "age": age_group,
-                    "division": division,
-                    "top_candidates": top_candidates
-                })
-                
+                    candidate_division = candidate_divisions.get(candidate["team_id_master"])
+
+                    top_candidates.append(
+                        {
+                            "team_name": candidate["team_name"],
+                            "score": candidate["score"],
+                            "division": candidate_division,
+                            "division_match": candidate.get("division_match", False),
+                            "token_overlap": candidate.get("token_overlap", False),
+                        }
+                    )
+
+                self.summary["fuzzy_reject_details"].append(
+                    {
+                        "incoming": incoming_name,
+                        "reason": rejection_reason,
+                        "best_score": best["score"],
+                        "best_team": best["team_name"],
+                        "best_division_match": best.get("division_match", False),
+                        "best_token_overlap": best.get("token_overlap", False),
+                        "second_score": second_best_score,
+                        "second_team": scored_candidates[1]["team_name"] if len(scored_candidates) > 1 else None,
+                        "score_gap": score_gap,
+                        "age": age_group,
+                        "division": division,
+                        "top_candidates": top_candidates,
+                    }
+                )
+
                 logger.debug(
                     f"[Modular11] Match rejected for {incoming_name}: "
                     f"score={best['score']:.3f} (need >= {MODULAR11_MIN_CONFIDENCE}), "
                     f"gap={score_gap:.3f} (need >= {MODULAR11_MIN_GAP})"
                 )
                 return None
-            
+
         except Exception as e:
             logger.error(f"[Modular11] Fuzzy match error: {e}")
             return None
-    
+
     def _has_token_overlap(self, name1: str, name2: str) -> bool:
         """
         Check if two team names share at least one major token.
-        
+
         This prevents false matches between unrelated teams that happen to have
         high similarity scores but no actual club/team name overlap.
         """
+
         def extract_tokens(name: str) -> set:
             """Extract normalized tokens from team name"""
             if not name:
                 return set()
-            
+
             # Normalize: lowercase, remove punctuation, split
             normalized = name.lower().strip()
-            normalized = re.sub(r'[^\w\s]', ' ', normalized)
+            normalized = re.sub(r"[^\w\s]", " ", normalized)
             tokens = set(normalized.split())
-            
+
             # Remove common stop words
-            stop_words = {'u13', 'u14', 'u15', 'u16', 'u17', 'u18', 'hd', 'ad', 'mls', 'next', 'boys', 'girls'}
+            stop_words = {"u13", "u14", "u15", "u16", "u17", "u18", "hd", "ad", "mls", "next", "boys", "girls"}
             tokens = tokens - stop_words
-            
+
             return tokens
-        
+
         tokens1 = extract_tokens(name1)
         tokens2 = extract_tokens(name2)
-        
+
         # Check for major token overlap
         overlap = tokens1 & tokens2
-        
+
         # If any overlapping token is a "major token", return True
         for token in overlap:
             if token in MAJOR_TOKENS or len(token) >= 4:  # Major token or substantial word
                 return True
-        
+
         # Also check if any major token from either name appears in the other
         for major_token in MAJOR_TOKENS:
             if major_token in name1.lower() and major_token in name2.lower():
                 return True
-        
+
         return False
-    
-    def _get_candidate_divisions(
-        self,
-        team_ids: List[str],
-        provider_id: Optional[str]
-    ) -> Dict[str, Optional[str]]:
+
+    def _get_candidate_divisions(self, team_ids: List[str], provider_id: Optional[str]) -> Dict[str, Optional[str]]:
         """
         Get division (HD/AD) for candidate teams from their Modular11 aliases.
-        
+
         Returns dict mapping team_id_master -> division (or None)
         """
         if not provider_id or not team_ids:
             return {}
-        
+
         try:
             # Query team_alias_map for division info
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, division'
-            ).eq('provider_id', provider_id).in_(
-                'team_id_master', team_ids
-            ).execute()
-            
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, division")
+                .eq("provider_id", provider_id)
+                .in_("team_id_master", team_ids)
+                .execute()
+            )
+
             divisions = {}
             for row in result.data:
-                divisions[row['team_id_master']] = row.get('division')
-            
+                divisions[row["team_id_master"]] = row.get("division")
+
             return divisions
         except Exception as e:
             logger.debug(f"[Modular11] Error fetching candidate divisions: {e}")
             return {}
-    
+
     def _extract_division_from_name(self, team_name: str) -> Optional[str]:
         """
         Extract division (HD/AD) from team name.
-        
+
         Modular11 team names often end with " HD" or " AD".
         """
         if not team_name:
             return None
-        
+
         team_name_upper = team_name.upper().strip()
-        if team_name_upper.endswith(' HD'):
-            return 'HD'
-        elif team_name_upper.endswith(' AD'):
-            return 'AD'
-        
+        if team_name_upper.endswith(" HD"):
+            return "HD"
+        elif team_name_upper.endswith(" AD"):
+            return "AD"
+
         return None
-    
+
     def _build_aliased_provider_team_id(
-        self,
-        base_provider_team_id: str,
-        age_group: Optional[str] = None,
-        division: Optional[str] = None
+        self, base_provider_team_id: str, age_group: Optional[str] = None, division: Optional[str] = None
     ) -> str:
         """
         Build aliased provider_team_id format: {club_id}_{age}_{division}
-        
+
         For Modular11, the same club_id is used for all age groups/divisions,
         so we need to create unique identifiers by appending age and division.
-        
+
         Examples:
         - base="564", age="U13", division="HD" -> "564_U13_HD"
         - base="564", age="U13", division=None -> "564_U13"
         - base="564", age=None, division=None -> "564"
         - base="564", age="u13", division="hd" -> "564_U13_HD" (normalized)
         - base="564", age="13", division=None -> "564_U13" (adds U prefix)
-        
+
         Edge cases handled:
         - Empty/None base_provider_team_id: Returns empty string
         - Empty/None age_group: Skips age suffix
         - Empty/None/invalid division: Skips division suffix
         - Whitespace in age_group: Stripped before processing
         - Case variations: Normalized to uppercase
-        
+
         Args:
             base_provider_team_id: Raw club_id from Modular11 (e.g., "564")
             age_group: Age group (e.g., "U13", "u13", "13", " u13 ")
             division: Division (e.g., "HD", "AD", "hd", "ad")
-            
+
         Returns:
             Aliased provider_team_id string
         """
         # Handle empty/None base_provider_team_id
         if not base_provider_team_id:
-            return ''
-        
+            return ""
+
         # Strip whitespace from base
         base_provider_team_id = str(base_provider_team_id).strip()
         if not base_provider_team_id:
-            return ''
-        
+            return ""
+
         aliased_id = base_provider_team_id
         suffix_parts = []
-        
+
         # Add age group suffix (CRITICAL: same club ID used for all ages)
         if age_group:
             # Strip whitespace and normalize
@@ -1091,28 +1160,28 @@ class Modular11GameMatcher(GameHistoryMatcher):
             if age_group:
                 # Normalize age format: handle "U13", "u13", "13", " u13 ", etc.
                 age_lower = age_group.lower()
-                if age_lower.startswith('u'):
+                if age_lower.startswith("u"):
                     # Already has U prefix (e.g., "U13", "u13") - just uppercase
                     age_normalized = age_group.upper()
                 else:
                     # No U prefix (e.g., "13") - add it
                     age_normalized = f"U{age_group.upper()}"
-                
+
                 suffix_parts.append(age_normalized)
-        
+
         # Add division suffix (HD/AD)
         if division:
             # Strip whitespace and normalize
             division = str(division).strip().upper()
-            if division in ('HD', 'AD'):
+            if division in ("HD", "AD"):
                 suffix_parts.append(division)
-        
+
         # Build final aliased ID
         if suffix_parts:
             aliased_id = f"{base_provider_team_id}_{'_'.join(suffix_parts)}"
-        
+
         return aliased_id
-    
+
     def _get_fuzzy_suggestions(
         self,
         incoming_name: str,
@@ -1120,49 +1189,52 @@ class Modular11GameMatcher(GameHistoryMatcher):
         gender: str,
         division: Optional[str],
         club_name: Optional[str],
-        limit: int = 5
+        limit: int = 5,
     ) -> List[Dict[str, Any]]:
         """
         Get top fuzzy match suggestions (even if below threshold) for review queue.
         """
         try:
             age_group_normalized = age_group.lower() if age_group else age_group
-            
-            result = self.db.table('teams').select(
-                'team_id_master, team_name, club_name, age_group, gender'
-            ).eq('age_group', age_group_normalized).eq('gender', gender).limit(50).execute()
-            
+
+            result = (
+                self.db.table("teams")
+                .select("team_id_master, team_name, club_name, age_group, gender")
+                .eq("age_group", age_group_normalized)
+                .eq("gender", gender)
+                .limit(50)
+                .execute()
+            )
+
             suggestions = []
             for team in result.data:
-                provider_team = {
-                    'team_name': incoming_name,
-                    'club_name': club_name,
-                    'age_group': age_group
-                }
+                provider_team = {"team_name": incoming_name, "club_name": club_name, "age_group": age_group}
                 candidate = {
-                    'team_name': team.get('team_name', ''),
-                    'club_name': team.get('club_name'),
-                    'age_group': team.get('age_group', '')
+                    "team_name": team.get("team_name", ""),
+                    "club_name": team.get("club_name"),
+                    "age_group": team.get("age_group", ""),
                 }
-                
+
                 score = self._calculate_match_score(provider_team, candidate)
-                has_overlap = self._has_token_overlap(incoming_name, team.get('team_name', ''))
-                
+                has_overlap = self._has_token_overlap(incoming_name, team.get("team_name", ""))
+
                 if has_overlap:  # Only include suggestions with token overlap
-                    suggestions.append({
-                        'team_id_master': team['team_id_master'],
-                        'team_name': team.get('team_name', ''),
-                        'confidence': score
-                    })
-            
+                    suggestions.append(
+                        {
+                            "team_id_master": team["team_id_master"],
+                            "team_name": team.get("team_name", ""),
+                            "confidence": score,
+                        }
+                    )
+
             # Sort and return top N
-            suggestions.sort(key=lambda x: x['confidence'], reverse=True)
+            suggestions.sort(key=lambda x: x["confidence"], reverse=True)
             return suggestions[:limit]
-            
+
         except Exception as e:
             logger.debug(f"[Modular11] Error getting fuzzy suggestions: {e}")
             return []
-    
+
     def _create_new_modular11_team(
         self,
         team_name: str,
@@ -1171,18 +1243,18 @@ class Modular11GameMatcher(GameHistoryMatcher):
         gender: str,
         provider_id: Optional[str],
         provider_team_id: Optional[str] = None,
-        division: Optional[str] = None
+        division: Optional[str] = None,
     ) -> str:
         """
         Create a new team in the teams table for Modular11.
-        
+
         CRITICAL: For Modular11, provider_team_id must use the aliased format
         {club_id}_{age}_{division} (e.g., "564_U13_HD") to ensure uniqueness
         since the same club_id is used for all age groups/divisions.
-        
+
         If a team with the same provider_id and provider_team_id already exists,
         return that team's ID instead of creating a duplicate.
-        
+
         Returns the team_id_master UUID.
         """
         try:
@@ -1190,70 +1262,76 @@ class Modular11GameMatcher(GameHistoryMatcher):
             # If not provided, generate a hash-based one
             if not provider_team_id:
                 import hashlib
-                division_str = division or ''
-                base_provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[:16]
+
+                division_str = division or ""
+                base_provider_team_id = hashlib.md5(
+                    f"{team_name}_{age_group}_{gender}_{division_str}".encode()
+                ).hexdigest()[:16]
             else:
                 # Use provided provider_team_id as base (raw club_id)
                 base_provider_team_id = provider_team_id
-            
+
             # CRITICAL: Build aliased provider_team_id format: {club_id}_{age}_{division}
             # This ensures teams.provider_team_id matches team_alias_map.provider_team_id
             aliased_provider_team_id = self._build_aliased_provider_team_id(
-                base_provider_team_id=base_provider_team_id,
-                age_group=age_group,
-                division=division
+                base_provider_team_id=base_provider_team_id, age_group=age_group, division=division
             )
-            
+
             self._dlog(
                 f"Team creation: base_provider_team_id={base_provider_team_id}, "
                 f"aliased_provider_team_id={aliased_provider_team_id}"
             )
-            
+
             # Check if team with this provider_id + aliased_provider_team_id already exists
             if provider_id:
                 try:
-                    existing = self.db.table('teams').select('team_id_master').eq(
-                        'provider_id', provider_id
-                    ).eq('provider_team_id', aliased_provider_team_id).single().execute()
-                    
+                    existing = (
+                        self.db.table("teams")
+                        .select("team_id_master")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", aliased_provider_team_id)
+                        .single()
+                        .execute()
+                    )
+
                     if existing.data:
                         logger.debug(
                             f"[Modular11] Team with provider_team_id {aliased_provider_team_id} already exists, "
                             f"using existing team {existing.data['team_id_master']}"
                         )
-                        return existing.data['team_id_master']
+                        return existing.data["team_id_master"]
                 except Exception:
                     # No existing team found, continue to create new one
                     pass
-            
+
             # Generate new UUID
             team_id_master = str(uuid.uuid4())
-            
+
             # Normalize age_group
             age_group_normalized = age_group.lower() if age_group else age_group
-            
+
             # Normalize gender
-            gender_normalized = 'Male' if gender.upper() in ('M', 'MALE', 'BOYS') else 'Female'
-            
+            gender_normalized = "Male" if gender.upper() in ("M", "MALE", "BOYS") else "Female"
+
             # Clean team name (remove HD/AD suffix if present for storage)
             clean_team_name = team_name
-            if team_name.upper().endswith(' HD') or team_name.upper().endswith(' AD'):
+            if team_name.upper().endswith(" HD") or team_name.upper().endswith(" AD"):
                 clean_team_name = team_name[:-3].strip()
-            
+
             # Insert new team with ALIASED provider_team_id
             team_data = {
-                'team_id_master': team_id_master,
-                'team_name': clean_team_name,
-                'club_name': club_name or clean_team_name,
-                'age_group': age_group_normalized,
-                'gender': gender_normalized,
-                'provider_id': provider_id,  # Required for Modular11 teams
-                'provider_team_id': aliased_provider_team_id,  # Use aliased format: {club_id}_{age}_{division}
-                'created_at': datetime.utcnow().isoformat() + 'Z'
+                "team_id_master": team_id_master,
+                "team_name": clean_team_name,
+                "club_name": club_name or clean_team_name,
+                "age_group": age_group_normalized,
+                "gender": gender_normalized,
+                "provider_id": provider_id,  # Required for Modular11 teams
+                "provider_team_id": aliased_provider_team_id,  # Use aliased format: {club_id}_{age}_{division}
+                "created_at": datetime.utcnow().isoformat() + "Z",
             }
-            
-            self.db.table('teams').insert(team_data).execute()
-            
+
+            self.db.table("teams").insert(team_data).execute()
+
             self._dlog(
                 f"Creating NEW Modular11 team: {clean_team_name} "
                 f"({age_group_normalized}, {gender_normalized}, division={division}, "
@@ -1263,12 +1341,12 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 f"[Modular11] Created new team: {clean_team_name} ({age_group_normalized}, {gender_normalized}) "
                 f"with provider_team_id={aliased_provider_team_id}"
             )
-            
+
             return team_id_master
-            
+
         except Exception as e:
             # If duplicate key error, try to find existing team
-            if 'duplicate key' in str(e).lower() or '23505' in str(e):
+            if "duplicate key" in str(e).lower() or "23505" in str(e):
                 logger.debug(f"[Modular11] Duplicate key error, looking up existing team: {e}")
                 if provider_id:
                     # Rebuild aliased_provider_team_id for lookup (same format as what we tried to insert)
@@ -1276,34 +1354,40 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         # Determine base_provider_team_id
                         if not provider_team_id:
                             import hashlib
-                            division_str = division or ''
-                            base_provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}_{division_str}".encode()).hexdigest()[:16]
+
+                            division_str = division or ""
+                            base_provider_team_id = hashlib.md5(
+                                f"{team_name}_{age_group}_{gender}_{division_str}".encode()
+                            ).hexdigest()[:16]
                         else:
                             base_provider_team_id = provider_team_id
-                        
+
                         # Build aliased format
                         aliased_provider_team_id = self._build_aliased_provider_team_id(
-                            base_provider_team_id=base_provider_team_id,
-                            age_group=age_group,
-                            division=division
+                            base_provider_team_id=base_provider_team_id, age_group=age_group, division=division
                         )
-                        
-                        existing = self.db.table('teams').select('team_id_master').eq(
-                            'provider_id', provider_id
-                        ).eq('provider_team_id', aliased_provider_team_id).single().execute()
-                        
+
+                        existing = (
+                            self.db.table("teams")
+                            .select("team_id_master")
+                            .eq("provider_id", provider_id)
+                            .eq("provider_team_id", aliased_provider_team_id)
+                            .single()
+                            .execute()
+                        )
+
                         if existing.data:
                             logger.info(
                                 f"[Modular11] Found existing team with provider_team_id {aliased_provider_team_id}, "
                                 f"using {existing.data['team_id_master']}"
                             )
-                            return existing.data['team_id_master']
+                            return existing.data["team_id_master"]
                     except Exception as lookup_error:
                         logger.error(f"[Modular11] Error looking up existing team: {lookup_error}")
-            
+
             logger.error(f"[Modular11] Error creating new team: {e}")
             raise
-    
+
     def _create_modular11_alias(
         self,
         provider_id: str,
@@ -1312,7 +1396,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
         match_method: str,
         confidence: float,
         division: Optional[str],
-        age_group: Optional[str] = None
+        age_group: Optional[str] = None,
     ):
         """
         Create or update team alias map entry with division and age information.
@@ -1341,42 +1425,41 @@ class Modular11GameMatcher(GameHistoryMatcher):
             # This ensures each club+age+division combination has a unique alias
             # Use the helper function to ensure consistency with team creation
             aliased_provider_team_id = self._build_aliased_provider_team_id(
-                base_provider_team_id=provider_team_id,
-                age_group=age_group,
-                division=division
+                base_provider_team_id=provider_team_id, age_group=age_group, division=division
             )
-            
+
             self._dlog(f"Creating alias: base={provider_team_id}, aliased={aliased_provider_team_id}")
 
             # Check if alias already exists
-            query = self.db.table('team_alias_map').select('id').eq(
-                'provider_id', provider_id
-            ).eq('provider_team_id', aliased_provider_team_id)
-            
+            query = (
+                self.db.table("team_alias_map")
+                .select("id")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", aliased_provider_team_id)
+            )
+
             existing = query.execute()
 
             # team_alias_map schema: id, provider_id, provider_team_id, team_id_master,
             # match_confidence, match_method, review_status, created_at, division
             # NOTE: Does NOT have team_name, age_group, or gender columns
             alias_data = {
-                'provider_id': provider_id,
-                'provider_team_id': aliased_provider_team_id,  # Use division-suffixed ID
-                'team_id_master': team_id_master,
-                'match_method': match_method,
-                'match_confidence': confidence,
-                'review_status': 'approved',
-                'division': division,  # Store division (HD/AD) for reference
-                'created_at': datetime.utcnow().isoformat() + 'Z'
+                "provider_id": provider_id,
+                "provider_team_id": aliased_provider_team_id,  # Use division-suffixed ID
+                "team_id_master": team_id_master,
+                "match_method": match_method,
+                "match_confidence": confidence,
+                "review_status": "approved",
+                "division": division,  # Store division (HD/AD) for reference
+                "created_at": datetime.utcnow().isoformat() + "Z",
             }
 
             if existing.data:
                 # Update existing
-                self.db.table('team_alias_map').update(alias_data).eq(
-                    'id', existing.data[0]['id']
-                ).execute()
+                self.db.table("team_alias_map").update(alias_data).eq("id", existing.data[0]["id"]).execute()
             else:
                 # Create new
-                self.db.table('team_alias_map').insert(alias_data).execute()
+                self.db.table("team_alias_map").insert(alias_data).execute()
 
             self._dlog(
                 f"Creating alias -> provider_team_id={aliased_provider_team_id} "
@@ -1386,11 +1469,11 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 f"[Modular11] Created/updated alias: {aliased_provider_team_id} → {team_id_master} "
                 f"(method: {match_method}, division: {division})"
             )
-                
+
         except Exception as e:
             logger.error(f"[Modular11] Error creating alias: {e}")
             raise
-    
+
     def _enqueue_modular11_review_with_suggestions(
         self,
         provider_id: str,
@@ -1400,64 +1483,71 @@ class Modular11GameMatcher(GameHistoryMatcher):
         gender: str,
         division: Optional[str],
         suggested_master_team_id: Optional[str],
-        candidates: List[Dict[str, Any]]
+        candidates: List[Dict[str, Any]],
     ):
         """
         Add entry to team_match_review_queue with fuzzy match suggestions.
         """
         try:
             # Get provider code (team_match_review_queue uses VARCHAR provider_id)
-            provider_result = self.db.table('providers').select('code').eq('id', provider_id).single().execute()
-            provider_code = provider_result.data['code'] if provider_result.data else None
-            
+            provider_result = self.db.table("providers").select("code").eq("id", provider_id).single().execute()
+            provider_code = provider_result.data["code"] if provider_result.data else None
+
             if not provider_code:
                 logger.warning(f"[Modular11] Could not find provider code for {provider_id}")
                 return
-            
+
             review_entry = {
-                'provider_id': provider_code,  # VARCHAR code, not UUID
-                'provider_team_id': str(provider_team_id) if provider_team_id else None,
-                'provider_team_name': provider_team_name,
-                'suggested_master_team_id': suggested_master_team_id,
-                'confidence_score': 0.75,  # DB constraint requires >= 0.75
-                'match_details': {
-                    'age_group': age_group,
-                    'gender': gender,
-                    'division': division,
-                    'match_method': 'import',  # Consistent with team_alias_map match_method
-                    'candidates': candidates  # Top fuzzy suggestions
+                "provider_id": provider_code,  # VARCHAR code, not UUID
+                "provider_team_id": str(provider_team_id) if provider_team_id else None,
+                "provider_team_name": provider_team_name,
+                "suggested_master_team_id": suggested_master_team_id,
+                "confidence_score": 0.75,  # DB constraint requires >= 0.75
+                "match_details": {
+                    "age_group": age_group,
+                    "gender": gender,
+                    "division": division,
+                    "match_method": "import",  # Consistent with team_alias_map match_method
+                    "candidates": candidates,  # Top fuzzy suggestions
                 },
-                'status': 'pending'
+                "status": "pending",
             }
-            
+
             # Check if entry already exists
-            existing = self.db.table('team_match_review_queue').select('id').eq(
-                'provider_id', provider_code
-            ).eq('provider_team_id', str(provider_team_id)).eq('status', 'pending').execute()
-            
+            existing = (
+                self.db.table("team_match_review_queue")
+                .select("id")
+                .eq("provider_id", provider_code)
+                .eq("provider_team_id", str(provider_team_id))
+                .eq("status", "pending")
+                .execute()
+            )
+
             if not existing.data:
-                self.db.table('team_match_review_queue').insert(review_entry).execute()
-                
+                self.db.table("team_match_review_queue").insert(review_entry).execute()
+
                 # Track review queue entry
                 self.summary["review_queue"] += 1
-                self.summary["review_entries"].append({
-                    "incoming": provider_team_name,
-                    "suggestions": [c.get('team_name', 'Unknown') for c in candidates[:5]],  # top 5
-                    "age": age_group,
-                    "division": division
-                })
-                
+                self.summary["review_entries"].append(
+                    {
+                        "incoming": provider_team_name,
+                        "suggestions": [c.get("team_name", "Unknown") for c in candidates[:5]],  # top 5
+                        "age": age_group,
+                        "division": division,
+                    }
+                )
+
                 logger.info(
                     f"[Modular11] Created review queue entry for {provider_team_name} "
                     f"with {len(candidates)} suggestions"
                 )
         except Exception as e:
             logger.error(f"[Modular11] Error creating review queue entry: {e}")
-    
+
     def match_game_history(self, game_data: Dict) -> Dict:
         """
         Override match_game_history to extract and pass division for Modular11.
-        
+
         Extracts mls_division from game_data and passes it to _match_team calls.
         This ensures division-aware matching for both home and away teams.
         """
@@ -1466,174 +1556,204 @@ class Modular11GameMatcher(GameHistoryMatcher):
         if game_data.get("dry_run") is True or self.summary_only:
             self.debug = True
             # If summary_only is True, we still track summary but don't log per-team messages
-        
+
         # Extract division from game_data (mls_division field from CSV)
-        division = game_data.get('mls_division') or game_data.get('division')
-        
+        division = game_data.get("mls_division") or game_data.get("division")
+
         # If division not in game_data, try to extract from team names
         if not division:
-            team_name = game_data.get('team_name') or game_data.get('home_team_name')
+            team_name = game_data.get("team_name") or game_data.get("home_team_name")
             if team_name:
                 division = self._extract_division_from_name(team_name)
-        
+
         # Store division in game_data so _match_team can access it
         # We'll extract it in _match_team override
         if division:
-            game_data['_modular11_division'] = division
-        
+            game_data["_modular11_division"] = division
+
         # Get provider ID
-        provider_id = self._get_provider_id(game_data.get('provider'))
-        
+        provider_id = self._get_provider_id(game_data.get("provider"))
+
         # Initialize variables for both code paths
-        home_provider_id = ''
-        away_provider_id = ''
+        home_provider_id = ""
+        away_provider_id = ""
         home_score = None
         away_score = None
-        
+
         # Check if game is already transformed (has home_team_id/away_team_id)
-        if 'home_team_id' in game_data and 'away_team_id' in game_data:
+        if "home_team_id" in game_data and "away_team_id" in game_data:
             # Already transformed - use directly
-            home_provider_id_raw = game_data.get('home_provider_id') or game_data.get('home_team_id', '')
-            away_provider_id_raw = game_data.get('away_provider_id') or game_data.get('away_team_id', '')
+            home_provider_id_raw = game_data.get("home_provider_id") or game_data.get("home_team_id", "")
+            away_provider_id_raw = game_data.get("away_provider_id") or game_data.get("away_team_id", "")
             try:
-                home_provider_id = str(int(float(home_provider_id_raw))) if home_provider_id_raw and str(home_provider_id_raw).strip() else ''
+                home_provider_id = (
+                    str(int(float(home_provider_id_raw)))
+                    if home_provider_id_raw and str(home_provider_id_raw).strip()
+                    else ""
+                )
             except (ValueError, TypeError):
-                home_provider_id = str(home_provider_id_raw).strip() if home_provider_id_raw else ''
+                home_provider_id = str(home_provider_id_raw).strip() if home_provider_id_raw else ""
             try:
-                away_provider_id = str(int(float(away_provider_id_raw))) if away_provider_id_raw and str(away_provider_id_raw).strip() else ''
+                away_provider_id = (
+                    str(int(float(away_provider_id_raw)))
+                    if away_provider_id_raw and str(away_provider_id_raw).strip()
+                    else ""
+                )
             except (ValueError, TypeError):
-                away_provider_id = str(away_provider_id_raw).strip() if away_provider_id_raw else ''
-            
+                away_provider_id = str(away_provider_id_raw).strip() if away_provider_id_raw else ""
+
             # Extract division for home and away teams (may differ)
-            home_division = division or self._extract_division_from_name(game_data.get('home_team_name', ''))
-            away_division = division or self._extract_division_from_name(game_data.get('away_team_name', ''))
-            
+            home_division = division or self._extract_division_from_name(game_data.get("home_team_name", ""))
+            away_division = division or self._extract_division_from_name(game_data.get("away_team_name", ""))
+
             # Match home team
             home_match = self._match_team(
                 provider_id=provider_id,
                 provider_team_id=home_provider_id,
-                team_name=game_data.get('home_team_name'),
-                age_group=game_data.get('age_group'),
-                gender=game_data.get('gender'),
-                club_name=game_data.get('home_club_name') or game_data.get('club_name'),
-                division=home_division
+                team_name=game_data.get("home_team_name"),
+                age_group=game_data.get("age_group"),
+                gender=game_data.get("gender"),
+                club_name=game_data.get("home_club_name") or game_data.get("club_name"),
+                division=home_division,
             )
-            
+
             # Match away team
             away_match = self._match_team(
                 provider_id=provider_id,
                 provider_team_id=away_provider_id,
-                team_name=game_data.get('away_team_name'),
-                age_group=game_data.get('age_group'),
-                gender=game_data.get('gender'),
-                club_name=game_data.get('away_club_name') or game_data.get('opponent_club_name'),
-                division=away_division
+                team_name=game_data.get("away_team_name"),
+                age_group=game_data.get("age_group"),
+                gender=game_data.get("gender"),
+                club_name=game_data.get("away_club_name") or game_data.get("opponent_club_name"),
+                division=away_division,
             )
-            
-            home_team_master_id = home_match.get('team_id')
-            away_team_master_id = away_match.get('team_id')
-            home_score = game_data.get('home_score')
-            away_score = game_data.get('away_score')
+
+            home_team_master_id = home_match.get("team_id")
+            away_team_master_id = away_match.get("team_id")
+            home_score = game_data.get("home_score")
+            away_score = game_data.get("away_score")
             # home_provider_id and away_provider_id already set above
-            
+
         else:
             # Source format - transform and match
             # Extract division for team and opponent (may differ)
-            team_division = division or self._extract_division_from_name(game_data.get('team_name', ''))
-            opponent_division = division or self._extract_division_from_name(game_data.get('opponent_name', ''))
-            
+            team_division = division or self._extract_division_from_name(game_data.get("team_name", ""))
+            opponent_division = division or self._extract_division_from_name(game_data.get("opponent_name", ""))
+
             # Match team
             team_match = self._match_team(
                 provider_id=provider_id,
-                provider_team_id=game_data.get('team_id'),
-                team_name=game_data.get('team_name'),
-                age_group=game_data.get('age_group'),
-                gender=game_data.get('gender'),
-                club_name=game_data.get('club_name') or game_data.get('team_club_name'),
-                division=team_division
+                provider_team_id=game_data.get("team_id"),
+                team_name=game_data.get("team_name"),
+                age_group=game_data.get("age_group"),
+                gender=game_data.get("gender"),
+                club_name=game_data.get("club_name") or game_data.get("team_club_name"),
+                division=team_division,
             )
-            
+
             # Match opponent
             opponent_match = self._match_team(
                 provider_id=provider_id,
-                provider_team_id=game_data.get('opponent_id'),
-                team_name=game_data.get('opponent_name'),
-                age_group=game_data.get('age_group'),
-                gender=game_data.get('gender'),
-                club_name=game_data.get('opponent_club_name'),
-                division=opponent_division
+                provider_team_id=game_data.get("opponent_id"),
+                team_name=game_data.get("opponent_name"),
+                age_group=game_data.get("age_group"),
+                gender=game_data.get("gender"),
+                club_name=game_data.get("opponent_club_name"),
+                division=opponent_division,
             )
-            
+
             # Determine home/away teams based on home_away flag
-            home_away = game_data.get('home_away', 'H').upper()
-            
+            home_away = game_data.get("home_away", "H").upper()
+
             # Extract team_id and opponent_id, converting floats to strings if needed
-            team_id_raw = game_data.get('team_id', '')
-            opponent_id_raw = game_data.get('opponent_id', '')
-            
+            team_id_raw = game_data.get("team_id", "")
+            opponent_id_raw = game_data.get("opponent_id", "")
+
             try:
-                team_id = str(int(float(team_id_raw))) if team_id_raw and str(team_id_raw).strip() else ''
+                team_id = str(int(float(team_id_raw))) if team_id_raw and str(team_id_raw).strip() else ""
             except (ValueError, TypeError):
-                team_id = str(team_id_raw).strip() if team_id_raw else ''
+                team_id = str(team_id_raw).strip() if team_id_raw else ""
             try:
-                opponent_id = str(int(float(opponent_id_raw))) if opponent_id_raw and str(opponent_id_raw).strip() else ''
+                opponent_id = (
+                    str(int(float(opponent_id_raw))) if opponent_id_raw and str(opponent_id_raw).strip() else ""
+                )
             except (ValueError, TypeError):
-                opponent_id = str(opponent_id_raw).strip() if opponent_id_raw else ''
-            
-            if home_away == 'H':
-                home_team_master_id = team_match.get('team_id')
-                away_team_master_id = opponent_match.get('team_id')
+                opponent_id = str(opponent_id_raw).strip() if opponent_id_raw else ""
+
+            if home_away == "H":
+                home_team_master_id = team_match.get("team_id")
+                away_team_master_id = opponent_match.get("team_id")
                 home_provider_id = team_id
                 away_provider_id = opponent_id
-                home_score = game_data.get('goals_for')
-                away_score = game_data.get('goals_against')
+                home_score = game_data.get("goals_for")
+                away_score = game_data.get("goals_against")
             else:
-                home_team_master_id = opponent_match.get('team_id')
-                away_team_master_id = team_match.get('team_id')
+                home_team_master_id = opponent_match.get("team_id")
+                away_team_master_id = team_match.get("team_id")
                 home_provider_id = opponent_id
                 away_provider_id = team_id
-                home_score = game_data.get('goals_against')
-                away_score = game_data.get('goals_for')
-        
+                home_score = game_data.get("goals_against")
+                away_score = game_data.get("goals_for")
+
         # CRITICAL: Validate age groups match between home and away teams
         # This prevents age mismatches (e.g., U13 vs U16 games)
         match_status = None  # Initialize before age validation
-        
+
         # Log team matching results for debugging
-        game_uid_debug = game_data.get('game_uid', 'N/A')
+        game_uid_debug = game_data.get("game_uid", "N/A")
         logger.debug(
             f"[Modular11] Team matching results for game {game_uid_debug}: "
             f"home_team_master_id={home_team_master_id}, away_team_master_id={away_team_master_id}, "
             f"home_provider_id={home_provider_id}, away_provider_id={away_provider_id}"
         )
-        
+
         if home_team_master_id and away_team_master_id:
             try:
-                home_team_result = self.db.table('teams').select('age_group, gender, team_name').eq('team_id_master', home_team_master_id).single().execute()
-                away_team_result = self.db.table('teams').select('age_group, gender, team_name').eq('team_id_master', away_team_master_id).single().execute()
-                
+                home_team_result = (
+                    self.db.table("teams")
+                    .select("age_group, gender, team_name")
+                    .eq("team_id_master", home_team_master_id)
+                    .single()
+                    .execute()
+                )
+                away_team_result = (
+                    self.db.table("teams")
+                    .select("age_group, gender, team_name")
+                    .eq("team_id_master", away_team_master_id)
+                    .single()
+                    .execute()
+                )
+
                 if home_team_result.data and away_team_result.data:
-                    home_age = home_team_result.data.get('age_group', '').lower() if home_team_result.data.get('age_group') else None
-                    away_age = away_team_result.data.get('age_group', '').lower() if away_team_result.data.get('age_group') else None
-                    home_team_name = home_team_result.data.get('team_name', 'Unknown')
-                    away_team_name = away_team_result.data.get('team_name', 'Unknown')
-                    
+                    home_age = (
+                        home_team_result.data.get("age_group", "").lower()
+                        if home_team_result.data.get("age_group")
+                        else None
+                    )
+                    away_age = (
+                        away_team_result.data.get("age_group", "").lower()
+                        if away_team_result.data.get("age_group")
+                        else None
+                    )
+                    home_team_name = home_team_result.data.get("team_name", "Unknown")
+                    away_team_name = away_team_result.data.get("team_name", "Unknown")
+
                     logger.debug(
                         f"[Modular11] Age validation for game {game_uid_debug}: "
                         f"home={home_team_name} ({home_age}), away={away_team_name} ({away_age})"
                     )
-                    
+
                     if home_age and away_age:
                         try:
-                            home_age_num = int(home_age.replace('u', '').replace('U', ''))
-                            away_age_num = int(away_age.replace('u', '').replace('U', ''))
+                            home_age_num = int(home_age.replace("u", "").replace("U", ""))
+                            away_age_num = int(away_age.replace("u", "").replace("U", ""))
                             age_diff = abs(home_age_num - away_age_num)
-                            
+
                             logger.debug(
                                 f"[Modular11] Age difference for game {game_uid_debug}: "
                                 f"{home_age_num} vs {away_age_num} = {age_diff} years"
                             )
-                            
+
                             # Age mismatch if difference >= 2 years
                             if age_diff >= 2:
                                 logger.warning(
@@ -1645,7 +1765,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                                     f"REJECTING GAME"
                                 )
                                 # Reject the game by setting match_status to 'failed'
-                                match_status = 'failed'
+                                match_status = "failed"
                                 home_team_master_id = None
                                 away_team_master_id = None
                             else:
@@ -1670,43 +1790,38 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         f"game {game_uid_debug}, home_id={home_team_master_id}, away_id={away_team_master_id}"
                     )
             except Exception as e:
-                logger.error(
-                    f"[Modular11] Error validating age groups for game {game_uid_debug}: {e}"
-                )
+                logger.error(f"[Modular11] Error validating age groups for game {game_uid_debug}: {e}")
                 # If validation fails, allow the game (don't block on validation errors)
         else:
             logger.debug(
                 f"[Modular11] Age validation SKIPPED for game {game_uid_debug}: "
                 f"Missing team master IDs (home={home_team_master_id}, away={away_team_master_id})"
             )
-        
+
         # Determine overall match status
         # NOTE: Don't overwrite 'failed' status if age validation already set it
-        if match_status != 'failed':
+        if match_status != "failed":
             if home_team_master_id and away_team_master_id:
-                match_status = 'matched'
+                match_status = "matched"
                 logger.debug(
                     f"[Modular11] Game {game_uid_debug} MATCHED: "
                     f"Both teams found (home={home_team_master_id}, away={away_team_master_id})"
                 )
             elif home_team_master_id or away_team_master_id:
-                match_status = 'partial'
+                match_status = "partial"
                 logger.debug(
                     f"[Modular11] Game {game_uid_debug} PARTIAL MATCH: "
                     f"home={home_team_master_id}, away={away_team_master_id}"
                 )
             else:
-                match_status = 'failed'
+                match_status = "failed"
                 logger.warning(
                     f"[Modular11] Game {game_uid_debug} FAILED: "
                     f"No teams matched (home={home_team_master_id}, away={away_team_master_id})"
                 )
         else:
-            logger.warning(
-                f"[Modular11] Game {game_uid_debug} FAILED: "
-                f"Age validation rejected the game"
-            )
-        
+            logger.warning(f"[Modular11] Game {game_uid_debug} FAILED: Age validation rejected the game")
+
         # Generate game UID - ALWAYS regenerate for Modular11 to ensure it includes age_group and division
         # CRITICAL: For Modular11, include age_group AND division in game_uid to prevent collisions
         # between U13/U14 games (same provider IDs, different age groups)
@@ -1719,76 +1834,82 @@ class Modular11GameMatcher(GameHistoryMatcher):
         # NOTE: We always regenerate game_uid here (even if one exists) because validation
         # may have generated one without age_group/division, and we need the full format.
         if True:  # Always regenerate for Modular11 to ensure correct format
-            provider_code = game_data.get('provider', '')
-            age_group = game_data.get('age_group', '').upper() if game_data.get('age_group') else None
-            division = game_data.get('mls_division', '').upper() if game_data.get('mls_division') else None
-            
+            provider_code = game_data.get("provider", "")
+            age_group = game_data.get("age_group", "").upper() if game_data.get("age_group") else None
+            division = game_data.get("mls_division", "").upper() if game_data.get("mls_division") else None
+
             # For Modular11, include age_group AND division in game_uid
             # This matches the alias format: {provider_id}_{age_group}_{division}
             if age_group and division:
                 # Format: modular11:{date}:{team1}:{team2}:{age_group}:{division}
-                team1_id = home_provider_id or game_data.get('team_id', '')
-                team2_id = away_provider_id or game_data.get('opponent_id', '')
-                
+                team1_id = home_provider_id or game_data.get("team_id", "")
+                team2_id = away_provider_id or game_data.get("opponent_id", "")
+
                 # Normalize team IDs
                 def normalize_team_id(team_id):
-                    if not team_id or team_id == '' or str(team_id).strip().lower() == 'none':
-                        return ''
+                    if not team_id or team_id == "" or str(team_id).strip().lower() == "none":
+                        return ""
                     try:
                         return str(int(float(str(team_id))))
                     except (ValueError, TypeError):
                         return str(team_id).strip()
-                
+
                 team1_str = normalize_team_id(team1_id)
                 team2_str = normalize_team_id(team2_id)
                 sorted_teams = sorted([team1_str, team2_str])
-                
+
                 game_uid = f"{provider_code}:{game_data.get('game_date', '')}:{sorted_teams[0]}:{sorted_teams[1]}:{age_group}:{division}"
             elif age_group:
                 # Fallback: include age_group only if division not available
-                team1_id = home_provider_id or game_data.get('team_id', '')
-                team2_id = away_provider_id or game_data.get('opponent_id', '')
-                
+                team1_id = home_provider_id or game_data.get("team_id", "")
+                team2_id = away_provider_id or game_data.get("opponent_id", "")
+
                 def normalize_team_id(team_id):
-                    if not team_id or team_id == '' or str(team_id).strip().lower() == 'none':
-                        return ''
+                    if not team_id or team_id == "" or str(team_id).strip().lower() == "none":
+                        return ""
                     try:
                         return str(int(float(str(team_id))))
                     except (ValueError, TypeError):
                         return str(team_id).strip()
-                
+
                 team1_str = normalize_team_id(team1_id)
                 team2_str = normalize_team_id(team2_id)
                 sorted_teams = sorted([team1_str, team2_str])
-                
-                game_uid = f"{provider_code}:{game_data.get('game_date', '')}:{sorted_teams[0]}:{sorted_teams[1]}:{age_group}"
+
+                game_uid = (
+                    f"{provider_code}:{game_data.get('game_date', '')}:{sorted_teams[0]}:{sorted_teams[1]}:{age_group}"
+                )
             else:
                 # Fallback to standard format if age_group not available
                 game_uid = self.generate_game_uid(
                     provider=provider_code,
-                    game_date=game_data.get('game_date', ''),
-                    team1_id=home_provider_id or game_data.get('team_id', ''),
-                    team2_id=away_provider_id or game_data.get('opponent_id', '')
+                    game_date=game_data.get("game_date", ""),
+                    team1_id=home_provider_id or game_data.get("team_id", ""),
+                    team2_id=away_provider_id or game_data.get("opponent_id", ""),
                 )
-        
+
         # game_uid is now always regenerated with correct format (including age_group/division if available)
-        
+
         # Build game record
         try:
-            home_provider_id_final = str(int(float(home_provider_id))) if home_provider_id and str(home_provider_id).strip() else ''
+            home_provider_id_final = (
+                str(int(float(home_provider_id))) if home_provider_id and str(home_provider_id).strip() else ""
+            )
         except (ValueError, TypeError):
-            home_provider_id_final = str(home_provider_id).strip() if home_provider_id else ''
+            home_provider_id_final = str(home_provider_id).strip() if home_provider_id else ""
         try:
-            away_provider_id_final = str(int(float(away_provider_id))) if away_provider_id and str(away_provider_id).strip() else ''
+            away_provider_id_final = (
+                str(int(float(away_provider_id))) if away_provider_id and str(away_provider_id).strip() else ""
+            )
         except (ValueError, TypeError):
-            away_provider_id_final = str(away_provider_id).strip() if away_provider_id else ''
-        
+            away_provider_id_final = str(away_provider_id).strip() if away_provider_id else ""
+
         # Extract age_group and division for Modular11 (required for unique constraint)
-        raw_age_group = game_data.get('age_group')
-        raw_mls_division = game_data.get('mls_division')
+        raw_age_group = game_data.get("age_group")
+        raw_mls_division = game_data.get("mls_division")
         age_group = raw_age_group.upper() if raw_age_group else None
         mls_division = raw_mls_division.upper() if raw_mls_division else None
-        
+
         # Debug logging
         logger.info(
             f"[Modular11Matcher] Extracting age_group/division: "
@@ -1796,7 +1917,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
             f"raw_mls_division={raw_mls_division} (type={type(raw_mls_division)}), "
             f"extracted age_group={age_group}, mls_division={mls_division}"
         )
-        
+
         # Log if missing (for debugging) - use module-level logger
         if not age_group or not mls_division:
             logger.warning(
@@ -1804,48 +1925,48 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 f"age_group={raw_age_group}, mls_division={raw_mls_division}, "
                 f"game_data keys={list(game_data.keys())[:10]}"
             )
-        
+
         game_record = {
-            'game_uid': game_uid,
-            'home_team_master_id': home_team_master_id,
-            'away_team_master_id': away_team_master_id,
-            'home_provider_id': home_provider_id_final,
-            'away_provider_id': away_provider_id_final,
-            'team_id': game_data.get('team_id', ''),
-            'opponent_id': game_data.get('opponent_id', ''),
-            'home_score': home_score,
-            'away_score': away_score,
-            'result': game_data.get('result'),
-            'game_date': game_data.get('game_date'),
-            'competition': game_data.get('competition'),
-            'division_name': game_data.get('division_name'),
-            'event_name': game_data.get('event_name'),
-            'venue': game_data.get('venue'),
-            'provider_id': provider_id,
-            'source_url': game_data.get('source_url'),
-            'scraped_at': game_data.get('scraped_at'),
-            'match_status': match_status,
-            'raw_data': game_data,
+            "game_uid": game_uid,
+            "home_team_master_id": home_team_master_id,
+            "away_team_master_id": away_team_master_id,
+            "home_provider_id": home_provider_id_final,
+            "away_provider_id": away_provider_id_final,
+            "team_id": game_data.get("team_id", ""),
+            "opponent_id": game_data.get("opponent_id", ""),
+            "home_score": home_score,
+            "away_score": away_score,
+            "result": game_data.get("result"),
+            "game_date": game_data.get("game_date"),
+            "competition": game_data.get("competition"),
+            "division_name": game_data.get("division_name"),
+            "event_name": game_data.get("event_name"),
+            "venue": game_data.get("venue"),
+            "provider_id": provider_id,
+            "source_url": game_data.get("source_url"),
+            "scraped_at": game_data.get("scraped_at"),
+            "match_status": match_status,
+            "raw_data": game_data,
             # CRITICAL: Add age_group and mls_division for Modular11 unique constraint
-            'age_group': age_group,
-            'mls_division': mls_division
+            "age_group": age_group,
+            "mls_division": mls_division,
         }
-        
+
         # Debug: Verify they're in the record
         logger.info(
             f"[Modular11Matcher] Created game_record with age_group={game_record.get('age_group')}, "
             f"mls_division={game_record.get('mls_division')}, game_uid={game_record.get('game_uid')}"
         )
-        
+
         return game_record
-    
+
     def _match_by_provider_id(
         self,
         provider_id: str,
         provider_team_id: str,
         age_group: Optional[str] = None,
         gender: Optional[str] = None,
-        division: Optional[str] = None
+        division: Optional[str] = None,
     ) -> Optional[Dict]:
         """
         Match by exact provider ID with MANDATORY age_group validation.
@@ -1870,38 +1991,38 @@ class Modular11GameMatcher(GameHistoryMatcher):
             return None
 
         provider_team_id_str = str(provider_team_id).strip()
-        
+
         # Check if provider_team_id contains semicolon-separated aliases
         # Examples: "391;392_U14_AD", "391;392", "391_U14_AD;392_U14_AD"
         base_ids = []
-        
-        if ';' in provider_team_id_str:
+
+        if ";" in provider_team_id_str:
             # Split on semicolon
-            parts = [p.strip() for p in provider_team_id_str.split(';')]
-            
+            parts = [p.strip() for p in provider_team_id_str.split(";")]
+
             # Check if any part has a suffix pattern (e.g., "_U14_AD", "_U14", "_AD")
             # If found, extract it and apply to all base IDs
             extracted_suffix = None
             for part in parts:
-                if '_' in part:
+                if "_" in part:
                     # Try to find suffix pattern (starts with underscore, contains U/HD/AD)
                     # Look for patterns like "_U14", "_AD", "_U14_AD", "_HD", etc.
                     # Match underscore followed by U followed by digits, optionally followed by _HD or _AD
-                    suffix_match = re.search(r'_U\d+(_(HD|AD))?$', part, re.IGNORECASE)
+                    suffix_match = re.search(r"_U\d+(_(HD|AD))?$", part, re.IGNORECASE)
                     if suffix_match:
                         extracted_suffix = suffix_match.group(0)
                         break
                     # Also check for just "_HD" or "_AD" at the end
-                    if part.upper().endswith('_HD') or part.upper().endswith('_AD'):
-                        extracted_suffix = part[part.rfind('_'):]
+                    if part.upper().endswith("_HD") or part.upper().endswith("_AD"):
+                        extracted_suffix = part[part.rfind("_") :]
                         break
-            
+
             # Extract base IDs (remove suffix if found)
             if extracted_suffix:
                 base_ids = []
                 for part in parts:
                     if part.endswith(extracted_suffix):
-                        base_id = part[:-len(extracted_suffix)]
+                        base_id = part[: -len(extracted_suffix)]
                         if base_id:
                             base_ids.append(base_id)
                     else:
@@ -1913,25 +2034,25 @@ class Modular11GameMatcher(GameHistoryMatcher):
         else:
             # Single ID, no semicolon
             base_ids = [provider_team_id_str]
-        
+
         # Normalize age format
         age_normalized = None
         if age_group:
-            age_normalized = age_group.upper() if age_group.lower().startswith('u') else f"U{age_group}"
-        
+            age_normalized = age_group.upper() if age_group.lower().startswith("u") else f"U{age_group}"
+
         # Try each base ID until we find a match
         for base_id in base_ids:
             # Build list of alias formats to try for this base ID (most specific first)
             team_ids_to_try = []
-            
+
             # 1. Try full suffix: {id}_{age}_{division} (e.g., "391_U16_AD")
-            if age_normalized and division and division.upper() in ('HD', 'AD'):
+            if age_normalized and division and division.upper() in ("HD", "AD"):
                 team_ids_to_try.append(f"{base_id}_{age_normalized}_{division.upper()}")
-            
+
             # 2. Try age-only suffix: {id}_{age} (e.g., "391_U16")
             if age_normalized:
                 team_ids_to_try.append(f"{base_id}_{age_normalized}")
-            
+
             # 3. CRITICAL: When division is UNKNOWN (event/showcase games without HD/AD),
             #    try BOTH divisions as fallback. The same club's alias exists as
             #    {id}_{age}_AD or {id}_{age}_HD — we should find it either way.
@@ -1939,14 +2060,14 @@ class Modular11GameMatcher(GameHistoryMatcher):
             if age_normalized and not division:
                 team_ids_to_try.append(f"{base_id}_{age_normalized}_AD")
                 team_ids_to_try.append(f"{base_id}_{age_normalized}_HD")
-            
+
             # 4. Try division-only suffix: {id}_{division} (e.g., "391_AD") - backwards compatible
-            if division and division.upper() in ('HD', 'AD'):
+            if division and division.upper() in ("HD", "AD"):
                 team_ids_to_try.append(f"{base_id}_{division.upper()}")
-            
+
             # 5. Always fall back to original base ID
             team_ids_to_try.append(base_id)
-            
+
             # Deduplicate while preserving order
             seen = set()
             unique_ids_to_try = []
@@ -1955,23 +2076,31 @@ class Modular11GameMatcher(GameHistoryMatcher):
                     seen.add(tid)
                     unique_ids_to_try.append(tid)
             team_ids_to_try = unique_ids_to_try
-            
+
             # Check cache first (if available) - try division-suffixed IDs first
             for try_id in team_ids_to_try:
                 if self.alias_cache and try_id in self.alias_cache:
                     cached = self.alias_cache[try_id]
-                    team_id_master = cached['team_id_master']
+                    team_id_master = cached["team_id_master"]
 
                     # MODULAR11: ALWAYS validate age_group if provided
                     if age_group:
                         if not self._validate_team_age_group(team_id_master, age_group, gender):
                             # Get team details for logging
                             try:
-                                team_result = self.db.table('teams').select('team_name, age_group, gender').eq('team_id_master', team_id_master).single().execute()
+                                team_result = (
+                                    self.db.table("teams")
+                                    .select("team_name, age_group, gender")
+                                    .eq("team_id_master", team_id_master)
+                                    .single()
+                                    .execute()
+                                )
                                 if team_result.data:
-                                    team_age = team_result.data.get('age_group', 'Unknown')
-                                    team_gender = team_result.data.get('gender', 'Unknown')
-                                    self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})")
+                                    team_age = team_result.data.get("age_group", "Unknown")
+                                    team_gender = team_result.data.get("gender", "Unknown")
+                                    self._dlog(
+                                        f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})"
+                                    )
                                 else:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)")
                             except:
@@ -1983,46 +2112,59 @@ class Modular11GameMatcher(GameHistoryMatcher):
                             continue  # Try next ID instead of returning None
 
                     # Prefer direct_id matches
-                    if cached.get('match_method') == 'direct_id':
+                    if cached.get("match_method") == "direct_id":
                         self._dlog(f"Cache hit: {try_id} -> {team_id_master} (direct_id)")
                         return {
-                            'team_id_master': team_id_master,
-                            'review_status': cached.get('review_status', 'approved'),
-                            'match_method': 'direct_id'
+                            "team_id_master": team_id_master,
+                            "review_status": cached.get("review_status", "approved"),
+                            "match_method": "direct_id",
                         }
                     # Fallback to any cached match
                     self._dlog(f"Cache hit: {try_id} -> {team_id_master}")
                     return {
-                        'team_id_master': team_id_master,
-                        'review_status': cached.get('review_status', 'approved'),
-                        'match_method': cached.get('match_method')
+                        "team_id_master": team_id_master,
+                        "review_status": cached.get("review_status", "approved"),
+                        "match_method": cached.get("match_method"),
                     }
-            
+
             # Tier 1: Direct ID match (from team importer) - try division-suffixed IDs first
             for try_id in team_ids_to_try:
                 try:
-                    result = self.db.table('team_alias_map').select(
-                        'team_id_master, review_status, match_method'
-                    ).eq('provider_id', provider_id).eq(
-                        'provider_team_id', try_id
-                    ).eq('match_method', 'direct_id').eq(
-                        'review_status', 'approved'
-                    ).single().execute()
+                    result = (
+                        self.db.table("team_alias_map")
+                        .select("team_id_master, review_status, match_method")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", try_id)
+                        .eq("match_method", "direct_id")
+                        .eq("review_status", "approved")
+                        .single()
+                        .execute()
+                    )
 
                     if result.data:
-                        team_id_master = result.data['team_id_master']
+                        team_id_master = result.data["team_id_master"]
                         # MODULAR11: ALWAYS validate age_group if provided
                         if age_group:
                             if not self._validate_team_age_group(team_id_master, age_group, gender):
                                 # Get team details for logging
                                 try:
-                                    team_result = self.db.table('teams').select('team_name, age_group, gender').eq('team_id_master', team_id_master).single().execute()
+                                    team_result = (
+                                        self.db.table("teams")
+                                        .select("team_name, age_group, gender")
+                                        .eq("team_id_master", team_id_master)
+                                        .single()
+                                        .execute()
+                                    )
                                     if team_result.data:
-                                        team_age = team_result.data.get('age_group', 'Unknown')
-                                        team_gender = team_result.data.get('gender', 'Unknown')
-                                        self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})")
+                                        team_age = team_result.data.get("age_group", "Unknown")
+                                        team_gender = team_result.data.get("gender", "Unknown")
+                                        self._dlog(
+                                            f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})"
+                                        )
                                     else:
-                                        self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)")
+                                        self._dlog(
+                                            f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)"
+                                        )
                                 except:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group})")
                                 logger.debug(
@@ -2034,30 +2176,44 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         return result.data
                 except Exception as e:
                     logger.debug(f"No direct_id match found for {try_id}: {e}")
-            
+
             # Tier 2: Any approved alias map entry (fallback) - try division-suffixed IDs first
             for try_id in team_ids_to_try:
                 try:
-                    result = self.db.table('team_alias_map').select(
-                        'team_id_master, review_status, match_method'
-                    ).eq('provider_id', provider_id).eq(
-                        'provider_team_id', try_id
-                    ).eq('review_status', 'approved').single().execute()
+                    result = (
+                        self.db.table("team_alias_map")
+                        .select("team_id_master, review_status, match_method")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", try_id)
+                        .eq("review_status", "approved")
+                        .single()
+                        .execute()
+                    )
 
                     if result.data:
-                        team_id_master = result.data['team_id_master']
+                        team_id_master = result.data["team_id_master"]
                         # MODULAR11: ALWAYS validate age_group if provided
                         if age_group:
                             if not self._validate_team_age_group(team_id_master, age_group, gender):
                                 # Get team details for logging
                                 try:
-                                    team_result = self.db.table('teams').select('team_name, age_group, gender').eq('team_id_master', team_id_master).single().execute()
+                                    team_result = (
+                                        self.db.table("teams")
+                                        .select("team_name, age_group, gender")
+                                        .eq("team_id_master", team_id_master)
+                                        .single()
+                                        .execute()
+                                    )
                                     if team_result.data:
-                                        team_age = team_result.data.get('age_group', 'Unknown')
-                                        team_gender = team_result.data.get('gender', 'Unknown')
-                                        self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})")
+                                        team_age = team_result.data.get("age_group", "Unknown")
+                                        team_gender = team_result.data.get("gender", "Unknown")
+                                        self._dlog(
+                                            f"Alias rejected: age mismatch (incoming {age_group} vs team {team_age})"
+                                        )
                                     else:
-                                        self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)")
+                                        self._dlog(
+                                            f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)"
+                                        )
                                 except:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group})")
                                 logger.debug(
@@ -2069,19 +2225,16 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         return result.data
                 except Exception as e:
                     logger.debug(f"No alias map match found for {try_id}: {e}")
-        
+
         # No match found for any base ID
         return None
-    
+
     def _validate_team_age_group(
-        self, 
-        team_id_master: str, 
-        expected_age_group: str, 
-        expected_gender: Optional[str] = None
+        self, team_id_master: str, expected_age_group: str, expected_gender: Optional[str] = None
     ) -> bool:
         """
         Validate that a master team's age_group matches the expected age_group.
-        
+
         This is CRITICAL for Modular11 because the same provider_team_id (club ID)
         is used for all age groups. Without this validation, U16 games would
         incorrectly match to U13 teams.
@@ -2089,19 +2242,23 @@ class Modular11GameMatcher(GameHistoryMatcher):
         try:
             # Normalize age_group for comparison (U13 vs u13)
             expected_age_normalized = expected_age_group.lower() if expected_age_group else None
-            
+
             # Get team's age_group from database
-            team_result = self.db.table('teams').select(
-                'age_group, gender'
-            ).eq('team_id_master', team_id_master).single().execute()
-            
+            team_result = (
+                self.db.table("teams")
+                .select("age_group, gender")
+                .eq("team_id_master", team_id_master)
+                .single()
+                .execute()
+            )
+
             if not team_result.data:
                 logger.warning(f"[Modular11] Team {team_id_master} not found in database")
                 return False
-            
-            team_age = team_result.data.get('age_group', '').lower() if team_result.data.get('age_group') else None
-            team_gender = team_result.data.get('gender')
-            
+
+            team_age = team_result.data.get("age_group", "").lower() if team_result.data.get("age_group") else None
+            team_gender = team_result.data.get("gender")
+
             # Check age_group match
             if expected_age_normalized and team_age:
                 if expected_age_normalized != team_age:
@@ -2110,18 +2267,15 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         f"team has {team_result.data.get('age_group')}"
                     )
                     return False
-            
+
             # Check gender match if provided
             if expected_gender and team_gender:
                 if expected_gender != team_gender:
-                    logger.debug(
-                        f"[Modular11] Gender mismatch: game expects {expected_gender}, "
-                        f"team has {team_gender}"
-                    )
+                    logger.debug(f"[Modular11] Gender mismatch: game expects {expected_gender}, team has {team_gender}")
                     return False
-            
+
             return True
-            
+
         except Exception as e:
             logger.error(f"[Modular11] Error validating team age_group: {e}")
             # On error, be conservative and reject the match

--- a/src/models/sincsports_matcher.py
+++ b/src/models/sincsports_matcher.py
@@ -12,6 +12,7 @@ SincSports naming patterns:
   - Parenthesised age prefixes: "14 (12U) CSA UM Elite"
   - Dash-separated suffixes: "FCC 2014 Boys Gold - BA"
 """
+
 import logging
 import re
 import uuid
@@ -24,6 +25,7 @@ from src.models.game_matcher import GameHistoryMatcher, MATCHING_CONFIG
 # Import rapidfuzz for similarity scoring
 try:
     from rapidfuzz import fuzz as rapidfuzz_fuzz
+
     HAVE_RAPIDFUZZ = True
 except ImportError:
     HAVE_RAPIDFUZZ = False
@@ -37,6 +39,7 @@ try:
         has_ecnl_rl,
         has_ecnl_only,
     )
+
     HAVE_TEAM_NAME_UTILS = True
 except ImportError:
     HAVE_TEAM_NAME_UTILS = False
@@ -47,6 +50,7 @@ try:
         normalize_to_club,
         similarity_score as club_similarity_score,
     )
+
     HAVE_CLUB_NORMALIZER = True
 except ImportError:
     HAVE_CLUB_NORMALIZER = False
@@ -56,23 +60,23 @@ logger = logging.getLogger(__name__)
 # Regex patterns for stripping leading age/gender tokens that SincSports
 # places at the front of team names (e.g. "U12 PRE ECNL BOYS RED").
 _SINCSPORTS_AGE_PREFIX_RE = re.compile(
-    r'^'
-    r'(?:'
-    r'U-?\d{1,2}'               # U12, U-12
-    r'|\d{1,2}\s*\(?\d{1,2}U\)?' # "14 (12U)" or "14 12U"
-    r'|\d{4}'                    # Birth year: 2014
-    r')'
-    r'\s*',
+    r"^"
+    r"(?:"
+    r"U-?\d{1,2}"  # U12, U-12
+    r"|\d{1,2}\s*\(?\d{1,2}U\)?"  # "14 (12U)" or "14 12U"
+    r"|\d{4}"  # Birth year: 2014
+    r")"
+    r"\s*",
     re.IGNORECASE,
 )
 
 _SINCSPORTS_GENDER_TOKEN_RE = re.compile(
-    r'\b(?:boys?|girls?|men|women|male|female|coed)\b',
+    r"\b(?:boys?|girls?|men|women|male|female|coed)\b",
     re.IGNORECASE,
 )
 
 # Parenthesised age like "(12U)" that appears mid-name
-_PAREN_AGE_RE = re.compile(r'\(\d{1,2}U\)', re.IGNORECASE)
+_PAREN_AGE_RE = re.compile(r"\(\d{1,2}U\)", re.IGNORECASE)
 
 
 class SincSportsGameMatcher(GameHistoryMatcher):
@@ -122,36 +126,36 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         name_lower = name.lower()
 
         # U + number
-        for m in re.findall(r'\b(u\d{1,2})\b', name_lower):
+        for m in re.findall(r"\b(u\d{1,2})\b", name_lower):
             tokens.add(m)
-            num = re.search(r'\d+', m)
+            num = re.search(r"\d+", m)
             if num:
                 tokens.add(num.group())
 
         # age + letter (14b, 13a)
-        for m in re.findall(r'\b(\d{1,2}[a-z])\b', name_lower):
+        for m in re.findall(r"\b(\d{1,2}[a-z])\b", name_lower):
             tokens.add(m)
-            num = re.search(r'\d+', m)
+            num = re.search(r"\d+", m)
             if num:
                 tokens.add(num.group())
 
         # B/G + number
-        for m in re.findall(r'\b([bg]\d{1,2})\b', name_lower):
+        for m in re.findall(r"\b([bg]\d{1,2})\b", name_lower):
             tokens.add(m)
-            num = re.search(r'\d+', m)
+            num = re.search(r"\d+", m)
             if num:
                 tokens.add(num.group())
 
         # B/G + birth year
-        for m in re.findall(r'\b([bg]20[01]\d)\b', name_lower):
+        for m in re.findall(r"\b([bg]20[01]\d)\b", name_lower):
             tokens.add(m)
-            year = re.search(r'20[01]\d', m).group()
+            year = re.search(r"20[01]\d", m).group()
             tokens.add(year)
             tokens.add(year[2:])
             tokens.add(m[0] + year[2:])
 
         # Birth year standalone
-        for m in re.findall(r'\b(20[01]\d)\b', name_lower):
+        for m in re.findall(r"\b(20[01]\d)\b", name_lower):
             tokens.add(m)
             tokens.add(m[2:])
 
@@ -173,23 +177,23 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         which in turn uses the shared ``normalize_name_for_matching()``.
         """
         if not name:
-            return ''
+            return ""
 
         # Step 1: Strip parenthesised age like "(12U)"
-        name = _PAREN_AGE_RE.sub('', name).strip()
+        name = _PAREN_AGE_RE.sub("", name).strip()
 
         # Step 2: Strip leading age token (U12, 14, 2014, etc.)
-        name = _SINCSPORTS_AGE_PREFIX_RE.sub('', name).strip()
+        name = _SINCSPORTS_AGE_PREFIX_RE.sub("", name).strip()
 
         # Step 3: Strip remaining leading numeric-only prefix left over
         # e.g. "14 CSA UM Elite" after paren removal -> "CSA UM Elite"
-        name = re.sub(r'^\d{1,4}\s+', '', name).strip()
+        name = re.sub(r"^\d{1,4}\s+", "", name).strip()
 
         # Step 4: Strip gender tokens (BOYS, GIRLS, etc.)
-        name = _SINCSPORTS_GENDER_TOKEN_RE.sub('', name).strip()
+        name = _SINCSPORTS_GENDER_TOKEN_RE.sub("", name).strip()
 
         # Step 5: Collapse multiple spaces
-        name = re.sub(r'\s{2,}', ' ', name).strip()
+        name = re.sub(r"\s{2,}", " ", name).strip()
 
         # Delegate to base (shared normalize_name_for_matching)
         return super()._normalize_team_name(name)
@@ -202,10 +206,10 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         Enhanced match scoring with canonical club comparison and age-token
         overlap boost (mirrors TGS).
         """
-        provider_name_raw = provider_team.get('team_name', '')
-        candidate_name_raw = candidate.get('team_name', '')
-        provider_club = (provider_team.get('club_name') or '').strip() or None
-        candidate_club = (candidate.get('club_name') or '').strip() or None
+        provider_name_raw = provider_team.get("team_name", "")
+        candidate_name_raw = candidate.get("team_name", "")
+        provider_club = (provider_team.get("club_name") or "").strip() or None
+        candidate_club = (candidate.get("club_name") or "").strip() or None
 
         # Normalise names (SincSports preprocessing + shared normalisation)
         provider_name_normalized = self._normalize_team_name(provider_name_raw, provider_club)
@@ -213,10 +217,10 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         # Strip club prefix from candidate name before normalisation
         candidate_name_for_norm = candidate_name_raw
         if candidate_club:
-            club_core = re.sub(r'\b(sc|fc|sa)\b', '', candidate_club.lower()).strip()
+            club_core = re.sub(r"\b(sc|fc|sa)\b", "", candidate_club.lower()).strip()
             cand_lower = candidate_name_raw.lower()
             if club_core and cand_lower.startswith(club_core):
-                remaining = candidate_name_raw[len(club_core):].strip().lstrip('-\u2013\u2014').strip()
+                remaining = candidate_name_raw[len(club_core) :].strip().lstrip("-\u2013\u2014").strip()
                 if remaining:
                     candidate_name_for_norm = remaining
 
@@ -224,9 +228,9 @@ class SincSportsGameMatcher(GameHistoryMatcher):
 
         # Build normalised dicts for base scoring
         provider_team_normalized = provider_team.copy()
-        provider_team_normalized['team_name'] = provider_name_normalized
+        provider_team_normalized["team_name"] = provider_name_normalized
         candidate_normalized = candidate.copy()
-        candidate_normalized['team_name'] = candidate_name_normalized
+        candidate_normalized["team_name"] = candidate_name_normalized
 
         base_score = super()._calculate_match_score(provider_team_normalized, candidate_normalized)
 
@@ -264,7 +268,7 @@ class SincSportsGameMatcher(GameHistoryMatcher):
             prov_variant = extract_variant_shared(provider_name_raw) if HAVE_TEAM_NAME_UTILS else None
             cand_variant = extract_variant_shared(candidate_name_raw) if HAVE_TEAM_NAME_UTILS else None
             if prov_variant and cand_variant and prov_variant == cand_variant:
-                cv_boost = MATCHING_CONFIG.get('club_variant_match_boost', 0.15)
+                cv_boost = MATCHING_CONFIG.get("club_variant_match_boost", 0.15)
                 base_score = min(1.0, base_score + cv_boost)
 
         return base_score
@@ -306,33 +310,42 @@ class SincSportsGameMatcher(GameHistoryMatcher):
             club_filtered = False
             result = None
             if club_name:
-                result = self.db.table('teams').select(
-                    'team_id_master, team_name, club_name, age_group, gender, state_code'
-                ).eq('age_group', age_group_normalized).eq('gender', gender).ilike(
-                    'club_name', club_name
-                ).limit(100).execute()
+                result = (
+                    self.db.table("teams")
+                    .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                    .eq("age_group", age_group_normalized)
+                    .eq("gender", gender)
+                    .ilike("club_name", club_name)
+                    .limit(100)
+                    .execute()
+                )
                 if result and result.data:
                     club_filtered = True
 
             # Broad fallback only when club extraction failed
             if not club_filtered:
-                result = self.db.table('teams').select(
-                    'team_id_master, team_name, club_name, age_group, gender, state_code'
-                ).eq('age_group', age_group_normalized).eq('gender', gender).limit(2000).execute()
+                result = (
+                    self.db.table("teams")
+                    .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                    .eq("age_group", age_group_normalized)
+                    .eq("gender", gender)
+                    .limit(2000)
+                    .execute()
+                )
 
             best_match = None
             best_score = 0.0
             best_tiebreak = (False, 0.0)
 
             provider_team = {
-                'team_name': team_name,
-                'club_name': club_name,
-                'age_group': age_group,
-                'state_code': None,
+                "team_name": team_name,
+                "club_name": club_name,
+                "age_group": age_group,
+                "state_code": None,
             }
 
-            for team in (result.data if result else []):
-                cand_name = team.get('team_name', '')
+            for team in result.data if result else []:
+                cand_name = team.get("team_name", "")
 
                 # --- Gate: distinction-based hard rejection ---
                 if HAVE_TEAM_NAME_UTILS and provider_distinctions is not None:
@@ -361,21 +374,19 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                     cand_variant = None
 
                 candidate = {
-                    'team_name': cand_name,
-                    'club_name': team.get('club_name'),
-                    'age_group': team.get('age_group', ''),
-                    'state_code': team.get('state_code'),
+                    "team_name": cand_name,
+                    "club_name": team.get("club_name"),
+                    "age_group": team.get("age_group", ""),
+                    "state_code": team.get("state_code"),
                 }
 
                 score = self._calculate_match_score(provider_team, candidate)
 
                 # --- Deterministic tie-breaking ---
                 variant_match = (
-                    provider_variant is not None
-                    and cand_variant is not None
-                    and provider_variant == cand_variant
+                    provider_variant is not None and cand_variant is not None and provider_variant == cand_variant
                 )
-                cand_club = team.get('club_name', '')
+                cand_club = team.get("club_name", "")
                 club_sim = 0.0
                 if club_name and cand_club:
                     if HAVE_CLUB_NORMALIZER:
@@ -386,16 +397,13 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                 tiebreak = (variant_match, club_sim)
 
                 if score >= self.fuzzy_threshold:
-                    if (
-                        score > best_score + 0.001
-                        or (abs(score - best_score) <= 0.001 and tiebreak > best_tiebreak)
-                    ):
+                    if score > best_score + 0.001 or (abs(score - best_score) <= 0.001 and tiebreak > best_tiebreak):
                         best_score = score
                         best_tiebreak = tiebreak
                         best_match = {
-                            'team_id': team['team_id_master'],
-                            'team_name': team['team_name'],
-                            'confidence': round(score, 3),
+                            "team_id": team["team_id_master"],
+                            "team_name": team["team_name"],
+                            "confidence": round(score, 3),
                         }
 
             if best_match:
@@ -435,27 +443,30 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         # Check cache first
         if self.alias_cache and team_id_str in self.alias_cache:
             cached = self.alias_cache[team_id_str]
-            if cached.get('match_method') == 'direct_id':
+            if cached.get("match_method") == "direct_id":
                 return {
-                    'team_id_master': cached['team_id_master'],
-                    'review_status': cached.get('review_status', 'approved'),
-                    'match_method': 'direct_id',
+                    "team_id_master": cached["team_id_master"],
+                    "review_status": cached.get("review_status", "approved"),
+                    "match_method": "direct_id",
                 }
             return {
-                'team_id_master': cached['team_id_master'],
-                'review_status': cached.get('review_status', 'approved'),
-                'match_method': cached.get('match_method'),
+                "team_id_master": cached["team_id_master"],
+                "review_status": cached.get("review_status", "approved"),
+                "match_method": cached.get("match_method"),
             }
 
         # Tier 1: Direct ID match — exact match
         try:
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, review_status, match_method'
-            ).eq('provider_id', provider_id).eq(
-                'provider_team_id', team_id_str
-            ).eq('match_method', 'direct_id').eq(
-                'review_status', 'approved'
-            ).limit(1).execute()
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("match_method", "direct_id")
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
 
             if result.data:
                 return result.data[0]
@@ -464,11 +475,15 @@ class SincSportsGameMatcher(GameHistoryMatcher):
 
         # Tier 2: Any approved alias map entry — exact match (fallback)
         try:
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, review_status, match_method'
-            ).eq('provider_id', provider_id).eq(
-                'provider_team_id', team_id_str
-            ).eq('review_status', 'approved').limit(1).execute()
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
 
             if result.data:
                 return result.data[0]
@@ -494,19 +509,14 @@ class SincSportsGameMatcher(GameHistoryMatcher):
         (same strategy as TGS).
         """
         # First, try base matching (direct ID, alias, fuzzy)
-        base_result = super()._match_team(
-            provider_id, provider_team_id, team_name, age_group, gender, club_name
-        )
+        base_result = super()._match_team(provider_id, provider_team_id, team_name, age_group, gender, club_name)
 
-        if base_result.get('matched'):
+        if base_result.get("matched"):
             return base_result
 
         # No match found — create new team
         if team_name and age_group and gender:
-            logger.info(
-                f"[SincSports] No match found for '{team_name}' ({age_group}, {gender}), "
-                f"creating new team"
-            )
+            logger.info(f"[SincSports] No match found for '{team_name}' ({age_group}, {gender}), creating new team")
             try:
                 new_team_id = self._create_new_sincsports_team(
                     team_name=team_name,
@@ -517,7 +527,7 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                     provider_team_id=provider_team_id,
                 )
 
-                match_method = 'direct_id' if provider_team_id else 'import'
+                match_method = "direct_id" if provider_team_id else "import"
 
                 self._create_alias(
                     provider_id=provider_id,
@@ -528,19 +538,16 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                     confidence=1.0,
                     age_group=age_group,
                     gender=gender,
-                    review_status='approved',
+                    review_status="approved",
                 )
 
-                logger.info(
-                    f"[SincSports] Created new team: {team_name} ({age_group}, {gender}) "
-                    f"-> {new_team_id}"
-                )
+                logger.info(f"[SincSports] Created new team: {team_name} ({age_group}, {gender}) -> {new_team_id}")
 
                 return {
-                    'matched': True,
-                    'team_id': new_team_id,
-                    'method': match_method,
-                    'confidence': 1.0,
+                    "matched": True,
+                    "team_id": new_team_id,
+                    "method": match_method,
+                    "confidence": 1.0,
                 }
             except Exception as e:
                 logger.error(f"[SincSports] Error creating new team for {team_name}: {e}")
@@ -574,16 +581,21 @@ class SincSportsGameMatcher(GameHistoryMatcher):
             # provider_team_id is REQUIRED (NOT NULL constraint)
             if not provider_team_id:
                 import hashlib
-                provider_team_id = hashlib.md5(
-                    f"{team_name}_{age_group}_{gender}".encode()
-                ).hexdigest()[:16]
+
+                # MD5 for deterministic ID generation (not security)
+                provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}".encode()).hexdigest()[:16]
 
             # Check if team with this provider_id + provider_team_id already exists
             if provider_id:
                 try:
-                    existing = self.db.table('teams').select('team_id_master').eq(
-                        'provider_id', provider_id
-                    ).eq('provider_team_id', provider_team_id).single().execute()
+                    existing = (
+                        self.db.table("teams")
+                        .select("team_id_master")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", provider_team_id)
+                        .single()
+                        .execute()
+                    )
 
                     if existing.data:
                         logger.debug(
@@ -591,52 +603,56 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                             f"already exists, using existing team "
                             f"{existing.data['team_id_master']}"
                         )
-                        return existing.data['team_id_master']
+                        return existing.data["team_id_master"]
                 except Exception:
                     pass  # No existing team found
 
             team_id_master = str(uuid.uuid4())
             age_group_normalized = age_group.lower() if age_group else age_group
-            gender_normalized = 'Male' if gender.upper() in ('M', 'MALE', 'BOYS', 'B') else 'Female'
+            gender_normalized = "Male" if gender.upper() in ("M", "MALE", "BOYS", "B") else "Female"
 
             # Clean team name — strip club name prefix if present
             clean_team_name = team_name
             if club_name and team_name.lower().startswith(club_name.lower()):
-                remaining = team_name[len(club_name):].strip()
-                if remaining and remaining[0] in '-\u2013\u2014':
+                remaining = team_name[len(club_name) :].strip()
+                if remaining and remaining[0] in "-\u2013\u2014":
                     remaining = remaining[1:].strip()
                 if remaining:
                     clean_team_name = remaining
 
             team_data = {
-                'team_id_master': team_id_master,
-                'team_name': clean_team_name,
-                'club_name': club_name or clean_team_name,
-                'age_group': age_group_normalized,
-                'gender': gender_normalized,
-                'provider_id': provider_id,
-                'provider_team_id': provider_team_id,
-                'created_at': datetime.utcnow().isoformat() + 'Z',
+                "team_id_master": team_id_master,
+                "team_name": clean_team_name,
+                "club_name": club_name or clean_team_name,
+                "age_group": age_group_normalized,
+                "gender": gender_normalized,
+                "provider_id": provider_id,
+                "provider_team_id": provider_team_id,
+                "created_at": datetime.utcnow().isoformat() + "Z",
             }
 
-            self.db.table('teams').insert(team_data).execute()
+            self.db.table("teams").insert(team_data).execute()
 
             logger.info(
-                f"[SincSports] Created new team: {clean_team_name} "
-                f"({age_group_normalized}, {gender_normalized})"
+                f"[SincSports] Created new team: {clean_team_name} ({age_group_normalized}, {gender_normalized})"
             )
 
             return team_id_master
 
         except Exception as e:
             # Handle duplicate key errors gracefully
-            if 'duplicate key' in str(e).lower() or '23505' in str(e):
+            if "duplicate key" in str(e).lower() or "23505" in str(e):
                 logger.debug(f"[SincSports] Duplicate key error, looking up existing team: {e}")
                 if provider_id and provider_team_id:
                     try:
-                        existing = self.db.table('teams').select('team_id_master').eq(
-                            'provider_id', provider_id
-                        ).eq('provider_team_id', provider_team_id).single().execute()
+                        existing = (
+                            self.db.table("teams")
+                            .select("team_id_master")
+                            .eq("provider_id", provider_id)
+                            .eq("provider_team_id", provider_team_id)
+                            .single()
+                            .execute()
+                        )
 
                         if existing.data:
                             logger.info(
@@ -644,11 +660,9 @@ class SincSportsGameMatcher(GameHistoryMatcher):
                                 f"provider_team_id {provider_team_id}, "
                                 f"using {existing.data['team_id_master']}"
                             )
-                            return existing.data['team_id_master']
+                            return existing.data["team_id_master"]
                     except Exception as lookup_error:
-                        logger.error(
-                            f"[SincSports] Error looking up existing team: {lookup_error}"
-                        )
+                        logger.error(f"[SincSports] Error looking up existing team: {lookup_error}")
 
             logger.error(f"[SincSports] Error creating new team: {e}")
             raise

--- a/src/models/tgs_matcher.py
+++ b/src/models/tgs_matcher.py
@@ -4,6 +4,7 @@ TGS-specific game matcher with enhanced fuzzy matching for team name matching.
 This matcher extends GameHistoryMatcher to provide more aggressive fuzzy matching
 specifically for TGS teams, allowing better matching to existing teams in the database.
 """
+
 import logging
 import re
 import uuid
@@ -16,6 +17,7 @@ from src.models.game_matcher import GameHistoryMatcher, MATCHING_CONFIG
 # Import rapidfuzz for similarity scoring
 try:
     from rapidfuzz import fuzz as rapidfuzz_fuzz
+
     HAVE_RAPIDFUZZ = True
 except ImportError:
     HAVE_RAPIDFUZZ = False
@@ -29,6 +31,7 @@ try:
         has_ecnl_rl,
         has_ecnl_only,
     )
+
     HAVE_TEAM_NAME_UTILS = True
 except ImportError:
     HAVE_TEAM_NAME_UTILS = False
@@ -39,6 +42,7 @@ try:
         normalize_to_club,
         similarity_score as club_similarity_score,
     )
+
     HAVE_CLUB_NORMALIZER = True
 except ImportError:
     HAVE_CLUB_NORMALIZER = False
@@ -49,7 +53,7 @@ logger = logging.getLogger(__name__)
 class TGSGameMatcher(GameHistoryMatcher):
     """
     TGS-specific team matcher with enhanced fuzzy matching.
-    
+
     Key differences from base matcher:
     1. Lower fuzzy threshold (0.75 vs 0.85) for more aggressive matching
     2. Enhanced team name normalization for TGS naming patterns
@@ -57,7 +61,7 @@ class TGSGameMatcher(GameHistoryMatcher):
     4. More lenient matching to help match TGS teams to existing database teams
     5. Creates new teams when no match found (similar to Modular11)
     """
-    
+
     def __init__(self, supabase: Client, provider_id: Optional[str] = None, alias_cache: Optional[Dict] = None):
         """Initialize TGS matcher with same interface as base matcher"""
         super().__init__(supabase, provider_id=provider_id, alias_cache=alias_cache)
@@ -71,11 +75,11 @@ class TGSGameMatcher(GameHistoryMatcher):
             f"Initialized TGSGameMatcher with enhanced fuzzy matching "
             f"(fuzzy: {self.fuzzy_threshold}, auto-approve: {self.auto_approve_threshold}, review: {self.review_threshold})"
         )
-    
+
     def _extract_age_tokens(self, name: str) -> Set[str]:
         """
         Extract age group tokens from team name (e.g., "14b", "u11", "b12", "g13").
-        
+
         Examples:
         - "RSL-AZ 14b North" -> {"14b", "14"}
         - "14b GSA" -> {"14b", "14"}
@@ -84,46 +88,46 @@ class TGSGameMatcher(GameHistoryMatcher):
         """
         if not name:
             return set()
-        
+
         tokens = set()
         name_lower = name.lower()
-        
+
         # Pattern 1: Age + letter (e.g., "14b", "13a", "12c", "14B", "13A")
         # name_lower is already lowercase, so [a-z] will match both "14b" and "14B" (after lowercasing)
-        matches = re.findall(r'\b(\d{1,2}[a-z])\b', name_lower)
+        matches = re.findall(r"\b(\d{1,2}[a-z])\b", name_lower)
         tokens.update(matches)
         # Also extract just the number part
         for match in matches:
-            num_match = re.search(r'\d+', match)
+            num_match = re.search(r"\d+", match)
             if num_match:
                 tokens.add(num_match.group())
-        
+
         # Pattern 2: U + number (e.g., "u11", "u12")
-        matches = re.findall(r'\b(u\d{1,2})\b', name_lower)
+        matches = re.findall(r"\b(u\d{1,2})\b", name_lower)
         tokens.update(matches)
         # Also extract just the number part
         for match in matches:
-            num_match = re.search(r'\d+', match)
+            num_match = re.search(r"\d+", match)
             if num_match:
                 tokens.add(num_match.group())
-        
+
         # Pattern 3: B/G + number (e.g., "b12", "g13", "B12", "G13")
         # name_lower is already lowercase
-        matches = re.findall(r'\b([bg]\d{1,2})\b', name_lower)
+        matches = re.findall(r"\b([bg]\d{1,2})\b", name_lower)
         tokens.update(matches)
         # Also extract just the number part
         for match in matches:
-            num_match = re.search(r'\d+', match)
+            num_match = re.search(r"\d+", match)
             if num_match:
                 tokens.add(num_match.group())
-        
+
         # Pattern 4: B/G + birth year (e.g., "B2015", "G2012", "b2013")
         # name_lower is already lowercase
-        matches = re.findall(r'\b([bg]20[01]\d)\b', name_lower)
+        matches = re.findall(r"\b([bg]20[01]\d)\b", name_lower)
         tokens.update(matches)
         # Also extract just the year part
         for match in matches:
-            year_match = re.search(r'20[01]\d', match)
+            year_match = re.search(r"20[01]\d", match)
             if year_match:
                 year = year_match.group()
                 tokens.add(year)
@@ -132,13 +136,13 @@ class TGSGameMatcher(GameHistoryMatcher):
                     tokens.add(year[2:])
                 # Also add B/G + last 2 digits (e.g., "B2015" -> "b15")
                 tokens.add(match[0] + year[2:])
-        
+
         # Pattern 5: Birth year + B/G (e.g., "2013G", "2012B", "2014g")
         # name_lower is already lowercase
-        matches = re.findall(r'\b(20[01]\d[bg])\b', name_lower)
+        matches = re.findall(r"\b(20[01]\d[bg])\b", name_lower)
         tokens.update(matches)
         for match in matches:
-            year_match = re.search(r'20[01]\d', match)
+            year_match = re.search(r"20[01]\d", match)
             if year_match:
                 year = year_match.group()
                 tokens.add(year)
@@ -146,17 +150,17 @@ class TGSGameMatcher(GameHistoryMatcher):
                     tokens.add(year[2:])
                 # Also add B/G + last 2 digits (e.g., "2013G" -> "g13")
                 tokens.add(match[-1] + year[2:])
-        
+
         # Pattern 6: Birth year standalone (e.g., "2012", "2013")
-        matches = re.findall(r'\b(20[01]\d)\b', name_lower)
+        matches = re.findall(r"\b(20[01]\d)\b", name_lower)
         tokens.update(matches)
         # Also extract last 2 digits (e.g., "2012" -> "12")
         for match in matches:
             if len(match) == 4:
                 tokens.add(match[2:])
-        
+
         return tokens
-    
+
     def _normalize_team_name(self, name: str, club_name: Optional[str] = None) -> str:
         """
         Enhanced normalization for TGS team names.
@@ -166,12 +170,12 @@ class TGSGameMatcher(GameHistoryMatcher):
         base class.
         """
         if not name:
-            return ''
+            return ""
 
         # CRITICAL: Strip everything before the first dash BEFORE base
         # normalization.  TGS format:
         #   "Folsom Lake Surf- FLS 13B Premier I" → "FLS 13B Premier I"
-        dash_chars = ['-', '–', '—']
+        dash_chars = ["-", "–", "—"]
         for dash in dash_chars:
             if dash in name:
                 parts = name.split(dash, 1)
@@ -181,17 +185,17 @@ class TGSGameMatcher(GameHistoryMatcher):
 
         # Delegate to base (which uses shared normalize_name_for_matching)
         return super()._normalize_team_name(name)
-    
+
     def _calculate_match_score(self, provider_team: Dict, candidate: Dict) -> float:
         """
         Enhanced match scoring for TGS with club name matching via canonical
         registry and age token overlap boost.
         """
         # Normalize team names by stripping club name prefix
-        provider_name_raw = provider_team.get('team_name', '')
-        candidate_name_raw = candidate.get('team_name', '')
-        provider_club = provider_team.get('club_name', '').strip() if provider_team.get('club_name') else None
-        candidate_club = candidate.get('club_name', '').strip() if candidate.get('club_name') else None
+        provider_name_raw = provider_team.get("team_name", "")
+        candidate_name_raw = candidate.get("team_name", "")
+        provider_club = provider_team.get("club_name", "").strip() if provider_team.get("club_name") else None
+        candidate_club = candidate.get("club_name", "").strip() if candidate.get("club_name") else None
 
         # Strip club name from provider team name (TGS often includes it)
         provider_name_normalized = self._normalize_team_name(provider_name_raw, provider_club)
@@ -199,10 +203,10 @@ class TGSGameMatcher(GameHistoryMatcher):
         # Strip club from candidate name before normalization
         candidate_name_for_norm = candidate_name_raw
         if candidate_club:
-            club_core = re.sub(r'\b(sc|fc|sa)\b', '', candidate_club.lower()).strip()
+            club_core = re.sub(r"\b(sc|fc|sa)\b", "", candidate_club.lower()).strip()
             cand_lower = candidate_name_raw.lower()
             if club_core and cand_lower.startswith(club_core):
-                remaining = candidate_name_raw[len(club_core):].strip().lstrip('-–—').strip()
+                remaining = candidate_name_raw[len(club_core) :].strip().lstrip("-–—").strip()
                 if remaining:
                     candidate_name_for_norm = remaining
 
@@ -210,9 +214,9 @@ class TGSGameMatcher(GameHistoryMatcher):
 
         # Create normalized dicts for base scoring
         provider_team_normalized = provider_team.copy()
-        provider_team_normalized['team_name'] = provider_name_normalized
+        provider_team_normalized["team_name"] = provider_name_normalized
         candidate_normalized = candidate.copy()
-        candidate_normalized['team_name'] = candidate_name_normalized
+        candidate_normalized["team_name"] = candidate_name_normalized
 
         # Start with base scoring (includes club similarity, team sim, age, location)
         base_score = super()._calculate_match_score(provider_team_normalized, candidate_normalized)
@@ -252,17 +256,13 @@ class TGSGameMatcher(GameHistoryMatcher):
             prov_variant = extract_variant_shared(provider_name_raw) if HAVE_TEAM_NAME_UTILS else None
             cand_variant = extract_variant_shared(candidate_name_raw) if HAVE_TEAM_NAME_UTILS else None
             if prov_variant and cand_variant and prov_variant == cand_variant:
-                cv_boost = MATCHING_CONFIG.get('club_variant_match_boost', 0.15)
+                cv_boost = MATCHING_CONFIG.get("club_variant_match_boost", 0.15)
                 base_score = min(1.0, base_score + cv_boost)
 
         return base_score
-    
+
     def _fuzzy_match_team(
-        self,
-        team_name: str,
-        age_group: str,
-        gender: str,
-        club_name: Optional[str] = None
+        self, team_name: str, age_group: str, gender: str, club_name: Optional[str] = None
     ) -> Optional[Dict]:
         """
         Enhanced fuzzy matching for TGS teams with gated candidate funnel.
@@ -291,35 +291,39 @@ class TGSGameMatcher(GameHistoryMatcher):
             club_filtered = False
             result = None
             if club_name:
-                result = self.db.table('teams').select(
-                    'team_id_master, team_name, club_name, age_group, gender, state_code'
-                ).eq('age_group', age_group_normalized).eq('gender', gender).ilike(
-                    'club_name', club_name
-                ).limit(100).execute()
+                result = (
+                    self.db.table("teams")
+                    .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                    .eq("age_group", age_group_normalized)
+                    .eq("gender", gender)
+                    .ilike("club_name", club_name)
+                    .limit(100)
+                    .execute()
+                )
                 if result and result.data:
                     club_filtered = True
 
             # Broad fallback only when club extraction failed
             if not club_filtered:
-                result = self.db.table('teams').select(
-                    'team_id_master, team_name, club_name, age_group, gender, state_code'
-                ).eq('age_group', age_group_normalized).eq('gender', gender).limit(2000).execute()
+                result = (
+                    self.db.table("teams")
+                    .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+                    .eq("age_group", age_group_normalized)
+                    .eq("gender", gender)
+                    .limit(2000)
+                    .execute()
+                )
 
             best_match = None
             best_score = 0.0
             best_tiebreak = (False, 0.0)
 
-            provider_team = {
-                'team_name': team_name,
-                'club_name': club_name,
-                'age_group': age_group,
-                'state_code': None
-            }
+            provider_team = {"team_name": team_name, "club_name": club_name, "age_group": age_group, "state_code": None}
 
-            club_variant_boost = MATCHING_CONFIG.get('club_variant_match_boost', 0.15)
+            club_variant_boost = MATCHING_CONFIG.get("club_variant_match_boost", 0.15)
 
-            for team in (result.data if result else []):
-                cand_name = team.get('team_name', '')
+            for team in result.data if result else []:
+                cand_name = team.get("team_name", "")
 
                 # --- Gate: distinction-based hard rejection ---
                 if HAVE_TEAM_NAME_UTILS and provider_distinctions is not None:
@@ -337,28 +341,30 @@ class TGSGameMatcher(GameHistoryMatcher):
                     if provider_distinctions["squad_words"] != cand_distinctions["squad_words"]:
                         continue
                     cand_coach = cand_distinctions.get("coach_name")
-                    if (provider_distinctions.get("coach_name")
-                            and cand_coach
-                            and provider_distinctions["coach_name"] != cand_coach):
+                    if (
+                        provider_distinctions.get("coach_name")
+                        and cand_coach
+                        and provider_distinctions["coach_name"] != cand_coach
+                    ):
                         continue
                     cand_variant = cand_coach
                 else:
                     cand_variant = None
 
                 candidate = {
-                    'team_name': cand_name,
-                    'club_name': team.get('club_name'),
-                    'age_group': team.get('age_group', ''),
-                    'state_code': team.get('state_code')
+                    "team_name": cand_name,
+                    "club_name": team.get("club_name"),
+                    "age_group": team.get("age_group", ""),
+                    "state_code": team.get("state_code"),
                 }
 
                 score = self._calculate_match_score(provider_team, candidate)
 
                 # --- Deterministic tie-breaking ---
-                variant_match = (provider_variant is not None
-                                 and cand_variant is not None
-                                 and provider_variant == cand_variant)
-                cand_club = team.get('club_name', '')
+                variant_match = (
+                    provider_variant is not None and cand_variant is not None and provider_variant == cand_variant
+                )
+                cand_club = team.get("club_name", "")
                 club_sim = 0.0
                 if club_name and cand_club:
                     if HAVE_CLUB_NORMALIZER:
@@ -369,14 +375,13 @@ class TGSGameMatcher(GameHistoryMatcher):
                 tiebreak = (variant_match, club_sim)
 
                 if score >= self.fuzzy_threshold:
-                    if (score > best_score + 0.001
-                            or (abs(score - best_score) <= 0.001 and tiebreak > best_tiebreak)):
+                    if score > best_score + 0.001 or (abs(score - best_score) <= 0.001 and tiebreak > best_tiebreak):
                         best_score = score
                         best_tiebreak = tiebreak
                         best_match = {
-                            'team_id': team['team_id_master'],
-                            'team_name': team['team_name'],
-                            'confidence': round(score, 3)
+                            "team_id": team["team_id_master"],
+                            "team_name": team["team_name"],
+                            "confidence": round(score, 3),
                         }
 
             if best_match:
@@ -390,13 +395,9 @@ class TGSGameMatcher(GameHistoryMatcher):
         except Exception as e:
             logger.error(f"TGS fuzzy match error: {e}")
             return None
-    
+
     def _match_by_provider_id(
-        self,
-        provider_id: str,
-        provider_team_id: str,
-        age_group: Optional[str] = None,
-        gender: Optional[str] = None
+        self, provider_id: str, provider_team_id: str, age_group: Optional[str] = None, gender: Optional[str] = None
     ) -> Optional[Dict]:
         """
         Override base method to skip age_group validation for TGS.
@@ -423,28 +424,31 @@ class TGSGameMatcher(GameHistoryMatcher):
         if self.alias_cache and team_id_str in self.alias_cache:
             cached = self.alias_cache[team_id_str]
             # Skip age_group validation for TGS - provider_team_id is unique per team
-            if cached.get('match_method') == 'direct_id':
+            if cached.get("match_method") == "direct_id":
                 return {
-                    'team_id_master': cached['team_id_master'],
-                    'review_status': cached.get('review_status', 'approved'),
-                    'match_method': 'direct_id'
+                    "team_id_master": cached["team_id_master"],
+                    "review_status": cached.get("review_status", "approved"),
+                    "match_method": "direct_id",
                 }
             # Fallback to any cached match
             return {
-                'team_id_master': cached['team_id_master'],
-                'review_status': cached.get('review_status', 'approved'),
-                'match_method': cached.get('match_method')
+                "team_id_master": cached["team_id_master"],
+                "review_status": cached.get("review_status", "approved"),
+                "match_method": cached.get("match_method"),
             }
 
         # Tier 1: Direct ID match - exact match (from team importer)
         try:
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, review_status, match_method'
-            ).eq('provider_id', provider_id).eq(
-                'provider_team_id', team_id_str
-            ).eq('match_method', 'direct_id').eq(
-                'review_status', 'approved'
-            ).limit(1).execute()
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("match_method", "direct_id")
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
 
             if result.data:
                 # Skip age_group validation for TGS - provider_team_id is unique
@@ -455,34 +459,43 @@ class TGSGameMatcher(GameHistoryMatcher):
         # Tier 2: Check for semicolon-separated aliases containing this ID
         # This handles merged teams where provider_team_id is "123456;789012"
         try:
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, review_status, match_method, provider_team_id'
-            ).eq('provider_id', provider_id).eq(
-                'review_status', 'approved'
-            ).like('provider_team_id', f'%{team_id_str}%').execute()
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method, provider_team_id")
+                .eq("provider_id", provider_id)
+                .eq("review_status", "approved")
+                .like("provider_team_id", f"%{team_id_str}%")
+                .execute()
+            )
 
             if result.data:
                 # Verify this is actually a match (not a substring of a different ID)
                 for alias in result.data:
-                    alias_ids = str(alias['provider_team_id']).split(';')
+                    alias_ids = str(alias["provider_team_id"]).split(";")
                     alias_ids = [id.strip() for id in alias_ids]
                     if team_id_str in alias_ids:
-                        logger.debug(f"Matched {team_id_str} via semicolon-separated alias: {alias['provider_team_id']}")
+                        logger.debug(
+                            f"Matched {team_id_str} via semicolon-separated alias: {alias['provider_team_id']}"
+                        )
                         return {
-                            'team_id_master': alias['team_id_master'],
-                            'review_status': alias.get('review_status', 'approved'),
-                            'match_method': alias.get('match_method')
+                            "team_id_master": alias["team_id_master"],
+                            "review_status": alias.get("review_status", "approved"),
+                            "match_method": alias.get("match_method"),
                         }
         except Exception as e:
             logger.debug(f"No semicolon-separated alias match found: {e}")
 
         # Tier 3: Any approved alias map entry - exact match (fallback)
         try:
-            result = self.db.table('team_alias_map').select(
-                'team_id_master, review_status, match_method'
-            ).eq('provider_id', provider_id).eq(
-                'provider_team_id', team_id_str
-            ).eq('review_status', 'approved').limit(1).execute()
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
 
             if result.data:
                 # Skip age_group validation for TGS - provider_team_id is unique
@@ -490,7 +503,7 @@ class TGSGameMatcher(GameHistoryMatcher):
         except Exception as e:
             logger.debug(f"No alias map match found: {e}")
         return None
-    
+
     def _match_team(
         self,
         provider_id: str,
@@ -498,30 +511,26 @@ class TGSGameMatcher(GameHistoryMatcher):
         team_name: Optional[str],
         age_group: Optional[str],
         gender: Optional[str],
-        club_name: Optional[str] = None
+        club_name: Optional[str] = None,
     ) -> Dict:
         """
         Override base _match_team to create new teams when no match found (like Modular11).
-        
+
         Strategy:
         1. Try base matching (direct ID, alias, fuzzy)
         2. If no match found, create new team
         3. Return matched: True with new team ID
         """
         # First, try base matching
-        base_result = super()._match_team(
-            provider_id, provider_team_id, team_name, age_group, gender, club_name
-        )
-        
+        base_result = super()._match_team(provider_id, provider_team_id, team_name, age_group, gender, club_name)
+
         # If matched, return immediately
-        if base_result.get('matched'):
+        if base_result.get("matched"):
             return base_result
-        
+
         # No match found - create new team (like Modular11)
         if team_name and age_group and gender:
-            logger.info(
-                f"[TGS] ⚠️ No match found for '{team_name}' ({age_group}, {gender}), creating new team"
-            )
+            logger.info(f"[TGS] ⚠️ No match found for '{team_name}' ({age_group}, {gender}), creating new team")
             try:
                 new_team_id = self._create_new_tgs_team(
                     team_name=team_name,
@@ -529,13 +538,13 @@ class TGSGameMatcher(GameHistoryMatcher):
                     age_group=age_group,
                     gender=gender,
                     provider_id=provider_id,
-                    provider_team_id=provider_team_id
+                    provider_team_id=provider_team_id,
                 )
-                
+
                 # Create alias for new team
                 # Use 'direct_id' if provider_team_id exists (like GotSport/Modular11)
                 # This ensures consistent matching behavior across providers
-                match_method = 'direct_id' if provider_team_id else 'import'
+                match_method = "direct_id" if provider_team_id else "import"
 
                 self._create_alias(
                     provider_id=provider_id,
@@ -546,18 +555,16 @@ class TGSGameMatcher(GameHistoryMatcher):
                     confidence=1.0,  # New team = 100% confidence
                     age_group=age_group,
                     gender=gender,
-                    review_status='approved'
+                    review_status="approved",
                 )
-                
-                logger.info(
-                    f"[TGS] Created new team: {team_name} ({age_group}, {gender}) -> {new_team_id}"
-                )
-                
+
+                logger.info(f"[TGS] Created new team: {team_name} ({age_group}, {gender}) -> {new_team_id}")
+
                 return {
-                    'matched': True,
-                    'team_id': new_team_id,
-                    'method': match_method,  # Use same method as alias creation
-                    'confidence': 1.0
+                    "matched": True,
+                    "team_id": new_team_id,
+                    "method": match_method,  # Use same method as alias creation
+                    "confidence": 1.0,
                 }
             except Exception as e:
                 logger.error(f"[TGS] Error creating new team for {team_name}: {e}")
@@ -567,10 +574,10 @@ class TGSGameMatcher(GameHistoryMatcher):
                 f"[TGS] Cannot create new team - missing required fields: "
                 f"team_name={bool(team_name)}, age_group={bool(age_group)}, gender={bool(gender)}"
             )
-        
+
         # Fallback: return base result (shouldn't happen if we have required fields)
         return base_result
-    
+
     def _create_new_tgs_team(
         self,
         team_name: str,
@@ -578,14 +585,14 @@ class TGSGameMatcher(GameHistoryMatcher):
         age_group: str,
         gender: str,
         provider_id: Optional[str],
-        provider_team_id: Optional[str] = None
+        provider_team_id: Optional[str] = None,
     ) -> str:
         """
         Create a new team in the teams table for TGS.
-        
+
         If a team with the same provider_id and provider_team_id already exists,
         return that team's ID instead of creating a duplicate.
-        
+
         Returns the team_id_master UUID.
         """
         try:
@@ -593,83 +600,92 @@ class TGSGameMatcher(GameHistoryMatcher):
             # Use provided provider_team_id or generate one
             if not provider_team_id:
                 import hashlib
+
+                # MD5 for deterministic ID generation (not security)
                 provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}".encode()).hexdigest()[:16]
-            
+
             # Check if team with this provider_id + provider_team_id already exists
             if provider_id:
                 try:
-                    existing = self.db.table('teams').select('team_id_master').eq(
-                        'provider_id', provider_id
-                    ).eq('provider_team_id', provider_team_id).single().execute()
-                    
+                    existing = (
+                        self.db.table("teams")
+                        .select("team_id_master")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", provider_team_id)
+                        .single()
+                        .execute()
+                    )
+
                     if existing.data:
                         logger.debug(
                             f"[TGS] Team with provider_team_id {provider_team_id} already exists, "
                             f"using existing team {existing.data['team_id_master']}"
                         )
-                        return existing.data['team_id_master']
+                        return existing.data["team_id_master"]
                 except Exception:
                     # No existing team found, continue to create new one
                     pass
-            
+
             # Generate new UUID
             team_id_master = str(uuid.uuid4())
-            
+
             # Normalize age_group
             age_group_normalized = age_group.lower() if age_group else age_group
-            
+
             # Normalize gender
-            gender_normalized = 'Male' if gender.upper() in ('M', 'MALE', 'BOYS', 'B') else 'Female'
-            
+            gender_normalized = "Male" if gender.upper() in ("M", "MALE", "BOYS", "B") else "Female"
+
             # Clean team name (strip club name prefix if present)
             clean_team_name = team_name
             if club_name and team_name.startswith(club_name):
                 # Remove club name prefix
-                remaining = team_name[len(club_name):].strip()
-                if remaining.startswith('-') or remaining.startswith('–') or remaining.startswith('—'):
+                remaining = team_name[len(club_name) :].strip()
+                if remaining.startswith("-") or remaining.startswith("–") or remaining.startswith("—"):
                     remaining = remaining[1:].strip()
                 if remaining:
                     clean_team_name = remaining
-            
+
             # Insert new team
             team_data = {
-                'team_id_master': team_id_master,
-                'team_name': clean_team_name,
-                'club_name': club_name or clean_team_name,
-                'age_group': age_group_normalized,
-                'gender': gender_normalized,
-                'provider_id': provider_id,  # Required for TGS teams
-                'provider_team_id': provider_team_id,  # REQUIRED (NOT NULL)
-                'created_at': datetime.utcnow().isoformat() + 'Z'
+                "team_id_master": team_id_master,
+                "team_name": clean_team_name,
+                "club_name": club_name or clean_team_name,
+                "age_group": age_group_normalized,
+                "gender": gender_normalized,
+                "provider_id": provider_id,  # Required for TGS teams
+                "provider_team_id": provider_team_id,  # REQUIRED (NOT NULL)
+                "created_at": datetime.utcnow().isoformat() + "Z",
             }
-            
-            self.db.table('teams').insert(team_data).execute()
-            
-            logger.info(
-                f"[TGS] Created new team: {clean_team_name} ({age_group_normalized}, {gender_normalized})"
-            )
-            
+
+            self.db.table("teams").insert(team_data).execute()
+
+            logger.info(f"[TGS] Created new team: {clean_team_name} ({age_group_normalized}, {gender_normalized})")
+
             return team_id_master
-            
+
         except Exception as e:
             # If duplicate key error, try to find existing team
-            if 'duplicate key' in str(e).lower() or '23505' in str(e):
+            if "duplicate key" in str(e).lower() or "23505" in str(e):
                 logger.debug(f"[TGS] Duplicate key error, looking up existing team: {e}")
                 if provider_id and provider_team_id:
                     try:
-                        existing = self.db.table('teams').select('team_id_master').eq(
-                            'provider_id', provider_id
-                        ).eq('provider_team_id', provider_team_id).single().execute()
-                        
+                        existing = (
+                            self.db.table("teams")
+                            .select("team_id_master")
+                            .eq("provider_id", provider_id)
+                            .eq("provider_team_id", provider_team_id)
+                            .single()
+                            .execute()
+                        )
+
                         if existing.data:
                             logger.info(
                                 f"[TGS] Found existing team with provider_team_id {provider_team_id}, "
                                 f"using {existing.data['team_id_master']}"
                             )
-                            return existing.data['team_id_master']
+                            return existing.data["team_id_master"]
                     except Exception as lookup_error:
                         logger.error(f"[TGS] Error looking up existing team: {lookup_error}")
-            
+
             logger.error(f"[TGS] Error creating new team: {e}")
             raise
-

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -1,11 +1,11 @@
 """Integrated Rankings Calculator (v53e + ML Layer)"""
+
 from __future__ import annotations
 
 import asyncio
 import hashlib
 import logging
 from contextlib import nullcontext
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
@@ -55,7 +55,7 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
     failed_batches = []  # Collect for end-of-run retry
 
     for i in range(0, len(game_residuals), batch_size):
-        batch = game_residuals.iloc[i:i+batch_size]
+        batch = game_residuals.iloc[i : i + batch_size]
         batch_num = (i // batch_size) + 1
         total_batches = (len(game_residuals) + batch_size - 1) // batch_size
 
@@ -65,10 +65,7 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
 
         # Prepare batch data for RPC (Supabase client handles JSON conversion)
         batch_data = [
-            {
-                'id': str(row['game_id']),
-                'ml_overperformance': float(row['ml_overperformance'])
-            }
+            {"id": str(row["game_id"]), "ml_overperformance": float(row["ml_overperformance"])}
             for _, row in batch.iterrows()
         ]
 
@@ -80,8 +77,8 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
             try:
                 # Call RPC function for batch update
                 result = supabase_client.rpc(
-                    'batch_update_ml_overperformance',
-                    {'updates': batch_data}  # Pass list directly, not JSON string
+                    "batch_update_ml_overperformance",
+                    {"updates": batch_data},  # Pass list directly, not JSON string
                 ).execute()
 
                 # RPC returns the count of updated rows
@@ -97,19 +94,22 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
                 error_msg = str(e)
                 # Detect network/timeout errors specifically
                 is_retriable = (
-                    'SSL' in error_msg or
-                    'bad record' in error_msg.lower() or
-                    'ReadError' in error_msg or
-                    'WinError 10054' in error_msg or
-                    'timeout' in error_msg.lower() or
-                    'statement timeout' in error_msg.lower() or
-                    ('connection' in error_msg.lower() and (
-                        'closed' in error_msg.lower() or
-                        'reset' in error_msg.lower() or
-                        'forcibly' in error_msg.lower()
-                    )) or
-                    'forcibly closed' in error_msg.lower() or
-                    'remote host' in error_msg.lower()
+                    "SSL" in error_msg
+                    or "bad record" in error_msg.lower()
+                    or "ReadError" in error_msg
+                    or "WinError 10054" in error_msg
+                    or "timeout" in error_msg.lower()
+                    or "statement timeout" in error_msg.lower()
+                    or (
+                        "connection" in error_msg.lower()
+                        and (
+                            "closed" in error_msg.lower()
+                            or "reset" in error_msg.lower()
+                            or "forcibly" in error_msg.lower()
+                        )
+                    )
+                    or "forcibly closed" in error_msg.lower()
+                    or "remote host" in error_msg.lower()
                 )
 
                 if attempt < max_retries - 1 and is_retriable:
@@ -151,10 +151,7 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
             batch_retry_delay = retry_delay
             for attempt in range(max_retries):
                 try:
-                    result = supabase_client.rpc(
-                        'batch_update_ml_overperformance',
-                        {'updates': batch_data}
-                    ).execute()
+                    result = supabase_client.rpc("batch_update_ml_overperformance", {"updates": batch_data}).execute()
 
                     if result.data is not None:
                         total_updated += result.data
@@ -169,14 +166,16 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
                         await asyncio.sleep(batch_retry_delay)
                         batch_retry_delay *= 2
                     else:
-                        logger.error(
-                            f"Batch {batch_num} failed after all retries: {str(e)[:100]}"
-                        )
+                        logger.error(f"Batch {batch_num} failed after all retries: {str(e)[:100]}")
 
     if failed_count > 0 and total_updated == 0:
-        logger.error(f"❌ Residual persistence failed: 0/{len(game_residuals):,} games updated, {failed_count:,} failed")
+        logger.error(
+            f"❌ Residual persistence failed: 0/{len(game_residuals):,} games updated, {failed_count:,} failed"
+        )
     elif failed_count > 0:
-        logger.warning(f"⚠️ Residual persistence partial: {total_updated:,} updated, {failed_count:,} failed out of {len(game_residuals):,}")
+        logger.warning(
+            f"⚠️ Residual persistence partial: {total_updated:,} updated, {failed_count:,} failed out of {len(game_residuals):,}"
+        )
     else:
         logger.info(f"✅ Successfully updated {total_updated:,} games with ML residuals")
 
@@ -232,17 +231,14 @@ async def compute_rankings_with_ml(
                     supabase_client=supabase_client,
                     lookback_days=lookback_days,
                     provider_filter=provider_filter,
-                    today=today
+                    today=today,
                 )
         else:
             raise ValueError("games_df is required if fetch_from_supabase is False")
 
     if games_df.empty:
         logger.warning("⚠️  No games found - returning empty results")
-        return {
-            "teams": pd.DataFrame(),
-            "games_used": pd.DataFrame()
-        }
+        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
 
     logger.info(f"📊 Computing rankings for {len(games_df):,} game perspectives...")
 
@@ -275,10 +271,7 @@ async def compute_rankings_with_ml(
                         cached_games_used = pd.read_parquet(cache_file_games)
                     except Exception:
                         pass  # games_used cache failed, use empty
-                base = {
-                    "teams": cached_teams,
-                    "games_used": cached_games_used
-                }
+                base = {"teams": cached_teams, "games_used": cached_games_used}
         except Exception:
             # Cache load failed - continue with computation
             pass
@@ -318,17 +311,21 @@ async def compute_rankings_with_ml(
     if teams_base.empty:
         return {
             "teams": teams_base,
-            "games_used": games_used if not getattr(games_used, "empty", True) else pd.DataFrame()
+            "games_used": games_used if not getattr(games_used, "empty", True) else pd.DataFrame(),
         }
 
     # Log PowerScore summary before ML layer
     if not teams_base.empty and "powerscore_adj" in teams_base.columns:
         ps_stats = teams_base["powerscore_adj"]
-        logger.info(f"📊 Pre-ML PowerScore: min={ps_stats.min():.3f}, max={ps_stats.max():.3f}, mean={ps_stats.mean():.3f}, n={len(teams_base)}")
+        logger.info(
+            f"📊 Pre-ML PowerScore: min={ps_stats.min():.3f}, max={ps_stats.max():.3f}, mean={ps_stats.mean():.3f}, n={len(teams_base)}"
+        )
 
     # 3) Apply ML predictive adjustment
     logger.info("🤖 Applying ML predictive adjustment layer...")
-    logger.debug(f"games_df: {len(games_df)} rows, has_id={'id' in games_df.columns}, has_home_master={'home_team_master_id' in games_df.columns}")
+    logger.debug(
+        f"games_df: {len(games_df)} rows, has_id={'id' in games_df.columns}, has_home_master={'home_team_master_id' in games_df.columns}"
+    )
 
     ml_cfg = layer13_cfg or Layer13Config(
         lookback_days=v53_cfg.WINDOW_DAYS,
@@ -374,7 +371,7 @@ async def compute_rankings_with_ml(
         if "powerscore_adj" in teams_with_ml.columns:
             ps_max_before_ml = teams_with_ml.groupby(["age", "gender"])["powerscore_adj"].max().round(3)
             ps_max_after_ml = teams_with_ml.groupby(["age", "gender"])["powerscore_ml"].max().round(3)
-            for (age, gender) in ps_max_before_ml.index:
+            for age, gender in ps_max_before_ml.index:
                 before = ps_max_before_ml[(age, gender)]
                 after = ps_max_after_ml.get((age, gender), 0)
                 logger.debug(f"  {age} {gender}: pre-ML={before:.3f}, post-ML={after:.3f}, diff={after - before:+.3f}")
@@ -382,24 +379,18 @@ async def compute_rankings_with_ml(
     # Calculate rank changes using historical snapshots (7d and 30d)
     logger.info("📊 Calculating rank changes from historical data...")
     with _section(timing_report, "rank_changes"):
-        teams_with_ml = await calculate_rank_changes(
-            supabase_client=supabase_client,
-            current_rankings_df=teams_with_ml
-        )
+        teams_with_ml = await calculate_rank_changes(supabase_client=supabase_client, current_rankings_df=teams_with_ml)
 
     # Save current rankings as a snapshot for future rank change calculations
     # (Skip if save_snapshot=False, e.g., when called from compute_all_cohorts)
     if save_snapshot and not teams_with_ml.empty:
         logger.info("💾 Saving ranking snapshot for future comparisons...")
         with _section(timing_report, "save_ranking_snapshot"):
-            await save_ranking_snapshot(
-                supabase_client=supabase_client,
-                rankings_df=teams_with_ml
-            )
+            await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_with_ml)
 
     return {
         "teams": teams_with_ml,
-        "games_used": games_used if not getattr(games_used, "empty", True) else pd.DataFrame()
+        "games_used": games_used if not getattr(games_used, "empty", True) else pd.DataFrame(),
     }
 
 
@@ -441,10 +432,7 @@ async def compute_rankings_v53e_only(
 
     if games_df.empty:
         logger.warning("⚠️  No games found - returning empty results")
-        return {
-            "teams": pd.DataFrame(),
-            "games_used": pd.DataFrame()
-        }
+        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
 
     logger.info(f"📊 Computing v53e rankings for {len(games_df):,} game perspectives...")
 
@@ -507,17 +495,14 @@ async def compute_all_cohorts(
             raise ValueError("games_df is required if fetch_from_supabase is False")
 
     if games_df.empty:
-        return {
-            "teams": pd.DataFrame(),
-            "games_used": pd.DataFrame()
-        }
+        return {"teams": pd.DataFrame(), "games_used": pd.DataFrame()}
 
     # ========== FETCH TEAM STATE METADATA FOR SCF ==========
     # Fetch state_code for all teams to enable Schedule Connectivity Factor (SCF)
     # which detects and dampens regional bubbles (e.g., Idaho teams only playing each other)
     team_ids = set()
-    team_ids.update(games_df['team_id'].dropna().astype(str).tolist())
-    team_ids.update(games_df['opp_id'].dropna().astype(str).tolist())
+    team_ids.update(games_df["team_id"].dropna().astype(str).tolist())
+    team_ids.update(games_df["opp_id"].dropna().astype(str).tolist())
 
     team_state_map = {}
     with _section(timing_report, "team_state_map"):
@@ -527,17 +512,20 @@ async def compute_all_cohorts(
             batch_size = 100
 
             for i in range(0, len(team_ids_list), batch_size):
-                batch = team_ids_list[i:i + batch_size]
+                batch = team_ids_list[i : i + batch_size]
                 try:
-                    result = supabase_client.table('teams').select(
-                        'team_id_master, state_code'
-                    ).in_('team_id_master', batch).execute()
+                    result = (
+                        supabase_client.table("teams")
+                        .select("team_id_master, state_code")
+                        .in_("team_id_master", batch)
+                        .execute()
+                    )
                     if result.data:
                         for row in result.data:
-                            team_id = str(row.get('team_id_master', ''))
-                            state_code = row.get('state_code', 'UNKNOWN')
+                            team_id = str(row.get("team_id_master", ""))
+                            state_code = row.get("state_code", "UNKNOWN")
                             if team_id:
-                                team_state_map[team_id] = state_code if state_code else 'UNKNOWN'
+                                team_state_map[team_id] = state_code if state_code else "UNKNOWN"
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to fetch state metadata batch {i}: {str(e)[:100]}")
                     continue
@@ -560,9 +548,7 @@ async def compute_all_cohorts(
     VALID_AGE_MAX = 19
     games_df["_age_num"] = pd.to_numeric(games_df["age"], errors="coerce")
     invalid_age_mask = (
-        games_df["_age_num"].isna()
-        | (games_df["_age_num"] < VALID_AGE_MIN)
-        | (games_df["_age_num"] > VALID_AGE_MAX)
+        games_df["_age_num"].isna() | (games_df["_age_num"] < VALID_AGE_MIN) | (games_df["_age_num"] > VALID_AGE_MAX)
     )
     if invalid_age_mask.any():
         invalid_games = games_df.loc[invalid_age_mask]
@@ -680,68 +666,72 @@ async def compute_all_cohorts(
             deprecated_ids.update(merge_resolver.get_deprecated_teams())
 
         # Source 2: teams.is_deprecated field (canonical source of truth)
-        ranked_team_ids = teams_combined['team_id'].astype(str).unique().tolist()
+        ranked_team_ids = teams_combined["team_id"].astype(str).unique().tolist()
         batch_size = 100
         for i in range(0, len(ranked_team_ids), batch_size):
-            batch = ranked_team_ids[i:i + batch_size]
+            batch = ranked_team_ids[i : i + batch_size]
             try:
-                result = supabase_client.table('teams').select(
-                    'team_id_master'
-                ).in_('team_id_master', batch).eq('is_deprecated', True).execute()
+                result = (
+                    supabase_client.table("teams")
+                    .select("team_id_master")
+                    .in_("team_id_master", batch)
+                    .eq("is_deprecated", True)
+                    .execute()
+                )
                 if result.data:
-                    deprecated_ids.update(str(row['team_id_master']) for row in result.data)
+                    deprecated_ids.update(str(row["team_id_master"]) for row in result.data)
             except Exception as e:
                 logger.warning(f"⚠️ Failed to check is_deprecated for batch {i}: {str(e)[:100]}")
                 continue
 
         if deprecated_ids:
             before_count = len(teams_combined)
-            teams_combined = teams_combined[~teams_combined['team_id'].astype(str).isin(deprecated_ids)].copy()
+            teams_combined = teams_combined[~teams_combined["team_id"].astype(str).isin(deprecated_ids)].copy()
             filtered_count = before_count - len(teams_combined)
             if filtered_count > 0:
                 logger.info(f"🚫 Filtered {filtered_count} deprecated teams from ranking output")
 
     # ========== PASS 3: National/State SOS Normalization ==========
     # After all cohorts are combined, compute national and state-level SOS rankings
-    if not teams_combined.empty and 'sos' in teams_combined.columns:
+    if not teams_combined.empty and "sos" in teams_combined.columns:
         logger.info("📊 Pass 3: Computing national/state SOS normalization...")
 
         # Create sos_raw from the post-shrinkage SOS value
-        teams_combined['sos_raw'] = teams_combined['sos'].astype(float)
+        teams_combined["sos_raw"] = teams_combined["sos"].astype(float)
 
         # Reuse team_state_map from SCF fetch (line ~520) instead of re-querying Supabase
         if team_state_map:
-            teams_combined['state_code'] = teams_combined['team_id'].astype(str).map(team_state_map).fillna('UNKNOWN')
-            mapped_count = (teams_combined['state_code'] != 'UNKNOWN').sum()
+            teams_combined["state_code"] = teams_combined["team_id"].astype(str).map(team_state_map).fillna("UNKNOWN")
+            mapped_count = (teams_combined["state_code"] != "UNKNOWN").sum()
             logger.info(f"✅ Mapped state_code for {mapped_count:,} teams (reused SCF metadata)")
         else:
-            teams_combined['state_code'] = 'UNKNOWN'
+            teams_combined["state_code"] = "UNKNOWN"
             logger.warning("⚠️ No state metadata available - using 'UNKNOWN' for all teams")
 
         # Initialize new SOS columns
-        teams_combined['sos_norm_national'] = 0.0
-        teams_combined['sos_norm_state'] = 0.0
+        teams_combined["sos_norm_national"] = 0.0
+        teams_combined["sos_norm_state"] = 0.0
         # Use nullable Int64 type for ranks to support NULL values for ineligible teams
-        teams_combined['sos_rank_national'] = pd.array([pd.NA] * len(teams_combined), dtype="Int64")
-        teams_combined['sos_rank_state'] = pd.array([pd.NA] * len(teams_combined), dtype="Int64")
+        teams_combined["sos_rank_national"] = pd.array([pd.NA] * len(teams_combined), dtype="Int64")
+        teams_combined["sos_rank_state"] = pd.array([pd.NA] * len(teams_combined), dtype="Int64")
 
         # SOS rank eligibility is derived from Active status (which uses MIN_GAMES_PROVISIONAL)
         # so the ranking gate and SOS gate can never drift apart.
-        if 'status' in teams_combined.columns:
-            sos_rank_eligible = teams_combined['status'] == 'Active'
+        if "status" in teams_combined.columns:
+            sos_rank_eligible = teams_combined["status"] == "Active"
         else:
             logger.warning("⚠️ 'status' column not found - all teams will be eligible for SOS ranking")
             sos_rank_eligible = pd.Series([True] * len(teams_combined), index=teams_combined.index)
 
         # Compute national and state SOS rankings per cohort (age, gender)
-        for (age, gender), cohort_df in teams_combined.groupby(['age', 'gender']):
+        for (age, gender), cohort_df in teams_combined.groupby(["age", "gender"]):
             cohort_idx = cohort_df.index
 
             # National normalization: percentile rank across all states in this cohort
             # rank(pct=True) gives values from 0 to 1
             # NOTE: ALL teams get sos_norm values (for PowerScore), regardless of games played
-            teams_combined.loc[cohort_idx, 'sos_norm_national'] = (
-                cohort_df['sos_raw'].rank(method='average', pct=True).fillna(0.5)
+            teams_combined.loc[cohort_idx, "sos_norm_national"] = (
+                cohort_df["sos_raw"].rank(method="average", pct=True).fillna(0.5)
             )
 
             # National rank: only for Active teams
@@ -749,31 +739,31 @@ async def compute_all_cohorts(
             eligible_mask = sos_rank_eligible.loc[cohort_idx]
             eligible_idx = cohort_df[eligible_mask].index
             if len(eligible_idx) > 0:
-                eligible_sos_values = teams_combined.loc[eligible_idx, 'sos_raw']
-                ranks = eligible_sos_values.rank(method='min', ascending=False).astype("Int64")
-                teams_combined.loc[eligible_idx, 'sos_rank_national'] = ranks
+                eligible_sos_values = teams_combined.loc[eligible_idx, "sos_raw"]
+                ranks = eligible_sos_values.rank(method="min", ascending=False).astype("Int64")
+                teams_combined.loc[eligible_idx, "sos_rank_national"] = ranks
 
             # State-level normalization and ranking within this cohort
-            for state, state_df in cohort_df.groupby('state_code'):
+            for state, state_df in cohort_df.groupby("state_code"):
                 state_idx = state_df.index
 
                 # State normalization: percentile rank within state (ALL teams)
-                teams_combined.loc[state_idx, 'sos_norm_state'] = (
-                    state_df['sos_raw'].rank(method='average', pct=True).fillna(0.5)
+                teams_combined.loc[state_idx, "sos_norm_state"] = (
+                    state_df["sos_raw"].rank(method="average", pct=True).fillna(0.5)
                 )
 
                 # State rank: only for eligible teams within state
                 state_eligible_mask = sos_rank_eligible.loc[state_idx]
                 state_eligible_idx = state_df[state_eligible_mask].index
                 if len(state_eligible_idx) > 0:
-                    state_eligible_sos = teams_combined.loc[state_eligible_idx, 'sos_raw']
-                    state_ranks = state_eligible_sos.rank(method='min', ascending=False).astype("Int64")
-                    teams_combined.loc[state_eligible_idx, 'sos_rank_state'] = state_ranks
+                    state_eligible_sos = teams_combined.loc[state_eligible_idx, "sos_raw"]
+                    state_ranks = state_eligible_sos.rank(method="min", ascending=False).astype("Int64")
+                    teams_combined.loc[state_eligible_idx, "sos_rank_state"] = state_ranks
 
         # Log SOS normalization results
         excluded_count = (~sos_rank_eligible).sum()
         total_count = len(teams_combined)
-        ranked_national = teams_combined['sos_rank_national'].notna().sum()
+        ranked_national = teams_combined["sos_rank_national"].notna().sum()
         logger.info(
             f"✅ National/State SOS normalization complete: "
             f"sos_norm_national range=[{teams_combined['sos_norm_national'].min():.3f}, {teams_combined['sos_norm_national'].max():.3f}], "
@@ -782,16 +772,16 @@ async def compute_all_cohorts(
         )
 
         # Sample state distribution for diagnostics
-        state_counts = teams_combined['state_code'].value_counts()
+        state_counts = teams_combined["state_code"].value_counts()
         top_states = state_counts.head(5).to_dict()
         logger.info(f"📍 Top states by team count: {top_states}")
 
     # Ensure age_num exists after metadata merge (fallback safety check)
-    if 'age_num' not in teams_combined.columns and 'age' in teams_combined.columns:
+    if "age_num" not in teams_combined.columns and "age" in teams_combined.columns:
         try:
             # Convert age to numeric, coercing errors to NaN
-            age_numeric = pd.to_numeric(teams_combined['age'], errors='coerce')
-            teams_combined['age_num'] = age_numeric.fillna(0).astype(int)
+            age_numeric = pd.to_numeric(teams_combined["age"], errors="coerce")
+            teams_combined["age_num"] = age_numeric.fillna(0).astype(int)
 
             # Log any teams with invalid ages
             invalid_count = age_numeric.isna().sum()
@@ -801,7 +791,7 @@ async def compute_all_cohorts(
             logger.info("✅ Recreated age_num from age column after metadata merge")
         except Exception as e:
             logger.error(f"❌ Failed to create age_num column: {e}")
-            teams_combined['age_num'] = 0  # Default to 0, will get no anchor scaling
+            teams_combined["age_num"] = 0  # Default to 0, will get no anchor scaling
 
     # ========== National SOS Metrics (for display only) ==========
     # NOTE: PowerScore uses cohort-level sos_norm from v53e.compute_rankings().
@@ -855,55 +845,46 @@ async def compute_all_cohorts(
     # Diagnostic: Log distribution stats for sos_norm and powerscore_adj per cohort
     if not teams_combined.empty:
         logger.info("📊 Distribution diagnostics per age/gender cohort:")
-        for (age, gender), cohort_df in teams_combined.groupby(['age', 'gender']):
-            if 'sos_norm' in cohort_df.columns:
-                sos_stats = cohort_df['sos_norm']
-                logger.info(f"    {age} {gender}: sos_norm min={sos_stats.min():.3f}, "
-                           f"max={sos_stats.max():.3f}, mean={sos_stats.mean():.3f}")
-            if 'powerscore_adj' in cohort_df.columns:
-                ps_stats = cohort_df['powerscore_adj']
-                logger.info(f"    {age} {gender}: powerscore_adj min={ps_stats.min():.3f}, "
-                           f"max={ps_stats.max():.3f}, mean={ps_stats.mean():.3f}")
+        for (age, gender), cohort_df in teams_combined.groupby(["age", "gender"]):
+            if "sos_norm" in cohort_df.columns:
+                sos_stats = cohort_df["sos_norm"]
+                logger.info(
+                    f"    {age} {gender}: sos_norm min={sos_stats.min():.3f}, "
+                    f"max={sos_stats.max():.3f}, mean={sos_stats.mean():.3f}"
+                )
+            if "powerscore_adj" in cohort_df.columns:
+                ps_stats = cohort_df["powerscore_adj"]
+                logger.info(
+                    f"    {age} {gender}: powerscore_adj min={ps_stats.min():.3f}, "
+                    f"max={ps_stats.max():.3f}, mean={ps_stats.mean():.3f}"
+                )
 
     # ---- Final age-anchor scaling for PowerScore ----
     if not teams_combined.empty:
-        ANCHORS = {
-            10: 0.400,
-            11: 0.475,
-            12: 0.550,
-            13: 0.625,
-            14: 0.700,
-            15: 0.775,
-            16: 0.850,
-            17: 0.925,
-            18: 1.000,
-            19: 1.000,
-        }
-        
-        if 'age_num' not in teams_combined.columns:
+        from src.rankings.constants import AGE_TO_ANCHOR, SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
+        from src.rankings.shared import sos_ml_blend
+
+        if "age_num" not in teams_combined.columns:
             logger.warning("⚠️ compute_all_cohorts: 'age_num' column missing; skipping anchor scaling")
         else:
             # age_num is already integer from data adapter
-            age_nums = teams_combined['age_num']
-            
+            age_nums = teams_combined["age_num"]
+
             # Log age distribution
-            logger.info(
-                "📊 Applying anchor scaling by age. Age distribution: %s",
-                age_nums.value_counts().to_dict()
-            )
-            
+            logger.info("📊 Applying anchor scaling by age. Age distribution: %s", age_nums.value_counts().to_dict())
+
             # Initialize power_score_final column if it doesn't exist
-            if 'power_score_final' not in teams_combined.columns:
-                teams_combined['power_score_final'] = None
-            
+            if "power_score_final" not in teams_combined.columns:
+                teams_combined["power_score_final"] = None
+
             # Process each age group separately
-            for age, anchor_val in ANCHORS.items():
+            for age, anchor_val in AGE_TO_ANCHOR.items():
                 mask = age_nums == age
                 if not mask.any():
                     continue
-                
+
                 teams_age = teams_combined.loc[mask].copy()
-                
+
                 # =================================================================
                 # SOS-CONDITIONED ML SCALING
                 # =================================================================
@@ -911,30 +892,30 @@ async def compute_all_cohorts(
                 # ML can only adjust if schedule is strong enough.
                 # ml_scale = 0 when sos_norm < 0.45, scales to 1 when sos_norm >= 0.60
                 # =================================================================
-                SOS_ML_THRESHOLD_LOW = 0.45   # Below this, ML has no authority
-                SOS_ML_THRESHOLD_HIGH = 0.60  # Above this, ML has full authority
 
                 # Step 1: Get baseline (powerscore_adj is REQUIRED)
-                if 'powerscore_adj' not in teams_age.columns or not teams_age['powerscore_adj'].notna().any():
+                if "powerscore_adj" not in teams_age.columns or not teams_age["powerscore_adj"].notna().any():
                     logger.warning(f"⚠️  Age {age}: powerscore_adj not available, skipping")
                     continue
 
-                ps_adj = teams_age['powerscore_adj'].clip(0.0, 1.0)
+                ps_adj = teams_age["powerscore_adj"].clip(0.0, 1.0)
 
                 # Step 2: Calculate ML delta (if ML available)
-                has_ml = 'powerscore_ml' in teams_age.columns and teams_age['powerscore_ml'].notna().any()
-                has_sos = 'sos_norm' in teams_age.columns and teams_age['sos_norm'].notna().any()
+                has_ml = "powerscore_ml" in teams_age.columns and teams_age["powerscore_ml"].notna().any()
+                has_sos = "sos_norm" in teams_age.columns and teams_age["sos_norm"].notna().any()
 
                 if has_ml and has_sos:
-                    # ML delta = how much ML wants to adjust from baseline
-                    ps_ml = teams_age['powerscore_ml'].clip(0.0, 1.0)
+                    # Vectorized form of sos_ml_blend() (shared.py) for Series performance
+                    ps_ml = teams_age["powerscore_ml"].clip(0.0, 1.0)
                     ml_delta = ps_ml - ps_adj
 
                     # Step 3: Scale ML authority by schedule strength
                     # Weak schedule (sos_norm < 0.45) → ML has no authority
                     # Strong schedule (sos_norm >= 0.60) → ML has full authority
-                    sos_norm = teams_age['sos_norm'].fillna(0.5)
-                    ml_scale = ((sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)).clip(0.0, 1.0)
+                    sos_norm = teams_age["sos_norm"].fillna(0.5)
+                    ml_scale = (
+                        (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)
+                    ).clip(0.0, 1.0)
 
                     # Step 4: Final score = baseline + SOS-scaled ML adjustment
                     base = (ps_adj + ml_delta * ml_scale).clip(0.0, 1.0)
@@ -953,58 +934,57 @@ async def compute_all_cohorts(
                         logger.info(f"  📊 Age {age}: No ML data, using powerscore_adj directly")
                     elif not has_sos:
                         logger.info(f"  📊 Age {age}: No SOS data, using powerscore_adj directly")
-                
+
                 # Scale by anchor and clip to [0, anchor_val]
                 ps_scaled = (base * anchor_val).clip(0.0, anchor_val)
-                
+
                 logger.info(
                     "📊 Age %s: anchor %.3f, base max %.4f -> scaled max %.4f",
-                    age, anchor_val, base.max(), ps_scaled.max()
+                    age,
+                    anchor_val,
+                    base.max(),
+                    ps_scaled.max(),
                 )
-                
+
                 # Update power_score_final for this age group (index-aligned to avoid misalignment)
-                teams_combined.loc[ps_scaled.index, 'power_score_final'] = ps_scaled
+                teams_combined.loc[ps_scaled.index, "power_score_final"] = ps_scaled
 
             # Check for teams that didn't get anchor scaling (ages outside 10-19 range)
-            if 'power_score_final' in teams_combined.columns:
-                unscaled_mask = teams_combined['power_score_final'].isna()
+            if "power_score_final" in teams_combined.columns:
+                unscaled_mask = teams_combined["power_score_final"].isna()
                 unscaled_count = unscaled_mask.sum()
                 if unscaled_count > 0:
                     logger.warning(f"⚠️ {unscaled_count} teams didn't match any anchor age - applying fallback scaling")
                     # For teams outside age range, use median anchor (0.70) and apply scaling
                     # Also apply SOS-conditioned ML scaling (same thresholds as main loop)
                     fallback_anchor = 0.70
-                    SOS_ML_THRESHOLD_LOW = 0.45
-                    SOS_ML_THRESHOLD_HIGH = 0.60
 
                     for idx in teams_combined[unscaled_mask].index:
                         row = teams_combined.loc[idx]
 
                         # powerscore_adj is REQUIRED - skip if not available
-                        if 'powerscore_adj' not in teams_combined.columns or pd.isna(row.get('powerscore_adj')):
+                        if "powerscore_adj" not in teams_combined.columns or pd.isna(row.get("powerscore_adj")):
                             logger.warning(f"⚠️ Team {idx}: powerscore_adj not available, skipping fallback")
                             continue
 
-                        ps_adj = float(row['powerscore_adj'])
+                        ps_adj = float(row["powerscore_adj"])
 
                         # Apply SOS-conditioned ML scaling (same logic as main loop)
-                        has_ml = 'powerscore_ml' in teams_combined.columns and pd.notna(row.get('powerscore_ml'))
-                        has_sos = 'sos_norm' in teams_combined.columns and pd.notna(row.get('sos_norm'))
+                        has_ml = "powerscore_ml" in teams_combined.columns and pd.notna(row.get("powerscore_ml"))
+                        has_sos = "sos_norm" in teams_combined.columns and pd.notna(row.get("sos_norm"))
 
                         if has_ml and has_sos:
-                            ps_ml = float(row['powerscore_ml'])
-                            sos_norm = float(row['sos_norm'])
-                            ml_scale = max(0.0, min(1.0, (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)))
-                            ml_delta = ps_ml - ps_adj
-                            base_score = ps_adj + ml_delta * ml_scale
+                            base_score = sos_ml_blend(ps_adj, float(row["powerscore_ml"]), float(row["sos_norm"]))
                         else:
                             base_score = ps_adj
 
                         base_score = max(0.0, min(1.0, base_score))
-                        teams_combined.loc[idx, 'power_score_final'] = min(base_score * fallback_anchor, fallback_anchor)
+                        teams_combined.loc[idx, "power_score_final"] = min(
+                            base_score * fallback_anchor, fallback_anchor
+                        )
 
                 # Verify all teams have anchor-scaled power_score_final
-                still_null = teams_combined['power_score_final'].isna().sum()
+                still_null = teams_combined["power_score_final"].isna().sum()
                 if still_null > 0:
                     logger.error(f"❌ {still_null} teams still have NULL power_score_final after anchor scaling!")
 
@@ -1019,19 +999,15 @@ async def compute_all_cohorts(
                 after_min = teams_combined[col].min()
                 after_max = teams_combined[col].max()
                 if before_min < 0.0 or before_max > 1.0:
-                    logger.info(f"  🔒 Clipped {col}: [{before_min:.4f}, {before_max:.4f}] → [{after_min:.4f}, {after_max:.4f}]")
+                    logger.info(
+                        f"  🔒 Clipped {col}: [{before_min:.4f}, {before_max:.4f}] → [{after_min:.4f}, {after_max:.4f}]"
+                    )
 
     # Save one combined snapshot for all cohorts
     if not teams_combined.empty:
         logger.info("💾 Saving combined ranking snapshot for all cohorts...")
-        await save_ranking_snapshot(
-            supabase_client=supabase_client,
-            rankings_df=teams_combined
-        )
+        await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_combined)
 
     logger.info(f"✅ Two-pass SOS complete: {len(teams_combined):,} teams ranked")
 
-    return {
-        "teams": teams_combined,
-        "games_used": games_used_combined
-    }
+    return {"teams": teams_combined, "games_used": games_used_combined}

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -254,7 +254,7 @@ async def compute_rankings_with_ml(
     # This ensures cache key stays identical when no merges are configured
     if merge_version and merge_version != "no_merges":
         hash_input += f"_merge_{merge_version}"
-    cache_key = hashlib.md5(hash_input.encode()).hexdigest()
+    cache_key = hashlib.md5(hash_input.encode()).hexdigest()  # MD5 for cache key only (not security)
     cache_file_teams = cache_dir / f"rankings_{cache_key}_teams.parquet"
     cache_file_games = cache_dir / f"rankings_{cache_key}_games.parquet"
 

--- a/src/rankings/constants.py
+++ b/src/rankings/constants.py
@@ -1,0 +1,23 @@
+"""Shared constants for ranking calculations."""
+
+from __future__ import annotations
+
+# Static age → anchor mapping for U10–U19
+# Younger teams have lower max PowerScore, older teams can reach 1.0
+AGE_TO_ANCHOR: dict[int, float] = {
+    10: 0.400,
+    11: 0.475,
+    12: 0.550,
+    13: 0.625,
+    14: 0.700,
+    15: 0.775,
+    16: 0.850,
+    17: 0.925,
+    18: 1.000,  # Legacy: kept for safety if u18 data reaches v53e unmapped
+    19: 1.000,  # U19 encompasses birth years 2007+2008 (formerly U18+U19)
+}
+
+# SOS-conditioned ML scaling thresholds
+# Below LOW, ML has no authority; above HIGH, ML has full authority
+SOS_ML_THRESHOLD_LOW = 0.45
+SOS_ML_THRESHOLD_HIGH = 0.60

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -1,13 +1,16 @@
 """Data adapter to convert between Supabase format and v53e format"""
+
 from __future__ import annotations
 
 import logging
 import re
 import time
-from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 import pandas as pd
+
+from src.rankings.constants import AGE_TO_ANCHOR
+from src.rankings.shared import normalize_gender, sos_ml_blend
 
 if TYPE_CHECKING:
     from src.profiling.db_profiler import QueryProfiler
@@ -46,15 +49,22 @@ def retry_supabase_query(query_func, max_retries=4, initial_delay=2.0, descripti
             error_msg = str(e).lower()
 
             # Check if it's a retryable error (network/SSL/timeout)
-            is_retryable = any(keyword in error_msg for keyword in [
-                'ssl', 'timeout', 'connection', 'reset', 'network',
-                'temporarily unavailable', 'bad record', 'remote host'
-            ])
+            is_retryable = any(
+                keyword in error_msg
+                for keyword in [
+                    "ssl",
+                    "timeout",
+                    "connection",
+                    "reset",
+                    "network",
+                    "temporarily unavailable",
+                    "bad record",
+                    "remote host",
+                ]
+            )
 
             if attempt < max_retries - 1 and is_retryable:
-                logger.warning(
-                    f"⚠️  {description} failed (attempt {attempt + 1}/{max_retries}): {str(e)[:100]}"
-                )
+                logger.warning(f"⚠️  {description} failed (attempt {attempt + 1}/{max_retries}): {str(e)[:100]}")
                 logger.info(f"   Retrying in {delay:.1f}s...")
                 time.sleep(delay)
                 delay *= 2  # Exponential backoff
@@ -110,8 +120,8 @@ async def fetch_games_for_rankings(
     lookback_days: int = 365,
     provider_filter: Optional[str] = None,
     today: Optional[pd.Timestamp] = None,
-    merge_resolver: Optional['MergeResolver'] = None,
-    query_profiler: Optional['QueryProfiler'] = None,
+    merge_resolver: Optional["MergeResolver"] = None,
+    query_profiler: Optional["QueryProfiler"] = None,
 ) -> pd.DataFrame:
     """
     Fetch games from Supabase and convert to v53e format
@@ -133,55 +143,57 @@ async def fetch_games_for_rankings(
         today = pd.Timestamp.now("UTC").normalize()
 
     db = query_profiler.wrap(supabase_client) if query_profiler else supabase_client
-    
+
     cutoff = today - pd.Timedelta(days=lookback_days)
-    cutoff_date_str = cutoff.strftime('%Y-%m-%d')
-    
+    cutoff_date_str = cutoff.strftime("%Y-%m-%d")
+
     # Fetch games with pagination (Supabase defaults to 1000 rows per query)
     # Filter out games with NULL team IDs at the query level to avoid fetching
     # partial-match games that would be discarded during v53e conversion anyway.
     # These NULL-FK games corrupt SOS by creating phantom opponents.
-    today_date_str = today.strftime('%Y-%m-%d')
-    base_query = db.table('games').select(
-        'id, game_uid, game_date, home_team_master_id, away_team_master_id, '
-        'home_score, away_score, provider_id'
-    ).gte('game_date', cutoff_date_str).lte(
-        'game_date', today_date_str  # Exclude future-dated games (phantom 0-0 draws)
-    ).not_.is_(
-        'home_team_master_id', 'null'
-    ).not_.is_(
-        'away_team_master_id', 'null'
-    ).not_.is_(
-        'home_score', 'null'
-    ).not_.is_(
-        'away_score', 'null'
-    ).eq(
-        'is_excluded', False  # Exclude games flagged as non-ranking (e.g., futsal)
-    ).order('game_date', desc=False)  # Order for consistent pagination
-    
+    today_date_str = today.strftime("%Y-%m-%d")
+    base_query = (
+        db.table("games")
+        .select(
+            "id, game_uid, game_date, home_team_master_id, away_team_master_id, home_score, away_score, provider_id"
+        )
+        .gte("game_date", cutoff_date_str)
+        .lte(
+            "game_date",
+            today_date_str,  # Exclude future-dated games (phantom 0-0 draws)
+        )
+        .not_.is_("home_team_master_id", "null")
+        .not_.is_("away_team_master_id", "null")
+        .not_.is_("home_score", "null")
+        .not_.is_("away_score", "null")
+        .eq(
+            "is_excluded",
+            False,  # Exclude games flagged as non-ranking (e.g., futsal)
+        )
+        .order("game_date", desc=False)
+    )  # Order for consistent pagination
+
     if provider_filter:
         # Get provider ID with retry logic
         try:
             provider_result = retry_supabase_query(
-                lambda: db.table('providers').select('id').eq(
-                    'code', provider_filter
-                ).single().execute(),
+                lambda: db.table("providers").select("id").eq("code", provider_filter).single().execute(),
                 max_retries=4,
                 initial_delay=2.0,
-                description=f"Fetching provider filter '{provider_filter}'"
+                description=f"Fetching provider filter '{provider_filter}'",
             )
-            if getattr(provider_result, 'data', None):
-                base_query = base_query.eq('provider_id', provider_result.data['id'])
+            if getattr(provider_result, "data", None):
+                base_query = base_query.eq("provider_id", provider_result.data["id"])
         except Exception as e:
             logger.warning(f"⚠️  Failed to fetch provider filter '{provider_filter}' after retries: {str(e)[:100]}")
             # Continue without provider filter
-    
+
     # Paginate to fetch all games (Supabase max is 1000 per query)
     games_data = []
     page_size = 1000
     offset = 0
     max_games = 1000000  # Safety limit
-    
+
     logger.info(f"📥 Fetching games from Supabase (cutoff: {cutoff_date_str})...")
 
     while len(games_data) < max_games:
@@ -193,7 +205,7 @@ async def fetch_games_for_rankings(
                 lambda q=query: q.execute(),
                 max_retries=4,
                 initial_delay=2.0,
-                description=f"Fetching games batch at offset {offset}"
+                description=f"Fetching games batch at offset {offset}",
             )
         except Exception as e:
             # If all retries fail, log and break (use what we have)
@@ -218,7 +230,7 @@ async def fetch_games_for_rankings(
         # Progress indicator for large fetches (every 10k games)
         if len(games_data) % 10000 == 0:
             logger.info(f"  ✓ Fetched {len(games_data):,} games...")
-    
+
     logger.info(f"✅ Fetched {len(games_data):,} total games from database")
 
     if not games_data:
@@ -230,7 +242,7 @@ async def fetch_games_for_rankings(
     # Deduplicate games by ID to prevent duplicate perspective rows
     # (can occur from pagination overlap or duplicate inserts in source)
     before_dedup = len(games_df)
-    games_df = games_df.drop_duplicates(subset=['id'])
+    games_df = games_df.drop_duplicates(subset=["id"])
     after_dedup = len(games_df)
     if before_dedup != after_dedup:
         logger.warning(f"⚠️  Removed {before_dedup - after_dedup:,} duplicate games")
@@ -240,8 +252,8 @@ async def fetch_games_for_rankings(
     # DIAGNOSTIC: Count how many raw games involve deprecated vs canonical teams
     if merge_resolver is not None and merge_resolver.has_merges:
         deprecated_ids = merge_resolver.get_deprecated_teams()
-        home_strs = games_df['home_team_master_id'].astype(str)
-        away_strs = games_df['away_team_master_id'].astype(str)
+        home_strs = games_df["home_team_master_id"].astype(str)
+        away_strs = games_df["away_team_master_id"].astype(str)
         dep_game_count = (home_strs.isin(deprecated_ids) | away_strs.isin(deprecated_ids)).sum()
         logger.info(
             f"  [MERGE-DIAG] {len(deprecated_ids)} deprecated teams in merge map; "
@@ -250,38 +262,41 @@ async def fetch_games_for_rankings(
 
     # Fetch teams for age_group and gender
     team_ids = set()
-    team_ids.update(games_df['home_team_master_id'].dropna().tolist())
-    team_ids.update(games_df['away_team_master_id'].dropna().tolist())
-    
+    team_ids.update(games_df["home_team_master_id"].dropna().tolist())
+    team_ids.update(games_df["away_team_master_id"].dropna().tolist())
+
     if not team_ids:
         logger.warning("⚠️  No team IDs found in games")
         return pd.DataFrame()
-    
+
     logger.info(f"👥 Fetching metadata for {len(team_ids):,} unique teams...")
-    
+
     # Fetch teams in batches (Supabase has URI length limit - UUIDs are long)
     teams_data = []
     team_ids_list = list(team_ids)
     batch_size = 100  # Reduced from 1000 to avoid URI too long errors
 
     for i in range(0, len(team_ids_list), batch_size):
-        batch = team_ids_list[i:i + batch_size]
+        batch = team_ids_list[i : i + batch_size]
         try:
             # Use retry wrapper for team metadata fetching
             # Include is_deprecated to filter out deprecated teams
             teams_result = retry_supabase_query(
-                lambda b=batch: db.table('teams').select(
-                    'team_id_master, age_group, gender, is_deprecated'
-                ).in_('team_id_master', b).execute(),
+                lambda b=batch: (
+                    db.table("teams")
+                    .select("team_id_master, age_group, gender, is_deprecated")
+                    .in_("team_id_master", b)
+                    .execute()
+                ),
                 max_retries=4,
                 initial_delay=2.0,
-                description=f"Fetching team metadata batch {i}-{i+batch_size}"
+                description=f"Fetching team metadata batch {i}-{i + batch_size}",
             )
 
-            if getattr(teams_result, 'data', None):
+            if getattr(teams_result, "data", None):
                 teams_data.extend(teams_result.data)
         except Exception as e:
-            logger.warning(f"⚠️  Team metadata batch failed ({i}-{i+batch_size}) after retries: {str(e)[:100]}")
+            logger.warning(f"⚠️  Team metadata batch failed ({i}-{i + batch_size}) after retries: {str(e)[:100]}")
             continue
 
         # Progress indicator for team fetching
@@ -297,47 +312,30 @@ async def fetch_games_for_rankings(
     # Build set of deprecated team IDs and exclude them from metadata lookups
     # This prevents deprecated teams from appearing in rankings even if they
     # aren't in the team_merge_map (e.g., deprecated but not yet merged)
-    deprecated_team_ids = set(
-        str(row['team_id_master'])
-        for row in teams_data
-        if row.get('is_deprecated', False)
-    )
+    deprecated_team_ids = set(str(row["team_id_master"]) for row in teams_data if row.get("is_deprecated", False))
     if deprecated_team_ids:
         logger.info(f"🚫 Found {len(deprecated_team_ids):,} deprecated teams — excluding from rankings input")
-    teams_df['age'] = teams_df['age_group'].apply(age_group_to_age)
+    teams_df["age"] = teams_df["age_group"].apply(age_group_to_age)
     # Normalize gender values
-    teams_df["gender"] = (
-        teams_df["gender"]
-        .astype(str)
-        .str.lower()
-        .str.strip()
-        .replace({
-            "boys": "male",
-            "boy": "male",
-            "girls": "female",
-            "girl": "female",
-        })
-    )
-    
+    teams_df["gender"] = normalize_gender(teams_df["gender"])
+
     logger.info(f"🔄 Converting {len(games_df):,} games to v53e format (vectorized)...")
 
     # Create team lookup Series (indexed by team_id_master) for vectorized mapping
-    team_age_map = dict(zip(teams_df['team_id_master'], teams_df['age']))
-    team_gender_map = dict(zip(teams_df['team_id_master'], teams_df['gender']))
+    team_age_map = dict(zip(teams_df["team_id_master"], teams_df["age"]))
+    team_gender_map = dict(zip(teams_df["team_id_master"], teams_df["gender"]))
     team_age_series = pd.Series(team_age_map)
     team_gender_series = pd.Series(team_gender_map)
 
     # Vectorized conversion: build game_id column
-    game_uid_col = games_df['game_uid'] if 'game_uid' in games_df.columns else pd.Series(dtype='object')
+    game_uid_col = games_df["game_uid"] if "game_uid" in games_df.columns else pd.Series(dtype="object")
     games_df = games_df.copy()
-    games_df['_game_id'] = game_uid_col.fillna(games_df['id']).astype(str)
-    games_df['_date'] = pd.to_datetime(games_df['game_date'])
+    games_df["_game_id"] = game_uid_col.fillna(games_df["id"]).astype(str)
+    games_df["_date"] = pd.to_datetime(games_df["game_date"])
 
     # Filter out rows missing required fields
     valid_mask = (
-        games_df['home_team_master_id'].notna() &
-        games_df['away_team_master_id'].notna() &
-        games_df['_date'].notna()
+        games_df["home_team_master_id"].notna() & games_df["away_team_master_id"].notna() & games_df["_date"].notna()
     )
     games_valid = games_df[valid_mask]
     skipped_missing = len(games_df) - len(games_valid)
@@ -346,17 +344,21 @@ async def fetch_games_for_rankings(
 
     # Map team metadata vectorized
     games_valid = games_valid.copy()
-    games_valid['_home_age'] = games_valid['home_team_master_id'].map(team_age_series)
-    games_valid['_home_gender'] = games_valid['home_team_master_id'].map(team_gender_series)
-    games_valid['_away_age'] = games_valid['away_team_master_id'].map(team_age_series)
-    games_valid['_away_gender'] = games_valid['away_team_master_id'].map(team_gender_series)
+    games_valid["_home_age"] = games_valid["home_team_master_id"].map(team_age_series)
+    games_valid["_home_gender"] = games_valid["home_team_master_id"].map(team_gender_series)
+    games_valid["_away_age"] = games_valid["away_team_master_id"].map(team_age_series)
+    games_valid["_away_gender"] = games_valid["away_team_master_id"].map(team_gender_series)
 
     # Filter out games where any team is missing age/gender metadata
     meta_mask = (
-        games_valid['_home_age'].notna() & (games_valid['_home_age'] != '') &
-        games_valid['_home_gender'].notna() & (games_valid['_home_gender'] != '') &
-        games_valid['_away_age'].notna() & (games_valid['_away_age'] != '') &
-        games_valid['_away_gender'].notna() & (games_valid['_away_gender'] != '')
+        games_valid["_home_age"].notna()
+        & (games_valid["_home_age"] != "")
+        & games_valid["_home_gender"].notna()
+        & (games_valid["_home_gender"] != "")
+        & games_valid["_away_age"].notna()
+        & (games_valid["_away_age"] != "")
+        & games_valid["_away_gender"].notna()
+        & (games_valid["_away_gender"] != "")
     )
     games_ready = games_valid[meta_mask]
     skipped_meta = len(games_valid) - len(games_ready)
@@ -368,36 +370,40 @@ async def fetch_games_for_rankings(
         return pd.DataFrame()
 
     # Build home perspective DataFrame
-    home_df = pd.DataFrame({
-        'game_id': games_ready['_game_id'].values,
-        'id': games_ready['id'].values,
-        'date': games_ready['_date'].values,
-        'team_id': games_ready['home_team_master_id'].astype(str).values,
-        'opp_id': games_ready['away_team_master_id'].astype(str).values,
-        'home_team_master_id': games_ready['home_team_master_id'].astype(str).values,
-        'age': games_ready['_home_age'].values,
-        'gender': games_ready['_home_gender'].values,
-        'opp_age': games_ready['_away_age'].values,
-        'opp_gender': games_ready['_away_gender'].values,
-        'gf': pd.to_numeric(games_ready['home_score'], errors='coerce').values,
-        'ga': pd.to_numeric(games_ready['away_score'], errors='coerce').values,
-    })
+    home_df = pd.DataFrame(
+        {
+            "game_id": games_ready["_game_id"].values,
+            "id": games_ready["id"].values,
+            "date": games_ready["_date"].values,
+            "team_id": games_ready["home_team_master_id"].astype(str).values,
+            "opp_id": games_ready["away_team_master_id"].astype(str).values,
+            "home_team_master_id": games_ready["home_team_master_id"].astype(str).values,
+            "age": games_ready["_home_age"].values,
+            "gender": games_ready["_home_gender"].values,
+            "opp_age": games_ready["_away_age"].values,
+            "opp_gender": games_ready["_away_gender"].values,
+            "gf": pd.to_numeric(games_ready["home_score"], errors="coerce").values,
+            "ga": pd.to_numeric(games_ready["away_score"], errors="coerce").values,
+        }
+    )
 
     # Build away perspective DataFrame
-    away_df = pd.DataFrame({
-        'game_id': games_ready['_game_id'].values,
-        'id': games_ready['id'].values,
-        'date': games_ready['_date'].values,
-        'team_id': games_ready['away_team_master_id'].astype(str).values,
-        'opp_id': games_ready['home_team_master_id'].astype(str).values,
-        'home_team_master_id': games_ready['home_team_master_id'].astype(str).values,
-        'age': games_ready['_away_age'].values,
-        'gender': games_ready['_away_gender'].values,
-        'opp_age': games_ready['_home_age'].values,
-        'opp_gender': games_ready['_home_gender'].values,
-        'gf': pd.to_numeric(games_ready['away_score'], errors='coerce').values,
-        'ga': pd.to_numeric(games_ready['home_score'], errors='coerce').values,
-    })
+    away_df = pd.DataFrame(
+        {
+            "game_id": games_ready["_game_id"].values,
+            "id": games_ready["id"].values,
+            "date": games_ready["_date"].values,
+            "team_id": games_ready["away_team_master_id"].astype(str).values,
+            "opp_id": games_ready["home_team_master_id"].astype(str).values,
+            "home_team_master_id": games_ready["home_team_master_id"].astype(str).values,
+            "age": games_ready["_away_age"].values,
+            "gender": games_ready["_away_gender"].values,
+            "opp_age": games_ready["_home_age"].values,
+            "opp_gender": games_ready["_home_gender"].values,
+            "gf": pd.to_numeric(games_ready["away_score"], errors="coerce").values,
+            "ga": pd.to_numeric(games_ready["home_score"], errors="coerce").values,
+        }
+    )
 
     # Concatenate both perspectives
     v53e_df = pd.concat([home_df, away_df], ignore_index=True)
@@ -405,20 +411,22 @@ async def fetch_games_for_rankings(
 
     # Apply merge resolution if resolver provided
     if merge_resolver is not None and merge_resolver.has_merges:
-        logger.info(f"🔀 Applying merge resolution ({merge_resolver.merge_count} merges, version: {merge_resolver.version})")
+        logger.info(
+            f"🔀 Applying merge resolution ({merge_resolver.merge_count} merges, version: {merge_resolver.version})"
+        )
 
         # DIAGNOSTIC: Count deprecated team perspective rows before merge
         deprecated_in_merge = merge_resolver.get_deprecated_teams()
-        team_id_strs = v53e_df['team_id'].astype(str)
+        team_id_strs = v53e_df["team_id"].astype(str)
         dep_rows_before = team_id_strs.isin(deprecated_in_merge).sum()
         logger.info(f"  [MERGE-DIAG] Pre-merge: {dep_rows_before:,} perspective rows have deprecated team_id")
 
-        v53e_df = merge_resolver.resolve_dataframe(v53e_df, ['team_id', 'opp_id', 'home_team_master_id'])
+        v53e_df = merge_resolver.resolve_dataframe(v53e_df, ["team_id", "opp_id", "home_team_master_id"])
 
         # DIAGNOSTIC: Verify merge resolution worked (team_id, opp_id, home_team_master_id)
-        team_id_strs_after = v53e_df['team_id'].astype(str)
+        team_id_strs_after = v53e_df["team_id"].astype(str)
         dep_rows_after = team_id_strs_after.isin(deprecated_in_merge).sum()
-        home_master_strs_after = v53e_df['home_team_master_id'].astype(str)
+        home_master_strs_after = v53e_df["home_team_master_id"].astype(str)
         dep_home_after = home_master_strs_after.isin(deprecated_in_merge).sum()
         if dep_rows_after > 0 or dep_home_after > 0:
             logger.warning(
@@ -431,10 +439,10 @@ async def fetch_games_for_rankings(
         # After merge resolution, team_id/opp_id point to canonical teams but
         # age/gender still reflect the deprecated team's metadata.  Re-map them
         # so the canonical team's games land in the correct cohort.
-        v53e_df['age'] = v53e_df['team_id'].map(team_age_map).fillna(v53e_df['age'])
-        v53e_df['gender'] = v53e_df['team_id'].map(team_gender_map).fillna(v53e_df['gender'])
-        v53e_df['opp_age'] = v53e_df['opp_id'].map(team_age_map).fillna(v53e_df['opp_age'])
-        v53e_df['opp_gender'] = v53e_df['opp_id'].map(team_gender_map).fillna(v53e_df['opp_gender'])
+        v53e_df["age"] = v53e_df["team_id"].map(team_age_map).fillna(v53e_df["age"])
+        v53e_df["gender"] = v53e_df["team_id"].map(team_gender_map).fillna(v53e_df["gender"])
+        v53e_df["opp_age"] = v53e_df["opp_id"].map(team_age_map).fillna(v53e_df["opp_age"])
+        v53e_df["opp_gender"] = v53e_df["opp_id"].map(team_gender_map).fillna(v53e_df["opp_gender"])
     else:
         # DIAGNOSTIC: Log why merge resolution was skipped
         if merge_resolver is None:
@@ -451,210 +459,203 @@ async def fetch_games_for_rankings(
     # This catches any that slipped through (e.g., deprecated without a merge mapping).
     if deprecated_team_ids:
         before_deprecated_filter = len(v53e_df)
-        v53e_df = v53e_df[~v53e_df['team_id'].astype(str).isin(deprecated_team_ids)]
+        v53e_df = v53e_df[~v53e_df["team_id"].astype(str).isin(deprecated_team_ids)]
         removed_deprecated = before_deprecated_filter - len(v53e_df)
         if removed_deprecated > 0:
-            logger.info(f"🚫 Removed {removed_deprecated:,} perspective rows for {len(deprecated_team_ids)} deprecated teams")
+            logger.info(
+                f"🚫 Removed {removed_deprecated:,} perspective rows for {len(deprecated_team_ids)} deprecated teams"
+            )
         else:
-            logger.info(f"✅ Deprecated filter: 0 rows removed (all {len(deprecated_team_ids)} deprecated teams properly merged)")
+            logger.info(
+                f"✅ Deprecated filter: 0 rows removed (all {len(deprecated_team_ids)} deprecated teams properly merged)"
+            )
 
     # Filter out rows with missing scores
     before_filter = len(v53e_df)
-    v53e_df = v53e_df.dropna(subset=['gf', 'ga'])
+    v53e_df = v53e_df.dropna(subset=["gf", "ga"])
     after_filter = len(v53e_df)
-    
+
     if before_filter != after_filter:
         logger.info(f"🔍 Filtered out {before_filter - after_filter:,} rows with missing scores")
-    
+
     # Ensure date is datetime
-    v53e_df['date'] = pd.to_datetime(v53e_df['date'])
-    
+    v53e_df["date"] = pd.to_datetime(v53e_df["date"])
+
     logger.info(f"✅ Final v53e dataset: {len(v53e_df):,} rows ready for rankings")
-    
+
     return v53e_df
 
 
-def supabase_to_v53e_format(
-    games_df: pd.DataFrame,
-    teams_df: pd.DataFrame
-) -> pd.DataFrame:
+def supabase_to_v53e_format(games_df: pd.DataFrame, teams_df: pd.DataFrame) -> pd.DataFrame:
     """
     Convert Supabase games DataFrame to v53e format
-    
+
     Args:
         games_df: DataFrame with Supabase game columns
         teams_df: DataFrame with team metadata (team_id_master, age_group, gender)
-    
+
     Returns:
         DataFrame in v53e format
     """
     if games_df.empty or teams_df.empty:
         return pd.DataFrame()
-    
+
     # Prepare team lookup
     teams_df = teams_df.copy()
-    teams_df['age'] = teams_df['age_group'].apply(age_group_to_age)
+    teams_df["age"] = teams_df["age_group"].apply(age_group_to_age)
     # Normalize gender values
-    teams_df["gender"] = (
-        teams_df["gender"]
-        .astype(str)
-        .str.lower()
-        .str.strip()
-        .replace({
-            "boys": "male",
-            "boy": "male",
-            "girls": "female",
-            "girl": "female",
-        })
-    )
-    team_age_map = dict(zip(teams_df['team_id_master'], teams_df['age']))
-    team_gender_map = dict(zip(teams_df['team_id_master'], teams_df['gender']))
-    
+    teams_df["gender"] = normalize_gender(teams_df["gender"])
+    team_age_map = dict(zip(teams_df["team_id_master"], teams_df["age"]))
+    team_gender_map = dict(zip(teams_df["team_id_master"], teams_df["gender"]))
+
     # Convert to v53e format (perspective-based)
     v53e_rows = []
-    
+
     for _, game in games_df.iterrows():
-        game_id = str(game.get('game_uid') or game.get('id', ''))
-        game_uuid = game.get('id')  # Keep original UUID for ML residual mapping
-        game_date = pd.to_datetime(game.get('game_date'))
-        home_team_id = game.get('home_team_master_id')
-        away_team_id = game.get('away_team_master_id')
-        home_score = game.get('home_score')
-        away_score = game.get('away_score')
+        game_id = str(game.get("game_uid") or game.get("id", ""))
+        game_uuid = game.get("id")  # Keep original UUID for ML residual mapping
+        game_date = pd.to_datetime(game.get("game_date"))
+        home_team_id = game.get("home_team_master_id")
+        away_team_id = game.get("away_team_master_id")
+        home_score = game.get("home_score")
+        away_score = game.get("away_score")
 
         if pd.isna(home_team_id) or pd.isna(away_team_id) or pd.isna(game_date):
             continue
 
-        home_age = team_age_map.get(home_team_id, '')
-        home_gender = team_gender_map.get(home_team_id, '')
-        away_age = team_age_map.get(away_team_id, '')
-        away_gender = team_gender_map.get(away_team_id, '')
+        home_age = team_age_map.get(home_team_id, "")
+        home_gender = team_gender_map.get(home_team_id, "")
+        away_age = team_age_map.get(away_team_id, "")
+        away_gender = team_gender_map.get(away_team_id, "")
 
         if not home_age or not home_gender or not away_age or not away_gender:
             continue
 
         # Home perspective
-        v53e_rows.append({
-            'game_id': game_id,
-            'id': game_uuid,  # Include UUID for ML residual mapping
-            'date': game_date,
-            'team_id': str(home_team_id),
-            'opp_id': str(away_team_id),
-            'home_team_master_id': str(home_team_id),  # Track which team is home
-            'age': home_age,
-            'gender': home_gender,
-            'opp_age': away_age,
-            'opp_gender': away_gender,
-            'gf': safe_int(home_score),
-            'ga': safe_int(away_score),
-        })
+        v53e_rows.append(
+            {
+                "game_id": game_id,
+                "id": game_uuid,  # Include UUID for ML residual mapping
+                "date": game_date,
+                "team_id": str(home_team_id),
+                "opp_id": str(away_team_id),
+                "home_team_master_id": str(home_team_id),  # Track which team is home
+                "age": home_age,
+                "gender": home_gender,
+                "opp_age": away_age,
+                "opp_gender": away_gender,
+                "gf": safe_int(home_score),
+                "ga": safe_int(away_score),
+            }
+        )
 
         # Away perspective
-        v53e_rows.append({
-            'game_id': game_id,
-            'id': game_uuid,  # Include UUID for ML residual mapping
-            'date': game_date,
-            'team_id': str(away_team_id),
-            'opp_id': str(home_team_id),
-            'home_team_master_id': str(home_team_id),  # Track which team is home
-            'age': away_age,
-            'gender': away_gender,
-            'opp_age': home_age,
-            'opp_gender': home_gender,
-            'gf': safe_int(away_score),
-            'ga': safe_int(home_score),
-        })
-    
+        v53e_rows.append(
+            {
+                "game_id": game_id,
+                "id": game_uuid,  # Include UUID for ML residual mapping
+                "date": game_date,
+                "team_id": str(away_team_id),
+                "opp_id": str(home_team_id),
+                "home_team_master_id": str(home_team_id),  # Track which team is home
+                "age": away_age,
+                "gender": away_gender,
+                "opp_age": home_age,
+                "opp_gender": home_gender,
+                "gf": safe_int(away_score),
+                "ga": safe_int(home_score),
+            }
+        )
+
     if not v53e_rows:
         return pd.DataFrame()
-    
+
     v53e_df = pd.DataFrame(v53e_rows)
-    v53e_df = v53e_df.dropna(subset=['gf', 'ga'])
-    v53e_df['date'] = pd.to_datetime(v53e_df['date'])
-    
+    v53e_df = v53e_df.dropna(subset=["gf", "ga"])
+    v53e_df["date"] = pd.to_datetime(v53e_df["date"])
+
     return v53e_df
 
 
 def v53e_to_supabase_format(teams_df: pd.DataFrame) -> pd.DataFrame:
     """
     Convert v53e teams output to Supabase current_rankings format
-    
+
     Args:
         teams_df: DataFrame from v53e compute_rankings() output
-    
+
     Returns:
         DataFrame ready for current_rankings table
     """
     if teams_df.empty:
         logger.warning("⚠️ Empty rankings DataFrame — nothing to convert.")
         return pd.DataFrame()
-    
+
     # Map v53e columns to Supabase columns
     rankings_df = teams_df.copy()
-    
+
     # Ensure team_id is UUID string
-    rankings_df['team_id'] = rankings_df['team_id'].astype(str)
-    
+    rankings_df["team_id"] = rankings_df["team_id"].astype(str)
+
     # Map PowerScore columns and clip to valid bounds
-    if 'powerscore_ml' in rankings_df.columns:
-        col = 'powerscore_ml'
-    elif 'powerscore_adj' in rankings_df.columns:
-        col = 'powerscore_adj'
-    elif 'powerscore_core' in rankings_df.columns:
-        col = 'powerscore_core'
+    if "powerscore_ml" in rankings_df.columns:
+        col = "powerscore_ml"
+    elif "powerscore_adj" in rankings_df.columns:
+        col = "powerscore_adj"
+    elif "powerscore_core" in rankings_df.columns:
+        col = "powerscore_core"
     else:
         logger.warning("⚠️ No PowerScore column found during export.")
         col = None
-    
+
     if col:
-        rankings_df['national_power_score'] = rankings_df[col].clip(0.0, 1.0)
+        rankings_df["national_power_score"] = rankings_df[col].clip(0.0, 1.0)
     else:
-        rankings_df['national_power_score'] = 0.0
-    
+        rankings_df["national_power_score"] = 0.0
+
     # Map rank with proper defaults and dtype
-    if 'rank_in_cohort_ml' in rankings_df.columns:
-        rankings_df['national_rank'] = rankings_df['rank_in_cohort_ml']
-    elif 'rank_in_cohort' in rankings_df.columns:
-        rankings_df['national_rank'] = rankings_df['rank_in_cohort']
+    if "rank_in_cohort_ml" in rankings_df.columns:
+        rankings_df["national_rank"] = rankings_df["rank_in_cohort_ml"]
+    elif "rank_in_cohort" in rankings_df.columns:
+        rankings_df["national_rank"] = rankings_df["rank_in_cohort"]
     else:
-        rankings_df['national_rank'] = pd.NA
-    
+        rankings_df["national_rank"] = pd.NA
+
     # Use nullable Int64 to preserve NULL for unranked teams (rank 0 is semantically incorrect)
-    rankings_df['national_rank'] = rankings_df['national_rank'].astype("Int64")
-    
+    rankings_df["national_rank"] = rankings_df["national_rank"].astype("Int64")
+
     logger.info(f"🧾 Prepared {len(rankings_df):,} records for Supabase upload.")
-    
+
     return rankings_df
 
 
 def v53e_to_rankings_full_format(
-    teams_df: pd.DataFrame,
-    teams_metadata_df: Optional[pd.DataFrame] = None
+    teams_df: pd.DataFrame, teams_metadata_df: Optional[pd.DataFrame] = None
 ) -> pd.DataFrame:
     """
     Convert v53e + Layer 13 teams output to Supabase rankings_full format
-    
+
     This function maps ALL fields from the ranking engine to the comprehensive
     rankings_full table, preserving all v53E and ML layer outputs.
-    
+
     Args:
         teams_df: DataFrame from v53e compute_rankings() + Layer 13 ML adjustment
         teams_metadata_df: Optional DataFrame with team metadata (team_id_master, age_group, gender, state_code)
                           If not provided, will extract from teams_df if available
-    
+
     Returns:
         DataFrame ready for rankings_full table with all fields mapped
     """
     if teams_df.empty:
         logger.warning("⚠️ Empty rankings DataFrame — nothing to convert.")
         return pd.DataFrame()
-    
+
     # Start with a copy
     rankings_df = teams_df.copy()
-    
+
     # Ensure team_id is UUID string
-    rankings_df['team_id'] = rankings_df['team_id'].astype(str)
-    
+    rankings_df["team_id"] = rankings_df["team_id"].astype(str)
+
     # Map team identity fields
     # If teams_metadata_df is provided, merge it; otherwise try to extract from teams_df
     # NOTE: Don't merge gender from metadata - v53e always provides it and it's the source of truth
@@ -662,241 +663,238 @@ def v53e_to_rankings_full_format(
     if teams_metadata_df is not None and not teams_metadata_df.empty:
         # Merge team metadata (only columns not already in rankings_df)
         teams_metadata_df = teams_metadata_df.copy()
-        teams_metadata_df['team_id_master'] = teams_metadata_df['team_id_master'].astype(str)
+        teams_metadata_df["team_id_master"] = teams_metadata_df["team_id_master"].astype(str)
 
         # Determine which metadata columns to merge (skip if already present in rankings_df)
         # NOTE: Never merge age_group from metadata - always derive from actual 'age' field
         # to ensure rankings match the age group of games played, not team registration
-        merge_cols = ['team_id_master']
-        if 'state_code' not in rankings_df.columns and 'state_code' in teams_metadata_df.columns:
-            merge_cols.append('state_code')
+        merge_cols = ["team_id_master"]
+        if "state_code" not in rankings_df.columns and "state_code" in teams_metadata_df.columns:
+            merge_cols.append("state_code")
 
         if len(merge_cols) > 1:  # More than just team_id_master
             rankings_df = rankings_df.merge(
-                teams_metadata_df[merge_cols],
-                left_on='team_id',
-                right_on='team_id_master',
-                how='left'
+                teams_metadata_df[merge_cols], left_on="team_id", right_on="team_id_master", how="left"
             )
             # Drop duplicate column if it exists
-            if 'team_id_master' in rankings_df.columns and 'team_id' in rankings_df.columns:
-                rankings_df = rankings_df.drop(columns=['team_id_master'])
+            if "team_id_master" in rankings_df.columns and "team_id" in rankings_df.columns:
+                rankings_df = rankings_df.drop(columns=["team_id_master"])
 
     # ALWAYS derive age_group from the actual 'age' field used in ranking calculation
     # This ensures teams are ranked in the age group they actually played in, not their registration
-    if 'age' in rankings_df.columns:
-        rankings_df['age_group'] = rankings_df['age'].apply(lambda x: f"u{int(float(x))}" if pd.notna(x) and str(x).strip() else None)
+    if "age" in rankings_df.columns:
+        rankings_df["age_group"] = rankings_df["age"].apply(
+            lambda x: f"u{int(float(x))}" if pd.notna(x) and str(x).strip() else None
+        )
         # Create numeric age column for anchor scaling
-        rankings_df['age_num'] = pd.to_numeric(rankings_df['age'], errors='coerce').fillna(0).astype(int)
-    
+        rankings_df["age_num"] = pd.to_numeric(rankings_df["age"], errors="coerce").fillna(0).astype(int)
+
     # Normalize gender to match database format (Male/Female)
     # CRITICAL: gender is NOT NULL in rankings_full, so ensure it's always populated
-    if 'gender' in rankings_df.columns:
-        rankings_df['gender'] = (
-            rankings_df['gender']
+    if "gender" in rankings_df.columns:
+        rankings_df["gender"] = (
+            rankings_df["gender"]
             .astype(str)
             .str.strip()
             .str.title()
-            .replace({
-                'Male': 'Male',
-                'Female': 'Female',
-                'Boys': 'Male',
-                'Girls': 'Female',
-                'Boy': 'Male',
-                'Girl': 'Female',
-                'Nan': None,  # Handle NaN string
-                'None': None,
-            })
+            .replace(
+                {
+                    "Male": "Male",
+                    "Female": "Female",
+                    "Boys": "Male",
+                    "Girls": "Female",
+                    "Boy": "Male",
+                    "Girl": "Female",
+                    "Nan": None,  # Handle NaN string
+                    "None": None,
+                }
+            )
         )
         # Replace invalid values with None, then fill with a default
-        rankings_df['gender'] = rankings_df['gender'].replace(['', 'Nan', 'None', 'Null'], None)
+        rankings_df["gender"] = rankings_df["gender"].replace(["", "Nan", "None", "Null"], None)
         # If still NULL after normalization, use 'Unknown' as fallback (or skip record)
         # But ideally this shouldn't happen since v53e always provides gender
-        if rankings_df['gender'].isna().any():
-            logger.warning(f"⚠️ Found {rankings_df['gender'].isna().sum()} teams with NULL gender. Using 'Unknown' as fallback.")
-            rankings_df['gender'] = rankings_df['gender'].fillna('Unknown')
+        if rankings_df["gender"].isna().any():
+            logger.warning(
+                f"⚠️ Found {rankings_df['gender'].isna().sum()} teams with NULL gender. Using 'Unknown' as fallback."
+            )
+            rankings_df["gender"] = rankings_df["gender"].fillna("Unknown")
     else:
         # If gender column doesn't exist at all, create it (shouldn't happen with v53e)
         logger.warning("⚠️ Gender column missing from teams_df. Creating with 'Unknown' default.")
-        rankings_df['gender'] = 'Unknown'
-    
+        rankings_df["gender"] = "Unknown"
+
     # Map status field (from v53e)
-    if 'status' in rankings_df.columns:
-        rankings_df['status'] = rankings_df['status'].astype(str)
+    if "status" in rankings_df.columns:
+        rankings_df["status"] = rankings_df["status"].astype(str)
     else:
-        rankings_df['status'] = None
-    
+        rankings_df["status"] = None
+
     # Map last_game timestamp
-    if 'last_game' in rankings_df.columns:
-        rankings_df['last_game'] = pd.to_datetime(rankings_df['last_game'], errors='coerce')
+    if "last_game" in rankings_df.columns:
+        rankings_df["last_game"] = pd.to_datetime(rankings_df["last_game"], errors="coerce")
     else:
-        rankings_df['last_game'] = None
-    
+        rankings_df["last_game"] = None
+
     # Map game statistics (these may need to be calculated from games if not present)
     # For now, use what's available in teams_df
-    if 'gp' in rankings_df.columns:
-        rankings_df['games_played'] = rankings_df['gp'].fillna(0).astype(int)
-    elif 'games_played' not in rankings_df.columns:
-        rankings_df['games_played'] = 0
+    if "gp" in rankings_df.columns:
+        rankings_df["games_played"] = rankings_df["gp"].fillna(0).astype(int)
+    elif "games_played" not in rankings_df.columns:
+        rankings_df["games_played"] = 0
 
     # Map games in activity window (used for activity filtering)
-    if 'gp_last_window' in rankings_df.columns:
-        rankings_df['games_last_180_days'] = rankings_df['gp_last_window'].fillna(0).astype(int)
-    elif 'gp_last_180' in rankings_df.columns:
-        rankings_df['games_last_180_days'] = rankings_df['gp_last_180'].fillna(0).astype(int)
-    elif 'games_last_180_days' not in rankings_df.columns:
-        rankings_df['games_last_180_days'] = 0
-    
+    if "gp_last_window" in rankings_df.columns:
+        rankings_df["games_last_180_days"] = rankings_df["gp_last_window"].fillna(0).astype(int)
+    elif "gp_last_180" in rankings_df.columns:
+        rankings_df["games_last_180_days"] = rankings_df["gp_last_180"].fillna(0).astype(int)
+    elif "games_last_180_days" not in rankings_df.columns:
+        rankings_df["games_last_180_days"] = 0
+
     # Wins/losses/draws may not be in v53e output - will need to calculate from games
     # For now, set defaults
-    for col in ['wins', 'losses', 'draws', 'goals_for', 'goals_against']:
+    for col in ["wins", "losses", "draws", "goals_for", "goals_against"]:
         if col not in rankings_df.columns:
             rankings_df[col] = 0
-    
+
     # Calculate win_percentage if we have wins and games_played
-    if 'wins' in rankings_df.columns and 'games_played' in rankings_df.columns:
-        rankings_df['win_percentage'] = (
-            rankings_df.apply(
-                lambda row: (row['wins'] / row['games_played'] * 100) 
-                if pd.notna(row.get('wins')) and pd.notna(row.get('games_played')) and row['games_played'] > 0 else None,
-                axis=1
-            )
+    if "wins" in rankings_df.columns and "games_played" in rankings_df.columns:
+        rankings_df["win_percentage"] = rankings_df.apply(
+            lambda row: (
+                (row["wins"] / row["games_played"] * 100)
+                if pd.notna(row.get("wins")) and pd.notna(row.get("games_played")) and row["games_played"] > 0
+                else None
+            ),
+            axis=1,
         )
     else:
-        rankings_df['win_percentage'] = None
-    
+        rankings_df["win_percentage"] = None
+
     # Map Offense/Defense metrics (v53E Layers 2-5, 7, 9)
-    for col in ['off_raw', 'sad_raw', 'off_shrunk', 'sad_shrunk', 'def_shrunk', 'off_norm', 'def_norm']:
+    for col in ["off_raw", "sad_raw", "off_shrunk", "sad_shrunk", "def_shrunk", "off_norm", "def_norm"]:
         if col not in rankings_df.columns:
             rankings_df[col] = None
-    
-    # Map Strength of Schedule (v53E Layer 8)
-    if 'sos' in rankings_df.columns:
-        rankings_df['sos'] = rankings_df['sos'].astype(float)
-        rankings_df['strength_of_schedule'] = rankings_df['sos']  # Alias for backward compatibility
-    else:
-        rankings_df['sos'] = None
-        rankings_df['strength_of_schedule'] = None
 
-    if 'sos_norm' in rankings_df.columns:
-        rankings_df['sos_norm'] = rankings_df['sos_norm'].astype(float)
+    # Map Strength of Schedule (v53E Layer 8)
+    if "sos" in rankings_df.columns:
+        rankings_df["sos"] = rankings_df["sos"].astype(float)
+        rankings_df["strength_of_schedule"] = rankings_df["sos"]  # Alias for backward compatibility
     else:
-        rankings_df['sos_norm'] = None
+        rankings_df["sos"] = None
+        rankings_df["strength_of_schedule"] = None
+
+    if "sos_norm" in rankings_df.columns:
+        rankings_df["sos_norm"] = rankings_df["sos_norm"].astype(float)
+    else:
+        rankings_df["sos_norm"] = None
 
     # Map National/State SOS fields (computed in calculator.py Pass 3)
     # sos_raw: post-shrinkage SOS value used for national/state ranking
-    if 'sos_raw' in rankings_df.columns:
-        rankings_df['sos_raw'] = rankings_df['sos_raw'].astype(float)
+    if "sos_raw" in rankings_df.columns:
+        rankings_df["sos_raw"] = rankings_df["sos_raw"].astype(float)
     else:
-        rankings_df['sos_raw'] = None
+        rankings_df["sos_raw"] = None
 
     # sos_norm_national: percentile rank across all states in cohort (age, gender)
-    if 'sos_norm_national' in rankings_df.columns:
-        rankings_df['sos_norm_national'] = rankings_df['sos_norm_national'].astype(float)
+    if "sos_norm_national" in rankings_df.columns:
+        rankings_df["sos_norm_national"] = rankings_df["sos_norm_national"].astype(float)
     else:
-        rankings_df['sos_norm_national'] = None
+        rankings_df["sos_norm_national"] = None
 
     # sos_norm_state: percentile rank within state for cohort (age, gender, state)
-    if 'sos_norm_state' in rankings_df.columns:
-        rankings_df['sos_norm_state'] = rankings_df['sos_norm_state'].astype(float)
+    if "sos_norm_state" in rankings_df.columns:
+        rankings_df["sos_norm_state"] = rankings_df["sos_norm_state"].astype(float)
     else:
-        rankings_df['sos_norm_state'] = None
+        rankings_df["sos_norm_state"] = None
 
     # sos_rank_national: descending rank across all states in cohort
     # Preserve NULL values (don't convert to 0, as 0 is not a valid rank)
-    if 'sos_rank_national' in rankings_df.columns:
+    if "sos_rank_national" in rankings_df.columns:
         # Use nullable Int64 type to preserve NULL values
-        rankings_df['sos_rank_national'] = pd.to_numeric(rankings_df['sos_rank_national'], errors='coerce').astype('Int64')
+        rankings_df["sos_rank_national"] = pd.to_numeric(rankings_df["sos_rank_national"], errors="coerce").astype(
+            "Int64"
+        )
     else:
-        rankings_df['sos_rank_national'] = None
+        rankings_df["sos_rank_national"] = None
 
     # sos_rank_state: descending rank within state for cohort
     # Preserve NULL values (don't convert to 0, as 0 is not a valid rank)
-    if 'sos_rank_state' in rankings_df.columns:
+    if "sos_rank_state" in rankings_df.columns:
         # Use nullable Int64 type to preserve NULL values
-        rankings_df['sos_rank_state'] = pd.to_numeric(rankings_df['sos_rank_state'], errors='coerce').astype('Int64')
+        rankings_df["sos_rank_state"] = pd.to_numeric(rankings_df["sos_rank_state"], errors="coerce").astype("Int64")
     else:
-        rankings_df['sos_rank_state'] = None
+        rankings_df["sos_rank_state"] = None
 
     # sample_flag: LOW_SAMPLE or OK based on games played threshold
-    if 'sample_flag' in rankings_df.columns:
-        rankings_df['sample_flag'] = rankings_df['sample_flag'].astype(str)
+    if "sample_flag" in rankings_df.columns:
+        rankings_df["sample_flag"] = rankings_df["sample_flag"].astype(str)
     else:
-        rankings_df['sample_flag'] = None
-    
+        rankings_df["sample_flag"] = None
+
     # Map Power Score layers (v53E Layer 10)
-    for col in ['power_presos', 'anchor', 'abs_strength', 'powerscore_core', 'provisional_mult', 'powerscore_adj']:
+    for col in ["power_presos", "anchor", "abs_strength", "powerscore_core", "provisional_mult", "powerscore_adj"]:
         if col not in rankings_df.columns:
             rankings_df[col] = None
         else:
             rankings_df[col] = rankings_df[col].astype(float)
-    
+
     # Map Performance metrics (v53E Layer 6)
-    for col in ['perf_raw', 'perf_centered']:
+    for col in ["perf_raw", "perf_centered"]:
         if col not in rankings_df.columns:
             rankings_df[col] = None
         else:
             rankings_df[col] = rankings_df[col].astype(float)
-    
+
     # Map ML Layer fields (Layer 13)
-    for col in ['ml_overperf', 'ml_norm', 'powerscore_ml']:
+    for col in ["ml_overperf", "ml_norm", "powerscore_ml"]:
         if col not in rankings_df.columns:
             rankings_df[col] = None
         else:
             rankings_df[col] = rankings_df[col].astype(float)
-    
+
     # Preserve NULL rank_in_cohort_ml for non-Active teams (don't fill with 0)
     # NULL means "not enough games to be ranked" — filling with 0 would cause
     # COALESCE(rank_in_cohort_ml, rank_in_cohort) in DB views to show rank 0
-    if 'rank_in_cohort_ml' in rankings_df.columns:
-        rankings_df['rank_in_cohort_ml'] = pd.to_numeric(
-            rankings_df['rank_in_cohort_ml'], errors='coerce'
-        ).astype('Int64')
+    if "rank_in_cohort_ml" in rankings_df.columns:
+        rankings_df["rank_in_cohort_ml"] = pd.to_numeric(rankings_df["rank_in_cohort_ml"], errors="coerce").astype(
+            "Int64"
+        )
     else:
-        rankings_df['rank_in_cohort_ml'] = pd.array([pd.NA] * len(rankings_df), dtype='Int64')
+        rankings_df["rank_in_cohort_ml"] = pd.array([pd.NA] * len(rankings_df), dtype="Int64")
 
     # Map Ranking fields — preserve NULL for non-Active teams
-    if 'rank_in_cohort' in rankings_df.columns:
-        rankings_df['rank_in_cohort'] = pd.to_numeric(
-            rankings_df['rank_in_cohort'], errors='coerce'
-        ).astype('Int64')
+    if "rank_in_cohort" in rankings_df.columns:
+        rankings_df["rank_in_cohort"] = pd.to_numeric(rankings_df["rank_in_cohort"], errors="coerce").astype("Int64")
     else:
-        rankings_df['rank_in_cohort'] = pd.array([pd.NA] * len(rankings_df), dtype='Int64')
-    
+        rankings_df["rank_in_cohort"] = pd.array([pd.NA] * len(rankings_df), dtype="Int64")
+
     # National/state/global ranks will be computed in views, but store rank_in_cohort values
     # Set these to None initially - they'll be computed dynamically in views
-    rankings_df['national_rank'] = None
-    rankings_df['state_rank'] = None
-    rankings_df['global_rank'] = None
-    
+    rankings_df["national_rank"] = None
+    rankings_df["state_rank"] = None
+    rankings_df["global_rank"] = None
+
     # Map Rank change tracking (from calculator.py)
-    for col in ['rank_change_7d', 'rank_change_30d', 'rank_change_state_7d', 'rank_change_state_30d']:
+    for col in ["rank_change_7d", "rank_change_30d", "rank_change_state_7d", "rank_change_state_30d"]:
         if col not in rankings_df.columns:
             rankings_df[col] = None
         else:
             rankings_df[col] = rankings_df[col].fillna(0).astype(int)
-    
+
     # Map Final power scores
     # Determine primary power score: ML > adj > core
-    if 'powerscore_ml' in rankings_df.columns and rankings_df['powerscore_ml'].notna().any():
-        rankings_df['national_power_score'] = rankings_df['powerscore_ml'].clip(0.0, 1.0)
-    elif 'powerscore_adj' in rankings_df.columns:
-        rankings_df['national_power_score'] = rankings_df['powerscore_adj'].clip(0.0, 1.0)
-    elif 'powerscore_core' in rankings_df.columns:
-        rankings_df['national_power_score'] = rankings_df['powerscore_core'].clip(0.0, 1.0)
+    if "powerscore_ml" in rankings_df.columns and rankings_df["powerscore_ml"].notna().any():
+        rankings_df["national_power_score"] = rankings_df["powerscore_ml"].clip(0.0, 1.0)
+    elif "powerscore_adj" in rankings_df.columns:
+        rankings_df["national_power_score"] = rankings_df["powerscore_adj"].clip(0.0, 1.0)
+    elif "powerscore_core" in rankings_df.columns:
+        rankings_df["national_power_score"] = rankings_df["powerscore_core"].clip(0.0, 1.0)
     else:
-        rankings_df['national_power_score'] = 0.0
-    
+        rankings_df["national_power_score"] = 0.0
+
     # Global power score (may not be computed yet)
-    if 'global_power_score' not in rankings_df.columns:
-        rankings_df['global_power_score'] = None
-    
-    # Anchor values for age-based power score scaling
-    AGE_ANCHORS = {
-        10: 0.400, 11: 0.475, 12: 0.550, 13: 0.625,
-        14: 0.700, 15: 0.775, 16: 0.850, 17: 0.925,
-        18: 1.000, 19: 1.000,
-    }
+    if "global_power_score" not in rankings_df.columns:
+        rankings_df["global_power_score"] = None
 
     # =================================================================
     # ALWAYS apply anchor scaling to power_score_final
@@ -910,31 +908,23 @@ def v53e_to_rankings_full_format(
     # scaling here guarantees correctness regardless of upstream issues.
     # =================================================================
 
-    # Determine SOS-conditioned ML scaling thresholds (same as calculator.py)
-    SOS_ML_THRESHOLD_LOW = 0.45
-    SOS_ML_THRESHOLD_HIGH = 0.60
-
     def calculate_anchor_scaled_power(row):
         """Calculate anchor-scaled power_score_final with SOS-conditioned ML."""
         # Step 1: powerscore_adj is ALWAYS the baseline
-        if pd.notna(row.get('powerscore_adj')):
-            ps_adj = float(row['powerscore_adj'])
-        elif pd.notna(row.get('powerscore_core')):
-            ps_adj = float(row['powerscore_core'])
+        if pd.notna(row.get("powerscore_adj")):
+            ps_adj = float(row["powerscore_adj"])
+        elif pd.notna(row.get("powerscore_core")):
+            ps_adj = float(row["powerscore_core"])
         else:
             ps_adj = 0.5
         ps_adj = max(0.0, min(1.0, ps_adj))
 
-        # Step 2: Apply SOS-conditioned ML adjustment (same logic as calculator.py)
-        has_ml = pd.notna(row.get('powerscore_ml'))
-        has_sos = pd.notna(row.get('sos_norm'))
+        # Step 2: Apply SOS-conditioned ML adjustment
+        has_ml = pd.notna(row.get("powerscore_ml"))
+        has_sos = pd.notna(row.get("sos_norm"))
 
         if has_ml and has_sos:
-            ps_ml = max(0.0, min(1.0, float(row['powerscore_ml'])))
-            sos_norm = float(row['sos_norm'])
-            ml_scale = max(0.0, min(1.0, (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)))
-            ml_delta = ps_ml - ps_adj
-            base = max(0.0, min(1.0, ps_adj + ml_delta * ml_scale))
+            base = sos_ml_blend(ps_adj, float(row["powerscore_ml"]), float(row["sos_norm"]))
         elif has_ml:
             # ML available but no SOS — use powerscore_adj as baseline
             base = ps_adj
@@ -942,67 +932,116 @@ def v53e_to_rankings_full_format(
             base = ps_adj
 
         # Step 3: Get anchor for this age
-        age_num = row.get('age_num', 0)
+        age_num = row.get("age_num", 0)
         if pd.isna(age_num):
             age_num = 0
         age_num = int(age_num)
-        anchor = AGE_ANCHORS.get(age_num, 0.70)  # Default to median anchor
+        anchor = AGE_TO_ANCHOR.get(age_num, 0.70)  # Default to median anchor
 
         # Step 4: Apply anchor scaling and clip to [0, anchor]
         return min(base * anchor, anchor)
 
     # Log what we're doing
-    incoming_psf = rankings_df.get('power_score_final')
+    incoming_psf = rankings_df.get("power_score_final")
     if incoming_psf is not None and incoming_psf.notna().any():
-        logger.info(f"🔄 Re-applying anchor scaling to power_score_final (defensive) - {incoming_psf.notna().sum()} incoming values")
+        logger.info(
+            f"🔄 Re-applying anchor scaling to power_score_final (defensive) - {incoming_psf.notna().sum()} incoming values"
+        )
         # Diagnostic: check if incoming values look already-scaled or not
-        if 'age_num' in rankings_df.columns:
-            for age_val in sorted(rankings_df['age_num'].unique()):
-                if age_val in AGE_ANCHORS:
-                    mask = rankings_df['age_num'] == age_val
-                    max_psf = rankings_df.loc[mask, 'power_score_final'].max()
-                    anchor = AGE_ANCHORS[age_val]
+        if "age_num" in rankings_df.columns:
+            for age_val in sorted(rankings_df["age_num"].unique()):
+                if age_val in AGE_TO_ANCHOR:
+                    mask = rankings_df["age_num"] == age_val
+                    max_psf = rankings_df.loc[mask, "power_score_final"].max()
+                    anchor = AGE_TO_ANCHOR[age_val]
                     status = "✅ scaled" if max_psf <= anchor + 0.01 else "⚠️  UNSCALED"
-                    logger.info(f"   Age {age_val}: max incoming power_score_final={max_psf:.4f}, anchor={anchor:.3f} → {status}")
+                    logger.info(
+                        f"   Age {age_val}: max incoming power_score_final={max_psf:.4f}, anchor={anchor:.3f} → {status}"
+                    )
     else:
         logger.info("🔄 Applying anchor scaling to power_score_final (no incoming values)")
 
-    rankings_df['power_score_final'] = rankings_df.apply(calculate_anchor_scaled_power, axis=1)
+    rankings_df["power_score_final"] = rankings_df.apply(calculate_anchor_scaled_power, axis=1)
 
     # Diagnostic: log the result
-    if 'age_num' in rankings_df.columns:
+    if "age_num" in rankings_df.columns:
         logger.info("📊 Anchor scaling results (power_score_final):")
-        for age_val in sorted(rankings_df['age_num'].unique()):
-            if age_val in AGE_ANCHORS:
-                mask = rankings_df['age_num'] == age_val
-                max_psf = rankings_df.loc[mask, 'power_score_final'].max()
-                max_nps = rankings_df.loc[mask, 'national_power_score'].max() if 'national_power_score' in rankings_df.columns else None
-                anchor = AGE_ANCHORS[age_val]
+        for age_val in sorted(rankings_df["age_num"].unique()):
+            if age_val in AGE_TO_ANCHOR:
+                mask = rankings_df["age_num"] == age_val
+                max_psf = rankings_df.loc[mask, "power_score_final"].max()
+                max_nps = (
+                    rankings_df.loc[mask, "national_power_score"].max()
+                    if "national_power_score" in rankings_df.columns
+                    else None
+                )
+                anchor = AGE_TO_ANCHOR[age_val]
                 nps_str = f", max national_power_score={max_nps:.4f}" if max_nps is not None else ""
                 logger.info(f"   Age {age_val}: max power_score_final={max_psf:.4f} (anchor={anchor:.3f}){nps_str}")
-    
+
     # Rename team_id to match database column name
-    rankings_df = rankings_df.rename(columns={'team_id': 'team_id'})
+    rankings_df = rankings_df.rename(columns={"team_id": "team_id"})
     # Ensure team_id column exists (it should already be there)
-    
+
     # Select only columns that exist in rankings_full table
     # This ensures we don't include extra columns that might cause issues
     expected_columns = [
-        'team_id', 'age_group', 'gender', 'state_code',
-        'status', 'last_game', 'last_calculated',
-        'games_played', 'games_last_180_days', 'wins', 'losses', 'draws', 'goals_for', 'goals_against', 'win_percentage',
-        'off_raw', 'sad_raw', 'off_shrunk', 'sad_shrunk', 'def_shrunk', 'off_norm', 'def_norm',
-        'sos', 'sos_norm', 'sos_raw', 'sos_norm_national', 'sos_norm_state', 'sos_rank_national', 'sos_rank_state',
-        'sample_flag', 'strength_of_schedule',
-        'power_presos', 'anchor', 'abs_strength', 'powerscore_core', 'provisional_mult', 'powerscore_adj',
-        'perf_raw', 'perf_centered',
-        'ml_overperf', 'ml_norm', 'powerscore_ml', 'rank_in_cohort_ml',
-        'rank_in_cohort', 'national_rank', 'state_rank', 'global_rank',
-        'rank_change_7d', 'rank_change_30d',
-        'rank_change_state_7d', 'rank_change_state_30d',  # State rank changes
-        'national_power_score', 'global_power_score', 'power_score_final'
+        "team_id",
+        "age_group",
+        "gender",
+        "state_code",
+        "status",
+        "last_game",
+        "last_calculated",
+        "games_played",
+        "games_last_180_days",
+        "wins",
+        "losses",
+        "draws",
+        "goals_for",
+        "goals_against",
+        "win_percentage",
+        "off_raw",
+        "sad_raw",
+        "off_shrunk",
+        "sad_shrunk",
+        "def_shrunk",
+        "off_norm",
+        "def_norm",
+        "sos",
+        "sos_norm",
+        "sos_raw",
+        "sos_norm_national",
+        "sos_norm_state",
+        "sos_rank_national",
+        "sos_rank_state",
+        "sample_flag",
+        "strength_of_schedule",
+        "power_presos",
+        "anchor",
+        "abs_strength",
+        "powerscore_core",
+        "provisional_mult",
+        "powerscore_adj",
+        "perf_raw",
+        "perf_centered",
+        "ml_overperf",
+        "ml_norm",
+        "powerscore_ml",
+        "rank_in_cohort_ml",
+        "rank_in_cohort",
+        "national_rank",
+        "state_rank",
+        "global_rank",
+        "rank_change_7d",
+        "rank_change_30d",
+        "rank_change_state_7d",
+        "rank_change_state_30d",  # State rank changes
+        "national_power_score",
+        "global_power_score",
+        "power_score_final",
     ]
-    
+
     # Create result DataFrame with all expected columns
     result_df = pd.DataFrame(index=rankings_df.index)
     for col in expected_columns:
@@ -1010,9 +1049,10 @@ def v53e_to_rankings_full_format(
             result_df[col] = rankings_df[col]
         else:
             result_df[col] = None
-    
-    logger.info(f"🧾 Prepared {len(result_df):,} records for rankings_full table upload.")
-    logger.info(f"   Fields populated: {sum(result_df[col].notna().any() for col in result_df.columns)}/{len(result_df.columns)}")
-    
-    return result_df
 
+    logger.info(f"🧾 Prepared {len(result_df):,} records for rankings_full table upload.")
+    logger.info(
+        f"   Fields populated: {sum(result_df[col].notna().any() for col in result_df.columns)}/{len(result_df.columns)}"
+    )
+
+    return result_df

--- a/src/rankings/layer13_predictive_adjustment.py
+++ b/src/rankings/layer13_predictive_adjustment.py
@@ -1,4 +1,5 @@
 """Layer 13: ML Predictive Adjustment for Rankings"""
+
 from __future__ import annotations
 
 import logging
@@ -13,9 +14,11 @@ logger = logging.getLogger(__name__)
 # Prefer XGBoost; fall back to RandomForest
 try:
     from xgboost import XGBRegressor  # type: ignore
+
     _HAS_XGB = True
 except Exception:
     from sklearn.ensemble import RandomForestRegressor  # type: ignore
+
     _HAS_XGB = False
 
 # Import ML_CONFIG if available (may not exist in older configs)
@@ -31,25 +34,25 @@ except ImportError:
 @dataclass
 class Layer13Config:
     enabled: bool = True
-    
+
     # data window and cohorting
     lookback_days: int = 365
     cohort_key_cols: Tuple[str, str] = ("age", "gender")
-    
+
     # residual aggregation
-    recency_decay_lambda: float = 0.06     # exp(-lambda * (recency-1)); short-term form focus
+    recency_decay_lambda: float = 0.06  # exp(-lambda * (recency-1)); short-term form focus
     min_team_games_for_residual: int = 6
-    residual_clip_goals: float = 3.5       # guardrail on residual outliers
-    min_training_rows: int = 30            # Minimum rows to enable ML (prevents leakage)
-    
+    residual_clip_goals: float = 3.5  # guardrail on residual outliers
+    min_training_rows: int = 30  # Minimum rows to enable ML (prevents leakage)
+
     # blend into PowerScore
-    alpha: float = 0.08                    # Tuned via weight simulator: 0.08 optimal (quality 14→19/23)
-    norm_mode: str = "percentile"          # or "zscore"
-    
+    alpha: float = 0.08  # Tuned via weight simulator: 0.08 optimal (quality 14→19/23)
+    norm_mode: str = "percentile"  # or "zscore"
+
     # supabase
-    table_name: str = "games"              # Supabase games table
-    provider_filter: Optional[str] = None   # e.g., "gotsport"
-    
+    table_name: str = "games"  # Supabase games table
+    provider_filter: Optional[str] = None  # e.g., "gotsport"
+
     # core column names (Supabase format)
     date_col: str = "game_date"
     team_id_col: str = "team_id_master"
@@ -60,21 +63,23 @@ class Layer13Config:
     gender_col: str = "gender"
     opp_age_col: str = "opp_age"
     opp_gender_col: str = "opp_gender"
-    
+
     # model params
     xgb_params: Optional[Dict] = None
     rf_params: Optional[Dict] = None
-    
+
     def __post_init__(self):
         # Load from ML_CONFIG if available
         if ML_CONFIG:
-            self.enabled = ML_CONFIG.get('enabled', self.enabled)
-            self.alpha = ML_CONFIG.get('alpha', self.alpha)
-            self.recency_decay_lambda = ML_CONFIG.get('recency_decay_lambda', self.recency_decay_lambda)
-            self.min_team_games_for_residual = ML_CONFIG.get('min_team_games_for_residual', self.min_team_games_for_residual)
-            self.residual_clip_goals = ML_CONFIG.get('residual_clip_goals', self.residual_clip_goals)
-            self.norm_mode = ML_CONFIG.get('norm_mode', self.norm_mode)
-        
+            self.enabled = ML_CONFIG.get("enabled", self.enabled)
+            self.alpha = ML_CONFIG.get("alpha", self.alpha)
+            self.recency_decay_lambda = ML_CONFIG.get("recency_decay_lambda", self.recency_decay_lambda)
+            self.min_team_games_for_residual = ML_CONFIG.get(
+                "min_team_games_for_residual", self.min_team_games_for_residual
+            )
+            self.residual_clip_goals = ML_CONFIG.get("residual_clip_goals", self.residual_clip_goals)
+            self.norm_mode = ML_CONFIG.get("norm_mode", self.norm_mode)
+
         if self.xgb_params is None:
             self.xgb_params = dict(
                 n_estimators=220,
@@ -88,7 +93,7 @@ class Layer13Config:
                 tree_method="hist",
                 random_state=42,
             )
-        
+
         if self.rf_params is None:
             self.rf_params = dict(
                 n_estimators=240,
@@ -103,10 +108,7 @@ class Layer13Config:
 # Ranking helper with SOS tiebreaker
 # ----------------------------
 def _rank_with_sos_tiebreaker(
-    df: pd.DataFrame,
-    cohort_cols: List[str],
-    score_col: str,
-    sos_col: str = "sos"
+    df: pd.DataFrame, cohort_cols: List[str], score_col: str, sos_col: str = "sos"
 ) -> pd.Series:
     """
     Calculate ranks with SOS as tiebreaker for teams with same score.
@@ -125,9 +127,7 @@ def _rank_with_sos_tiebreaker(
 
     # If SOS column doesn't exist, fall back to original ranking
     if sos_col not in df.columns:
-        return df.groupby(list(cohort_cols))[score_col].rank(
-            ascending=False, method="min"
-        ).astype(int)
+        return df.groupby(list(cohort_cols))[score_col].rank(ascending=False, method="min").astype(int)
 
     # Sort by cohort, then score DESC, then SOS DESC (tiebreaker)
     sort_cols = list(cohort_cols) + [score_col, sos_col]
@@ -168,9 +168,7 @@ def _rank_active_only(
 
     if active_mask.any():
         active_df = df.loc[active_mask]
-        active_ranks = _rank_with_sos_tiebreaker(
-            active_df, cohort_cols, score_col, sos_col
-        )
+        active_ranks = _rank_with_sos_tiebreaker(active_df, cohort_cols, score_col, sos_col)
         result.loc[active_mask] = active_ranks.astype("Int64")
 
     return result
@@ -199,50 +197,67 @@ def _extract_game_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.DataF
 
     logger.debug(f"_extract_game_residuals: {len(feats)} rows, columns: {list(feats.columns)}")
 
-    if feats.empty or 'residual' not in feats.columns:
+    if feats.empty or "residual" not in feats.columns:
         logger.warning("_extract_game_residuals: feats empty or missing 'residual' column")
-        return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
+        return pd.DataFrame(columns=["game_id", "ml_overperformance"])
 
     # Check if v53e format has the required fields (id, team_id, home_team_master_id)
-    required_cols = {'id', 'team_id', 'home_team_master_id', 'residual'}
+    required_cols = {"id", "team_id", "home_team_master_id", "residual"}
     if not required_cols.issubset(feats.columns):
         missing = required_cols - set(feats.columns)
         logger.warning(f"_extract_game_residuals: missing required columns: {missing}")
-        return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
+        return pd.DataFrame(columns=["game_id", "ml_overperformance"])
 
     # Filter to home team perspective only (where team_id == home_team_master_id)
     # Convert to string and normalize for comparison to handle UUID/string mismatches
-    feats['team_id_str'] = feats['team_id'].astype(str).str.strip().str.lower()
-    feats['home_team_master_id_str'] = feats['home_team_master_id'].astype(str).str.strip().str.lower()
-    home_perspective = feats[feats['team_id_str'] == feats['home_team_master_id_str']].copy()
+    feats["team_id_str"] = feats["team_id"].astype(str).str.strip().str.lower()
+    feats["home_team_master_id_str"] = feats["home_team_master_id"].astype(str).str.strip().str.lower()
+    home_perspective = feats[feats["team_id_str"] == feats["home_team_master_id_str"]].copy()
     logger.debug(f"_extract_game_residuals: home perspective={len(home_perspective)} rows from {len(feats)} total")
 
     # Warn if home perspective filter eliminates all rows (likely a merge resolution issue)
     if len(home_perspective) == 0 and len(feats) > 0:
-        match_count = (feats['team_id_str'] == feats['home_team_master_id_str']).sum()
+        match_count = (feats["team_id_str"] == feats["home_team_master_id_str"]).sum()
         logger.warning(
             f"_extract_game_residuals: all {len(feats)} rows filtered out (0 home perspective matches). "
             f"This likely means home_team_master_id was not resolved through MergeResolver."
         )
-        logger.debug(f"  Sample team_id: {feats['team_id_str'].head(3).tolist()}, home_master: {feats['home_team_master_id_str'].head(3).tolist()}")
+        logger.debug(
+            f"  Sample team_id: {feats['team_id_str'].head(3).tolist()}, home_master: {feats['home_team_master_id_str'].head(3).tolist()}"
+        )
 
     if home_perspective.empty:
-        return pd.DataFrame(columns=['game_id', 'ml_overperformance'])
+        return pd.DataFrame(columns=["game_id", "ml_overperformance"])
 
     # Extract game_id (UUID) and residual
-    result_df = home_perspective[['id', 'residual']].copy()
-    result_df = result_df.rename(columns={'id': 'game_id', 'residual': 'ml_overperformance'})
+    result_df = home_perspective[["id", "residual"]].copy()
+    result_df = result_df.rename(columns={"id": "game_id", "residual": "ml_overperformance"})
 
     # Ensure game_id is string UUID
-    result_df['game_id'] = result_df['game_id'].astype(str)
-    result_df['ml_overperformance'] = result_df['ml_overperformance'].astype(float)
+    result_df["game_id"] = result_df["game_id"].astype(str)
+    result_df["ml_overperformance"] = result_df["ml_overperformance"].astype(float)
 
     # Remove duplicates (shouldn't happen, but safety check)
-    result_df = result_df.drop_duplicates(subset=['game_id'], keep='first')
+    result_df = result_df.drop_duplicates(subset=["game_id"], keep="first")
 
     logger.info(f"✅ Extracted {len(result_df):,} game residuals from {len(feats):,} feature rows")
 
     return result_df
+
+
+def _passthrough_ml(out, cfg, return_game_residuals, base_power_col=None):
+    """Return *out* unchanged except for zeroed ML columns and a fresh rank."""
+    out["ml_overperf"] = 0.0
+    out["ml_norm"] = 0.0
+    if base_power_col:
+        out["powerscore_ml"] = out[base_power_col]
+    else:
+        out["powerscore_ml"] = out.get("powerscore_adj", out.get("powerscore_core", 0.0))
+    out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
+    out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
+    if return_game_residuals:
+        return out, pd.DataFrame(columns=["game_id", "ml_overperformance"])
+    return out
 
 
 # ----------------------------
@@ -250,10 +265,10 @@ def _extract_game_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.DataF
 # ----------------------------
 async def apply_predictive_adjustment(
     supabase_client,
-    teams_df: pd.DataFrame,                # output["teams"] from compute_rankings()
+    teams_df: pd.DataFrame,  # output["teams"] from compute_rankings()
     games_used_df: Optional[pd.DataFrame] = None,  # optional; if None, fetched from Supabase
     cfg: Optional[Layer13Config] = None,
-    return_game_residuals: bool = False,   # If True, also return per-game residuals
+    return_game_residuals: bool = False,  # If True, also return per-game residuals
 ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     """
     Returns a copy of teams_df with:
@@ -269,16 +284,7 @@ async def apply_predictive_adjustment(
     out = teams_df.copy()
 
     if not cfg.enabled or out.empty:
-        # ensure columns exist for downstream consumers
-        out["ml_overperf"] = 0.0
-        out["ml_norm"] = 0.0
-        out["powerscore_ml"] = out.get("powerscore_adj", out.get("powerscore_core", 0.0))
-        # Clamp PowerScore within [0.0, 1.0] to preserve normalization bounds
-        out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
-        out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
-        if return_game_residuals:
-            return out, pd.DataFrame(columns=['game_id', 'residual'])
-        return out
+        return _passthrough_ml(out, cfg, return_game_residuals)
 
     # 1) Acquire training data
     if games_used_df is None or games_used_df.empty:
@@ -296,15 +302,15 @@ async def apply_predictive_adjustment(
     # v53e format: date, team_id, opp_id, gf, ga, age, gender, opp_age, opp_gender
     # config format: game_date, team_id_master, opp_id_master, etc.
     required_pairs = [
-        ('date', cfg.date_col),
-        ('team_id', cfg.team_id_col),
-        ('opp_id', cfg.opp_id_col),
-        ('gf', cfg.gf_col),
-        ('ga', cfg.ga_col),
-        ('age', cfg.age_col),
-        ('gender', cfg.gender_col),
-        ('opp_age', cfg.opp_age_col),
-        ('opp_gender', cfg.opp_gender_col),
+        ("date", cfg.date_col),
+        ("team_id", cfg.team_id_col),
+        ("opp_id", cfg.opp_id_col),
+        ("gf", cfg.gf_col),
+        ("ga", cfg.ga_col),
+        ("age", cfg.age_col),
+        ("gender", cfg.gender_col),
+        ("opp_age", cfg.opp_age_col),
+        ("opp_gender", cfg.opp_gender_col),
     ]
 
     missing = []
@@ -314,16 +320,7 @@ async def apply_predictive_adjustment(
 
     if missing:
         logger.warning(f"⚠️ Missing required columns: {missing}. Cannot train ML model.")
-        # If we can't train, return pass-through
-        out["ml_overperf"] = 0.0
-        out["ml_norm"] = 0.0
-        out["powerscore_ml"] = out.get("powerscore_adj", out.get("powerscore_core", 0.0))
-        # Clamp PowerScore within [0.0, 1.0] to preserve normalization bounds
-        out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
-        out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
-        if return_game_residuals:
-            return out, pd.DataFrame(columns=['game_id', 'residual'])
-        return out
+        return _passthrough_ml(out, cfg, return_game_residuals)
 
     # 2) Build feature matrix from games + current powers
     base_power_col = "powerscore_adj" if "powerscore_adj" in out.columns else "powerscore_core"
@@ -342,8 +339,8 @@ async def apply_predictive_adjustment(
     if not feats.empty and "team_power" in feats.columns:
         # Count games where team or opp had to use fallback
         teams_in_power_map = set(power_map.keys())
-        team_id_col = 'team_id' if 'team_id' in games_df.columns else cfg.team_id_col
-        opp_id_col = 'opp_id' if 'opp_id' in games_df.columns else cfg.opp_id_col
+        team_id_col = "team_id" if "team_id" in games_df.columns else cfg.team_id_col
+        opp_id_col = "opp_id" if "opp_id" in games_df.columns else cfg.opp_id_col
         missing_team = ~games_df[team_id_col].astype(str).isin(teams_in_power_map)
         missing_opp = ~games_df[opp_id_col].astype(str).isin(teams_in_power_map)
         missing_count = (missing_team | missing_opp).sum()
@@ -354,18 +351,10 @@ async def apply_predictive_adjustment(
                 f"⚠️  {missing_pct:.1f}% of games ({missing_count:,}) involve teams with missing PowerScores. "
                 f"Using cohort mean as fallback. ML accuracy may be degraded."
             )
-    
+
     if feats.empty:
         logger.warning(f"⚠️ feats DataFrame is empty after _build_features. Input games_df had {len(games_df)} rows.")
-        out["ml_overperf"] = 0.0
-        out["ml_norm"] = 0.0
-        out["powerscore_ml"] = out[base_power_col]
-        # Clamp PowerScore within [0.0, 1.0] to preserve normalization bounds
-        out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
-        out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
-        if return_game_residuals:
-            return out, pd.DataFrame(columns=['game_id', 'ml_overperformance'])
-        return out
+        return _passthrough_ml(out, cfg, return_game_residuals, base_power_col=base_power_col)
 
     # 3) Fit model and compute residuals (with ML leakage protection)
     # 30-day time-based split to prevent leakage
@@ -379,43 +368,28 @@ async def apply_predictive_adjustment(
                 f"⚠️  Layer 13 disabled: only {len(train_feats)} training rows "
                 f"(need ≥{cfg.min_training_rows}). Passing through base v53E scores."
             )
-            out["ml_overperf"] = 0.0
-            out["ml_norm"] = 0.0
-            out["powerscore_ml"] = out.get("powerscore_adj", out.get("powerscore_core", 0.0))
-            out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
-            out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
-            if return_game_residuals:
-                return out, pd.DataFrame(columns=['game_id', 'ml_overperformance'])
-            return out
+            return _passthrough_ml(out, cfg, return_game_residuals)
     else:
         # No date column or empty feats - disable ML
         logger.warning("⚠️  Layer 13 disabled: no date column in feats. Passing through base v53E scores.")
-        out["ml_overperf"] = 0.0
-        out["ml_norm"] = 0.0
-        out["powerscore_ml"] = out.get("powerscore_adj", out.get("powerscore_core", 0.0))
-        out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
-        out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
-        if return_game_residuals:
-            return out, pd.DataFrame(columns=['game_id', 'ml_overperformance'])
-        return out
-    
+        return _passthrough_ml(out, cfg, return_game_residuals)
+
     feats = _fit_and_residualize(feats, train_feats, cfg)
-    
+
     # 4) Aggregate residuals by (team, age, gender) with recency decay
     team_resid = _aggregate_team_residuals(feats, cfg)
-    
+
     # 5) Merge & normalize within cohort
     out = out.merge(team_resid, on=["team_id", "age", "gender"], how="left")
-    out["ml_overperf"] = out["ml_overperf"].fillna(0.0).clip(
-        lower=-cfg.residual_clip_goals, upper=cfg.residual_clip_goals
+    out["ml_overperf"] = (
+        out["ml_overperf"].fillna(0.0).clip(lower=-cfg.residual_clip_goals, upper=cfg.residual_clip_goals)
     )
     normalized = _normalize_by_cohort(
-        out, value_col="ml_overperf", out_col="__tmp__", mode=cfg.norm_mode,
-        cohort_cols=list(cfg.cohort_key_cols)
+        out, value_col="ml_overperf", out_col="__tmp__", mode=cfg.norm_mode, cohort_cols=list(cfg.cohort_key_cols)
     )
     # Use .reindex() to align by index, not positional order (groupby may reorder rows)
     out["ml_norm"] = normalized["__tmp__"].reindex(out.index).values - 0.5
-    
+
     # 6) Blend into PowerScore and rerank
     #
     # Formula: powerscore_ml = powerscore_adj + α * ml_norm
@@ -449,23 +423,21 @@ async def _fetch_games_from_supabase(
 ) -> pd.DataFrame:
     """Fetch games from Supabase and convert to v53e format for ML"""
     from src.rankings.data_adapter import fetch_games_for_rankings
-    
+
     # Use data adapter to fetch and convert
     games_df = await fetch_games_for_rankings(
-        supabase_client=supabase_client,
-        lookback_days=lookback_days,
-        provider_filter=provider_filter
+        supabase_client=supabase_client, lookback_days=lookback_days, provider_filter=provider_filter
     )
-    
+
     if games_df.empty:
         return pd.DataFrame()
-    
+
     # v53e format already has: date, team_id, opp_id, gf, ga, age, gender, opp_age, opp_gender
     # ML layer expects these column names, so we're good
     # Just ensure date column matches
-    if date_col != 'date' and 'date' in games_df.columns:
-        games_df = games_df.rename(columns={'date': date_col})
-    
+    if date_col != "date" and "date" in games_df.columns:
+        games_df = games_df.rename(columns={"date": date_col})
+
     return games_df
 
 
@@ -477,7 +449,7 @@ def _build_features(
     power_map: Dict[str, float],
     cfg: Layer13Config,
     cohort_power_means: Optional[Dict[Tuple[str, str], float]] = None,
-    global_power_mean: float = 0.5
+    global_power_mean: float = 0.5,
 ) -> pd.DataFrame:
     """Build feature matrix for ML model
 
@@ -489,19 +461,23 @@ def _build_features(
         global_power_mean: Fallback mean if cohort mean not available
     """
     f = games.copy()
-    
+
     # v53e format uses: team_id, opp_id, gf, ga, age, gender, opp_age, opp_gender, date
     # Map to expected column names (v53e format is already correct)
-    team_id_col = 'team_id' if 'team_id' in f.columns else (cfg.team_id_col if cfg.team_id_col in f.columns else 'team_id_master')
-    opp_id_col = 'opp_id' if 'opp_id' in f.columns else (cfg.opp_id_col if cfg.opp_id_col in f.columns else 'opp_id_master')
-    gf_col = 'gf' if 'gf' in f.columns else cfg.gf_col
-    ga_col = 'ga' if 'ga' in f.columns else cfg.ga_col
-    age_col = 'age' if 'age' in f.columns else cfg.age_col
-    gender_col = 'gender' if 'gender' in f.columns else cfg.gender_col
-    opp_age_col = 'opp_age' if 'opp_age' in f.columns else cfg.opp_age_col
-    opp_gender_col = 'opp_gender' if 'opp_gender' in f.columns else cfg.opp_gender_col
-    date_col = 'date' if 'date' in f.columns else cfg.date_col
-    
+    team_id_col = (
+        "team_id" if "team_id" in f.columns else (cfg.team_id_col if cfg.team_id_col in f.columns else "team_id_master")
+    )
+    opp_id_col = (
+        "opp_id" if "opp_id" in f.columns else (cfg.opp_id_col if cfg.opp_id_col in f.columns else "opp_id_master")
+    )
+    gf_col = "gf" if "gf" in f.columns else cfg.gf_col
+    ga_col = "ga" if "ga" in f.columns else cfg.ga_col
+    age_col = "age" if "age" in f.columns else cfg.age_col
+    gender_col = "gender" if "gender" in f.columns else cfg.gender_col
+    opp_age_col = "opp_age" if "opp_age" in f.columns else cfg.opp_age_col
+    opp_gender_col = "opp_gender" if "opp_gender" in f.columns else cfg.opp_gender_col
+    date_col = "date" if "date" in f.columns else cfg.date_col
+
     f["goal_margin"] = (f[gf_col] - f[ga_col]).astype(float)
 
     # Use cohort mean as fallback for missing PowerScores (not hardcoded 0.5)
@@ -530,31 +506,40 @@ def _build_features(
     f["team_power"] = f.apply(get_team_power, axis=1).astype(float)
     f["opp_power"] = f.apply(get_opp_power, axis=1).astype(float)
     f["power_diff"] = f["team_power"] - f["opp_power"]
-    
+
     # age gap
     def _gap(a, b):
         try:
             return abs(int(float(a)) - int(float(b)))
         except Exception:
             return 0
-    
+
     f["age_gap"] = f.apply(lambda r: _gap(r[age_col], r[opp_age_col]), axis=1)
-    
+
     # basic cross-gender flag
-    f["cross_gender"] = (f[gender_col].astype(str).str.lower()
-                         != f[opp_gender_col].astype(str).str.lower()).astype(int)
-    
+    f["cross_gender"] = (f[gender_col].astype(str).str.lower() != f[opp_gender_col].astype(str).str.lower()).astype(int)
+
     # recency rank per team to allow decay
     f = f.sort_values([team_id_col, date_col], ascending=[True, False])
     f["rank_recency"] = f.groupby(team_id_col)[date_col].rank(ascending=False, method="first")
-    
+
     needed = [
-        date_col, team_id_col, opp_id_col, age_col, gender_col,
-        "goal_margin", "team_power", "opp_power", "power_diff", "age_gap", "cross_gender", "rank_recency"
+        date_col,
+        team_id_col,
+        opp_id_col,
+        age_col,
+        gender_col,
+        "goal_margin",
+        "team_power",
+        "opp_power",
+        "power_diff",
+        "age_gap",
+        "cross_gender",
+        "rank_recency",
     ]
 
     # Include additional columns if present (needed for extracting per-game residuals)
-    for col in ['game_id', 'id', 'home_team_master_id']:
+    for col in ["game_id", "id", "home_team_master_id"]:
         if col in f.columns:
             needed.append(col)
 
@@ -574,18 +559,18 @@ def _fit_and_residualize(feats: pd.DataFrame, train_feats: pd.DataFrame, cfg: La
     # Fit model on training data only (to prevent leakage)
     X_train = train_feats[["team_power", "opp_power", "power_diff", "age_gap", "cross_gender"]].astype(float).values
     y_train = train_feats["goal_margin"].astype(float).values
-    
+
     if _HAS_XGB:
         model = XGBRegressor(**cfg.xgb_params)
         model.fit(X_train, y_train)
     else:
         model = RandomForestRegressor(**cfg.rf_params)
         model.fit(X_train, y_train)
-    
+
     # Compute residuals on full feats DataFrame (for all games)
     X_full = feats[["team_power", "opp_power", "power_diff", "age_gap", "cross_gender"]].astype(float).values
     y_pred = model.predict(X_full)
-    
+
     out = feats.copy()
     out["pred_margin"] = y_pred.astype(float)
     out["residual"] = (out["goal_margin"] - out["pred_margin"]).astype(float)
@@ -602,9 +587,13 @@ def _aggregate_team_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.Dat
     df["recency_w"] = np.exp(-cfg.recency_decay_lambda * (df["rank_recency"].astype(float) - 1.0))
 
     # Get team_id and age/gender columns (v53e format uses team_id, age, gender)
-    team_id_col = 'team_id' if 'team_id' in df.columns else ('team_id_master' if 'team_id_master' in df.columns else cfg.team_id_col)
-    age_col = 'age' if 'age' in df.columns else cfg.age_col
-    gender_col = 'gender' if 'gender' in df.columns else cfg.gender_col
+    team_id_col = (
+        "team_id"
+        if "team_id" in df.columns
+        else ("team_id_master" if "team_id_master" in df.columns else cfg.team_id_col)
+    )
+    age_col = "age" if "age" in df.columns else cfg.age_col
+    gender_col = "gender" if "gender" in df.columns else cfg.gender_col
 
     # Compute weighted average per group (avoiding deprecated .apply pattern)
     def compute_group_wavg(group_df):
@@ -616,28 +605,33 @@ def _aggregate_team_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.Dat
 
     # Use pd.concat + list comprehension (pandas 3.0 compat: groupby().apply() drops group keys)
     parts = [
-        pd.DataFrame({
-            team_id_col: [grp[team_id_col].iloc[0]],
-            age_col: [grp[age_col].iloc[0]],
-            gender_col: [grp[gender_col].iloc[0]],
-            "ml_overperf": [compute_group_wavg(grp)]
-        })
+        pd.DataFrame(
+            {
+                team_id_col: [grp[team_id_col].iloc[0]],
+                age_col: [grp[age_col].iloc[0]],
+                gender_col: [grp[gender_col].iloc[0]],
+                "ml_overperf": [compute_group_wavg(grp)],
+            }
+        )
         for _, grp in df.groupby([team_id_col, age_col, gender_col])
     ]
     if not parts:
         return pd.DataFrame(columns=["team_id", "age", "gender", "ml_overperf"])
     agg = pd.concat(parts).reset_index(drop=True)
-    
+
     # require a minimum number of games to avoid yo-yo
-    counts = df.groupby([team_id_col, age_col, gender_col], as_index=False)["residual"].count() \
-               .rename(columns={"residual": "game_count"})
+    counts = (
+        df.groupby([team_id_col, age_col, gender_col], as_index=False)["residual"]
+        .count()
+        .rename(columns={"residual": "game_count"})
+    )
     merged = agg.merge(counts, on=[team_id_col, age_col, gender_col], how="left")
     merged.loc[merged["game_count"] < cfg.min_team_games_for_residual, "ml_overperf"] = 0.0
-    
+
     # Ensure team_id column name for merging (v53e uses 'team_id')
-    if team_id_col != 'team_id':
-        merged = merged.rename(columns={team_id_col: 'team_id'})
-    
+    if team_id_col != "team_id":
+        merged = merged.rename(columns={team_id_col: "team_id"})
+
     return merged[["team_id", "age", "gender", "ml_overperf"]]
 
 
@@ -669,4 +663,3 @@ def _normalize_by_cohort(
                 g[out_col] = s.rank(method="average", pct=True).astype(float)
         parts.append(g)
     return pd.concat(parts, axis=0)
-

--- a/src/rankings/layer13_predictive_adjustment.py
+++ b/src/rankings/layer13_predictive_adjustment.py
@@ -480,31 +480,27 @@ def _build_features(
 
     f["goal_margin"] = (f[gf_col] - f[ga_col]).astype(float)
 
-    # Use cohort mean as fallback for missing PowerScores (not hardcoded 0.5)
-    def get_team_power(row):
-        team_id = str(row[team_id_col])
-        if team_id in power_map:
-            return power_map[team_id]
-        # Fallback to cohort mean, then global mean
-        if cohort_power_means:
-            cohort_key = (str(row[age_col]), str(row[gender_col]).lower())
-            if cohort_key in cohort_power_means:
-                return cohort_power_means[cohort_key]
-        return global_power_mean
+    # Vectorized power lookup: direct map → cohort mean fallback → global mean fallback
+    team_cohort = pd.Series(
+        list(zip(f[age_col].astype(str), f[gender_col].astype(str).str.lower())),
+        index=f.index,
+    )
+    opp_cohort = pd.Series(
+        list(zip(f[opp_age_col].astype(str), f[opp_gender_col].astype(str).str.lower())),
+        index=f.index,
+    )
 
-    def get_opp_power(row):
-        opp_id = str(row[opp_id_col])
-        if opp_id in power_map:
-            return power_map[opp_id]
-        # Fallback to opponent's cohort mean, then global mean
-        if cohort_power_means:
-            cohort_key = (str(row[opp_age_col]), str(row[opp_gender_col]).lower())
-            if cohort_key in cohort_power_means:
-                return cohort_power_means[cohort_key]
-        return global_power_mean
+    # Cohort fallback Series (empty when no cohort means available)
+    _no_fill = pd.Series(dtype=float)
+    team_cohort_fill = team_cohort.map(cohort_power_means) if cohort_power_means else _no_fill
+    opp_cohort_fill = opp_cohort.map(cohort_power_means) if cohort_power_means else _no_fill
 
-    f["team_power"] = f.apply(get_team_power, axis=1).astype(float)
-    f["opp_power"] = f.apply(get_opp_power, axis=1).astype(float)
+    f["team_power"] = (
+        f[team_id_col].astype(str).map(power_map).fillna(team_cohort_fill).fillna(global_power_mean).astype(float)
+    )
+    f["opp_power"] = (
+        f[opp_id_col].astype(str).map(power_map).fillna(opp_cohort_fill).fillna(global_power_mean).astype(float)
+    )
     f["power_diff"] = f["team_power"] - f["opp_power"]
 
     # age gap

--- a/src/rankings/shared.py
+++ b/src/rankings/shared.py
@@ -1,0 +1,35 @@
+"""Shared utility functions for ranking calculations."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.rankings.constants import SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
+
+
+def sos_ml_blend(ps_adj: float, ps_ml: float, sos_norm: float) -> float:
+    """Blend ML-adjusted PowerScore with baseline using SOS-conditioned scaling.
+
+    Returns a score in [0, 1] where ML authority scales linearly from 0 to 1
+    as sos_norm moves from SOS_ML_THRESHOLD_LOW to SOS_ML_THRESHOLD_HIGH.
+    """
+    ml_scale = max(0.0, min(1.0, (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)))
+    ml_delta = ps_ml - ps_adj
+    return max(0.0, min(1.0, ps_adj + ml_delta * ml_scale))
+
+
+def normalize_gender(series: pd.Series) -> pd.Series:
+    """Normalize gender labels: boys/girls → male/female."""
+    return (
+        series.astype(str)
+        .str.lower()
+        .str.strip()
+        .replace(
+            {
+                "boys": "male",
+                "boy": "male",
+                "girls": "female",
+                "girl": "female",
+            }
+        )
+    )


### PR DESCRIPTION
The ranking engine had the same age-anchor mapping defined in three files, the SOS-ML scaling formula written out in three places, gender normalization duplicated in two functions, and five near-identical early-return blocks in the ML layer. This PR consolidates all of it and adds a few more improvements on top.

New files:
- `src/rankings/constants.py`: `AGE_TO_ANCHOR` dict, `SOS_ML_THRESHOLD_LOW`/`HIGH`
- `src/rankings/shared.py`: `sos_ml_blend()` (scalar SOS-conditioned ML blending), `normalize_gender()` (boys/girls to male/female)

Changes:
- `v53e.py`, `calculator.py`, `data_adapter.py` now import from the shared modules instead of defining their own copies
- `layer13_predictive_adjustment.py` gets a `_passthrough_ml()` helper that replaces five duplicated early-return blocks. This also fixes an inconsistency where two blocks returned `['game_id', 'residual']` while the caller expected `['game_id', 'ml_overperformance']`
- The vectorized SOS-ML path in `calculator.py` stays inline for performance but references the shared constants and has a comment linking to `sos_ml_blend()`
- `config/settings.py` derives `AGE_GROUPS.anchor_score` from `AGE_TO_ANCHOR` instead of hardcoding. Single source of truth.
- `scripts/diagnose_ranking.py` imports shared constants and uses `sos_ml_blend()` instead of duplicating the formula
- `layer13_predictive_adjustment.py` replaces row-by-row `df.apply()` power lookups with vectorized `.map()/.fillna()` chains (5-20x faster on large DataFrames)
- MD5 usage across `calculator.py` and all four matcher files now has inline comments clarifying non-security intent