### PR TITLE
Fix bare except clauses, deduplicate normalize_team_id, guard sys.path

### DIFF
--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -1,4 +1,5 @@
 """Enhanced ETL Pipeline with metrics tracking and bulk operations"""
+
 import asyncio
 from typing import List, Tuple, Optional, Dict, Any
 from datetime import datetime
@@ -11,8 +12,10 @@ import time
 import random
 from pathlib import Path
 
-# Add parent directory to path
-sys.path.append(str(Path(__file__).parent.parent.parent))
+# Ensure project root is on path (needed for direct script execution only)
+_project_root = str(Path(__file__).parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.append(_project_root)
 
 from supabase import Client, create_client
 from config.settings import MATCHING_CONFIG, BUILD_ID, SUPABASE_URL, SUPABASE_KEY
@@ -22,6 +25,7 @@ from src.utils.enhanced_validators import EnhancedDataValidator, parse_game_date
 # Import club normalizer for pre-match normalization
 try:
     from src.utils.club_normalizer import normalize_to_club as _normalize_to_club
+
     _HAVE_CLUB_NORMALIZER = True
 except ImportError:
     _HAVE_CLUB_NORMALIZER = False
@@ -32,6 +36,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ImportMetrics:
     """Track detailed metrics for build logs"""
+
     games_processed: int = 0
     games_accepted: int = 0
     games_quarantined: int = 0
@@ -58,34 +63,41 @@ class ImportMetrics:
     def to_dict(self) -> Dict[str, Any]:
         """Convert metrics to dictionary for JSONB storage"""
         return {
-            'games_processed': self.games_processed,
-            'games_accepted': self.games_accepted,
-            'games_quarantined': self.games_quarantined,
-            'duplicates_found': self.duplicates_found,
-            'duplicates_skipped': self.duplicates_skipped,
-            'teams_matched': self.teams_matched,
-            'teams_created': self.teams_created,
-            'fuzzy_matches_auto': self.fuzzy_matches_auto,
-            'fuzzy_matches_manual': self.fuzzy_matches_manual,
-            'fuzzy_matches_rejected': self.fuzzy_matches_rejected,
-            'processing_time_seconds': round(self.processing_time_seconds, 2),
-            'memory_usage_mb': round(self.memory_usage_mb, 2),
-            'errors': self.errors,
-            'matched_games_count': self.matched_games_count,
-            'partial_games_count': self.partial_games_count,
-            'failed_games_count': self.failed_games_count,
-            'skipped_empty_provider_ids': self.skipped_empty_provider_ids,
-            'skipped_empty_game_date': self.skipped_empty_game_date,
-            'skipped_empty_scores': self.skipped_empty_scores,
-            'duplicate_key_violations': self.duplicate_key_violations,
-            'duplicate_links_backfilled': self.duplicate_links_backfilled
+            "games_processed": self.games_processed,
+            "games_accepted": self.games_accepted,
+            "games_quarantined": self.games_quarantined,
+            "duplicates_found": self.duplicates_found,
+            "duplicates_skipped": self.duplicates_skipped,
+            "teams_matched": self.teams_matched,
+            "teams_created": self.teams_created,
+            "fuzzy_matches_auto": self.fuzzy_matches_auto,
+            "fuzzy_matches_manual": self.fuzzy_matches_manual,
+            "fuzzy_matches_rejected": self.fuzzy_matches_rejected,
+            "processing_time_seconds": round(self.processing_time_seconds, 2),
+            "memory_usage_mb": round(self.memory_usage_mb, 2),
+            "errors": self.errors,
+            "matched_games_count": self.matched_games_count,
+            "partial_games_count": self.partial_games_count,
+            "failed_games_count": self.failed_games_count,
+            "skipped_empty_provider_ids": self.skipped_empty_provider_ids,
+            "skipped_empty_game_date": self.skipped_empty_game_date,
+            "skipped_empty_scores": self.skipped_empty_scores,
+            "duplicate_key_violations": self.duplicate_key_violations,
+            "duplicate_links_backfilled": self.duplicate_links_backfilled,
         }
 
 
 class EnhancedETLPipeline:
     """Enhanced ETL pipeline with bulk operations, validation, and metrics tracking"""
-    
-    def __init__(self, supabase: Client, provider_code: str, dry_run: bool = False, skip_validation: bool = False, summary_only: bool = False):
+
+    def __init__(
+        self,
+        supabase: Client,
+        provider_code: str,
+        dry_run: bool = False,
+        skip_validation: bool = False,
+        summary_only: bool = False,
+    ):
         self.supabase = supabase
         self.provider_code = provider_code
         self.dry_run = dry_run
@@ -103,33 +115,33 @@ class EnhancedETLPipeline:
         self._total_games_hint = 0  # Set externally for ETA display (0 = unknown)
         self.validator = EnhancedDataValidator()
         self.build_id = BUILD_ID
-        
+
         # Get provider UUID with retry logic
         max_retries = 5
         retry_delay = 0.5
         self.provider_id = None
-        
+
         for attempt in range(max_retries):
             try:
-                result = self.supabase.table('providers').select('id').eq(
-                    'code', provider_code
-                ).single().execute()
-                self.provider_id = result.data['id']
+                result = self.supabase.table("providers").select("id").eq("code", provider_code).single().execute()
+                self.provider_id = result.data["id"]
                 break
             except Exception as e:
                 if attempt < max_retries - 1:
-                    wait_time = retry_delay * (2 ** attempt)
-                    logger.warning(f"Provider lookup failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s: {e}")
+                    wait_time = retry_delay * (2**attempt)
+                    logger.warning(
+                        f"Provider lookup failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s: {e}"
+                    )
                     time.sleep(wait_time)
                     continue
                 else:
                     logger.error(f"Provider not found after {max_retries} attempts: {provider_code}")
                     raise ValueError(f"Provider not found: {provider_code}") from e
-        
+
         # Pre-flight health check: verify Supabase can read AND write before
         # spending minutes on validation/matching only to fail at insert time.
         try:
-            self.supabase.table('games').select('game_uid').limit(1).execute()
+            self.supabase.table("games").select("game_uid").limit(1).execute()
             logger.info("Pre-flight health check passed: Supabase connection OK")
         except Exception as e:
             raise ConnectionError(
@@ -149,33 +161,38 @@ class EnhancedETLPipeline:
             page_size = 1000
             offset = 0
             while True:
-                alias_result = self.supabase.table('team_alias_map').select(
-                    'provider_team_id, team_id_master, match_method, review_status'
-                ).eq('provider_id', self.provider_id).eq(
-                    'review_status', 'approved'
-                ).range(offset, offset + page_size - 1).execute()
-                
+                alias_result = (
+                    self.supabase.table("team_alias_map")
+                    .select("provider_team_id, team_id_master, match_method, review_status")
+                    .eq("provider_id", self.provider_id)
+                    .eq("review_status", "approved")
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                )
+
                 if not alias_result.data:
                     break
                 all_alias_data.extend(alias_result.data)
                 if len(alias_result.data) < page_size:
                     break  # Last page
                 offset += page_size
-            
-            logger.info(f"Fetched {len(all_alias_data)} approved aliases from database ({offset // page_size + 1} pages)")
+
+            logger.info(
+                f"Fetched {len(all_alias_data)} approved aliases from database ({offset // page_size + 1} pages)"
+            )
 
             for alias in all_alias_data:
-                raw_team_id = str(alias['provider_team_id'])
+                raw_team_id = str(alias["provider_team_id"])
                 cache_entry = {
-                    'team_id_master': alias['team_id_master'],
-                    'match_method': alias.get('match_method'),
-                    'review_status': alias.get('review_status')
+                    "team_id_master": alias["team_id_master"],
+                    "match_method": alias.get("match_method"),
+                    "review_status": alias.get("review_status"),
                 }
 
                 # Handle semicolon-separated provider_team_ids (e.g., "123456;789012")
                 # Create cache entry for EACH individual ID so lookups work
-                if ';' in raw_team_id:
-                    individual_ids = [id.strip() for id in raw_team_id.split(';') if id.strip()]
+                if ";" in raw_team_id:
+                    individual_ids = [id.strip() for id in raw_team_id.split(";") if id.strip()]
                     for individual_id in individual_ids:
                         if individual_id not in self.alias_cache:
                             self.alias_cache[individual_id] = cache_entry
@@ -190,131 +207,141 @@ class EnhancedETLPipeline:
         except Exception as e:
             logger.warning(f"Could not preload alias cache: {e}")
             self.alias_cache = {}
-        
+
         # Use provider-specific matchers when available
-        if provider_code.lower() == 'modular11':
+        if provider_code.lower() == "modular11":
             # Lazy import to avoid breaking other providers if module doesn't exist yet
             from src.models.modular11_matcher import Modular11GameMatcher
+
             logger.info("Using Modular11GameMatcher (with age_group validation)")
             # Enable debug mode for dry runs OR summary_only mode (to track summary data)
             # But suppress per-team logs if summary_only is True
             debug_mode = dry_run or summary_only
-            self.matcher = Modular11GameMatcher(supabase, provider_id=self.provider_id, alias_cache=self.alias_cache, debug=debug_mode, summary_only=summary_only)
-        elif provider_code.lower() == 'tgs':
+            self.matcher = Modular11GameMatcher(
+                supabase,
+                provider_id=self.provider_id,
+                alias_cache=self.alias_cache,
+                debug=debug_mode,
+                summary_only=summary_only,
+            )
+        elif provider_code.lower() == "tgs":
             # TGS-specific matcher with enhanced fuzzy matching
             from src.models.tgs_matcher import TGSGameMatcher
+
             logger.info("Using TGSGameMatcher (with enhanced fuzzy matching)")
             self.matcher = TGSGameMatcher(supabase, provider_id=self.provider_id, alias_cache=self.alias_cache)
-        elif provider_code.lower() == 'sincsports':
+        elif provider_code.lower() == "sincsports":
             from src.models.sincsports_matcher import SincSportsGameMatcher
+
             logger.info("Using SincSportsGameMatcher (with enhanced fuzzy matching)")
             self.matcher = SincSportsGameMatcher(supabase, provider_id=self.provider_id, alias_cache=self.alias_cache)
-        elif provider_code.lower() == 'affinity_wa':
+        elif provider_code.lower() == "affinity_wa":
             from src.models.affinity_wa_matcher import AffinityWAGameMatcher
+
             logger.info("Using AffinityWAGameMatcher (WA-specific normalization + auto-create)")
             self.matcher = AffinityWAGameMatcher(supabase, provider_id=self.provider_id, alias_cache=self.alias_cache)
         else:
             logger.info(f"Using standard GameHistoryMatcher for provider: {provider_code}")
             self.matcher = GameHistoryMatcher(supabase, provider_id=self.provider_id, alias_cache=self.alias_cache)
-    
+
     def _has_valid_scores(self, game: Dict) -> bool:
         """
         Return True only if both goals_for and goals_against are valid numeric values.
-        
-        Handles: None, 'None' (case-insensitive), 'null' (case-insensitive), empty strings, 
+
+        Handles: None, 'None' (case-insensitive), 'null' (case-insensitive), empty strings,
         and non-numeric values. Returns False for any missing, invalid, or partial scores.
-        
-        Supports both source format (goals_for/goals_against) and transformed format 
+
+        Supports both source format (goals_for/goals_against) and transformed format
         (home_score/away_score).
-        
+
         Args:
             game: Game dictionary with either:
                 - 'goals_for' and 'goals_against' keys (source format), or
                 - 'home_score' and 'away_score' keys (transformed format)
-            
+
         Returns:
             True if both scores are valid numeric values, False otherwise
         """
         try:
             # Check for transformed format first (home_score/away_score)
-            if 'home_score' in game or 'away_score' in game:
-                goals_for = game.get('home_score')
-                goals_against = game.get('away_score')
+            if "home_score" in game or "away_score" in game:
+                goals_for = game.get("home_score")
+                goals_against = game.get("away_score")
             else:
                 # Source format (goals_for/goals_against)
-                goals_for = game.get('goals_for')
-                goals_against = game.get('goals_against')
-            
+                goals_for = game.get("goals_for")
+                goals_against = game.get("goals_against")
+
             # Normalize to string and check for empty/missing values
             def normalize_score(score):
                 if score is None:
-                    return ''
+                    return ""
                 return str(score).strip().lower()
-            
+
             gf = normalize_score(goals_for)
             ga = normalize_score(goals_against)
-            
+
             # Check if either score is missing or invalid
-            if gf in ('', 'none', 'null') or ga in ('', 'none', 'null'):
+            if gf in ("", "none", "null") or ga in ("", "none", "null"):
                 return False
-            
+
             # Validate that both can be converted to float (numeric)
             float(gf)
             float(ga)
-            
+
             return True
         except (ValueError, TypeError):
             # Non-numeric values or conversion errors
             return False
-    
+
     def _make_composite_key(self, game: Dict) -> str:
         """
         Construct composite key matching the database unique constraint.
-        
-        Mirrors the DB constraint: (provider_id, home_provider_id, away_provider_id, 
+
+        Mirrors the DB constraint: (provider_id, home_provider_id, away_provider_id,
         game_date, COALESCE(home_score, -1), COALESCE(away_score, -1))
-        
+
         Args:
-            game: Game record dictionary with provider_id, home_provider_id, 
+            game: Game record dictionary with provider_id, home_provider_id,
                   away_provider_id, game_date, home_score, away_score
-            
+
         Returns:
             Composite key string: "provider_id|home_provider_id|away_provider_id|game_date|home_score|-1|away_score|-1"
         """
-        provider_id = str(game.get('provider_id', ''))
-        home_provider_id = str(game.get('home_provider_id', ''))
-        away_provider_id = str(game.get('away_provider_id', ''))
-        game_date = str(game.get('game_date', ''))
+        provider_id = str(game.get("provider_id", ""))
+        home_provider_id = str(game.get("home_provider_id", ""))
+        away_provider_id = str(game.get("away_provider_id", ""))
+        game_date = str(game.get("game_date", ""))
         # Handle None scores by converting to -1 (matching COALESCE behavior)
-        home_score = game.get('home_score')
-        away_score = game.get('away_score')
-        home_score_str = str(home_score) if home_score is not None else '-1'
-        away_score_str = str(away_score) if away_score is not None else '-1'
-        
+        home_score = game.get("home_score")
+        away_score = game.get("away_score")
+        home_score_str = str(home_score) if home_score is not None else "-1"
+        away_score_str = str(away_score) if away_score is not None else "-1"
+
         return f"{provider_id}|{home_provider_id}|{away_provider_id}|{game_date}|{home_score_str}|{away_score_str}"
-        
+
     async def import_games(self, games: List[Dict], provider_code: Optional[str] = None) -> ImportMetrics:
         """
         Import games with bulk operations, validation, and metrics tracking
-        
+
         Args:
             games: List of game dictionaries
             provider_code: Optional provider code override
-            
+
         Returns:
             ImportMetrics object with detailed statistics for THIS BATCH ONLY
             (to avoid double-counting when batches run concurrently)
         """
         start_time = datetime.now()
-        
+
         # Initialize import start time on first batch
-        if not hasattr(self, '_import_start_time'):
+        if not hasattr(self, "_import_start_time"):
             self._import_start_time = start_time
-        
+
         # Create batch-specific metrics to avoid double-counting in concurrent batches
         # We'll still update self.metrics for overall tracking, but return batch_metrics
         batch_metrics = ImportMetrics()
-        
+
         try:
             # Step 1: Validate all games (or skip if flag is set)
             if self.skip_validation:
@@ -325,27 +352,27 @@ class EnhancedETLPipeline:
             # Track batch-specific metrics (no self.metrics mutation in validation)
             batch_metrics.games_processed = len(games)
             batch_metrics.games_quarantined = len(invalid_games)
-            batch_metrics.duplicates_skipped = val_stats['duplicates_skipped']
-            batch_metrics.skipped_empty_scores = val_stats['skipped_empty_scores']
-            if val_stats['date_mismatches'] > 0:
+            batch_metrics.duplicates_skipped = val_stats["duplicates_skipped"]
+            batch_metrics.skipped_empty_scores = val_stats["skipped_empty_scores"]
+            if val_stats["date_mismatches"] > 0:
                 batch_metrics.errors.append(f"{val_stats['date_mismatches']} games had date mismatches")
 
             # Also update shared metrics for logging (but aggregation will use batch_metrics)
             self.metrics.games_processed += len(games)  # ACCUMULATE
             self.metrics.games_quarantined += len(invalid_games)  # ACCUMULATE
-            self.metrics.duplicates_skipped += val_stats['duplicates_skipped']  # ACCUMULATE
-            self.metrics.skipped_empty_scores += val_stats['skipped_empty_scores']  # ACCUMULATE
-            
+            self.metrics.duplicates_skipped += val_stats["duplicates_skipped"]  # ACCUMULATE
+            self.metrics.skipped_empty_scores += val_stats["skipped_empty_scores"]  # ACCUMULATE
+
             # Log invalid games for review
             if invalid_games:
                 await self._log_invalid_games(invalid_games)
-            
+
             # Step 2: Check for duplicates by game_uid
             # NOTE: We check game_uid here but DON'T filter yet, because game_uid doesn't include scores.
             # Games with the same game_uid but different scores should proceed to team matching,
             # where the composite key check (which includes scores) will catch true duplicates.
             existing_uids, game_uid_to_master_ids = await self._check_duplicates(valid_games)
-            
+
             # Step 3: Match teams and prepare game records
             # We match ALL games, not just "new" ones, because game_uid check doesn't account for scores
             new_games = valid_games
@@ -353,13 +380,13 @@ class EnhancedETLPipeline:
             matched_count = 0
             partial_count = 0
             failed_count = 0
-            
+
             # Connection refresh interval (number of games between client refreshes)
-            refresh_interval = MATCHING_CONFIG.get('connection_refresh_interval', 1000)
+            refresh_interval = MATCHING_CONFIG.get("connection_refresh_interval", 1000)
             games_since_refresh = 0
 
             for game in new_games:
-                game_uid = game.get('game_uid', 'N/A')
+                game_uid = game.get("game_uid", "N/A")
 
                 # --- Periodic Supabase client refresh for long imports ---
                 games_since_refresh += 1
@@ -369,41 +396,45 @@ class EnhancedETLPipeline:
                             self.supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
                             self.matcher.db = self.supabase
                             games_since_refresh = 0
-                            logger.info(
-                                f"[Pipeline] Refreshed Supabase client after {refresh_interval} games"
-                            )
+                            logger.info(f"[Pipeline] Refreshed Supabase client after {refresh_interval} games")
                     except Exception as refresh_err:
                         logger.warning(f"[Pipeline] Client refresh failed (non-fatal): {refresh_err}")
 
                 try:
                     # Convert age_year to age_group if needed (for TGS and other providers using birth year)
-                    if 'age_year' in game and not game.get('age_group'):
+                    if "age_year" in game and not game.get("age_group"):
                         from src.utils.team_utils import calculate_age_group_from_birth_year
-                        age_year = game.get('age_year')
+
+                        age_year = game.get("age_year")
                         if age_year:
                             try:
                                 birth_year = int(age_year)
                                 age_group = calculate_age_group_from_birth_year(birth_year)
                                 if age_group:
-                                    game['age_group'] = age_group.lower()  # Normalize to lowercase
+                                    game["age_group"] = age_group.lower()  # Normalize to lowercase
                             except (ValueError, TypeError):
                                 pass  # Keep age_group as None if conversion fails
 
                     # Normalize gender: "Boys" -> "Male", "Girls" -> "Female" (for database compatibility)
-                    gender = game.get('gender', '')
+                    gender = game.get("gender", "")
                     if gender:
                         gender_normalized = gender.strip()
-                        if gender_normalized.lower() == 'boys':
-                            game['gender'] = 'Male'
-                        elif gender_normalized.lower() == 'girls':
-                            game['gender'] = 'Female'
+                        if gender_normalized.lower() == "boys":
+                            game["gender"] = "Male"
+                        elif gender_normalized.lower() == "girls":
+                            game["gender"] = "Female"
                         # Keep other values as-is (Male, Female, Coed, etc.)
 
                     # Pre-match club normalization: pass canonical club name
                     # to the matcher so it sees consistent club names.
                     if _HAVE_CLUB_NORMALIZER:
-                        for club_field in ('club_name', 'team_club_name', 'home_club_name',
-                                           'away_club_name', 'opponent_club_name'):
+                        for club_field in (
+                            "club_name",
+                            "team_club_name",
+                            "home_club_name",
+                            "away_club_name",
+                            "opponent_club_name",
+                        ):
                             raw_club = game.get(club_field)
                             if raw_club and raw_club.strip():
                                 result = _normalize_to_club(raw_club.strip())
@@ -411,7 +442,7 @@ class EnhancedETLPipeline:
                                     game[club_field] = result.club_norm
 
                     # Log game details before matching (including mls_division for Modular11)
-                    if self.provider_code and self.provider_code.lower() == 'modular11':
+                    if self.provider_code and self.provider_code.lower() == "modular11":
                         logger.info(
                             f"[Pipeline] Matching Modular11 game {game_uid}: "
                             f"team_id={game.get('team_id')}, opponent_id={game.get('opponent_id')}, "
@@ -425,49 +456,49 @@ class EnhancedETLPipeline:
                             f"age_group={game.get('age_group')}, gender={game.get('gender')}, "
                             f"game_date={game.get('game_date')}"
                         )
-                    
+
                     # Match game history to get structured game record
                     # Pass dry_run flag to game_data for diagnostic mode
                     if self.dry_run:
-                        game['dry_run'] = True
+                        game["dry_run"] = True
                     matched_game = self.matcher.match_game_history(game)
-                    match_status = matched_game.get('match_status')
-                    home_team_id = matched_game.get('home_team_master_id')
-                    away_team_id = matched_game.get('away_team_master_id')
-                    home_score = matched_game.get('home_score')
-                    away_score = matched_game.get('away_score')
-                    
+                    match_status = matched_game.get("match_status")
+                    home_team_id = matched_game.get("home_team_master_id")
+                    away_team_id = matched_game.get("away_team_master_id")
+                    home_score = matched_game.get("home_score")
+                    away_score = matched_game.get("away_score")
+
                     logger.debug(
                         f"[Pipeline] Match result for game {game_uid}: "
                         f"status={match_status}, home_team={home_team_id}, away_team={away_team_id}, "
                         f"scores={home_score}-{away_score}"
                     )
-                    
-                    if match_status == 'matched':
+
+                    if match_status == "matched":
                         # Regenerate game_uid using master IDs so the same physical game
                         # always gets the same UID regardless of which scraper found it.
                         # This prevents cross-scraper duplicates at the game_uid level.
                         if home_team_id and away_team_id:
                             master_game_uid = GameHistoryMatcher.generate_game_uid(
-                                provider=self.provider_code or 'gotsport',
-                                game_date=matched_game.get('game_date', ''),
+                                provider=self.provider_code or "gotsport",
+                                game_date=matched_game.get("game_date", ""),
                                 team1_id=home_team_id,
                                 team2_id=away_team_id,
                             )
-                            old_uid = matched_game.get('game_uid', '')
+                            old_uid = matched_game.get("game_uid", "")
                             if master_game_uid != old_uid:
                                 logger.debug(
                                     f"[Pipeline] Regenerated game_uid from provider IDs to master IDs: "
                                     f"{old_uid} -> {master_game_uid}"
                                 )
-                            matched_game['game_uid'] = master_game_uid
+                            matched_game["game_uid"] = master_game_uid
 
                         game_records.append(matched_game)
                         matched_count += 1
                         batch_metrics.teams_matched += 2  # Home and away
                         self.metrics.teams_matched += 2  # Also update shared for logging
                         logger.debug(f"[Pipeline] Game {game_uid} added to records (MATCHED)")
-                    elif match_status == 'partial':
+                    elif match_status == "partial":
                         game_records.append(matched_game)
                         partial_count += 1
                         batch_metrics.teams_matched += 1
@@ -482,13 +513,10 @@ class EnhancedETLPipeline:
                         # Don't increment teams_matched for failed matches
                 except Exception as e:
                     failed_count += 1
-                    logger.error(
-                        f"[Pipeline] Exception matching game {game_uid}: {e}",
-                        exc_info=True
-                    )
+                    logger.error(f"[Pipeline] Exception matching game {game_uid}: {e}", exc_info=True)
                     batch_metrics.errors.append(f"Match error for {game_uid}: {str(e)}")
                     self.metrics.errors.append(f"Match error for {game_uid}: {str(e)}")
-            
+
             # Store counts in batch metrics for debugging
             batch_metrics.matched_games_count = matched_count
             batch_metrics.partial_games_count = partial_count
@@ -497,19 +525,23 @@ class EnhancedETLPipeline:
             self.metrics.matched_games_count += matched_count
             self.metrics.partial_games_count += partial_count
             self.metrics.failed_games_count += failed_count
-            
-            logger.info(f"Matched {len(game_records)} games (matched: {matched_count}, partial: {partial_count}, failed: {failed_count})")
-            
+
+            logger.info(
+                f"Matched {len(game_records)} games (matched: {matched_count}, partial: {partial_count}, failed: {failed_count})"
+            )
+
             # Step 3b: Check for duplicates using composite key (after team matching)
             # For Modular11: game_uid now includes age_group and division, so it's more specific than composite key.
             # If game_uid doesn't exist, trust it (even if composite key matches, because composite key doesn't include age_group/division).
             # For other providers: composite key is authoritative (includes scores).
-            if self.provider_code and self.provider_code.lower() == 'modular11':
+            if self.provider_code and self.provider_code.lower() == "modular11":
                 # For Modular11, game_uid was regenerated during team matching with age_group/division.
                 # We need to check duplicates again using the regenerated game_uids.
                 existing_uids, game_uid_to_master_ids = await self._check_duplicates(game_records)
-                logger.info(f"[Pipeline] Modular11: Re-checked duplicates after team matching, found {len(existing_uids)} existing game_uids out of {len(game_records)} total games")
-                
+                logger.info(
+                    f"[Pipeline] Modular11: Re-checked duplicates after team matching, found {len(existing_uids)} existing game_uids out of {len(game_records)} total games"
+                )
+
                 # CRITICAL: Also check for LEGACY UIDs (without age_group/division suffix).
                 # Older imports used format "modular11:{date}:{team1}:{team2}" while new imports
                 # use "modular11:{date}:{team1}:{team2}:{age_group}:{division}".
@@ -517,26 +549,28 @@ class EnhancedETLPipeline:
                 legacy_uid_map = {}  # maps legacy_uid -> new_uid for games not already matched
                 legacy_uids_to_check = []
                 for g in game_records:
-                    new_uid = g.get('game_uid', '')
+                    new_uid = g.get("game_uid", "")
                     if new_uid and new_uid not in existing_uids:
                         # Strip the :AGE_GROUP:DIVISION suffix to get the legacy UID
-                        parts = new_uid.split(':')
+                        parts = new_uid.split(":")
                         if len(parts) >= 6:
                             # New format: modular11:date:team1:team2:age_group:division
-                            legacy_uid = ':'.join(parts[:4])  # modular11:date:team1:team2
+                            legacy_uid = ":".join(parts[:4])  # modular11:date:team1:team2
                             legacy_uid_map[legacy_uid] = new_uid
                             legacy_uids_to_check.append(legacy_uid)
-                
+
                 legacy_existing = set()
                 if legacy_uids_to_check:
-                    logger.info(f"[Pipeline] Modular11: Checking {len(legacy_uids_to_check)} legacy UIDs for backward compatibility")
+                    logger.info(
+                        f"[Pipeline] Modular11: Checking {len(legacy_uids_to_check)} legacy UIDs for backward compatibility"
+                    )
                     batch_size = 200
                     for chunk in self._chunks(legacy_uids_to_check, batch_size):
                         try:
-                            result = self.supabase.table('games').select('game_uid').in_('game_uid', chunk).execute()
+                            result = self.supabase.table("games").select("game_uid").in_("game_uid", chunk).execute()
                             if result.data:
                                 for row in result.data:
-                                    uid = row.get('game_uid')
+                                    uid = row.get("game_uid")
                                     if uid:
                                         legacy_existing.add(uid)
                                         # Also add the corresponding new UID to existing_uids
@@ -547,45 +581,65 @@ class EnhancedETLPipeline:
                         except Exception as e:
                             logger.error(f"CRITICAL: Error checking legacy UIDs: {e}")
                             raise
-                    
+
                     if legacy_existing:
-                        logger.info(f"[Pipeline] Modular11: Found {len(legacy_existing)} games with LEGACY UIDs in DB (these are NOT new games)")
-                
+                        logger.info(
+                            f"[Pipeline] Modular11: Found {len(legacy_existing)} games with LEGACY UIDs in DB (these are NOT new games)"
+                        )
+
                 # For Modular11, check game_uid first (it includes age_group and division)
                 # Only check composite key for games where game_uid already exists (to catch score updates)
-                games_with_existing_uid = [g for g in game_records if g.get('game_uid') and g.get('game_uid') in existing_uids]
-                games_with_new_uid = [g for g in game_records if not g.get('game_uid') or g.get('game_uid') not in existing_uids]
-                
-                logger.info(f"[Pipeline] Modular11: {len(games_with_new_uid)} games with NEW game_uid, {len(games_with_existing_uid)} games with EXISTING game_uid")
-                
+                games_with_existing_uid = [
+                    g for g in game_records if g.get("game_uid") and g.get("game_uid") in existing_uids
+                ]
+                games_with_new_uid = [
+                    g for g in game_records if not g.get("game_uid") or g.get("game_uid") not in existing_uids
+                ]
+
+                logger.info(
+                    f"[Pipeline] Modular11: {len(games_with_new_uid)} games with NEW game_uid, {len(games_with_existing_uid)} games with EXISTING game_uid"
+                )
+
                 # For games with new game_uid, trust it (don't check composite key - it doesn't include age_group/division)
                 # For games with existing game_uid, check composite key to see if scores differ
                 if games_with_existing_uid:
                     existing_composite_keys = await self._check_duplicates_by_composite_key(games_with_existing_uid)
                     if existing_composite_keys:
-                        logger.info(f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)")
+                        logger.info(
+                            f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)"
+                        )
                         # Capture duplicates before filtering for backfill
-                        m11_composite_dupes = [g for g in games_with_existing_uid if self._make_composite_key(g) in existing_composite_keys]
+                        m11_composite_dupes = [
+                            g for g in games_with_existing_uid if self._make_composite_key(g) in existing_composite_keys
+                        ]
                         # Filter out games with existing composite keys
-                        games_with_existing_uid = [g for g in games_with_existing_uid if self._make_composite_key(g) not in existing_composite_keys]
+                        games_with_existing_uid = [
+                            g
+                            for g in games_with_existing_uid
+                            if self._make_composite_key(g) not in existing_composite_keys
+                        ]
                         batch_metrics.duplicates_found = len(existing_composite_keys)
                         self.metrics.duplicates_found += len(existing_composite_keys)
-                        logger.info(f"[Pipeline] Filtered to {len(games_with_existing_uid)} games after composite key duplicate check")
+                        logger.info(
+                            f"[Pipeline] Filtered to {len(games_with_existing_uid)} games after composite key duplicate check"
+                        )
                         # Backfill missing master IDs on Modular11 composite-key duplicates
                         bf = await self._backfill_duplicate_team_links(m11_composite_dupes)
                         batch_metrics.duplicate_links_backfilled += bf
                         self.metrics.duplicate_links_backfilled += bf
-                
+
                 # Combine: games with new game_uid (trust them) + games with existing game_uid that passed composite key check
                 game_records = games_with_new_uid + games_with_existing_uid
-                logger.info(f"[Pipeline] Modular11: Final - {len(games_with_new_uid)} games with new game_uid (trusted), {len(games_with_existing_uid)} games with existing game_uid (checked), total: {len(game_records)}")
-                
+                logger.info(
+                    f"[Pipeline] Modular11: Final - {len(games_with_new_uid)} games with new game_uid (trusted), {len(games_with_existing_uid)} games with existing game_uid (checked), total: {len(game_records)}"
+                )
+
                 # CRITICAL: For Modular11, skip composite key deduplication in _bulk_insert_games
                 # because composite key doesn't include age_group/division, but game_uid does.
                 # We've already filtered duplicates by game_uid above, so trust that.
                 # Store a flag to skip composite key dedup in bulk insert
                 for g in game_records:
-                    g['_skip_composite_dedup'] = True
+                    g["_skip_composite_dedup"] = True
             else:
                 # Game UIDs were regenerated using master IDs after team matching.
                 # Re-check against the DB to catch cross-scraper duplicates where
@@ -593,11 +647,11 @@ class EnhancedETLPipeline:
                 regen_existing_uids, regen_uid_master_ids = await self._check_duplicates(game_records)
                 if regen_existing_uids:
                     pre_count = len(game_records)
-                    regen_dupes_list = [g for g in game_records if g.get('game_uid') in regen_existing_uids]
-                    game_records = [g for g in game_records if g.get('game_uid') not in regen_existing_uids]
+                    regen_dupes_list = [g for g in game_records if g.get("game_uid") in regen_existing_uids]
+                    game_records = [g for g in game_records if g.get("game_uid") not in regen_existing_uids]
                     regen_dupes = pre_count - len(game_records)
                     if regen_dupes > 0:
-                        batch_metrics.duplicates_found = getattr(batch_metrics, 'duplicates_found', 0) + regen_dupes
+                        batch_metrics.duplicates_found = getattr(batch_metrics, "duplicates_found", 0) + regen_dupes
                         self.metrics.duplicates_found += regen_dupes
                         logger.info(
                             f"[Pipeline] Regenerated game_uid dedup: {regen_dupes} duplicates caught "
@@ -614,14 +668,24 @@ class EnhancedETLPipeline:
                 # For other providers, composite key is authoritative
                 existing_composite_keys = await self._check_duplicates_by_composite_key(game_records)
                 if existing_composite_keys:
-                    logger.info(f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)")
+                    logger.info(
+                        f"[Pipeline] Found {len(existing_composite_keys)} duplicate games by composite key (already in DB)"
+                    )
                     # Capture duplicates before filtering for backfill
-                    composite_dupes_list = [g for g in game_records if self._make_composite_key(g) in existing_composite_keys]
+                    composite_dupes_list = [
+                        g for g in game_records if self._make_composite_key(g) in existing_composite_keys
+                    ]
                     # Filter out games with existing composite keys
-                    game_records = [g for g in game_records if self._make_composite_key(g) not in existing_composite_keys]
-                    batch_metrics.duplicates_found = len(existing_composite_keys)  # Set (not +=) because this is the authoritative count
+                    game_records = [
+                        g for g in game_records if self._make_composite_key(g) not in existing_composite_keys
+                    ]
+                    batch_metrics.duplicates_found = len(
+                        existing_composite_keys
+                    )  # Set (not +=) because this is the authoritative count
                     self.metrics.duplicates_found += len(existing_composite_keys)
-                    logger.info(f"[Pipeline] Filtered to {len(game_records)} new games after composite key duplicate check")
+                    logger.info(
+                        f"[Pipeline] Filtered to {len(game_records)} new games after composite key duplicate check"
+                    )
                     # Backfill missing master IDs on composite-key duplicates
                     bf = await self._backfill_duplicate_team_links(composite_dupes_list)
                     batch_metrics.duplicate_links_backfilled += bf
@@ -636,9 +700,9 @@ class EnhancedETLPipeline:
             master_dedup_removed = await self._check_duplicates_by_master_ids(game_records)
             if master_dedup_removed > 0:
                 pre_count = len(game_records)
-                master_dupes_list = [g for g in game_records if g.get('_master_dedup_skip')]
-                game_records = [g for g in game_records if not g.get('_master_dedup_skip')]
-                batch_metrics.duplicates_found = getattr(batch_metrics, 'duplicates_found', 0) + master_dedup_removed
+                master_dupes_list = [g for g in game_records if g.get("_master_dedup_skip")]
+                game_records = [g for g in game_records if not g.get("_master_dedup_skip")]
+                batch_metrics.duplicates_found = getattr(batch_metrics, "duplicates_found", 0) + master_dedup_removed
                 self.metrics.duplicates_found += master_dedup_removed
                 logger.info(
                     f"[Pipeline] Master-level dedup: removed {master_dedup_removed} cross-scraper "
@@ -655,23 +719,22 @@ class EnhancedETLPipeline:
             games_to_update = []
             games_to_insert = []
             games_with_age_conflict = []
-            
+
             for game in game_records:
-                game_uid = game.get('game_uid')
+                game_uid = game.get("game_uid")
                 if game_uid and game_uid in existing_uids:
                     # game_uid exists - check if master team IDs match
                     db_master_ids = game_uid_to_master_ids.get(game_uid, {})
-                    csv_home_master = game.get('home_team_master_id')
-                    csv_away_master = game.get('away_team_master_id')
-                    db_home_master = db_master_ids.get('home_team_master_id')
-                    db_away_master = db_master_ids.get('away_team_master_id')
-                    
+                    csv_home_master = game.get("home_team_master_id")
+                    csv_away_master = game.get("away_team_master_id")
+                    db_home_master = db_master_ids.get("home_team_master_id")
+                    db_away_master = db_master_ids.get("away_team_master_id")
+
                     # Check if master team IDs match (accounting for home/away swap)
-                    master_ids_match = (
-                        (csv_home_master == db_home_master and csv_away_master == db_away_master) or
-                        (csv_home_master == db_away_master and csv_away_master == db_home_master)
+                    master_ids_match = (csv_home_master == db_home_master and csv_away_master == db_away_master) or (
+                        csv_home_master == db_away_master and csv_away_master == db_home_master
                     )
-                    
+
                     if master_ids_match:
                         # Same teams, different scores - update existing game
                         games_to_update.append(game)
@@ -684,13 +747,13 @@ class EnhancedETLPipeline:
                         # Different teams (e.g., U13 vs U14, or HD vs AD) - this is a different game
                         # This should be rare now since game_uid includes age_group and division
                         # But handle it as a fallback for edge cases
-                        age_group = game.get('age_group', '').upper() if game.get('age_group') else None
-                        division = game.get('mls_division', '').upper() if game.get('mls_division') else None
-                        
+                        age_group = game.get("age_group", "").upper() if game.get("age_group") else None
+                        division = game.get("mls_division", "").upper() if game.get("mls_division") else None
+
                         if age_group and division:
                             # Generate modified game_uid with age group and division: modular11:2025-09-06:14:249:U14:HD
                             # Extract components from original game_uid
-                            parts = game_uid.split(':')
+                            parts = game_uid.split(":")
                             if len(parts) >= 4:
                                 provider = parts[0]
                                 date = parts[1]
@@ -698,7 +761,7 @@ class EnhancedETLPipeline:
                                 team2 = parts[3]
                                 # Create new game_uid with age group and division suffix
                                 modified_game_uid = f"{provider}:{date}:{team1}:{team2}:{age_group}:{division}"
-                                game['game_uid'] = modified_game_uid
+                                game["game_uid"] = modified_game_uid
                                 logger.info(
                                     f"[Pipeline] Modified game_uid for conflict: {game_uid} -> {modified_game_uid} "
                                     f"(CSV teams: home={csv_home_master}, away={csv_away_master}, "
@@ -711,14 +774,14 @@ class EnhancedETLPipeline:
                                 )
                         elif age_group:
                             # Fallback: age group only
-                            parts = game_uid.split(':')
+                            parts = game_uid.split(":")
                             if len(parts) >= 4:
                                 provider = parts[0]
                                 date = parts[1]
                                 team1 = parts[2]
                                 team2 = parts[3]
                                 modified_game_uid = f"{provider}:{date}:{team1}:{team2}:{age_group}"
-                                game['game_uid'] = modified_game_uid
+                                game["game_uid"] = modified_game_uid
                                 logger.info(
                                     f"[Pipeline] Modified game_uid for conflict (age only): {game_uid} -> {modified_game_uid}"
                                 )
@@ -734,29 +797,31 @@ class EnhancedETLPipeline:
                                 f"Will attempt insertion but may fail due to unique constraint."
                             )
                             games_to_insert.append(game)
-                        
+
                         games_with_age_conflict.append(game)
                 else:
                     games_to_insert.append(game)
-            
+
             if games_with_age_conflict:
                 logger.warning(
                     f"[Pipeline] Found {len(games_with_age_conflict)} games with game_uid conflicts "
                     f"due to age group mismatch (U13 vs U14). These will fail insertion due to unique constraint."
                 )
-            
+
             if games_to_update:
-                logger.info(f"[Pipeline] Found {len(games_to_update)} games to update (game_uid exists with different scores)")
+                logger.info(
+                    f"[Pipeline] Found {len(games_to_update)} games to update (game_uid exists with different scores)"
+                )
                 # Update existing games with CSV scores
                 updated_count = await self._update_games_with_scores(games_to_update)
                 batch_metrics.games_accepted += updated_count
                 self.metrics.games_accepted += updated_count
                 logger.info(f"[Pipeline] Updated {updated_count} games with new scores from CSV")
-            
+
             # Use games_to_insert for the rest of the pipeline
             game_records = games_to_insert
             logger.info(f"[Pipeline] Final count: {len(game_records)} new games ready for insertion")
-            
+
             # Step 4: Filter games with invalid scores before bulk insert
             valid_game_records = []
             skipped_games = []
@@ -765,15 +830,15 @@ class EnhancedETLPipeline:
                     valid_game_records.append(g)
                 else:
                     skipped_games.append(g)
-                    game_uid = g.get('game_uid', 'N/A')
-                    home_score = g.get('home_score')
-                    away_score = g.get('away_score')
+                    game_uid = g.get("game_uid", "N/A")
+                    home_score = g.get("home_score")
+                    away_score = g.get("away_score")
                     logger.warning(
                         f"[Pipeline] Game {game_uid} REJECTED due to invalid scores: "
                         f"home_score={home_score} (type={type(home_score)}), "
                         f"away_score={away_score} (type={type(away_score)})"
                     )
-            
+
             skipped_count = len(skipped_games)
             if skipped_count > 0:
                 batch_metrics.skipped_empty_scores = skipped_count
@@ -782,7 +847,7 @@ class EnhancedETLPipeline:
                     f"[Pipeline] Skipped {skipped_count} games with invalid or missing scores "
                     f"(out of {len(game_records)} matched games)"
                 )
-            
+
             # Step 5: Bulk insert games
             if valid_game_records and not self.dry_run:
                 logger.info(
@@ -792,7 +857,7 @@ class EnhancedETLPipeline:
                 inserted_count = await self._bulk_insert_games(valid_game_records)
                 batch_metrics.games_accepted = inserted_count  # Batch-specific count
                 self.metrics.games_accepted += inserted_count  # Also update shared for logging
-                
+
                 if inserted_count != len(valid_game_records):
                     logger.warning(
                         f"[Pipeline] Insert mismatch: attempted {len(valid_game_records)}, "
@@ -800,10 +865,9 @@ class EnhancedETLPipeline:
                     )
                 else:
                     logger.info(
-                        f"[Pipeline] Successfully inserted {inserted_count} games "
-                        f"(batch accepted: {inserted_count})"
+                        f"[Pipeline] Successfully inserted {inserted_count} games (batch accepted: {inserted_count})"
                     )
-                
+
                 # Step 5b: Propagate exclusions — auto-exclude newly inserted games
                 # that match previously excluded games (same date + master teams + scores).
                 # This prevents excluded tournament games from reappearing when re-scraped
@@ -822,27 +886,31 @@ class EnhancedETLPipeline:
                 self.metrics.games_accepted += len(valid_game_records)  # Also update shared for logging
                 logger.info("Dry run mode - games not inserted")
             elif not valid_game_records:
-                logger.warning(f"No game records to insert after matching and score validation (matched: {matched_count}, partial: {partial_count}, failed: {failed_count}, skipped scores: {skipped_count})")
-            
+                logger.warning(
+                    f"No game records to insert after matching and score validation (matched: {matched_count}, partial: {partial_count}, failed: {failed_count}, skipped scores: {skipped_count})"
+                )
+
             # Step 6: Process team matching statistics
             await self._process_team_matching_stats()
-            
+
             # Step 7: Calculate processing time
             batch_metrics.processing_time_seconds = (datetime.now() - start_time).total_seconds()
             self.metrics.processing_time_seconds += batch_metrics.processing_time_seconds  # Accumulate for logging
-            
+
             # Step 8: Log build metrics and progress updates
             self._batch_count += 1
-            
+
             # Check if we should log progress update (every 10k games)
             games_since_last_log = self.metrics.games_processed - self._last_logged_games
             should_log_progress = games_since_last_log >= self._log_every_n_games
-            
+
             # Log to database (less frequent, every N batches)
             if self._batch_count % self._log_every_n_batches == 0 or self._batch_count == 1:
                 await self._log_build_metrics()
-                logger.info(f"📊 [DB LOG] Batch {self._batch_count} | Processed: {self.metrics.games_processed:,} | Accepted: {self.metrics.games_accepted:,} | Quarantined: {self.metrics.games_quarantined:,} | Duplicates: {self.metrics.duplicates_found:,}")
-            
+                logger.info(
+                    f"📊 [DB LOG] Batch {self._batch_count} | Processed: {self.metrics.games_processed:,} | Accepted: {self.metrics.games_accepted:,} | Quarantined: {self.metrics.games_quarantined:,} | Duplicates: {self.metrics.duplicates_found:,}"
+                )
+
             # Log progress update to console (every 10k games)
             if should_log_progress:
                 elapsed_time = (datetime.now() - getattr(self, "_import_start_time", datetime.now())).total_seconds()
@@ -850,7 +918,7 @@ class EnhancedETLPipeline:
 
                 # ETA based on total_games_hint if set, otherwise just show rate
                 eta_line = ""
-                if getattr(self, '_total_games_hint', 0) > 0:
+                if getattr(self, "_total_games_hint", 0) > 0:
                     remaining = self._total_games_hint - self.metrics.games_processed
                     if remaining > 0 and games_per_sec > 0:
                         eta_minutes = (remaining / games_per_sec) / 60
@@ -858,39 +926,40 @@ class EnhancedETLPipeline:
                         eta_line = f"  ETA:             {eta_minutes:.1f} min remaining ({pct:.0f}% done)\n"
 
                 logger.info(
-                    f"\n{'='*80}\n"
+                    f"\n{'=' * 80}\n"
                     f"PROGRESS UPDATE ({self.metrics.games_processed:,} games processed)\n"
-                    f"{'='*80}\n"
+                    f"{'=' * 80}\n"
                     f"  Accepted:        {self.metrics.games_accepted:,} games\n"
                     f"  Quarantined:     {self.metrics.games_quarantined:,} games\n"
                     f"  Duplicates:      {self.metrics.duplicates_found:,} games (already in DB)\n"
                     f"  Links backfilled:{self.metrics.duplicate_links_backfilled:,} healed\n"
                     f"  Perspective dup: {self.metrics.duplicates_skipped:,} skipped\n"
                     f"  Processing rate: {games_per_sec:.1f} games/sec\n"
-                    f"  Elapsed time:    {elapsed_time/60:.1f} minutes\n"
+                    f"  Elapsed time:    {elapsed_time / 60:.1f} minutes\n"
                     f"{eta_line}"
-                    f"{'='*80}\n"
+                    f"{'=' * 80}\n"
                 )
                 self._last_logged_games = self.metrics.games_processed
-            
+
             if self.dry_run:
                 logger.info("Dry run completed - no changes committed")
             else:
                 logger.info(f"Batch completed: {batch_metrics.games_accepted} games imported")
-            
+
             # Return batch-specific metrics (not shared self.metrics) to avoid double-counting
             return batch_metrics
-            
+
         except Exception as e:
             batch_metrics.errors.append(str(e))
             self.metrics.errors.append(str(e))
             logger.error(f"Import failed: {e}")
             import traceback
+
             logger.error(f"Traceback: {traceback.format_exc()}")
             await self._log_build_metrics()  # Log partial metrics
             # Return batch metrics even on error so aggregation can track failures
             return batch_metrics
-            
+
     async def _validate_games(self, games: List[Dict]) -> Tuple[List[Dict], List[Dict], Dict]:
         """Validate, deduplicate, and transform games. Delegates to shared implementation."""
         return await self._validate_and_dedup(games, run_validation=True)
@@ -901,7 +970,7 @@ class EnhancedETLPipeline:
 
     @staticmethod
     def _is_empty_score(score) -> bool:
-        return score is None or score == '' or str(score).strip().lower() in ('none', 'null')
+        return score is None or score == "" or str(score).strip().lower() in ("none", "null")
 
     async def _validate_and_dedup(
         self, games: List[Dict], *, run_validation: bool = True
@@ -927,7 +996,7 @@ class EnhancedETLPipeline:
 
         for game in games:
             # Skip games with no scores
-            if self._is_empty_score(game.get('goals_for')) and self._is_empty_score(game.get('goals_against')):
+            if self._is_empty_score(game.get("goals_for")) and self._is_empty_score(game.get("goals_against")):
                 skipped_empty_scores += 1
                 if skipped_empty_scores <= 5:
                     logger.debug(
@@ -941,29 +1010,29 @@ class EnhancedETLPipeline:
                 is_valid, errors = self.validator.validate_game(game)
                 if not is_valid:
                     game_copy = game.copy()
-                    game_copy['validation_errors'] = errors
+                    game_copy["validation_errors"] = errors
                     invalid.append(game_copy)
                     continue
 
             # --- Perspective deduplication (shared by both paths) ---
-            provider_code = game.get('provider', self.provider_code)
-            game_date_raw = game.get('game_date', '')
+            provider_code = game.get("provider", self.provider_code)
+            game_date_raw = game.get("game_date", "")
 
             try:
                 date_obj = parse_game_date(game_date_raw)
-                game_date_normalized = date_obj.strftime('%Y-%m-%d')
+                game_date_normalized = date_obj.strftime("%Y-%m-%d")
             except ValueError:
                 game_date_normalized = game_date_raw
 
-            team1_id = str(game.get('team_id', ''))
-            team2_id = str(game.get('opponent_id', ''))
+            team1_id = str(game.get("team_id", ""))
+            team2_id = str(game.get("opponent_id", ""))
             sorted_teams = sorted([team1_id, team2_id])
 
             # For Modular11, include age_group AND division in the dedup key
             # to avoid silently dropping games in different age groups
-            if provider_code and provider_code.lower() == 'modular11':
-                age_group_key = (game.get('age_group') or '').upper()
-                division_key = (game.get('mls_division') or '').upper()
+            if provider_code and provider_code.lower() == "modular11":
+                age_group_key = (game.get("age_group") or "").upper()
+                division_key = (game.get("mls_division") or "").upper()
                 game_key = (
                     f"{provider_code}:{game_date_normalized}:"
                     f"{sorted_teams[0]}:{sorted_teams[1]}:"
@@ -973,11 +1042,10 @@ class EnhancedETLPipeline:
                 game_key = f"{provider_code}:{game_date_normalized}:{sorted_teams[0]}:{sorted_teams[1]}"
 
             if game_key in seen_games:
-                existing_date = seen_games[game_key].get('game_date', '')
+                existing_date = seen_games[game_key].get("game_date", "")
                 if existing_date != game_date_normalized:
                     logger.warning(
-                        f"Date mismatch for game {game_key}: "
-                        f"existing={existing_date}, current={game_date_normalized}"
+                        f"Date mismatch for game {game_key}: existing={existing_date}, current={game_date_normalized}"
                     )
                     date_mismatches += 1
                 duplicates_skipped += 1
@@ -992,17 +1060,17 @@ class EnhancedETLPipeline:
                 team1_id=sorted_teams[0],
                 team2_id=sorted_teams[1],
             )
-            transformed_game['game_uid'] = game_uid
-            transformed_game['game_date'] = game_date_normalized
+            transformed_game["game_uid"] = game_uid
+            transformed_game["game_date"] = game_date_normalized
 
             seen_games[game_key] = transformed_game
             valid.append(transformed_game)
 
         # Build stats dict (caller merges into metrics — no self.metrics mutation)
         stats = {
-            'duplicates_skipped': duplicates_skipped,
-            'skipped_empty_scores': skipped_empty_scores,
-            'date_mismatches': date_mismatches,
+            "duplicates_skipped": duplicates_skipped,
+            "skipped_empty_scores": skipped_empty_scores,
+            "date_mismatches": date_mismatches,
         }
 
         if date_mismatches > 0:
@@ -1019,25 +1087,25 @@ class EnhancedETLPipeline:
         )
 
         return valid, invalid, stats
-    
+
     def _transform_game_perspective(self, game: Dict) -> Dict:
         """
         Transform game from perspective-based format to neutral home/away format.
-        
+
         Source format:
         - team_id, opponent_id, home_away ("H" or "A"), goals_for, goals_against
-        
+
         Target format:
         - home_team_id, away_team_id, home_score, away_score
         """
-        team_id = game.get('team_id')
-        opponent_id = game.get('opponent_id')
-        home_away = game.get('home_away', 'H').upper()
-        goals_for = game.get('goals_for')
-        goals_against = game.get('goals_against')
-        
+        team_id = game.get("team_id")
+        opponent_id = game.get("opponent_id")
+        home_away = game.get("home_away", "H").upper()
+        goals_for = game.get("goals_for")
+        goals_against = game.get("goals_against")
+
         # Determine home/away based on home_away flag
-        if home_away == 'H':
+        if home_away == "H":
             # team_id is home, opponent_id is away
             home_team_id = team_id
             away_team_id = opponent_id
@@ -1049,167 +1117,176 @@ class EnhancedETLPipeline:
             away_team_id = team_id
             home_score = goals_against
             away_score = goals_for
-        
+
         # Ensure scores are integers (not floats) - database expects INTEGER type
         # Handle None, empty string, and string 'None' cases
-        if home_score is None or home_score == '' or str(home_score).strip().lower() == 'none':
+        if home_score is None or home_score == "" or str(home_score).strip().lower() == "none":
             home_score_int = None
         else:
             try:
                 home_score_int = int(float(home_score))
             except (ValueError, TypeError):
                 home_score_int = None
-        
-        if away_score is None or away_score == '' or str(away_score).strip().lower() == 'none':
+
+        if away_score is None or away_score == "" or str(away_score).strip().lower() == "none":
             away_score_int = None
         else:
             try:
                 away_score_int = int(float(away_score))
             except (ValueError, TypeError):
                 away_score_int = None
-        
+
         # Create transformed game record
         transformed = game.copy()
-        transformed['home_team_id'] = home_team_id
-        transformed['away_team_id'] = away_team_id
-        transformed['home_provider_id'] = home_team_id  # For provider ID lookup
-        transformed['away_provider_id'] = away_team_id
-        transformed['home_score'] = home_score_int
-        transformed['away_score'] = away_score_int
-        
+        transformed["home_team_id"] = home_team_id
+        transformed["away_team_id"] = away_team_id
+        transformed["home_provider_id"] = home_team_id  # For provider ID lookup
+        transformed["away_provider_id"] = away_team_id
+        transformed["home_score"] = home_score_int
+        transformed["away_score"] = away_score_int
+
         # Transform team names based on home/away
-        team_name = game.get('team_name', '')
-        opponent_name = game.get('opponent_name', '')
-        club_name = game.get('club_name', '')
-        opponent_club_name = game.get('opponent_club_name', '')
-        
-        if home_away == 'H':
-            transformed['home_team_name'] = team_name
-            transformed['away_team_name'] = opponent_name
-            transformed['home_club_name'] = club_name
-            transformed['away_club_name'] = opponent_club_name
+        team_name = game.get("team_name", "")
+        opponent_name = game.get("opponent_name", "")
+        club_name = game.get("club_name", "")
+        opponent_club_name = game.get("opponent_club_name", "")
+
+        if home_away == "H":
+            transformed["home_team_name"] = team_name
+            transformed["away_team_name"] = opponent_name
+            transformed["home_club_name"] = club_name
+            transformed["away_club_name"] = opponent_club_name
         else:
-            transformed['home_team_name'] = opponent_name
-            transformed['away_team_name'] = team_name
-            transformed['home_club_name'] = opponent_club_name
-            transformed['away_club_name'] = club_name
-        
+            transformed["home_team_name"] = opponent_name
+            transformed["away_team_name"] = team_name
+            transformed["home_club_name"] = opponent_club_name
+            transformed["away_club_name"] = club_name
+
         # Keep original fields for reference
-        transformed['_source_team_id'] = team_id
-        transformed['_source_opponent_id'] = opponent_id
-        transformed['_source_home_away'] = home_away
-        
+        transformed["_source_team_id"] = team_id
+        transformed["_source_opponent_id"] = opponent_id
+        transformed["_source_home_away"] = home_away
+
         # Preserve mls_division and age_group for Modular11 (needed for division-aware matching and unique constraint)
-        if 'mls_division' in game:
-            transformed['mls_division'] = game['mls_division']
-        if 'age_group' in game:
-            transformed['age_group'] = game['age_group']
-        
+        if "mls_division" in game:
+            transformed["mls_division"] = game["mls_division"]
+        if "age_group" in game:
+            transformed["age_group"] = game["age_group"]
+
         return transformed
-    
+
     async def _check_duplicates(self, games: List[Dict]) -> Tuple[set, Dict[str, Dict]]:
         """
         Check for existing game UIDs - OPTIMIZED with larger batches.
-        
+
         Returns:
             Tuple of (existing_game_uids_set, game_uid_to_master_ids_dict)
             The dict maps game_uid to {'home_team_master_id': ..., 'away_team_master_id': ...}
         """
         if not games:
             return set(), {}
-        
+
         # Extract game UIDs
-        game_uids = [g.get('game_uid') for g in games if g.get('game_uid')]
-        
+        game_uids = [g.get("game_uid") for g in games if g.get("game_uid")]
+
         if not game_uids:
             return set(), {}
-        
+
         # CRITICAL: Use small batch size (200) to avoid Supabase URL length limit.
         # Modular11 game_uids are long (e.g., "modular11:2025-12-15:74:85:U15:AD")
         # and 2000 UIDs in an IN clause easily exceeds the ~8KB URL limit,
         # causing the query to silently fail and ALL games to be treated as new.
         existing = set()
         game_uid_to_master_ids = {}  # Map game_uid to master team IDs
-        
+
         batch_size = 200  # Conservative batch size to stay well under URL length limit
         for chunk in self._chunks(game_uids, batch_size):
             try:
                 # Query Supabase for existing game_uid values AND master team IDs
-                result = self.supabase.table('games').select(
-                    'game_uid, home_team_master_id, away_team_master_id'
-                ).in_('game_uid', chunk).execute()
-                
+                result = (
+                    self.supabase.table("games")
+                    .select("game_uid, home_team_master_id, away_team_master_id")
+                    .in_("game_uid", chunk)
+                    .execute()
+                )
+
                 if result.data:
                     for row in result.data:
-                        game_uid = row.get('game_uid')
+                        game_uid = row.get("game_uid")
                         if game_uid:
                             existing.add(game_uid)
                             game_uid_to_master_ids[game_uid] = {
-                                'home_team_master_id': row.get('home_team_master_id'),
-                                'away_team_master_id': row.get('away_team_master_id')
+                                "home_team_master_id": row.get("home_team_master_id"),
+                                "away_team_master_id": row.get("away_team_master_id"),
                             }
             except Exception as e:
                 logger.error(f"CRITICAL: Error checking duplicates for batch of {len(chunk)} UIDs: {e}")
                 # Re-raise instead of silently continuing - duplicate check failure
                 # means ALL games will be treated as new, causing mass duplication
                 raise
-        
+
         return existing, game_uid_to_master_ids
-    
+
     async def _check_duplicates_by_composite_key(self, game_records: List[Dict]) -> set:
         """
         Check for existing games using composite key matching database constraint.
-        
-        Database constraint: (provider_id, home_provider_id, away_provider_id, 
+
+        Database constraint: (provider_id, home_provider_id, away_provider_id,
         game_date, COALESCE(home_score, -1), COALESCE(away_score, -1))
-        
+
         This catches duplicates that game_uid check missed (e.g., same game imported
         with different game_uid format but same composite key).
         """
         if not game_records:
             return set()
-        
+
         existing_composite_keys = set()
-        
+
         # Build composite keys for all games
         composite_keys_to_check = {}
         for game in game_records:
             # Only check games that have all required fields
-            if not all([
-                game.get('provider_id'),
-                game.get('home_provider_id'),
-                game.get('away_provider_id'),
-                game.get('game_date')
-            ]):
+            if not all(
+                [
+                    game.get("provider_id"),
+                    game.get("home_provider_id"),
+                    game.get("away_provider_id"),
+                    game.get("game_date"),
+                ]
+            ):
                 continue
-            
+
             composite_key = self._make_composite_key(game)
             composite_keys_to_check[composite_key] = game
-        
+
         if not composite_keys_to_check:
             return set()
-        
+
         # Query database for existing games matching composite keys
         # We need to query by the components since we can't query by composite key directly
         # Group by provider_id for efficiency
         provider_id = self.provider_id
         games_by_date = {}
-        
+
         for composite_key, game in composite_keys_to_check.items():
-            game_date = game.get('game_date', '')
+            game_date = game.get("game_date", "")
             if game_date:
                 if game_date not in games_by_date:
                     games_by_date[game_date] = []
                 games_by_date[game_date].append(game)
-        
+
         # Query in batches by date
         for game_date, games_for_date in games_by_date.items():
             try:
                 # Query all games for this provider and date
-                result = self.supabase.table('games').select(
-                    'provider_id, home_provider_id, away_provider_id, game_date, home_score, away_score'
-                ).eq('provider_id', provider_id).eq('game_date', game_date).execute()
-                
+                result = (
+                    self.supabase.table("games")
+                    .select("provider_id, home_provider_id, away_provider_id, game_date, home_score, away_score")
+                    .eq("provider_id", provider_id)
+                    .eq("game_date", game_date)
+                    .execute()
+                )
+
                 if result.data:
                     # Build composite keys for existing games
                     for row in result.data:
@@ -1219,7 +1296,7 @@ class EnhancedETLPipeline:
             except Exception as e:
                 logger.warning(f"Error checking composite key duplicates for date {game_date}: {e}")
                 # Continue processing even if duplicate check fails
-        
+
         return existing_composite_keys
 
     async def _check_duplicates_by_master_ids(self, game_records: List[Dict]) -> int:
@@ -1257,9 +1334,9 @@ class EnhancedETLPipeline:
         # Group incoming games by date for efficient querying
         games_by_date: Dict[str, List[Dict]] = {}
         for game in game_records:
-            game_date = game.get('game_date', '')
-            home_master = game.get('home_team_master_id')
-            away_master = game.get('away_team_master_id')
+            game_date = game.get("game_date", "")
+            home_master = game.get("home_team_master_id")
+            away_master = game.get("away_team_master_id")
 
             # Only check games where BOTH master IDs are resolved
             if not game_date or not home_master or not away_master:
@@ -1278,19 +1355,22 @@ class EnhancedETLPipeline:
                 # Collect all master IDs involved in incoming games for this date
                 master_ids = set()
                 for g in incoming_games:
-                    master_ids.add(g['home_team_master_id'])
-                    master_ids.add(g['away_team_master_id'])
+                    master_ids.add(g["home_team_master_id"])
+                    master_ids.add(g["away_team_master_id"])
 
                 # Query existing games on this date involving any of these master teams
                 master_id_list = list(master_ids)
-                or_filter = ','.join(
-                    f'home_team_master_id.eq.{mid},away_team_master_id.eq.{mid}'
-                    for mid in master_id_list
+                or_filter = ",".join(
+                    f"home_team_master_id.eq.{mid},away_team_master_id.eq.{mid}" for mid in master_id_list
                 )
 
-                result = self.supabase.table('games').select(
-                    'home_team_master_id, away_team_master_id, home_score, away_score'
-                ).eq('game_date', game_date).or_(or_filter).execute()
+                result = (
+                    self.supabase.table("games")
+                    .select("home_team_master_id, away_team_master_id, home_score, away_score")
+                    .eq("game_date", game_date)
+                    .or_(or_filter)
+                    .execute()
+                )
 
                 if not result.data:
                     continue
@@ -1299,10 +1379,10 @@ class EnhancedETLPipeline:
                 # Key: (sorted_master_id_1, sorted_master_id_2, score_for_id_1, score_for_id_2)
                 existing_master_keys = set()
                 for row in result.data:
-                    h_master = row.get('home_team_master_id')
-                    a_master = row.get('away_team_master_id')
-                    h_score = _safe_int(row.get('home_score'))
-                    a_score = _safe_int(row.get('away_score'))
+                    h_master = row.get("home_team_master_id")
+                    a_master = row.get("away_team_master_id")
+                    h_score = _safe_int(row.get("home_score"))
+                    a_score = _safe_int(row.get("away_score"))
 
                     if h_master and a_master:
                         sorted_ids = tuple(sorted([h_master, a_master]))
@@ -1314,13 +1394,13 @@ class EnhancedETLPipeline:
 
                 # Check incoming games against existing master-level keys
                 for game in incoming_games:
-                    if game.get('_master_dedup_skip'):
+                    if game.get("_master_dedup_skip"):
                         continue  # Already marked
 
-                    h_master = game.get('home_team_master_id')
-                    a_master = game.get('away_team_master_id')
-                    h_score = _safe_int(game.get('home_score'))
-                    a_score = _safe_int(game.get('away_score'))
+                    h_master = game.get("home_team_master_id")
+                    a_master = game.get("away_team_master_id")
+                    h_score = _safe_int(game.get("home_score"))
+                    a_score = _safe_int(game.get("away_score"))
 
                     sorted_ids = tuple(sorted([h_master, a_master]))
                     if sorted_ids[0] == h_master:
@@ -1329,7 +1409,7 @@ class EnhancedETLPipeline:
                         key = (sorted_ids[0], sorted_ids[1], a_score, h_score)
 
                     if key in existing_master_keys:
-                        game['_master_dedup_skip'] = True
+                        game["_master_dedup_skip"] = True
                         duplicates_found += 1
                         logger.info(
                             f"[Pipeline] Master-level duplicate: game on {game_date} "
@@ -1365,7 +1445,7 @@ class EnhancedETLPipeline:
         # Explicitly disable duplicate-link backfill for Modular11. Its identity
         # model includes age_group/division and we do not want any healing writes
         # on deduped Modular11 rows.
-        if self.provider_code and self.provider_code.lower() == 'modular11':
+        if self.provider_code and self.provider_code.lower() == "modular11":
             return 0
         if not duplicate_games or self.dry_run:
             return 0
@@ -1373,23 +1453,27 @@ class EnhancedETLPipeline:
         backfilled = 0
 
         for game in duplicate_games:
-            candidate_home = game.get('home_team_master_id')
-            candidate_away = game.get('away_team_master_id')
+            candidate_home = game.get("home_team_master_id")
+            candidate_away = game.get("away_team_master_id")
 
             # Nothing to backfill if the candidate itself has no master IDs
             if not candidate_home and not candidate_away:
                 continue
 
-            game_uid = game.get('game_uid')
+            game_uid = game.get("game_uid")
             existing_row = None
 
             # --- locate existing row ---
             # Try game_uid first (fast, indexed)
             if game_uid:
                 try:
-                    result = self.supabase.table('games').select(
-                        'id, game_uid, home_team_master_id, away_team_master_id'
-                    ).eq('game_uid', game_uid).limit(1).execute()
+                    result = (
+                        self.supabase.table("games")
+                        .select("id, game_uid, home_team_master_id, away_team_master_id")
+                        .eq("game_uid", game_uid)
+                        .limit(1)
+                        .execute()
+                    )
                     if result.data:
                         existing_row = result.data[0]
                 except Exception as e:
@@ -1398,18 +1482,21 @@ class EnhancedETLPipeline:
             # Fallback: composite key lookup
             if not existing_row:
                 try:
-                    provider_id = game.get('provider_id') or self.provider_id
-                    game_date = game.get('game_date')
-                    home_pid = game.get('home_provider_id')
-                    away_pid = game.get('away_provider_id')
+                    provider_id = game.get("provider_id") or self.provider_id
+                    game_date = game.get("game_date")
+                    home_pid = game.get("home_provider_id")
+                    away_pid = game.get("away_provider_id")
                     if provider_id and game_date and home_pid and away_pid:
-                        result = self.supabase.table('games').select(
-                            'id, game_uid, home_team_master_id, away_team_master_id'
-                        ).eq('provider_id', provider_id).eq(
-                            'game_date', game_date
-                        ).eq('home_provider_id', home_pid).eq(
-                            'away_provider_id', away_pid
-                        ).limit(1).execute()
+                        result = (
+                            self.supabase.table("games")
+                            .select("id, game_uid, home_team_master_id, away_team_master_id")
+                            .eq("provider_id", provider_id)
+                            .eq("game_date", game_date)
+                            .eq("home_provider_id", home_pid)
+                            .eq("away_provider_id", away_pid)
+                            .limit(1)
+                            .execute()
+                        )
                         if result.data:
                             existing_row = result.data[0]
                 except Exception as e:
@@ -1420,23 +1507,21 @@ class EnhancedETLPipeline:
 
             # --- determine which fields need backfill ---
             updates = {}
-            if not existing_row.get('home_team_master_id') and candidate_home:
-                updates['home_team_master_id'] = candidate_home
-            if not existing_row.get('away_team_master_id') and candidate_away:
-                updates['away_team_master_id'] = candidate_away
+            if not existing_row.get("home_team_master_id") and candidate_home:
+                updates["home_team_master_id"] = candidate_home
+            if not existing_row.get("away_team_master_id") and candidate_away:
+                updates["away_team_master_id"] = candidate_away
 
             if not updates:
                 continue
 
             # --- apply update ---
-            row_id = existing_row.get('id')
-            row_uid = existing_row.get('game_uid') or game_uid or 'unknown'
+            row_id = existing_row.get("id")
+            row_uid = existing_row.get("game_uid") or game_uid or "unknown"
             try:
-                self.supabase.table('games').update(updates).eq('id', row_id).execute()
+                self.supabase.table("games").update(updates).eq("id", row_id).execute()
                 backfilled += 1
-                logger.info(
-                    f"[Backfill] Healed game {row_uid}: set {updates}"
-                )
+                logger.info(f"[Backfill] Healed game {row_uid}: set {updates}")
             except Exception as e:
                 logger.warning(f"[Backfill] Failed to update game {row_uid}: {e}")
 
@@ -1448,37 +1533,39 @@ class EnhancedETLPipeline:
     async def _update_games_with_scores(self, game_records: List[Dict]) -> int:
         """
         Update existing games with new scores from CSV.
-        
+
         This handles cases where game_uid exists but scores differ.
         Since CSV is fresh data, we trust it over existing database scores.
         """
         if not game_records:
             return 0
-        
+
         updated_count = 0
-        
+
         for game in game_records:
-            game_uid = game.get('game_uid')
+            game_uid = game.get("game_uid")
             if not game_uid:
                 continue
-            
+
             try:
                 # Update the game by game_uid
                 update_data = {
-                    'home_score': game.get('home_score'),
-                    'away_score': game.get('away_score'),
+                    "home_score": game.get("home_score"),
+                    "away_score": game.get("away_score"),
                 }
-                
+
                 # Only update if scores are valid
-                if update_data['home_score'] is not None and update_data['away_score'] is not None:
-                    result = self.supabase.table('games').update(update_data).eq('game_uid', game_uid).execute()
+                if update_data["home_score"] is not None and update_data["away_score"] is not None:
+                    result = self.supabase.table("games").update(update_data).eq("game_uid", game_uid).execute()
                     if result.data:
                         updated_count += 1
-                        logger.debug(f"Updated game {game_uid} with scores {update_data['home_score']}-{update_data['away_score']}")
+                        logger.debug(
+                            f"Updated game {game_uid} with scores {update_data['home_score']}-{update_data['away_score']}"
+                        )
             except Exception as e:
                 logger.warning(f"Failed to update game {game_uid}: {e}")
                 continue
-        
+
         return updated_count
 
     async def _propagate_exclusions_to_new_games(self, game_records: List[Dict]) -> int:
@@ -1511,9 +1598,9 @@ class EnhancedETLPipeline:
         # Group by date for efficient querying
         games_by_date: Dict[str, List[Dict]] = {}
         for game in game_records:
-            game_date = game.get('game_date', '')
-            home_master = game.get('home_team_master_id')
-            away_master = game.get('away_team_master_id')
+            game_date = game.get("game_date", "")
+            home_master = game.get("home_team_master_id")
+            away_master = game.get("away_team_master_id")
             if not game_date or not home_master or not away_master:
                 continue
             if game_date not in games_by_date:
@@ -1528,19 +1615,19 @@ class EnhancedETLPipeline:
                 # Query for excluded games on this date involving any of these teams
                 master_ids = set()
                 for g in incoming_games:
-                    master_ids.add(g['home_team_master_id'])
-                    master_ids.add(g['away_team_master_id'])
+                    master_ids.add(g["home_team_master_id"])
+                    master_ids.add(g["away_team_master_id"])
 
-                or_filter = ','.join(
-                    f'home_team_master_id.eq.{mid},away_team_master_id.eq.{mid}'
-                    for mid in master_ids
+                or_filter = ",".join(f"home_team_master_id.eq.{mid},away_team_master_id.eq.{mid}" for mid in master_ids)
+
+                result = (
+                    self.supabase.table("games")
+                    .select("home_team_master_id, away_team_master_id, home_score, away_score")
+                    .eq("game_date", game_date)
+                    .eq("is_excluded", True)
+                    .or_(or_filter)
+                    .execute()
                 )
-
-                result = self.supabase.table('games').select(
-                    'home_team_master_id, away_team_master_id, home_score, away_score'
-                ).eq('game_date', game_date).eq(
-                    'is_excluded', True
-                ).or_(or_filter).execute()
 
                 if not result.data:
                     continue
@@ -1548,10 +1635,10 @@ class EnhancedETLPipeline:
                 # Build set of excluded master-level keys
                 excluded_keys = set()
                 for row in result.data:
-                    h = row.get('home_team_master_id')
-                    a = row.get('away_team_master_id')
-                    hs = _safe_int(row.get('home_score'))
-                    as_ = _safe_int(row.get('away_score'))
+                    h = row.get("home_team_master_id")
+                    a = row.get("away_team_master_id")
+                    hs = _safe_int(row.get("home_score"))
+                    as_ = _safe_int(row.get("away_score"))
                     if h and a:
                         sorted_ids = tuple(sorted([h, a]))
                         if sorted_ids[0] == h:
@@ -1564,10 +1651,10 @@ class EnhancedETLPipeline:
 
                 # Check each incoming game against excluded keys
                 for game in incoming_games:
-                    h = game.get('home_team_master_id')
-                    a = game.get('away_team_master_id')
-                    hs = _safe_int(game.get('home_score'))
-                    as_ = _safe_int(game.get('away_score'))
+                    h = game.get("home_team_master_id")
+                    a = game.get("away_team_master_id")
+                    hs = _safe_int(game.get("home_score"))
+                    as_ = _safe_int(game.get("away_score"))
 
                     sorted_ids = tuple(sorted([h, a]))
                     if sorted_ids[0] == h:
@@ -1576,12 +1663,10 @@ class EnhancedETLPipeline:
                         key = (sorted_ids[0], sorted_ids[1], as_, hs)
 
                     if key in excluded_keys:
-                        game_uid = game.get('game_uid', 'N/A')
+                        game_uid = game.get("game_uid", "N/A")
                         try:
-                            self.supabase.table('games').update(
-                                {'is_excluded': True}
-                            ).eq('game_uid', game_uid).eq(
-                                'is_excluded', False
+                            self.supabase.table("games").update({"is_excluded": True}).eq("game_uid", game_uid).eq(
+                                "is_excluded", False
                             ).execute()
                             excluded_count += 1
                             logger.info(
@@ -1590,14 +1675,10 @@ class EnhancedETLPipeline:
                                 f"({h[:8]}.. vs {a[:8]}.. score {hs}-{as_})"
                             )
                         except Exception as e:
-                            logger.warning(
-                                f"[Pipeline] Failed to auto-exclude game {game_uid}: {e}"
-                            )
+                            logger.warning(f"[Pipeline] Failed to auto-exclude game {game_uid}: {e}")
 
             except Exception as e:
-                logger.warning(
-                    f"[Pipeline] Error in exclusion propagation for date {game_date}: {e}"
-                )
+                logger.warning(f"[Pipeline] Error in exclusion propagation for date {game_date}: {e}")
 
         return excluded_count
 
@@ -1606,109 +1687,111 @@ class EnhancedETLPipeline:
         if not game_records:
             logger.warning("_bulk_insert_games called with empty game_records list")
             return 0
-        
+
         logger.info(f"Preparing {len(game_records)} game records for insertion...")
         inserted = 0
         duplicate_violations = 0  # Track duplicates caught during insert
-        
+
         # Prepare game records for insertion
         insert_records = []
         skipped_empty_provider_ids = 0
         skipped_empty_game_date = 0
-        
+
         for game in game_records:
             # Ensure all required fields are present
             # Convert scores to integers (database expects INTEGER, not FLOAT)
-            home_score = game.get('home_score')
-            away_score = game.get('away_score')
+            home_score = game.get("home_score")
+            away_score = game.get("away_score")
             # Handle string scores like "0.0" or float scores
             # Also handle string 'None' which can occur from JSON serialization issues
-            if home_score is None or home_score == '' or str(home_score).strip().lower() == 'none':
+            if home_score is None or home_score == "" or str(home_score).strip().lower() == "none":
                 home_score_int = None
             else:
                 try:
                     home_score_int = int(float(home_score))
                 except (ValueError, TypeError):
                     home_score_int = None
-            
-            if away_score is None or away_score == '' or str(away_score).strip().lower() == 'none':
+
+            if away_score is None or away_score == "" or str(away_score).strip().lower() == "none":
                 away_score_int = None
             else:
                 try:
                     away_score_int = int(float(away_score))
                 except (ValueError, TypeError):
                     away_score_int = None
-            
+
             record = {
-                'game_uid': game.get('game_uid'),
-                'home_team_master_id': game.get('home_team_master_id'),
-                'away_team_master_id': game.get('away_team_master_id'),
+                "game_uid": game.get("game_uid"),
+                "home_team_master_id": game.get("home_team_master_id"),
+                "away_team_master_id": game.get("away_team_master_id"),
                 # Use home_provider_id/away_provider_id from matcher, with fallback to team_id/opponent_id
                 # The matcher sets these based on home_away flag, so fallback should work correctly
-                'home_provider_id': game.get('home_provider_id') or game.get('team_id', ''),
-                'away_provider_id': game.get('away_provider_id') or game.get('opponent_id', ''),
-                'home_score': home_score_int,
-                'away_score': away_score_int,
-                'result': game.get('result'),
-                'game_date': game.get('game_date'),
-                'competition': game.get('competition'),
-                'division_name': game.get('division_name'),
-                'event_name': game.get('event_name'),
-                'venue': game.get('venue'),
-                'provider_id': self.provider_id,
-                'source_url': game.get('source_url'),
-                'scraped_at': game.get('scraped_at'),
-                'is_immutable': True,
-                'original_import_id': None,  # Can be set to build_id if needed
+                "home_provider_id": game.get("home_provider_id") or game.get("team_id", ""),
+                "away_provider_id": game.get("away_provider_id") or game.get("opponent_id", ""),
+                "home_score": home_score_int,
+                "away_score": away_score_int,
+                "result": game.get("result"),
+                "game_date": game.get("game_date"),
+                "competition": game.get("competition"),
+                "division_name": game.get("division_name"),
+                "event_name": game.get("event_name"),
+                "venue": game.get("venue"),
+                "provider_id": self.provider_id,
+                "source_url": game.get("source_url"),
+                "scraped_at": game.get("scraped_at"),
+                "is_immutable": True,
+                "original_import_id": None,  # Can be set to build_id if needed
                 # CRITICAL: Include age_group and mls_division for Modular11 unique constraint
-                'age_group': game.get('age_group'),
-                'mls_division': game.get('mls_division')
+                "age_group": game.get("age_group"),
+                "mls_division": game.get("mls_division"),
             }
-            
+
             # Validate required fields before adding to insert batch
-            if not record['home_provider_id'] or not record['away_provider_id']:
+            if not record["home_provider_id"] or not record["away_provider_id"]:
                 skipped_empty_provider_ids += 1
                 if skipped_empty_provider_ids <= 5:  # Log first 5 examples
-                    logger.warning(f"Skipping game with empty provider IDs: home={record['home_provider_id']}, away={record['away_provider_id']}, game_uid={record['game_uid']}")
+                    logger.warning(
+                        f"Skipping game with empty provider IDs: home={record['home_provider_id']}, away={record['away_provider_id']}, game_uid={record['game_uid']}"
+                    )
                 # Don't increment metrics - this is a data quality issue
                 continue
-            if not record['game_date']:
+            if not record["game_date"]:
                 skipped_empty_game_date += 1
                 if skipped_empty_game_date <= 5:  # Log first 5 examples
                     logger.warning(f"Skipping game with empty game_date: game_uid={record['game_uid']}")
                 continue
-            
+
             # Normalize date to YYYY-MM-DD format for database consistency
             try:
-                date_obj = parse_game_date(record['game_date'])
-                record['game_date'] = date_obj.strftime('%Y-%m-%d')
+                date_obj = parse_game_date(record["game_date"])
+                record["game_date"] = date_obj.strftime("%Y-%m-%d")
             except ValueError as e:
                 logger.warning(f"Failed to normalize date '{record['game_date']}': {e}")
                 # Skip this record if date normalization fails
                 skipped_empty_game_date += 1
                 continue
-                
+
             insert_records.append(record)
-        
+
         if skipped_empty_provider_ids > 0:
             logger.warning(f"⚠️  Skipped {skipped_empty_provider_ids} games due to empty provider IDs")
             self.metrics.skipped_empty_provider_ids = skipped_empty_provider_ids
         if skipped_empty_game_date > 0:
             logger.warning(f"⚠️  Skipped {skipped_empty_game_date} games due to empty game_date")
             self.metrics.skipped_empty_game_date = skipped_empty_game_date
-        
+
         logger.info(
             f"[Pipeline] Prepared {len(insert_records)} records for insertion "
             f"(skipped {skipped_empty_provider_ids} empty provider IDs, "
             f"{skipped_empty_game_date} empty game_date)"
         )
-        
+
         # Deduplicate using composite key constraint (matches DB unique constraint)
         # This prevents duplicate constraint violations during insert
         # EXCEPTION: For Modular11, skip composite key dedup because composite key doesn't include
         # age_group/division, but game_uid does. We've already filtered by game_uid above.
-        skip_composite_dedup = self.provider_code and self.provider_code.lower() == 'modular11'
-        
+        skip_composite_dedup = self.provider_code and self.provider_code.lower() == "modular11"
+
         if skip_composite_dedup:
             logger.info(f"[Pipeline] Modular11: Skipping composite key deduplication (game_uid is authoritative)")
             deduped_records = insert_records
@@ -1716,47 +1799,46 @@ class EnhancedETLPipeline:
             seen_composite_keys = set()
             deduped_records = []
             composite_duplicates_count = 0
-            
+
             for record in insert_records:
                 composite_key = self._make_composite_key(record)
-                game_uid = record.get('game_uid', 'N/A')
+                game_uid = record.get("game_uid", "N/A")
                 if composite_key not in seen_composite_keys:
                     seen_composite_keys.add(composite_key)
                     deduped_records.append(record)
                 else:
                     composite_duplicates_count += 1
                     logger.debug(
-                        f"[Pipeline] Duplicate detected pre-insert for game {game_uid}: "
-                        f"composite_key={composite_key}"
+                        f"[Pipeline] Duplicate detected pre-insert for game {game_uid}: composite_key={composite_key}"
                     )
                     # These are cross-run duplicates (already exist in DB by composite constraint)
                     self.metrics.duplicates_found += 1
-            
+
             if composite_duplicates_count > 0:
                 logger.warning(
                     f"[Pipeline] Deduped {composite_duplicates_count} games pre-insert "
                     f"using composite constraint (already exist in DB)"
                 )
-        
+
         insert_records = deduped_records
-        
+
         # Insert in batches
         # Track SSL error frequency for adaptive batch sizing
         ssl_error_count = 0
         current_batch_size = self.batch_size
-        
+
         for chunk in self._chunks(insert_records, current_batch_size):
             # Enhanced retry logic: more retries for SSL errors, fewer for other errors
             max_retries = 5  # Increased from 3 for SSL errors
             retry_delay = 1.0
             inserted_chunk = False
             is_ssl_error = False
-            
+
             for attempt in range(max_retries):
                 try:
                     # Use Supabase insert with batch (returning='minimal' for performance)
-                    result = self.supabase.table('games').insert(chunk, returning='minimal').execute()
-                    
+                    result = self.supabase.table("games").insert(chunk, returning="minimal").execute()
+
                     # Supabase Python client: if no exception is raised, insert succeeded
                     # With returning='minimal', result.data is typically [] or None
                     # No status_code attribute exists - success = no exception
@@ -1766,7 +1848,7 @@ class EnhancedETLPipeline:
                         f"[Pipeline] ✅ Successfully inserted batch of {len(chunk)} games "
                         f"(total inserted so far: {inserted}/{len(insert_records)})"
                     )
-                    
+
                     # Reset SSL error count on success
                     if is_ssl_error:
                         ssl_error_count = 0
@@ -1775,36 +1857,41 @@ class EnhancedETLPipeline:
                             current_batch_size = min(current_batch_size + 500, self.batch_size)
                             logger.info(f"Restoring batch size to {current_batch_size} after successful insert")
                     break
-                    
+
                 except Exception as e:
                     import traceback
+
                     error_str = str(e).lower()
                     error_type = type(e).__name__
-                    
+
                     # Check for HTTP status code (Supabase APIError has code attribute)
                     status_code = None
-                    if hasattr(e, 'code'):
+                    if hasattr(e, "code"):
                         status_code = e.code
-                    elif hasattr(e, 'status_code'):
+                    elif hasattr(e, "status_code"):
                         status_code = e.status_code
-                    
-                    logger.error(f"Exception during batch insert (attempt {attempt + 1}/{max_retries}): {error_type}: {str(e)}")
+
+                    logger.error(
+                        f"Exception during batch insert (attempt {attempt + 1}/{max_retries}): {error_type}: {str(e)}"
+                    )
                     if status_code:
                         logger.error(f"HTTP status code: {status_code}")
                     logger.debug(f"Full traceback: {traceback.format_exc()}")
-                    
+
                     # Check for duplicate/unique constraint violations or 409 Conflict
                     is_duplicate_error = (
-                        'duplicate' in error_str or 
-                        'unique' in error_str or 
-                        '23505' in error_str or
-                        status_code == 409 or
-                        ('409' in error_str and 'conflict' in error_str)
+                        "duplicate" in error_str
+                        or "unique" in error_str
+                        or "23505" in error_str
+                        or status_code == 409
+                        or ("409" in error_str and "conflict" in error_str)
                     )
-                    
+
                     if is_duplicate_error:
                         # Duplicate key violation or 409 Conflict - fall back to individual inserts to save valid records
-                        logger.warning(f"⚠️  Duplicate key violation or 409 Conflict in batch of {len(chunk)} games - falling back to individual inserts")
+                        logger.warning(
+                            f"⚠️  Duplicate key violation or 409 Conflict in batch of {len(chunk)} games - falling back to individual inserts"
+                        )
                         logger.debug(f"Full error details: {str(e)}")
 
                         # Try inserting each record individually to save valid ones
@@ -1815,7 +1902,7 @@ class EnhancedETLPipeline:
                         for idx, record in enumerate(chunk):
                             try:
                                 # Debug: Log what we're inserting for Modular11
-                                if self.provider_code and self.provider_code.lower() == 'modular11' and idx < 3:
+                                if self.provider_code and self.provider_code.lower() == "modular11" and idx < 3:
                                     logger.info(
                                         f"[Pipeline] Inserting Modular11 game {idx}: "
                                         f"game_uid={record.get('game_uid')}, "
@@ -1825,36 +1912,46 @@ class EnhancedETLPipeline:
                                         f"away_provider_id={record.get('away_provider_id')}, "
                                         f"game_date={record.get('game_date')}"
                                     )
-                                self.supabase.table('games').insert(record, returning='minimal').execute()
+                                self.supabase.table("games").insert(record, returning="minimal").execute()
                                 individual_inserted += 1
                             except Exception as individual_e:
                                 individual_error_str = str(individual_e).lower()
                                 individual_status_code = None
-                                if hasattr(individual_e, 'code'):
+                                if hasattr(individual_e, "code"):
                                     individual_status_code = individual_e.code
-                                elif hasattr(individual_e, 'status_code'):
+                                elif hasattr(individual_e, "status_code"):
                                     individual_status_code = individual_e.status_code
-                                
+
                                 is_individual_duplicate = (
-                                    'duplicate' in individual_error_str or 
-                                    'unique' in individual_error_str or 
-                                    '23505' in individual_error_str or
-                                    individual_status_code == 409 or
-                                    ('409' in individual_error_str and 'conflict' in individual_error_str)
+                                    "duplicate" in individual_error_str
+                                    or "unique" in individual_error_str
+                                    or "23505" in individual_error_str
+                                    or individual_status_code == 409
+                                    or ("409" in individual_error_str and "conflict" in individual_error_str)
                                 )
-                                
+
                                 # For Modular11: The composite key constraint doesn't include age_group/division.
                                 # So if game_uid is unique (includes age_group/division), it's NOT a duplicate,
                                 # even if the composite key collides. The composite key collision is expected
                                 # for different age groups/divisions with same provider IDs/date/scores.
                                 is_modular11_false_duplicate = False
-                                if self.provider_code and self.provider_code.lower() == 'modular11' and is_individual_duplicate:
+                                if (
+                                    self.provider_code
+                                    and self.provider_code.lower() == "modular11"
+                                    and is_individual_duplicate
+                                ):
                                     # Check if game_uid exists in DB - if NOT, then this is a FALSE duplicate
                                     # (composite key collision but game_uid is unique)
-                                    game_uid = record.get('game_uid')
+                                    game_uid = record.get("game_uid")
                                     if game_uid:
                                         try:
-                                            uid_check = self.supabase.table('games').select('game_uid').eq('game_uid', game_uid).limit(1).execute()
+                                            uid_check = (
+                                                self.supabase.table("games")
+                                                .select("game_uid")
+                                                .eq("game_uid", game_uid)
+                                                .limit(1)
+                                                .execute()
+                                            )
                                             if not uid_check.data or len(uid_check.data) == 0:
                                                 # game_uid doesn't exist = this is a FALSE duplicate
                                                 # The composite key constraint is blocking a legitimate unique game
@@ -1872,7 +1969,7 @@ class EnhancedETLPipeline:
                                         except Exception as check_e:
                                             logger.debug(f"Error checking game_uid: {check_e}")
                                             # If check fails, treat as duplicate to be safe
-                                
+
                                 if is_modular11_false_duplicate:
                                     # This is a FALSE duplicate - game_uid is unique but composite key collides
                                     # We cannot insert due to database constraint, but it's NOT a real duplicate
@@ -1889,68 +1986,97 @@ class EnhancedETLPipeline:
                                         logger.debug(f"Individual duplicate (game {idx}): {str(individual_e)}")
                                 else:
                                     individual_other_errors += 1
-                                    logger.warning(f"Individual insert failed (NOT duplicate, game {idx}): {type(individual_e).__name__}: {str(individual_e)}")
+                                    logger.warning(
+                                        f"Individual insert failed (NOT duplicate, game {idx}): {type(individual_e).__name__}: {str(individual_e)}"
+                                    )
                                     if individual_status_code:
                                         logger.warning(f"  HTTP status code: {individual_status_code}")
-                                    logger.debug(f"Failed record: game_uid={record.get('game_uid')}, home_provider_id={record.get('home_provider_id')}, away_provider_id={record.get('away_provider_id')}")
+                                    logger.debug(
+                                        f"Failed record: game_uid={record.get('game_uid')}, home_provider_id={record.get('home_provider_id')}, away_provider_id={record.get('away_provider_id')}"
+                                    )
                                     logger.debug(f"Full error: {traceback.format_exc()}")
 
                         inserted += individual_inserted
                         duplicate_violations += individual_duplicates
                         self.metrics.duplicates_found += individual_duplicates
-                        
-                        if individual_other_errors > 0:
-                            logger.error(f"⚠️  {individual_other_errors} games failed for NON-DUPLICATE reasons! Check logs above.")
 
-                        logger.info(f"✅ Fallback complete: {individual_inserted} inserted, {individual_duplicates} duplicates skipped, {individual_other_errors} other errors")
+                        if individual_other_errors > 0:
+                            logger.error(
+                                f"⚠️  {individual_other_errors} games failed for NON-DUPLICATE reasons! Check logs above."
+                            )
+
+                        logger.info(
+                            f"✅ Fallback complete: {individual_inserted} inserted, {individual_duplicates} duplicates skipped, {individual_other_errors} other errors"
+                        )
                         inserted_chunk = True
                         break
-                    elif '429' in error_str or 'rate limit' in error_str or 'too many requests' in error_str:
+                    elif "429" in error_str or "rate limit" in error_str or "too many requests" in error_str:
                         # Rate limit error - wait longer and reduce batch size
                         logger.warning(f"⚠️  Rate limit hit (429) - reducing batch size and waiting longer")
                         if current_batch_size > 500:
                             new_batch_size = max(500, int(current_batch_size * 0.5))
-                            logger.warning(f"Reducing batch size from {current_batch_size} to {new_batch_size} due to rate limit")
+                            logger.warning(
+                                f"Reducing batch size from {current_batch_size} to {new_batch_size} due to rate limit"
+                            )
                             current_batch_size = new_batch_size
-                        
+
                         # Longer wait for rate limits (60-120 seconds)
                         if attempt < max_retries - 1:
                             wait_time = 60 + (attempt * 20) + random.uniform(0, 10)  # 60s, 80s, 100s...
-                            logger.warning(f"Rate limit error (attempt {attempt + 1}/{max_retries}), waiting {wait_time:.1f}s before retry...")
+                            logger.warning(
+                                f"Rate limit error (attempt {attempt + 1}/{max_retries}), waiting {wait_time:.1f}s before retry..."
+                            )
                             time.sleep(wait_time)
                             continue
                         else:
-                            logger.error(f"Rate limit error after {max_retries} attempts - consider reducing batch size further")
+                            logger.error(
+                                f"Rate limit error after {max_retries} attempts - consider reducing batch size further"
+                            )
                             self.metrics.errors.append(f"Rate limit error (429) after {max_retries} attempts")
                             break
-                    elif 'ssl' in error_str or 'sslv3' in error_str or 'bad record mac' in error_str or 'connection' in error_str or 'timeout' in error_str or 'forcibly closed' in error_str:
+                    elif (
+                        "ssl" in error_str
+                        or "sslv3" in error_str
+                        or "bad record mac" in error_str
+                        or "connection" in error_str
+                        or "timeout" in error_str
+                        or "forcibly closed" in error_str
+                    ):
                         # Enhanced SSL/network error handling
                         is_ssl_error = True
                         ssl_error_count += 1
-                        
+
                         # Reduce batch size if multiple SSL errors occur
                         if ssl_error_count >= 3 and current_batch_size > 500:
                             new_batch_size = max(500, int(current_batch_size * 0.7))
-                            logger.warning(f"Reducing batch size from {current_batch_size} to {new_batch_size} due to SSL errors")
+                            logger.warning(
+                                f"Reducing batch size from {current_batch_size} to {new_batch_size} due to SSL errors"
+                            )
                             current_batch_size = new_batch_size
-                        
+
                         # Retry with exponential backoff + jitter
                         if attempt < max_retries - 1:
-                            wait_time = retry_delay * (2 ** attempt) + random.uniform(0, 0.5)  # Add jitter
-                            logger.warning(f"SSL/Network error inserting batch (attempt {attempt + 1}/{max_retries}), retrying in {wait_time:.1f}s: {e}")
+                            wait_time = retry_delay * (2**attempt) + random.uniform(0, 0.5)  # Add jitter
+                            logger.warning(
+                                f"SSL/Network error inserting batch (attempt {attempt + 1}/{max_retries}), retrying in {wait_time:.1f}s: {e}"
+                            )
                             time.sleep(wait_time)
                             continue
                         else:
                             logger.error(f"SSL/Network error inserting batch after {max_retries} attempts: {e}")
-                            self.metrics.errors.append(f"Batch insert SSL/network error (attempts: {max_retries}): {str(e)[:200]}")
+                            self.metrics.errors.append(
+                                f"Batch insert SSL/network error (attempts: {max_retries}): {str(e)[:200]}"
+                            )
                             # Try splitting batch in half if SSL error persists
                             if len(chunk) > 100:
-                                logger.info(f"Attempting to split failed batch of {len(chunk)} games into smaller chunks")
+                                logger.info(
+                                    f"Attempting to split failed batch of {len(chunk)} games into smaller chunks"
+                                )
                                 mid = len(chunk) // 2
                                 # Recursively try smaller batches (will be handled in next iteration)
                                 # For now, just log and continue
                             break
-                    elif 'null' in error_str and ('violates' in error_str or 'constraint' in error_str):
+                    elif "null" in error_str and ("violates" in error_str or "constraint" in error_str):
                         # NOT NULL constraint violation - log and skip batch
                         logger.error(f"❌ NOT NULL constraint violation: {str(e)}")
                         logger.error(f"Sample record: {chunk[0] if chunk else 'N/A'}")
@@ -1963,206 +2089,223 @@ class EnhancedETLPipeline:
                         logger.error(f"Sample record from failed batch: {chunk[0] if chunk else 'No records'}")
                         logger.debug(f"Full traceback: {traceback.format_exc()}")
                         if attempt < max_retries - 1:
-                            wait_time = retry_delay * (2 ** attempt)
+                            wait_time = retry_delay * (2**attempt)
                             logger.warning(f"Retrying in {wait_time}s...")
                             time.sleep(wait_time)
                             continue
                         else:
                             self.metrics.errors.append(f"Batch insert error: {str(e)[:200]}")
                             break
-            
+
             if not inserted_chunk:
                 logger.warning(f"Failed to insert batch of {len(chunk)} games after retries")
-            
+
             # Add delay between batches to avoid rate limits (especially for large imports)
             # Small delay helps prevent hitting Supabase API rate limits
             if inserted_chunk and len(insert_records) > 10000:  # Only for large imports
                 time.sleep(0.1)  # 100ms delay between batches
-        
+
         # Update metrics with duplicate violations
         if duplicate_violations > 0:
             self.metrics.duplicate_key_violations = duplicate_violations
-            logger.info(f"📊 Summary: Inserted {inserted} new games, {duplicate_violations} were duplicates (already in DB)")
-        
+            logger.info(
+                f"📊 Summary: Inserted {inserted} new games, {duplicate_violations} were duplicates (already in DB)"
+            )
+
         return inserted
-    
+
     async def _update_team_scrape_dates(self, game_records: List[Dict]):
         """
         Update last_scraped_at for teams based on scraped_at timestamps from imported games.
-        
+
         This ensures that teams show as recently scraped even when importing from files,
         which helps the dashboard track which teams have recent data.
-        
+
         Args:
             game_records: List of game records that were successfully inserted
         """
         if not game_records or self.dry_run:
             return
-        
+
         try:
             # Extract unique team IDs and their most recent scraped_at timestamps
             team_scrape_dates: Dict[str, datetime] = {}
-            
+
             for game in game_records:
-                scraped_at_str = game.get('scraped_at')
+                scraped_at_str = game.get("scraped_at")
                 if not scraped_at_str:
                     continue
-                
+
                 # Parse scraped_at timestamp
                 try:
                     # Handle ISO format with or without timezone
-                    scraped_at = datetime.fromisoformat(scraped_at_str.replace('Z', '+00:00'))
+                    scraped_at = datetime.fromisoformat(scraped_at_str.replace("Z", "+00:00"))
                 except (ValueError, TypeError):
                     try:
                         # Fallback: try parsing as standard format
-                        scraped_at = datetime.strptime(scraped_at_str, '%Y-%m-%dT%H:%M:%S.%f')
+                        scraped_at = datetime.strptime(scraped_at_str, "%Y-%m-%dT%H:%M:%S.%f")
                     except (ValueError, TypeError):
                         logger.debug(f"Could not parse scraped_at: {scraped_at_str}")
                         continue
-                
+
                 # Track most recent scraped_at for each team
-                home_team_id = game.get('home_team_master_id')
-                away_team_id = game.get('away_team_master_id')
-                
+                home_team_id = game.get("home_team_master_id")
+                away_team_id = game.get("away_team_master_id")
+
                 if home_team_id:
                     if home_team_id not in team_scrape_dates or scraped_at > team_scrape_dates[home_team_id]:
                         team_scrape_dates[home_team_id] = scraped_at
-                
+
                 if away_team_id:
                     if away_team_id not in team_scrape_dates or scraped_at > team_scrape_dates[away_team_id]:
                         team_scrape_dates[away_team_id] = scraped_at
-            
+
             if not team_scrape_dates:
                 logger.debug("No valid scraped_at timestamps found in imported games")
                 return
-            
+
             # Update teams.last_scraped_at in batches
             batch_size = 100
             updated_count = 0
-            
+
             team_ids = list(team_scrape_dates.keys())
             for i in range(0, len(team_ids), batch_size):
-                batch_ids = team_ids[i:i + batch_size]
-                
+                batch_ids = team_ids[i : i + batch_size]
+
                 for team_id in batch_ids:
                     scraped_at = team_scrape_dates[team_id]
                     scraped_at_iso = scraped_at.isoformat()
-                    
+
                     try:
                         # Update last_scraped_at for this team
-                        self.supabase.table('teams').update({
-                            'last_scraped_at': scraped_at_iso
-                        }).eq('team_id_master', team_id).eq('provider_id', self.provider_id).execute()
+                        self.supabase.table("teams").update({"last_scraped_at": scraped_at_iso}).eq(
+                            "team_id_master", team_id
+                        ).eq("provider_id", self.provider_id).execute()
                         updated_count += 1
                     except Exception as e:
                         logger.warning(f"Error updating last_scraped_at for team {team_id}: {e}")
-            
+
             if updated_count > 0:
                 logger.info(f"Updated last_scraped_at for {updated_count} teams based on imported games")
-        
+
         except Exception as e:
             logger.warning(f"Error updating team scrape dates: {e}")
             # Don't fail the import if this step fails
-    
+
     async def _process_team_matching_stats(self):
         """Process team matching statistics from alias map"""
         try:
             # Count direct ID matches
-            direct_result = self.supabase.table('team_alias_map').select(
-                'id', count='exact'
-            ).eq('provider_id', self.provider_id).eq(
-                'match_method', 'direct_id'
-            ).eq('review_status', 'approved').execute()
-            
-            if hasattr(direct_result, 'count'):
+            direct_result = (
+                self.supabase.table("team_alias_map")
+                .select("id", count="exact")
+                .eq("provider_id", self.provider_id)
+                .eq("match_method", "direct_id")
+                .eq("review_status", "approved")
+                .execute()
+            )
+
+            if hasattr(direct_result, "count"):
                 # Direct ID matches are tracked in teams_matched
                 pass  # Already counted during import
-            
+
             # Count fuzzy matches by confidence level
             # Auto-approved (>= 0.9)
-            auto_result = self.supabase.table('team_alias_map').select(
-                'id', count='exact'
-            ).eq('provider_id', self.provider_id).eq(
-                'match_method', 'fuzzy_auto'
-            ).eq('review_status', 'approved').execute()
-            
-            if hasattr(auto_result, 'count'):
+            auto_result = (
+                self.supabase.table("team_alias_map")
+                .select("id", count="exact")
+                .eq("provider_id", self.provider_id)
+                .eq("match_method", "fuzzy_auto")
+                .eq("review_status", "approved")
+                .execute()
+            )
+
+            if hasattr(auto_result, "count"):
                 self.metrics.fuzzy_matches_auto = auto_result.count or 0
-            
+
             # Manual review (0.75-0.9)
-            review_result = self.supabase.table('team_alias_map').select(
-                'id', count='exact'
-            ).eq('provider_id', self.provider_id).eq(
-                'match_method', 'fuzzy_review'
-            ).eq('review_status', 'pending').execute()
-            
-            if hasattr(review_result, 'count'):
+            review_result = (
+                self.supabase.table("team_alias_map")
+                .select("id", count="exact")
+                .eq("provider_id", self.provider_id)
+                .eq("match_method", "fuzzy_review")
+                .eq("review_status", "pending")
+                .execute()
+            )
+
+            if hasattr(review_result, "count"):
                 self.metrics.fuzzy_matches_manual = review_result.count or 0
-            
+
             # Rejected matches would need to be tracked separately
             # For now, we'll estimate based on processing
-            
+
         except Exception as e:
             logger.warning(f"Error processing team matching stats: {e}")
-    
+
     async def _log_invalid_games(self, invalid_games: List[Dict]):
         """Log invalid games to quarantine table"""
         if not invalid_games or self.dry_run:
             return
-        
+
         for game in invalid_games:
             try:
-                self.supabase.table('quarantine_games').insert({
-                    'raw_data': game,
-                    'reason_code': 'validation_failed',
-                    'error_details': '; '.join(game.get('validation_errors', []))
-                }).execute()
+                self.supabase.table("quarantine_games").insert(
+                    {
+                        "raw_data": game,
+                        "reason_code": "validation_failed",
+                        "error_details": "; ".join(game.get("validation_errors", [])),
+                    }
+                ).execute()
             except Exception as e:
                 logger.warning(f"Could not quarantine game: {e}")
-    
+
     async def _log_build_metrics(self):
         """Log detailed metrics to build_logs table"""
         try:
             # Get or create build log entry
             build_log_data = {
-                'build_id': self.build_id,
-                'stage': 'game_import',
-                'provider_id': self.provider_id,
-                'parameters': {
-                    'provider_code': self.provider_code,
-                    'batch_size': self.batch_size,
-                    'dry_run': self.dry_run
+                "build_id": self.build_id,
+                "stage": "game_import",
+                "provider_id": self.provider_id,
+                "parameters": {
+                    "provider_code": self.provider_code,
+                    "batch_size": self.batch_size,
+                    "dry_run": self.dry_run,
                 },
-                'started_at': datetime.now().isoformat(),
-                'completed_at': datetime.now().isoformat(),
-                'records_processed': self.metrics.games_processed,
-                'records_succeeded': self.metrics.games_accepted,
-                'records_failed': self.metrics.games_quarantined + self.metrics.duplicates_found,
-                'errors': self.metrics.errors[:100],  # Limit stored errors
-                'metrics': self.metrics.to_dict()
+                "started_at": datetime.now().isoformat(),
+                "completed_at": datetime.now().isoformat(),
+                "records_processed": self.metrics.games_processed,
+                "records_succeeded": self.metrics.games_accepted,
+                "records_failed": self.metrics.games_quarantined + self.metrics.duplicates_found,
+                "errors": self.metrics.errors[:100],  # Limit stored errors
+                "metrics": self.metrics.to_dict(),
             }
-            
+
             # Check if build log exists
-            existing = self.supabase.table('build_logs').select('id').eq(
-                'build_id', self.build_id
-            ).eq('stage', 'game_import').execute()
-            
+            existing = (
+                self.supabase.table("build_logs")
+                .select("id")
+                .eq("build_id", self.build_id)
+                .eq("stage", "game_import")
+                .execute()
+            )
+
             if existing.data:
                 # Update existing
-                self.supabase.table('build_logs').update(build_log_data).eq(
-                    'build_id', self.build_id
-                ).eq('stage', 'game_import').execute()
+                self.supabase.table("build_logs").update(build_log_data).eq("build_id", self.build_id).eq(
+                    "stage", "game_import"
+                ).execute()
             else:
                 # Create new
-                self.supabase.table('build_logs').insert(build_log_data).execute()
-                
+                self.supabase.table("build_logs").insert(build_log_data).execute()
+
         except Exception as e:
             logger.error(f"Error logging build metrics: {e}")
-    
+
     def print_modular11_summary(self, metrics: ImportMetrics) -> None:
         """
         Print a clean structured summary for Modular11 imports.
-        
+
         Includes:
         - Total games processed
         - Unique games, imported, duplicates
@@ -2171,15 +2314,15 @@ class EnhancedETLPipeline:
         - Rejected fuzzy matches (top candidate only)
         - New teams created
         """
-        if not hasattr(self.matcher, 'summary') or self.provider_code.lower() != 'modular11':
+        if not hasattr(self.matcher, "summary") or self.provider_code.lower() != "modular11":
             return
-        
+
         summary = self.matcher.summary
-        
+
         print("\n" + "=" * 70)
         print("MODULAR11 IMPORT SUMMARY")
         print("=" * 70)
-        
+
         # Game Statistics
         print("\nGAME STATISTICS:")
         print(f"  Total Games Processed: {metrics.games_processed:,}")
@@ -2198,54 +2341,53 @@ class EnhancedETLPipeline:
         print(f"  Fuzzy Matches: {summary['fuzzy_matches']:,}")
         print(f"  New Teams Created: {summary['new_teams']:,}")
         print(f"  Review Queue Entries (Optional): {summary['review_queue']:,}")
-        
+
         # Age Breakdown
-        if summary['by_age']:
+        if summary["by_age"]:
             print("\nBy Age:")
-            for age in sorted(summary['by_age'].keys()):
-                stats = summary['by_age'][age]
-                matched = stats.get('matched', 0)
-                new = stats.get('new', 0)
+            for age in sorted(summary["by_age"].keys()):
+                stats = summary["by_age"][age]
+                matched = stats.get("matched", 0)
+                new = stats.get("new", 0)
                 print(f"  {age.upper()}: {new} created, {matched} matched")
-        
+
         # Rejected Fuzzy Matches (top candidate only)
-        if summary['fuzzy_reject_details']:
+        if summary["fuzzy_reject_details"]:
             print("\nFUZZY MATCHES REJECTED (Top Candidate Only):")
-            for i, detail in enumerate(summary['fuzzy_reject_details'], 1):
+            for i, detail in enumerate(summary["fuzzy_reject_details"], 1):
                 print(f"\n  {i}. {detail['incoming']}")
                 print(f"     Age: {detail['age']}, Division: {detail.get('division', 'N/A')}")
-                if detail.get('top_candidates') and len(detail['top_candidates']) > 0:
-                    top = detail['top_candidates'][0]
-                    div_info = f" (div: {top.get('division', 'N/A')})" if top.get('division') else ""
+                if detail.get("top_candidates") and len(detail["top_candidates"]) > 0:
+                    top = detail["top_candidates"][0]
+                    div_info = f" (div: {top.get('division', 'N/A')})" if top.get("division") else ""
                     print(f"     Best Candidate: {top['team_name']}{div_info}")
                     print(f"       Score: {top['score']:.4f} (need >= 0.93)")
                     print(f"       Division Match: {'Yes' if top.get('division_match') else 'No'}")
                     print(f"       Token Overlap: {'Yes' if top.get('token_overlap') else 'No'}")
-                    if detail.get('second_team'):
+                    if detail.get("second_team"):
                         print(f"       Gap to 2nd: {detail.get('score_gap', 0):.4f} (need >= 0.07)")
                 print(f"     Reason: {detail['reason']}")
-        
+
         # New Teams Created
-        if summary['new_team_details']:
+        if summary["new_team_details"]:
             print("\nNEW TEAMS CREATED:")
-            for i, detail in enumerate(summary['new_team_details'], 1):
+            for i, detail in enumerate(summary["new_team_details"], 1):
                 print(f"  {i}. {detail['clean_name']}")
                 print(f"     ID: {detail['team_id']}")
                 print(f"     Age: {detail['age']}, Division: {detail.get('division', 'N/A')}")
-        
+
         # Accepted Fuzzy Matches
-        if summary['fuzzy_details']:
+        if summary["fuzzy_details"]:
             print("\nFUZZY MATCHES ACCEPTED:")
-            for i, detail in enumerate(summary['fuzzy_details'], 1):
+            for i, detail in enumerate(summary["fuzzy_details"], 1):
                 print(f"  {i}. {detail['incoming']} → {detail['matched_team']}")
                 print(f"     Score: {detail['score']:.4f}, Gap: {detail['gap']:.4f}")
                 print(f"     Age: {detail['age']}, Division: {detail.get('division', 'N/A')}")
-        
+
         print("\n" + "=" * 70 + "\n")
-    
+
     @staticmethod
     def _chunks(lst: List, size: int):
         """Yield successive chunks from list"""
         for i in range(0, len(lst), size):
-            yield lst[i:i + size]
-
+            yield lst[i : i + size]

--- a/src/models/modular11_matcher.py
+++ b/src/models/modular11_matcher.py
@@ -508,7 +508,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         final_team_name = (
                             team_result.data.get("team_name", "Unknown") if team_result.data else "Unknown"
                         )
-                    except:
+                    except Exception:
                         final_team_name = "Unknown"
                     self._dlog(f"FINAL DECISION: alias -> {final_team_name} ({team_id_master})")
 
@@ -555,7 +555,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                         .execute()
                     )
                     final_team_name = team_result.data.get("team_name", "Unknown") if team_result.data else "Unknown"
-                except:
+                except Exception:
                     final_team_name = "Unknown"
                 self._dlog(f"FINAL DECISION: fuzzy_auto -> matched {final_team_name} ({fuzzy_match.team_id_master})")
                 return {
@@ -1840,19 +1840,18 @@ class Modular11GameMatcher(GameHistoryMatcher):
 
             # For Modular11, include age_group AND division in game_uid
             # This matches the alias format: {provider_id}_{age_group}_{division}
+            def normalize_team_id(team_id):
+                if not team_id or team_id == "" or str(team_id).strip().lower() == "none":
+                    return ""
+                try:
+                    return str(int(float(str(team_id))))
+                except (ValueError, TypeError):
+                    return str(team_id).strip()
+
             if age_group and division:
                 # Format: modular11:{date}:{team1}:{team2}:{age_group}:{division}
                 team1_id = home_provider_id or game_data.get("team_id", "")
                 team2_id = away_provider_id or game_data.get("opponent_id", "")
-
-                # Normalize team IDs
-                def normalize_team_id(team_id):
-                    if not team_id or team_id == "" or str(team_id).strip().lower() == "none":
-                        return ""
-                    try:
-                        return str(int(float(str(team_id))))
-                    except (ValueError, TypeError):
-                        return str(team_id).strip()
 
                 team1_str = normalize_team_id(team1_id)
                 team2_str = normalize_team_id(team2_id)
@@ -1863,14 +1862,6 @@ class Modular11GameMatcher(GameHistoryMatcher):
                 # Fallback: include age_group only if division not available
                 team1_id = home_provider_id or game_data.get("team_id", "")
                 team2_id = away_provider_id or game_data.get("opponent_id", "")
-
-                def normalize_team_id(team_id):
-                    if not team_id or team_id == "" or str(team_id).strip().lower() == "none":
-                        return ""
-                    try:
-                        return str(int(float(str(team_id))))
-                    except (ValueError, TypeError):
-                        return str(team_id).strip()
 
                 team1_str = normalize_team_id(team1_id)
                 team2_str = normalize_team_id(team2_id)
@@ -2103,7 +2094,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                                     )
                                 else:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)")
-                            except:
+                            except Exception:
                                 self._dlog(f"Alias rejected: age mismatch (incoming {age_group})")
                             logger.debug(
                                 f"[Modular11] Provider ID {try_id} matched to team {team_id_master} "
@@ -2165,7 +2156,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                                         self._dlog(
                                             f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)"
                                         )
-                                except:
+                                except Exception:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group})")
                                 logger.debug(
                                     f"[Modular11] Provider ID {try_id} matched to team {team_id_master} "
@@ -2214,7 +2205,7 @@ class Modular11GameMatcher(GameHistoryMatcher):
                                         self._dlog(
                                             f"Alias rejected: age mismatch (incoming {age_group} vs team Unknown)"
                                         )
-                                except:
+                                except Exception:
                                     self._dlog(f"Alias rejected: age mismatch (incoming {age_group})")
                                 logger.debug(
                                     f"[Modular11] Provider ID {try_id} matched to team {team_id_master} "

--- a/src/predictions/validate_predictions.py
+++ b/src/predictions/validate_predictions.py
@@ -27,8 +27,10 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+# Ensure project root is on path (needed for direct script execution only)
+_project_root = os.path.join(os.path.dirname(__file__), "../..")
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
 
 from supabase import create_client, Client
 
@@ -36,6 +38,7 @@ from supabase import create_client, Client
 @dataclass
 class TeamRanking:
     """Team ranking data at a point in time"""
+
     team_id: str
     team_name: str
     power_score_final: float
@@ -49,6 +52,7 @@ class TeamRanking:
 @dataclass
 class GamePrediction:
     """Prediction for a single game"""
+
     game_id: str
     game_date: str
     team_a_id: str
@@ -83,19 +87,19 @@ class PredictionValidator:
         """Fetch current rankings from rankings_view"""
         print("Fetching current rankings...")
 
-        response = self.supabase.table('rankings_view').select('*').execute()
+        response = self.supabase.table("rankings_view").select("*").execute()
 
         rankings = {}
         for row in response.data:
-            rankings[row['team_id_master']] = TeamRanking(
-                team_id=row['team_id_master'],
-                team_name=row['team_name'],
-                power_score_final=row['power_score_final'] or 0.5,
-                sos_norm=row['sos_norm'] or 0.5,
-                offense_norm=row.get('offense_norm'),
-                defense_norm=row.get('defense_norm'),
-                win_percentage=row.get('win_percentage'),
-                games_played=row.get('games_played', 0)
+            rankings[row["team_id_master"]] = TeamRanking(
+                team_id=row["team_id_master"],
+                team_name=row["team_name"],
+                power_score_final=row["power_score_final"] or 0.5,
+                sos_norm=row["sos_norm"] or 0.5,
+                offense_norm=row.get("offense_norm"),
+                defense_norm=row.get("defense_norm"),
+                win_percentage=row.get("win_percentage"),
+                games_played=row.get("games_played", 0),
             )
 
         print(f"Loaded {len(rankings)} team rankings")
@@ -105,15 +109,15 @@ class PredictionValidator:
         """Fetch recent games for validation"""
         print(f"Fetching games from last {days} days (limit: {limit})...")
 
-        cutoff_date = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+        cutoff_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
 
         response = (
-            self.supabase.table('games')
-            .select('id, game_date, home_team_master_id, away_team_master_id, home_score, away_score')
-            .gte('game_date', cutoff_date)
-            .not_.is_('home_score', 'null')
-            .not_.is_('away_score', 'null')
-            .order('game_date', desc=True)
+            self.supabase.table("games")
+            .select("id, game_date, home_team_master_id, away_team_master_id, home_score, away_score")
+            .gte("game_date", cutoff_date)
+            .not_.is_("home_score", "null")
+            .not_.is_("away_score", "null")
+            .order("game_date", desc=True)
             .limit(limit)
             .execute()
         )
@@ -148,16 +152,12 @@ class PredictionValidator:
         predicted_margin = power_diff * margin_coefficient
 
         return {
-            'predicted_margin': predicted_margin,
-            'win_prob_a': win_prob_a,
-            'power_diff': power_diff,
+            "predicted_margin": predicted_margin,
+            "win_prob_a": win_prob_a,
+            "power_diff": power_diff,
         }
 
-    def validate_games(
-        self,
-        games_df: pd.DataFrame,
-        rankings: Dict[str, TeamRanking]
-    ) -> List[GamePrediction]:
+    def validate_games(self, games_df: pd.DataFrame, rankings: Dict[str, TeamRanking]) -> List[GamePrediction]:
         """Validate predictions against actual game outcomes"""
 
         predictions = []
@@ -167,8 +167,8 @@ class PredictionValidator:
 
         for idx, game in games_df.iterrows():
             # Get team rankings
-            team_a_id = game['home_team_master_id']
-            team_b_id = game['away_team_master_id']
+            team_a_id = game["home_team_master_id"]
+            team_b_id = game["away_team_master_id"]
 
             # Skip if rankings not available
             if team_a_id not in rankings or team_b_id not in rankings:
@@ -184,49 +184,51 @@ class PredictionValidator:
                 continue
 
             # Actual outcome
-            actual_score_a = game['home_score']
-            actual_score_b = game['away_score']
+            actual_score_a = game["home_score"]
+            actual_score_b = game["away_score"]
             actual_margin = actual_score_a - actual_score_b
 
             if actual_margin > 0:
-                actual_winner = 'a'
+                actual_winner = "a"
             elif actual_margin < 0:
-                actual_winner = 'b'
+                actual_winner = "b"
             else:
-                actual_winner = 'draw'
+                actual_winner = "draw"
 
             # Predict
             pred = self.predict_match(team_a, team_b)
 
             # Predicted winner
-            if pred['win_prob_a'] > 0.55:  # Add 5% threshold to avoid ties
-                predicted_winner = 'a'
-            elif pred['win_prob_a'] < 0.45:
-                predicted_winner = 'b'
+            if pred["win_prob_a"] > 0.55:  # Add 5% threshold to avoid ties
+                predicted_winner = "a"
+            elif pred["win_prob_a"] < 0.45:
+                predicted_winner = "b"
             else:
-                predicted_winner = 'draw'
+                predicted_winner = "draw"
 
             # Check if correct
-            prediction_correct = (predicted_winner == actual_winner)
+            prediction_correct = predicted_winner == actual_winner
 
-            predictions.append(GamePrediction(
-                game_id=game['id'],
-                game_date=game['game_date'],
-                team_a_id=team_a_id,
-                team_b_id=team_b_id,
-                team_a_name=team_a.team_name,
-                team_b_name=team_b.team_name,
-                actual_score_a=actual_score_a,
-                actual_score_b=actual_score_b,
-                actual_margin=actual_margin,
-                actual_winner=actual_winner,
-                predicted_margin=pred['predicted_margin'],
-                predicted_win_prob_a=pred['win_prob_a'],
-                predicted_winner=predicted_winner,
-                prediction_correct=prediction_correct,
-                power_diff=pred['power_diff'],
-                sos_diff=team_a.sos_norm - team_b.sos_norm,
-            ))
+            predictions.append(
+                GamePrediction(
+                    game_id=game["id"],
+                    game_date=game["game_date"],
+                    team_a_id=team_a_id,
+                    team_b_id=team_b_id,
+                    team_a_name=team_a.team_name,
+                    team_b_name=team_b.team_name,
+                    actual_score_a=actual_score_a,
+                    actual_score_b=actual_score_b,
+                    actual_margin=actual_margin,
+                    actual_winner=actual_winner,
+                    predicted_margin=pred["predicted_margin"],
+                    predicted_win_prob_a=pred["win_prob_a"],
+                    predicted_winner=predicted_winner,
+                    prediction_correct=prediction_correct,
+                    power_diff=pred["power_diff"],
+                    sos_diff=team_a.sos_norm - team_b.sos_norm,
+                )
+            )
 
         print(f"Validated {len(predictions)} games (skipped {skipped} due to missing rankings)")
         return predictions
@@ -235,10 +237,7 @@ class PredictionValidator:
         """Calculate accuracy metrics"""
 
         if not predictions:
-            return {
-                'error': 'No predictions to validate',
-                'total_games': 0
-            }
+            return {"error": "No predictions to validate", "total_games": 0}
 
         # Direction accuracy (winner prediction)
         correct = sum(1 for p in predictions if p.prediction_correct)
@@ -255,7 +254,7 @@ class PredictionValidator:
         # actual_outcome = 1 if team_a won, 0 if lost
         brier_scores = []
         for p in predictions:
-            actual_outcome = 1.0 if p.actual_winner == 'a' else 0.0
+            actual_outcome = 1.0 if p.actual_winner == "a" else 0.0
             brier_scores.append((p.predicted_win_prob_a - actual_outcome) ** 2)
         brier_score = np.mean(brier_scores)
 
@@ -266,27 +265,21 @@ class PredictionValidator:
         high_conf = [p for p in predictions if abs(p.predicted_win_prob_a - 0.5) > 0.2]
         low_conf = [p for p in predictions if abs(p.predicted_win_prob_a - 0.5) <= 0.2]
 
-        high_conf_accuracy = (
-            sum(1 for p in high_conf if p.prediction_correct) / len(high_conf)
-            if high_conf else 0
-        )
-        low_conf_accuracy = (
-            sum(1 for p in low_conf if p.prediction_correct) / len(low_conf)
-            if low_conf else 0
-        )
+        high_conf_accuracy = sum(1 for p in high_conf if p.prediction_correct) / len(high_conf) if high_conf else 0
+        low_conf_accuracy = sum(1 for p in low_conf if p.prediction_correct) / len(low_conf) if low_conf else 0
 
         return {
-            'total_games': total,
-            'direction_accuracy': direction_accuracy,
-            'correct_predictions': correct,
-            'mae': mae,
-            'rmse': rmse,
-            'brier_score': brier_score,
-            'calibration_bins': calibration_bins,
-            'high_confidence_games': len(high_conf),
-            'high_confidence_accuracy': high_conf_accuracy,
-            'low_confidence_games': len(low_conf),
-            'low_confidence_accuracy': low_conf_accuracy,
+            "total_games": total,
+            "direction_accuracy": direction_accuracy,
+            "correct_predictions": correct,
+            "mae": mae,
+            "rmse": rmse,
+            "brier_score": brier_score,
+            "calibration_bins": calibration_bins,
+            "high_confidence_games": len(high_conf),
+            "high_confidence_accuracy": high_conf_accuracy,
+            "low_confidence_games": len(low_conf),
+            "low_confidence_accuracy": low_conf_accuracy,
         }
 
     def _calculate_calibration(self, predictions: List[GamePrediction]) -> List[Dict]:
@@ -296,67 +289,80 @@ class PredictionValidator:
         For example, of all games predicted at 70% probability, do we win 70% of them?
         """
         bins = [
-            (0.0, 0.1), (0.1, 0.2), (0.2, 0.3), (0.3, 0.4), (0.4, 0.5),
-            (0.5, 0.6), (0.6, 0.7), (0.7, 0.8), (0.8, 0.9), (0.9, 1.0)
+            (0.0, 0.1),
+            (0.1, 0.2),
+            (0.2, 0.3),
+            (0.3, 0.4),
+            (0.4, 0.5),
+            (0.5, 0.6),
+            (0.6, 0.7),
+            (0.7, 0.8),
+            (0.8, 0.9),
+            (0.9, 1.0),
         ]
 
         calibration = []
 
         for bin_min, bin_max in bins:
-            bin_predictions = [
-                p for p in predictions
-                if bin_min <= p.predicted_win_prob_a < bin_max
-            ]
+            bin_predictions = [p for p in predictions if bin_min <= p.predicted_win_prob_a < bin_max]
 
             if not bin_predictions:
                 continue
 
             # Actual win rate for team_a in this bin
-            actual_wins = sum(1 for p in bin_predictions if p.actual_winner == 'a')
+            actual_wins = sum(1 for p in bin_predictions if p.actual_winner == "a")
             actual_rate = actual_wins / len(bin_predictions)
 
             # Expected win rate (midpoint of bin)
             expected_rate = (bin_min + bin_max) / 2
 
-            calibration.append({
-                'bin': f'{bin_min:.1f}-{bin_max:.1f}',
-                'count': len(bin_predictions),
-                'predicted_rate': expected_rate,
-                'actual_rate': actual_rate,
-                'difference': abs(actual_rate - expected_rate),
-            })
+            calibration.append(
+                {
+                    "bin": f"{bin_min:.1f}-{bin_max:.1f}",
+                    "count": len(bin_predictions),
+                    "predicted_rate": expected_rate,
+                    "actual_rate": actual_rate,
+                    "difference": abs(actual_rate - expected_rate),
+                }
+            )
 
         return calibration
 
     def print_report(self, metrics: Dict, predictions: List[GamePrediction]):
         """Print validation report"""
 
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
         print("MATCH PREDICTION VALIDATION REPORT")
-        print("="*70)
+        print("=" * 70)
 
-        if 'error' in metrics:
+        if "error" in metrics:
             print(f"\nERROR: {metrics['error']}")
             return
 
         print(f"\n📊 OVERALL METRICS (n={metrics['total_games']} games)")
         print("-" * 70)
-        print(f"Direction Accuracy:     {metrics['direction_accuracy']:.1%} ({metrics['correct_predictions']}/{metrics['total_games']})")
+        print(
+            f"Direction Accuracy:     {metrics['direction_accuracy']:.1%} ({metrics['correct_predictions']}/{metrics['total_games']})"
+        )
         print(f"MAE (Goal Margin):      {metrics['mae']:.2f} goals")
         print(f"RMSE (Goal Margin):     {metrics['rmse']:.2f} goals")
         print(f"Brier Score:            {metrics['brier_score']:.3f} (lower is better, <0.20 is good)")
 
         print(f"\n🎯 BY CONFIDENCE LEVEL")
         print("-" * 70)
-        print(f"High Confidence (>70%): {metrics['high_confidence_accuracy']:.1%} accurate (n={metrics['high_confidence_games']})")
-        print(f"Low Confidence (50-70%): {metrics['low_confidence_accuracy']:.1%} accurate (n={metrics['low_confidence_games']})")
+        print(
+            f"High Confidence (>70%): {metrics['high_confidence_accuracy']:.1%} accurate (n={metrics['high_confidence_games']})"
+        )
+        print(
+            f"Low Confidence (50-70%): {metrics['low_confidence_accuracy']:.1%} accurate (n={metrics['low_confidence_games']})"
+        )
 
         print(f"\n📈 CALIBRATION ANALYSIS")
         print("-" * 70)
         print(f"{'Probability Bin':<20} {'Count':<10} {'Predicted':<12} {'Actual':<12} {'Error':<10}")
         print("-" * 70)
 
-        for cal in metrics['calibration_bins']:
+        for cal in metrics["calibration_bins"]:
             print(
                 f"{cal['bin']:<20} "
                 f"{cal['count']:<10} "
@@ -376,45 +382,49 @@ class PredictionValidator:
         print("\n✅ CORRECT PREDICTIONS:")
         for p in correct_samples:
             print(f"  {p.team_a_name} vs {p.team_b_name}")
-            print(f"    Actual: {p.actual_score_a}-{p.actual_score_b} | Predicted: {p.predicted_win_prob_a:.0%} for {p.team_a_name}")
+            print(
+                f"    Actual: {p.actual_score_a}-{p.actual_score_b} | Predicted: {p.predicted_win_prob_a:.0%} for {p.team_a_name}"
+            )
             print(f"    Power diff: {p.power_diff:+.3f}")
 
         print("\n❌ INCORRECT PREDICTIONS:")
         for p in incorrect_samples:
             print(f"  {p.team_a_name} vs {p.team_b_name}")
-            print(f"    Actual: {p.actual_score_a}-{p.actual_score_b} | Predicted: {p.predicted_win_prob_a:.0%} for {p.team_a_name}")
+            print(
+                f"    Actual: {p.actual_score_a}-{p.actual_score_b} | Predicted: {p.predicted_win_prob_a:.0%} for {p.team_a_name}"
+            )
             print(f"    Power diff: {p.power_diff:+.3f}")
 
         # Interpretation
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
         print("INTERPRETATION")
-        print("="*70)
+        print("=" * 70)
 
-        if metrics['direction_accuracy'] >= 0.70:
+        if metrics["direction_accuracy"] >= 0.70:
             print("✅ EXCELLENT: >70% direction accuracy is very good for sports prediction")
-        elif metrics['direction_accuracy'] >= 0.60:
+        elif metrics["direction_accuracy"] >= 0.60:
             print("✅ GOOD: 60-70% direction accuracy is solid and useful")
-        elif metrics['direction_accuracy'] >= 0.55:
+        elif metrics["direction_accuracy"] >= 0.55:
             print("⚠️  FAIR: 55-60% is better than random but could be improved")
         else:
             print("❌ POOR: <55% accuracy suggests predictions need improvement")
 
-        if metrics['brier_score'] < 0.20:
+        if metrics["brier_score"] < 0.20:
             print("✅ GOOD: Brier score <0.20 indicates well-calibrated probabilities")
-        elif metrics['brier_score'] < 0.25:
+        elif metrics["brier_score"] < 0.25:
             print("⚠️  FAIR: Brier score shows room for calibration improvement")
         else:
             print("❌ POOR: Probabilities are poorly calibrated")
 
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
 
 
 async def main():
     """Main validation script"""
 
     # Check environment
-    url = os.getenv('SUPABASE_URL')
-    key = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
     if not url or not key:
         print("ERROR: Missing environment variables")
@@ -455,28 +465,31 @@ async def main():
         validator.print_report(metrics, predictions)
 
         # Export results (optional)
-        export_path = '/tmp/prediction_validation_results.csv'
-        predictions_df = pd.DataFrame([
-            {
-                'game_date': p.game_date,
-                'team_a': p.team_a_name,
-                'team_b': p.team_b_name,
-                'actual_score': f"{p.actual_score_a}-{p.actual_score_b}",
-                'predicted_win_prob_a': f"{p.predicted_win_prob_a:.1%}",
-                'correct': p.prediction_correct,
-                'power_diff': f"{p.power_diff:+.3f}",
-            }
-            for p in predictions
-        ])
+        export_path = "/tmp/prediction_validation_results.csv"
+        predictions_df = pd.DataFrame(
+            [
+                {
+                    "game_date": p.game_date,
+                    "team_a": p.team_a_name,
+                    "team_b": p.team_b_name,
+                    "actual_score": f"{p.actual_score_a}-{p.actual_score_b}",
+                    "predicted_win_prob_a": f"{p.predicted_win_prob_a:.1%}",
+                    "correct": p.prediction_correct,
+                    "power_diff": f"{p.power_diff:+.3f}",
+                }
+                for p in predictions
+            ]
+        )
         predictions_df.to_csv(export_path, index=False)
         print(f"\n💾 Results exported to: {export_path}")
 
     except Exception as e:
         print(f"\nERROR: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     asyncio.run(main())

--- a/src/utils/enhanced_validators.py
+++ b/src/utils/enhanced_validators.py
@@ -1,12 +1,15 @@
 """Enhanced data validation for PitchRank imports"""
+
 from typing import Dict, List, Tuple, Any, Optional
 from datetime import datetime, date
 import re
 import sys
 from pathlib import Path
 
-# Add parent directory to path for imports
-sys.path.append(str(Path(__file__).parent.parent.parent))
+# Ensure project root is on path (needed for direct script execution only)
+_project_root = str(Path(__file__).parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.append(_project_root)
 
 from config.settings import AGE_GROUPS
 
@@ -14,157 +17,157 @@ from config.settings import AGE_GROUPS
 def parse_game_date(date_str: str) -> date:
     """
     Parse game date from multiple formats (handles GotSport CSVs and standard formats).
-    
+
     Supported formats:
     - YYYY-MM-DD (ISO format)
     - M/D/YYYY (US format, e.g., 7/13/2025)
     - M/D/YY (US format with 2-digit year, e.g., 7/13/25)
-    
+
     Args:
         date_str: Date string in any supported format
-        
+
     Returns:
         date object parsed from the date string
-        
+
     Raises:
         ValueError: If date string doesn't match any supported format
     """
     date_str = str(date_str).strip()
     formats = ["%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"]
-    
+
     for fmt in formats:
         try:
             return datetime.strptime(date_str, fmt).date()
         except ValueError:
             continue
-    
+
     raise ValueError(f"Invalid date format: {date_str}")
 
 
 class EnhancedDataValidator:
     """Comprehensive data validation for imports with detailed error reporting"""
-    
+
     def __init__(self):
         # Get valid age groups from config (convert keys to uppercase for compatibility)
         # Only U10-U19 are tracked (birth years 2007-2016 for 2026 season)
         _age_groups_lower = [age.lower() for age in AGE_GROUPS.keys()]
-        self.valid_age_groups = frozenset(
-            _age_groups_lower + [age.upper() for age in _age_groups_lower]
-        )
+        self.valid_age_groups = frozenset(_age_groups_lower + [age.upper() for age in _age_groups_lower])
 
-        self.valid_genders = frozenset(['Male', 'Female', 'Boys', 'Girls', 'Coed'])
-        
+        self.valid_genders = frozenset(["Male", "Female", "Boys", "Girls", "Coed"])
+
     def validate_team(self, team: Dict[str, Any]) -> Tuple[bool, List[str]]:
         """Validate team data with comprehensive checks"""
         errors = []
-        
+
         # Required fields
-        if not team.get('team_name') and not team.get('name'):
+        if not team.get("team_name") and not team.get("name"):
             errors.append("Team name is required")
         else:
-            team_name = team.get('team_name') or team.get('name', '')
+            team_name = team.get("team_name") or team.get("name", "")
             if len(team_name) < 3:
                 errors.append(f"Team name too short: '{team_name}' (minimum 3 characters)")
             elif len(team_name) > 100:
                 errors.append(f"Team name too long: '{team_name}' (maximum 100 characters)")
-        
+
         # Validate provider_team_id if provided
-        if 'provider_team_id' in team and team['provider_team_id']:
-            provider_id = str(team['provider_team_id']).strip()
+        if "provider_team_id" in team and team["provider_team_id"]:
+            provider_id = str(team["provider_team_id"]).strip()
             if len(provider_id) == 0:
                 errors.append("provider_team_id cannot be empty")
-        
+
         # Validate state code (if provided)
-        if 'state_code' in team and team.get('state_code'):
-            state_code = str(team['state_code']).strip()
-            if not re.match(r'^[A-Z]{2}$', state_code):
+        if "state_code" in team and team.get("state_code"):
+            state_code = str(team["state_code"]).strip()
+            if not re.match(r"^[A-Z]{2}$", state_code):
                 errors.append(f"Invalid state code: '{state_code}' (must be exactly 2 uppercase letters)")
-        
+
         # Validate state name (if provided)
-        if 'state' in team and team.get('state'):
-            state = str(team['state']).strip()
+        if "state" in team and team.get("state"):
+            state = str(team["state"]).strip()
             if len(state) < 2 or len(state) > 50:
                 errors.append(f"Invalid state name length: '{state}' (must be 2-50 characters)")
-        
+
         # Validate age group
-        if 'age_group' in team and team.get('age_group'):
-            age_group = str(team['age_group']).strip().lower()
+        if "age_group" in team and team.get("age_group"):
+            age_group = str(team["age_group"]).strip().lower()
             if age_group not in self.valid_age_groups:
-                errors.append(f"Invalid age group: '{team['age_group']}' (must be one of {sorted(self.valid_age_groups)[:10]})")
-        
+                errors.append(
+                    f"Invalid age group: '{team['age_group']}' (must be one of {sorted(self.valid_age_groups)[:10]})"
+                )
+
         # Validate gender
-        if 'gender' in team and team.get('gender'):
-            gender = str(team['gender']).strip()
+        if "gender" in team and team.get("gender"):
+            gender = str(team["gender"]).strip()
             if gender not in self.valid_genders:
                 errors.append(f"Invalid gender: '{gender}' (must be one of {self.valid_genders})")
-        
+
         # Validate club_name length if provided
-        if 'club_name' in team and team.get('club_name'):
-            club_name = str(team['club_name']).strip()
+        if "club_name" in team and team.get("club_name"):
+            club_name = str(team["club_name"]).strip()
             if len(club_name) > 100:
                 errors.append(f"Club name too long: '{club_name}' (maximum 100 characters)")
-        
+
         return len(errors) == 0, errors
-    
+
     def validate_game(self, game: Dict[str, Any]) -> Tuple[bool, List[str]]:
         """
         Validate game data with comprehensive checks.
-        
+
         Handles source data format:
         - team_id, opponent_id, home_away, goals_for, goals_against
-        
+
         Or transformed format:
         - home_team_id, away_team_id, home_score, away_score
         """
         errors = []
-        
+
         # Check if this is source format (team_id/opponent_id) or transformed format
-        has_source_format = 'team_id' in game and 'opponent_id' in game
-        has_transformed_format = 'home_team_id' in game and 'away_team_id' in game
-        
+        has_source_format = "team_id" in game and "opponent_id" in game
+        has_transformed_format = "home_team_id" in game and "away_team_id" in game
+
         if has_source_format:
             # Source format validation
-            team_id = game.get('team_id')
-            opponent_id = game.get('opponent_id')
-            home_away = game.get('home_away')
-            goals_for = game.get('goals_for')
-            goals_against = game.get('goals_against')
-            
+            team_id = game.get("team_id")
+            opponent_id = game.get("opponent_id")
+            home_away = game.get("home_away")
+            goals_for = game.get("goals_for")
+            goals_against = game.get("goals_against")
+
             # Required fields for source format
             if not team_id:
                 errors.append("Missing required field: team_id")
             elif not str(team_id).strip():
                 errors.append("Empty team ID: team_id")
-            
+
             if not opponent_id:
                 errors.append("Missing required field: opponent_id")
             elif not str(opponent_id).strip():
                 errors.append("Empty opponent ID: opponent_id")
-            
+
             if not home_away:
                 errors.append("Missing required field: home_away")
-            elif home_away.upper() not in ['H', 'A']:
+            elif home_away.upper() not in ["H", "A"]:
                 errors.append(f"Invalid home_away value: '{home_away}' (must be 'H' or 'A')")
-            
+
             if goals_for is None:
                 errors.append("Missing required field: goals_for")
-            
+
             if goals_against is None:
                 errors.append("Missing required field: goals_against")
-            
-            if not game.get('game_date'):
+
+            if not game.get("game_date"):
                 errors.append("Missing required field: game_date")
-            
+
             if errors:
                 return False, errors
-            
+
             # Validate teams are different
             if str(team_id) == str(opponent_id):
                 errors.append(f"Team and opponent cannot be the same: '{team_id}'")
-            
+
             # Validate scores
             # Handle None, empty string, and string 'None' cases
-            if goals_for is None or goals_for == '' or str(goals_for).strip().lower() == 'none':
+            if goals_for is None or goals_for == "" or str(goals_for).strip().lower() == "none":
                 # Null scores are allowed (unknown result)
                 pass
             else:
@@ -176,8 +179,8 @@ class EnhancedDataValidator:
                         errors.append(f"Unusually high goals_for detected: {goals_for_int} (verify data accuracy)")
                 except (ValueError, TypeError):
                     errors.append(f"Scores must be integers: goals_for={goals_for}")
-            
-            if goals_against is None or goals_against == '' or str(goals_against).strip().lower() == 'none':
+
+            if goals_against is None or goals_against == "" or str(goals_against).strip().lower() == "none":
                 # Null scores are allowed (unknown result)
                 pass
             else:
@@ -186,75 +189,81 @@ class EnhancedDataValidator:
                     if goals_against_int < 0:
                         errors.append(f"goals_against cannot be negative: {goals_against_int}")
                     if goals_against_int > 50:
-                        errors.append(f"Unusually high goals_against detected: {goals_against_int} (verify data accuracy)")
+                        errors.append(
+                            f"Unusually high goals_against detected: {goals_against_int} (verify data accuracy)"
+                        )
                 except (ValueError, TypeError):
                     errors.append(f"Scores must be integers: goals_against={goals_against}")
-        
+
         elif has_transformed_format:
             # Transformed format validation (legacy support)
-            home_team_id = game.get('home_team_id') or game.get('home_provider_id')
-            away_team_id = game.get('away_team_id') or game.get('away_provider_id')
-            
+            home_team_id = game.get("home_team_id") or game.get("home_provider_id")
+            away_team_id = game.get("away_team_id") or game.get("away_provider_id")
+
             if not home_team_id:
                 errors.append("Missing required field: home_team_id or home_provider_id")
             elif not str(home_team_id).strip():
                 errors.append("Empty team ID: home_team_id")
-            
+
             if not away_team_id:
                 errors.append("Missing required field: away_team_id or away_provider_id")
             elif not str(away_team_id).strip():
                 errors.append("Empty team ID: away_team_id")
-            
-            if 'home_score' not in game or game['home_score'] is None:
+
+            if "home_score" not in game or game["home_score"] is None:
                 errors.append("Missing required field: home_score")
-            if 'away_score' not in game or game['away_score'] is None:
+            if "away_score" not in game or game["away_score"] is None:
                 errors.append("Missing required field: away_score")
-            
-            if not game.get('game_date'):
+
+            if not game.get("game_date"):
                 errors.append("Missing required field: game_date")
-            
+
             if errors:
                 return False, errors
-            
+
             # Validate teams are different
             if str(home_team_id) == str(away_team_id):
                 errors.append(f"Home and away teams cannot be the same: '{home_team_id}'")
-            
+
             # Validate scores
             try:
-                home_score = int(game['home_score'])
-                away_score = int(game['away_score'])
-                
+                home_score = int(game["home_score"])
+                away_score = int(game["away_score"])
+
                 if home_score < 0:
                     errors.append(f"Home score cannot be negative: {home_score}")
                 if away_score < 0:
                     errors.append(f"Away score cannot be negative: {away_score}")
-                
+
                 if home_score > 50:
                     errors.append(f"Unusually high home score detected: {home_score} (verify data accuracy)")
                 if away_score > 50:
                     errors.append(f"Unusually high away score detected: {away_score} (verify data accuracy)")
             except (ValueError, TypeError):
-                errors.append(f"Scores must be integers: home_score={game.get('home_score')}, away_score={game.get('away_score')}")
+                errors.append(
+                    f"Scores must be integers: home_score={game.get('home_score')}, away_score={game.get('away_score')}"
+                )
         else:
             # Neither format found
             errors.append("Game must have either (team_id, opponent_id) or (home_team_id, away_team_id)")
             return False, errors
-        
+
         if errors:  # Skip other validations if required fields missing
             return False, errors
-        
+
         # Validate game_uid format (if present - may be generated later)
-        if 'game_uid' in game and game.get('game_uid'):
-            game_uid = str(game['game_uid']).strip()
-            if not re.match(r'^[\w\-:]{10,}$', game_uid):
-                errors.append(f"Invalid game_uid format: '{game_uid}' (must be at least 10 alphanumeric characters, dashes, colons, or underscores)")
-        
+        if "game_uid" in game and game.get("game_uid"):
+            game_uid = str(game["game_uid"]).strip()
+            if not re.match(r"^[\w\-:]{10,}$", game_uid):
+                errors.append(
+                    f"Invalid game_uid format: '{game_uid}' (must be at least 10 alphanumeric characters, dashes, colons, or underscores)"
+                )
+
         # Validate date (common for both formats)
         try:
-            game_date_str = str(game['game_date']).strip()
+            game_date_str = str(game["game_date"]).strip()
             game_date = parse_game_date(game_date_str)
-            
+
             # Check date is reasonable (not too far in past or future)
             if game_date.year < 2000:
                 errors.append(f"Game date too far in past: {game_date_str} (year must be >= 2000)")
@@ -262,58 +271,58 @@ class EnhancedDataValidator:
                 # Allow up to 1 day in the future for scheduled games
                 if (game_date - datetime.now().date()).days > 1:
                     errors.append(f"Game date too far in future: {game_date_str} (must be within 1 day of today)")
-                    
+
         except ValueError as e:
             errors.append(f"Invalid date format: '{game_date_str}' - {str(e)}")
-        
+
         # Validate age group and gender if provided
-        if 'age_group' in game and game.get('age_group'):
-            age_group = str(game['age_group']).strip().lower()
+        if "age_group" in game and game.get("age_group"):
+            age_group = str(game["age_group"]).strip().lower()
             if age_group not in self.valid_age_groups:
-                errors.append(f"Invalid age group: '{game['age_group']}' (must be one of {sorted(self.valid_age_groups)[:10]})")
-                
-        if 'gender' in game and game.get('gender'):
-            gender = str(game['gender']).strip()
+                errors.append(
+                    f"Invalid age group: '{game['age_group']}' (must be one of {sorted(self.valid_age_groups)[:10]})"
+                )
+
+        if "gender" in game and game.get("gender"):
+            gender = str(game["gender"]).strip()
             if gender not in self.valid_genders:
                 errors.append(f"Invalid gender: '{gender}' (must be one of {self.valid_genders})")
-        
+
         # Validate state codes if provided
-        if 'state_code' in game and game.get('state_code'):
-            state_code = str(game['state_code']).strip()
-            if not re.match(r'^[A-Z]{2}$', state_code):
+        if "state_code" in game and game.get("state_code"):
+            state_code = str(game["state_code"]).strip()
+            if not re.match(r"^[A-Z]{2}$", state_code):
                 errors.append(f"Invalid state code: '{state_code}' (must be exactly 2 uppercase letters)")
-        
+
         return len(errors) == 0, errors
-    
-    def validate_import_batch(self, items: List[Dict[str, Any]], 
-                            item_type: str = 'game') -> Dict[str, Any]:
+
+    def validate_import_batch(self, items: List[Dict[str, Any]], item_type: str = "game") -> Dict[str, Any]:
         """Validate a batch of items and return summary"""
         valid_items = []
         invalid_items = []
-        
-        validator = self.validate_game if item_type == 'game' else self.validate_team
-        
+
+        validator = self.validate_game if item_type == "game" else self.validate_team
+
         for item in items:
             is_valid, errors = validator(item)
             if is_valid:
                 valid_items.append(item)
             else:
                 item_copy = item.copy()
-                item_copy['validation_errors'] = errors
+                item_copy["validation_errors"] = errors
                 invalid_items.append(item_copy)
-        
+
         total = len(items)
         valid_count = len(valid_items)
         invalid_count = len(invalid_items)
-        
-        return {
-            'valid': valid_items,
-            'invalid': invalid_items,
-            'summary': {
-                'total': total,
-                'valid_count': valid_count,
-                'invalid_count': invalid_count,
-                'validation_rate': valid_count / total if total > 0 else 0.0
-            }
-        }
 
+        return {
+            "valid": valid_items,
+            "invalid": invalid_items,
+            "summary": {
+                "total": total,
+                "valid_count": valid_count,
+                "invalid_count": invalid_count,
+                "validation_rate": valid_count / total if total > 0 else 0.0,
+            },
+        }


### PR DESCRIPTION
## Summary

- Replace 5 bare `except:` clauses with `except Exception:` in `modular11_matcher.py` to stop catching `SystemExit` and `KeyboardInterrupt`
- Hoist duplicate `normalize_team_id` function above conditional in `match_game_history` (was defined identically in two branches)
- Guard `sys.path.append` with `if not in sys.path` check in 3 files to prevent duplicate path entries

## Test plan

- [ ] Existing tests pass (no behavior changes, only safety improvements)
- [ ] Scraper/matcher workflows still run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)