### PR TITLE
Isolate age anchor to final scoring only

### DIFF
--- a/src/etl/v53e.py
+++ b/src/etl/v53e.py
@@ -64,10 +64,10 @@ class V53EConfig:
     # SOS trimming: reduce filler-game dilution by downweighting weakest opponents
     # Teams with many mandatory league games against weak opponents get penalized under
     # a pure weighted mean. Trimming reduces that dilution while protecting small samples.
-    SOS_TRIM_BOTTOM_PCT: float = 0.25   # Fraction of weakest opponents to trim (0.0 = disabled)
-    SOS_TRIM_MIN_GAMES: int = 8         # Don't trim teams with fewer games than this
-    SOS_TRIM_MAX_GAMES: int = 6         # Cap: never trim more than this many games per team
-    SOS_TRIM_MODE: str = "soft"         # "hard" = zero weight, "soft" = reduce weight
+    SOS_TRIM_BOTTOM_PCT: float = 0.25  # Fraction of weakest opponents to trim (0.0 = disabled)
+    SOS_TRIM_MIN_GAMES: int = 8  # Don't trim teams with fewer games than this
+    SOS_TRIM_MAX_GAMES: int = 6  # Cap: never trim more than this many games per team
+    SOS_TRIM_MODE: str = "soft"  # "hard" = zero weight, "soft" = reduce weight
     SOS_TRIM_SOFT_WEIGHT: float = 0.15  # In soft mode, trimmed games keep this fraction of original weight
 
     SOS_ITERATIONS: int = 1  # Single-pass SOS (no transitive propagation)
@@ -1030,7 +1030,8 @@ def compute_rankings(
 
     logger.info("✅ Static anchor mapping applied (U10=0.40 → U18=1.00)")
 
-    team["abs_strength"] = (team["power_presos"] * team["anchor"]).clip(cfg.UNRANKED_SOS_BASE, 1.0)
+    # True competitive strength (no anchor scaling — anchor is applied only at final scoring)
+    team["abs_strength"] = team["power_presos"].clip(cfg.UNRANKED_SOS_BASE, 1.0)
 
     strength_map = dict(zip(team["team_id"], team["abs_strength"]))
     power_map = dict(zip(team["team_id"], team["power_presos"]))
@@ -1095,12 +1096,20 @@ def compute_rankings(
         # Recalculate power_presos with adjusted OFF/DEF (50% each, no SOS to avoid circularity)
         team["power_presos"] = 0.5 * team["off_norm"] + 0.5 * team["def_norm"]
 
-        # Update strength_map and power_map with adjusted power
-        team["abs_strength"] = (team["power_presos"] * team["anchor"]).clip(cfg.UNRANKED_SOS_BASE, 1.0)
+        # Update strength_map and power_map with adjusted power (no anchor scaling)
+        team["abs_strength"] = team["power_presos"].clip(cfg.UNRANKED_SOS_BASE, 1.0)
         strength_map = dict(zip(team["team_id"], team["abs_strength"]))
         power_map = dict(zip(team["team_id"], team["power_presos"]))
 
         logger.info("✅ Opponent-adjusted offense/defense applied successfully")
+
+        # Diagnostic: opponent-adjusted OFF/DEF distribution (for anchor-isolation validation)
+        logger.info("📊 Opponent-adjusted OFF/DEF distribution:")
+        for (age, gender), grp in team.groupby(["age", "gender"]):
+            logger.info(
+                f"  {age} {gender}: off_raw mean={grp['off_raw'].mean():.4f} std={grp['off_raw'].std():.4f}, "
+                f"sad_raw mean={grp['sad_raw'].mean():.4f} std={grp['sad_raw'].std():.4f}"
+            )
 
     # -------------------------
     # Layer 5: Adaptive K per game (by abs strength gap)
@@ -1125,6 +1134,22 @@ def compute_rankings(
     g_365["w_game"] = g_365["w_base"]
     g_365["k_adapt"] = g_365.apply(adaptive_k, axis=1)
     g_365["w_sos"] = g_365["w_game"] * g_365["k_adapt"]
+
+    # Diagnostic: adaptive_k distribution per cohort (for anchor-isolation validation)
+    if "age" in team.columns and "gender" in team.columns:
+        _team_id_to_cohort = dict(zip(team["team_id"], zip(team["age"], team["gender"])))
+        _k_by_cohort: dict[tuple, list] = {}
+        for _, row in g_365[["team_id", "k_adapt"]].iterrows():
+            cohort = _team_id_to_cohort.get(row["team_id"])
+            if cohort:
+                _k_by_cohort.setdefault(cohort, []).append(row["k_adapt"])
+        logger.info("📊 adaptive_k distribution (365-day SOS games):")
+        for (age, gender), k_list in sorted(_k_by_cohort.items()):
+            k_arr = np.array(k_list)
+            logger.info(
+                f"  {age} {gender}: mean={k_arr.mean():.4f}, p90={np.percentile(k_arr, 90):.4f}, "
+                f"max={k_arr.max():.4f}, n={len(k_arr)}"
+            )
 
     logger.info(f"📊 SOS 365-day window: {len(g_365)} game-rows (vs {len(g)} in 30-game OFF/DEF window)")
 
@@ -1189,9 +1214,7 @@ def compute_rankings(
         eligible = team_counts >= cfg.SOS_TRIM_MIN_GAMES
 
         # Rank opponents by strength ascending within each team (weakest = rank 1)
-        g_sos["_str_rank"] = g_sos.groupby("team_id")[strength_col].rank(
-            method="first", ascending=True
-        )
+        g_sos["_str_rank"] = g_sos.groupby("team_id")[strength_col].rank(method="first", ascending=True)
 
         # Compute per-team trim count: min(floor(count * pct), max_games)
         n_trim_raw = np.floor(team_counts * cfg.SOS_TRIM_BOTTOM_PCT).astype(int)
@@ -1216,34 +1239,24 @@ def compute_rankings(
     team_off_norm_map = dict(zip(team["team_id"], team["off_norm"]))
     team_def_norm_map = dict(zip(team["team_id"], team["def_norm"]))
     team_gp_map = dict(zip(team["team_id"], team["gp"]))
-    team_anchor_map = dict(zip(team["team_id"], team["anchor"]))  # Need anchor for scale matching
 
-    # Calculate cohort average strength for shrinkage
-    # Using (age, gender) as cohort key
+    # Calculate cohort average strength for shrinkage (true competitive strength, no anchor)
     cohort_avg_strength = {}
     for (age, gender), grp in team.groupby(["age", "gender"]):
-        # Base power uses only OFF and DEF (50% each), scaled by anchor
-        # This matches the scale of global_strength_map (which uses abs_strength = power_presos * anchor)
         grp_base_power = 0.5 * grp["off_norm"] + 0.5 * grp["def_norm"]
-        grp_anchor = grp["anchor"]
-        cohort_avg_strength[(age, gender)] = float((grp_base_power * grp_anchor).mean())
+        cohort_avg_strength[(age, gender)] = float(grp_base_power.mean())
 
     # Map team_id to cohort for quick lookup
     team_cohort_map = dict(zip(team["team_id"], list(zip(team["age"], team["gender"]))))
 
-    # Calculate BASE strength for each team (OFF/DEF only, normalized to avoid drift)
-    # This represents opponent quality independent of their schedule
-    # IMPORTANT: Apply anchor to match scale with global_strength_map (which uses abs_strength)
+    # Calculate BASE strength for each team (OFF/DEF only, true competitive strength)
+    # This represents opponent quality independent of their schedule (no anchor scaling).
     # NOTE: Opponent-strength shrinkage was REMOVED - it injected games-played bias into SOS.
     # Teams playing opponents with more games got artificially higher SOS.
     base_strength_map = {}
     for tid in team["team_id"]:
-        # Base power uses only OFF and DEF (50% each of the non-SOS weight)
         base_power = 0.5 * team_off_norm_map.get(tid, 0.5) + 0.5 * team_def_norm_map.get(tid, 0.5)
-        # Apply anchor to match global_strength_map scale
-        # Raw strength is already anchored and bounded [0, 1]
-        anchor = team_anchor_map.get(tid, 0.7)
-        base_strength_map[tid] = float(np.clip(base_power * anchor, 0.0, 1.0))
+        base_strength_map[tid] = float(np.clip(base_power, 0.0, 1.0))
 
     # Use base strength for initial SOS calculation (Pass 1)
     # This represents how good opponents are at OFF/DEF
@@ -1276,6 +1289,13 @@ def compute_rankings(
         f"🔍 {_pass_tag}Cross-age SOS lookups: global_map_size={len(global_strength_map) if global_strength_map else 0}, "
         f"found={cross_age_found}, missing={cross_age_missing}"
     )
+
+    # Diagnostic: cross-age inflation guardrail — log teams with highest cross-age exposure
+    if cross_age_found > 0:
+        cross_age_mask = ~g_sos["opp_id"].isin(base_strength_map)
+        cross_age_by_team = cross_age_mask.groupby(g_sos["team_id"]).sum()
+        top_exposed = cross_age_by_team.nlargest(10)
+        logger.info(f"📊 {_pass_tag}Top 10 teams by cross-age game count: {dict(top_exposed)}")
 
     # Vectorized weighted mean — avoids groupby.apply returning scalar (deprecated pandas pattern)
     # Step A: Compute original (untrimmed) SOS for diagnostic comparison
@@ -1310,7 +1330,9 @@ def compute_rankings(
         sos_curr["sos"] = (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE + cfg.PAGERANK_ALPHA * sos_curr["sos"]
         # Apply same dampening to sos_orig for apples-to-apples diagnostic comparison
         if "sos_orig" in sos_curr.columns:
-            sos_curr["sos_orig"] = (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE + cfg.PAGERANK_ALPHA * sos_curr["sos_orig"]
+            sos_curr["sos_orig"] = (1 - cfg.PAGERANK_ALPHA) * cfg.PAGERANK_BASELINE + cfg.PAGERANK_ALPHA * sos_curr[
+                "sos_orig"
+            ]
         logger.info(f"📌 PageRank dampening applied: alpha={cfg.PAGERANK_ALPHA}, baseline={cfg.PAGERANK_BASELINE}")
 
     # Log initial SOS (Pass 1: Direct)
@@ -1750,9 +1772,7 @@ def compute_rankings(
         # 2. GP-SOS correlation before/after
         gp_sos_corr_orig = team[["gp", "sos_orig"]].corr().iloc[0, 1]
         gp_sos_corr_trim = team[["gp", "sos"]].corr().iloc[0, 1]
-        logger.info(
-            f"  GP-SOS correlation: orig={gp_sos_corr_orig:.3f} -> trimmed={gp_sos_corr_trim:.3f}"
-        )
+        logger.info(f"  GP-SOS correlation: orig={gp_sos_corr_orig:.3f} -> trimmed={gp_sos_corr_trim:.3f}")
 
         # 3. GP bucket analysis
         gp_buckets = pd.cut(team["gp"], bins=[0, 9, 14, 19, 29, 999], labels=["1-9", "10-14", "15-19", "20-29", "30+"])
@@ -1763,10 +1783,7 @@ def compute_rankings(
 
         # 4. Trim count distribution (how many games trimmed per team)
         if "w_sos_orig" in g_sos.columns:
-            is_trimmed = (
-                (g_sos["w_sos"] < g_sos["w_sos_orig"] - 1e-9)
-                .groupby(g_sos["team_id"]).sum()
-            )
+            is_trimmed = (g_sos["w_sos"] < g_sos["w_sos_orig"] - 1e-9).groupby(g_sos["team_id"]).sum()
             trimmed_nonzero = is_trimmed[is_trimmed > 0]
             if len(trimmed_nonzero) > 0:
                 pcts = trimmed_nonzero.quantile([0.25, 0.50, 0.75, 0.90])
@@ -1780,9 +1797,7 @@ def compute_rankings(
         # 5. Top opponent exposure (avg top-5 and top-10 opp strength)
         if "opp_strength" in g_sos.columns:
             # Rank opponents by strength descending within each team (vectorized, no groupby.apply)
-            _opp_desc_rank = g_sos.groupby("team_id")["opp_strength"].rank(
-                method="first", ascending=False
-            )
+            _opp_desc_rank = g_sos.groupby("team_id")["opp_strength"].rank(method="first", ascending=False)
             top_n_stats = []
             for n in [5, 10]:
                 top_n_mask = _opp_desc_rank <= n
@@ -1791,21 +1806,27 @@ def compute_rankings(
             logger.info(f"  Top opponent exposure: {', '.join(top_n_stats)}")
 
         # 6. Biggest movers (top 10 up, top 10 down)
-        team_shifts = pd.DataFrame({
-            "team_id": team["team_id"],
-            "shift": sos_shift,
-            "sos": team["sos"],
-            "sos_orig": team["sos_orig"],
-            "gp": team["gp"],
-        })
+        team_shifts = pd.DataFrame(
+            {
+                "team_id": team["team_id"],
+                "shift": sos_shift,
+                "sos": team["sos"],
+                "sos_orig": team["sos_orig"],
+                "gp": team["gp"],
+            }
+        )
         top_up = team_shifts.nlargest(10, "shift")
         top_down = team_shifts.nsmallest(10, "shift")
         logger.info("  Top 10 SOS gainers:")
         for _, r in top_up.iterrows():
-            logger.info(f"    {r['team_id'][:12]} | GP:{r['gp']:>2.0f} | {r['sos_orig']:.4f} -> {r['sos']:.4f} ({r['shift']:+.4f})")
+            logger.info(
+                f"    {r['team_id'][:12]} | GP:{r['gp']:>2.0f} | {r['sos_orig']:.4f} -> {r['sos']:.4f} ({r['shift']:+.4f})"
+            )
         logger.info("  Top 10 SOS losers:")
         for _, r in top_down.iterrows():
-            logger.info(f"    {r['team_id'][:12]} | GP:{r['gp']:>2.0f} | {r['sos_orig']:.4f} -> {r['sos']:.4f} ({r['shift']:+.4f})")
+            logger.info(
+                f"    {r['team_id'][:12]} | GP:{r['gp']:>2.0f} | {r['sos_orig']:.4f} -> {r['sos']:.4f} ({r['shift']:+.4f})"
+            )
 
         # 7. sos_norm before/after comparison
         norm_shift = team["sos_norm"] - team["sos_norm_orig"]
@@ -1860,7 +1881,6 @@ def compute_rankings(
         off_norms = team["off_norm"].values
         def_norms = team["def_norm"].values
         perf_centereds = team["perf_centered"].values
-        anchors = team["anchor"].values
         gps = team["gp"].values
 
         # Pre-compute weights for power score formula
@@ -1888,10 +1908,18 @@ def compute_rankings(
             # → even lower SOS. The floor says: "a team's contribution to opponents' SOS
             # cannot drop below their raw OFF/DEF quality (base_strength)."
             # Impact: +0.24 for closed elite leagues (correct fix), +0.03 for bubbles (negligible).
-            full_power_values = (team["powerscore_adj"].values * anchors).clip(0.0, 1.0)
+            # True competitive strength (no anchor scaling — anchor applied only at final scoring)
+            full_power_values = team["powerscore_adj"].values.clip(0.0, 1.0)
             base_strength_values = np.array([base_strength_map.get(tid, cfg.UNRANKED_SOS_BASE) for tid in team_ids])
             floored_power_values = np.maximum(full_power_values, base_strength_values)
             full_power_strength_map = dict(zip(team_ids, floored_power_values))
+
+            # Diagnostic: Power-SOS iteration distribution (for anchor-isolation validation)
+            logger.info(
+                f"  Iteration {power_iter}: full_power mean={full_power_values.mean():.4f}, "
+                f"std={np.std(full_power_values):.4f}, "
+                f"sos_delta={np.abs(team['sos'].values - prev_sos).mean():.6f}"
+            )
 
             # Step 2: Vectorized opponent strength lookup
             def lookup_strength(opp_id):

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -873,9 +873,11 @@ async def compute_all_cohorts(
             # Log age distribution
             logger.info("📊 Applying anchor scaling by age. Age distribution: %s", age_nums.value_counts().to_dict())
 
-            # Initialize power_score_final column if it doesn't exist
+            # Initialize output columns
             if "power_score_final" not in teams_combined.columns:
                 teams_combined["power_score_final"] = None
+            if "power_score_true" not in teams_combined.columns:
+                teams_combined["power_score_true"] = None
 
             # Process each age group separately
             for age, anchor_val in AGE_TO_ANCHOR.items():
@@ -946,7 +948,10 @@ async def compute_all_cohorts(
                     ps_scaled.max(),
                 )
 
-                # Update power_score_final for this age group (index-aligned to avoid misalignment)
+                # Save unanchored competitive score (single source of truth)
+                teams_combined.loc[ps_scaled.index, "power_score_true"] = base.values
+
+                # Apply anchor (sole application point)
                 teams_combined.loc[ps_scaled.index, "power_score_final"] = ps_scaled
 
             # Check for teams that didn't get anchor scaling (ages outside 10-19 range)
@@ -979,6 +984,7 @@ async def compute_all_cohorts(
                             base_score = ps_adj
 
                         base_score = max(0.0, min(1.0, base_score))
+                        teams_combined.loc[idx, "power_score_true"] = base_score
                         teams_combined.loc[idx, "power_score_final"] = min(
                             base_score * fallback_anchor, fallback_anchor
                         )
@@ -987,6 +993,75 @@ async def compute_all_cohorts(
                 still_null = teams_combined["power_score_final"].isna().sum()
                 if still_null > 0:
                     logger.error(f"❌ {still_null} teams still have NULL power_score_final after anchor scaling!")
+
+            # === MANDATORY: power_score_true bounds check ===
+            if "power_score_true" in teams_combined.columns:
+                pst = teams_combined["power_score_true"].dropna()
+                if len(pst) > 0:
+                    if pst.min() < 0 or pst.max() > 1.0:
+                        violations = ((pst < 0) | (pst > 1.0)).sum()
+                        logger.error(
+                            f"❌ power_score_true out of [0,1] bounds: {violations} violations, "
+                            f"min={pst.min():.6f}, max={pst.max():.6f}"
+                        )
+                    else:
+                        logger.info(f"✅ power_score_true bounds: [{pst.min():.4f}, {pst.max():.4f}]")
+
+            # === MANDATORY: Anchor integrity validation ===
+            if "power_score_true" in teams_combined.columns:
+                logger.info("🔒 Anchor integrity validation:")
+                for age_val in sorted(AGE_TO_ANCHOR.keys()):
+                    mask = teams_combined["age_num"] == age_val
+                    if not mask.any():
+                        continue
+                    subset = teams_combined.loc[mask]
+                    anchor_val = AGE_TO_ANCHOR[age_val]
+                    expected = (subset["power_score_true"] * anchor_val).clip(0.0, anchor_val)
+                    actual = subset["power_score_final"]
+                    max_diff = (expected - actual).abs().max()
+                    if max_diff >= 0.001:
+                        raise ValueError(
+                            f"❌ ANCHOR INTEGRITY FAILURE: Age {age_val}, max diff={max_diff:.6f}. "
+                            f"power_score_final must equal power_score_true * anchor."
+                        )
+                    logger.info(f"  Age {age_val}: anchor={anchor_val}, max_diff={max_diff:.6f} ✅")
+
+            # === MANDATORY: Monotonicity guarantee ===
+            if "power_score_true" in teams_combined.columns and "gender" in teams_combined.columns:
+                logger.info("🔒 Monotonicity validation (anchor must not change intra-cohort order):")
+                for (age_val, gender), grp in teams_combined.groupby(["age_num", "gender"]):
+                    if len(grp) < 2:
+                        continue
+                    pst_vals = grp["power_score_true"].dropna()
+                    psf_vals = grp["power_score_final"].dropna()
+                    if len(pst_vals) < 2 or len(psf_vals) < 2:
+                        continue
+                    rank_true = pst_vals.rank(ascending=False, method="min")
+                    rank_final = psf_vals.loc[rank_true.index].rank(ascending=False, method="min")
+                    mismatches = (rank_true != rank_final).sum()
+                    if mismatches > 0:
+                        raise ValueError(
+                            f"❌ MONOTONICITY FAILURE: {age_val} {gender} has {mismatches} rank order "
+                            f"changes between power_score_true and power_score_final"
+                        )
+                    logger.info(f"  {age_val} {gender}: {len(grp)} teams, rank order preserved ✅")
+
+            # === Anchor integrity sample (top 3 per age group) ===
+            if "power_score_true" in teams_combined.columns:
+                logger.info("📊 Anchor integrity sample (top 3 per age):")
+                for age_val in [10, 12, 14, 16, 19]:
+                    mask = (teams_combined["age_num"] == age_val) & teams_combined["power_score_true"].notna()
+                    if not mask.any():
+                        continue
+                    sample = teams_combined.loc[mask].nlargest(3, "power_score_true")
+                    anchor_val = AGE_TO_ANCHOR.get(age_val, 0.70)
+                    for _, row in sample.iterrows():
+                        logger.info(
+                            f"  Age {age_val}: power_score_true={row['power_score_true']:.4f}, "
+                            f"power_score_final={row['power_score_final']:.4f}, "
+                            f"anchor={anchor_val:.3f}, "
+                            f"expected_final={row['power_score_true'] * anchor_val:.4f}"
+                        )
 
     # 🔒 Ensure PowerScore is fully clipped to [0, 1] after all operations
     if not teams_combined.empty:

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional
 import pandas as pd
 
 from src.rankings.constants import AGE_TO_ANCHOR
-from src.rankings.shared import normalize_gender, sos_ml_blend
+from src.rankings.shared import normalize_gender
 
 if TYPE_CHECKING:
     from src.profiling.db_profiler import QueryProfiler
@@ -881,14 +881,14 @@ def v53e_to_rankings_full_format(
         else:
             rankings_df[col] = rankings_df[col].fillna(0).astype(int)
 
-    # Map Final power scores
-    # Determine primary power score: ML > adj > core
-    if "powerscore_ml" in rankings_df.columns and rankings_df["powerscore_ml"].notna().any():
+    # DEPRECATED: national_power_score is now derived from power_score_true (single source of truth)
+    if "power_score_true" in rankings_df.columns and rankings_df["power_score_true"].notna().any():
+        rankings_df["national_power_score"] = rankings_df["power_score_true"].clip(0.0, 1.0)
+    elif "powerscore_ml" in rankings_df.columns and rankings_df["powerscore_ml"].notna().any():
+        # Fallback for legacy compatibility
         rankings_df["national_power_score"] = rankings_df["powerscore_ml"].clip(0.0, 1.0)
     elif "powerscore_adj" in rankings_df.columns:
         rankings_df["national_power_score"] = rankings_df["powerscore_adj"].clip(0.0, 1.0)
-    elif "powerscore_core" in rankings_df.columns:
-        rankings_df["national_power_score"] = rankings_df["powerscore_core"].clip(0.0, 1.0)
     else:
         rankings_df["national_power_score"] = 0.0
 
@@ -897,87 +897,30 @@ def v53e_to_rankings_full_format(
         rankings_df["global_power_score"] = None
 
     # =================================================================
-    # ALWAYS apply anchor scaling to power_score_final
+    # ANCHOR PASS-THROUGH ASSERTION
     # =================================================================
-    # Even if calculator.py already applied anchor scaling, we re-apply here
-    # as a defensive measure. The anchor scaling in calculator.py was found to
-    # compute correct values in memory but those values were not persisting to
-    # the DB (power_score_final == national_power_score for all rows).
-    #
-    # This function is the last stop before DB write, so applying anchor
-    # scaling here guarantees correctness regardless of upstream issues.
+    # power_score_final is computed in calculator.py (sole application point).
+    # The adapter MUST NOT recompute it. Validate it arrived correctly.
     # =================================================================
-
-    def calculate_anchor_scaled_power(row):
-        """Calculate anchor-scaled power_score_final with SOS-conditioned ML."""
-        # Step 1: powerscore_adj is ALWAYS the baseline
-        if pd.notna(row.get("powerscore_adj")):
-            ps_adj = float(row["powerscore_adj"])
-        elif pd.notna(row.get("powerscore_core")):
-            ps_adj = float(row["powerscore_core"])
-        else:
-            ps_adj = 0.5
-        ps_adj = max(0.0, min(1.0, ps_adj))
-
-        # Step 2: Apply SOS-conditioned ML adjustment
-        has_ml = pd.notna(row.get("powerscore_ml"))
-        has_sos = pd.notna(row.get("sos_norm"))
-
-        if has_ml and has_sos:
-            base = sos_ml_blend(ps_adj, float(row["powerscore_ml"]), float(row["sos_norm"]))
-        elif has_ml:
-            # ML available but no SOS — use powerscore_adj as baseline
-            base = ps_adj
-        else:
-            base = ps_adj
-
-        # Step 3: Get anchor for this age
-        age_num = row.get("age_num", 0)
-        if pd.isna(age_num):
-            age_num = 0
-        age_num = int(age_num)
-        anchor = AGE_TO_ANCHOR.get(age_num, 0.70)  # Default to median anchor
-
-        # Step 4: Apply anchor scaling and clip to [0, anchor]
-        return min(base * anchor, anchor)
-
-    # Log what we're doing
-    incoming_psf = rankings_df.get("power_score_final")
-    if incoming_psf is not None and incoming_psf.notna().any():
-        logger.info(
-            f"🔄 Re-applying anchor scaling to power_score_final (defensive) - {incoming_psf.notna().sum()} incoming values"
-        )
-        # Diagnostic: check if incoming values look already-scaled or not
+    if "power_score_final" in rankings_df.columns and rankings_df["power_score_final"].notna().any():
+        logger.info("🔒 Anchor pass-through validation (power_score_final from calculator.py):")
         if "age_num" in rankings_df.columns:
-            for age_val in sorted(rankings_df["age_num"].unique()):
-                if age_val in AGE_TO_ANCHOR:
-                    mask = rankings_df["age_num"] == age_val
-                    max_psf = rankings_df.loc[mask, "power_score_final"].max()
-                    anchor = AGE_TO_ANCHOR[age_val]
-                    status = "✅ scaled" if max_psf <= anchor + 0.01 else "⚠️  UNSCALED"
-                    logger.info(
-                        f"   Age {age_val}: max incoming power_score_final={max_psf:.4f}, anchor={anchor:.3f} → {status}"
-                    )
-    else:
-        logger.info("🔄 Applying anchor scaling to power_score_final (no incoming values)")
-
-    rankings_df["power_score_final"] = rankings_df.apply(calculate_anchor_scaled_power, axis=1)
-
-    # Diagnostic: log the result
-    if "age_num" in rankings_df.columns:
-        logger.info("📊 Anchor scaling results (power_score_final):")
-        for age_val in sorted(rankings_df["age_num"].unique()):
-            if age_val in AGE_TO_ANCHOR:
-                mask = rankings_df["age_num"] == age_val
+            for age_val in sorted(rankings_df["age_num"].dropna().unique()):
+                age_int = int(age_val)
+                if age_int not in AGE_TO_ANCHOR:
+                    continue
+                mask = rankings_df["age_num"] == age_int
+                anchor_val = AGE_TO_ANCHOR[age_int]
                 max_psf = rankings_df.loc[mask, "power_score_final"].max()
-                max_nps = (
-                    rankings_df.loc[mask, "national_power_score"].max()
-                    if "national_power_score" in rankings_df.columns
-                    else None
-                )
-                anchor = AGE_TO_ANCHOR[age_val]
-                nps_str = f", max national_power_score={max_nps:.4f}" if max_nps is not None else ""
-                logger.info(f"   Age {age_val}: max power_score_final={max_psf:.4f} (anchor={anchor:.3f}){nps_str}")
+                if max_psf > anchor_val + 0.01:
+                    raise ValueError(
+                        f"❌ ANCHOR INTEGRITY FAILURE: Age {age_int} has power_score_final={max_psf:.4f} "
+                        f"exceeding anchor={anchor_val:.3f}. Calculator.py must be the sole anchor applier."
+                    )
+                logger.info(f"   Age {age_int}: max power_score_final={max_psf:.4f}, anchor={anchor_val:.3f} ✅")
+        logger.info("✅ Anchor pass-through validation passed")
+    else:
+        logger.warning("⚠️ power_score_final not available from calculator — this should not happen")
 
     # Rename team_id to match database column name
     rankings_df = rankings_df.rename(columns={"team_id": "team_id"})
@@ -1039,6 +982,7 @@ def v53e_to_rankings_full_format(
         "rank_change_state_30d",  # State rank changes
         "national_power_score",
         "global_power_score",
+        "power_score_true",
         "power_score_final",
     ]
 


### PR DESCRIPTION
## Summary

- Remove age anchor from all core ranking math (`abs_strength`, `base_strength_map`, `full_power_strength_map`, Power-SOS iterations) so the engine operates on true 0-1 competitive strength
- Consolidate anchor application to a single point in `calculator.py`. Remove the redundant defensive recomputation in `data_adapter.py`, replace with a hard pass-through assertion
- Add `power_score_true` as the authoritative unanchored competitive score. Derive `national_power_score` from it (eliminating dual computation path)
- Add mandatory validation: anchor integrity check, monotonicity guarantee, bounds check, adapter pass-through assertion
- Add diagnostic logging: adaptive_k distribution per cohort, opponent adjustment drift, cross-age inflation guardrail, Power-SOS iteration stats

## Motivation

The age anchor (U10=0.40 to U19=1.00) was baked into every intermediate strength value, compressing younger cohorts' strength ranges and distorting adaptive_k game weighting, opponent adjustment baselines, and cross-age SOS lookups. Rankings should be broadly stable, but measurable movement is expected due to nonlinear effects. All movement must be explained via validation metrics in the post-run evaluation.

## System invariants after this change

1. All core strength math operates on true 0-1 scale
2. Anchor is applied exactly once (calculator.py only)
3. Anchor does not influence SOS, opponent adjustment, or Power-SOS iterations
4. Within-cohort rankings are determined solely by `power_score_true`
5. `power_score_final` is strictly a presentation-layer transformation
6. `national_power_score` is derived from `power_score_true`, not independently computed

## Test plan

- [ ] All pre-existing tests pass (no regressions introduced)
- [ ] Full ranking workflow completes without anchor integrity or monotonicity failures
- [ ] Post-run evaluation: cohort stability, adaptive_k distribution, opponent adjustment drift, cross-age inflation, Power-SOS convergence
- [ ] 4 test teams diagnostic comparison (Phoenix United, Southeast, MVLA, LA Galaxy)
- [ ] Add `power_score_true` column to `rankings_full` table before run

🤖 Generated with [Claude Code](https://claude.com/claude-code)