### PR TITLE
Fix API route audit findings: auth gaps, error leaks, N+1 queries

### DIFF
--- a/frontend/app/api/agent-activity/route.ts
+++ b/frontend/app/api/agent-activity/route.ts
@@ -16,27 +16,29 @@ interface AgentMessage {
 // GET - fetch recent agent activity from Supabase
 export async function GET() {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     console.log('[AgentActivity] Fetching from Supabase');
-    
+
     const { data, error } = await supabase
       .from('agent_activity')
       .select('*')
       .order('created_at', { ascending: false })
       .limit(50);
-    
+
     if (error) {
       console.error('[AgentActivity] Supabase error:', error);
       return NextResponse.json(
-        { 
+        {
           error: 'Failed to fetch agent activity',
-          messages: [], 
+          messages: [],
           count: 0,
-          debug: { error: error.message }
         },
         { status: 500 }
       );
     }
-    
+
     // Transform to match frontend expectations
     const messages = (data || []).map((row: any) => ({
       timestamp: row.created_at,
@@ -47,9 +49,9 @@ export async function GET() {
       sessionId: row.session_key || 'unknown',
       messageType: row.message_type,
     }));
-    
+
     console.log(`[AgentActivity] Returning ${messages.length} messages from Supabase`);
-    
+
     return NextResponse.json({
       messages,
       count: messages.length,
@@ -58,11 +60,10 @@ export async function GET() {
   } catch (error) {
     console.error('[AgentActivity] Unexpected error:', error);
     return NextResponse.json(
-      { 
-        error: 'Failed to read agent activity', 
-        messages: [], 
+      {
+        error: 'Failed to read agent activity',
+        messages: [],
         count: 0,
-        debug: { error: String(error) }
       },
       { status: 500 }
     );
@@ -76,25 +77,15 @@ export async function POST(request: NextRequest) {
     if (auth.error) return auth.error;
 
     const body = await request.json();
-    const { 
-      session_key, 
-      agent_name, 
-      agent_emoji, 
-      message_preview, 
-      full_message, 
-      message_type 
-    } = body;
-    
+    const { session_key, agent_name, agent_emoji, message_preview, full_message, message_type } = body;
+
     // Validate required fields
     if (!agent_name || !message_preview) {
-      return NextResponse.json(
-        { error: 'Missing required fields: agent_name, message_preview' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing required fields: agent_name, message_preview' }, { status: 400 });
     }
-    
+
     console.log(`[AgentActivity] Logging ${message_type || 'message'} from ${agent_name}`);
-    
+
     const { data, error } = await supabase
       .from('agent_activity')
       .insert({
@@ -107,24 +98,21 @@ export async function POST(request: NextRequest) {
       })
       .select()
       .single();
-    
+
     if (error) {
       console.error('[AgentActivity] Insert error:', error);
-      return NextResponse.json(
-        { error: 'Failed to insert activity' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to insert activity' }, { status: 500 });
     }
-    
-    return NextResponse.json({ 
-      success: true, 
-      activity: data 
-    }, { status: 201 });
+
+    return NextResponse.json(
+      {
+        success: true,
+        activity: data,
+      },
+      { status: 201 }
+    );
   } catch (error) {
     console.error('[AgentActivity] POST error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/frontend/app/api/agent-status/route.ts
+++ b/frontend/app/api/agent-status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabaseClient';
+import { requireAdmin } from '@/lib/supabase/admin';
 
 interface AgentStatusResponse {
   id: string;
@@ -35,7 +36,7 @@ function formatRelativeTime(date: Date): string {
   if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
   if (diffDays === 1) return 'Yesterday';
   if (diffDays < 7) return `${diffDays} days ago`;
-  
+
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
@@ -47,7 +48,7 @@ function calculateNextRun(agentId: string, schedule: string): string | null {
   }
 
   const now = new Date();
-  
+
   // Simple heuristic: if it's a daily schedule, show "Tomorrow at [time]"
   if (schedule.toLowerCase().includes('daily')) {
     const timeMatch = schedule.match(/(\d+):?(\d+)?\s*(am|pm)/i);
@@ -56,7 +57,7 @@ function calculateNextRun(agentId: string, schedule: string): string | null {
       return `Tomorrow at ${timeMatch[1]}:${timeMatch[2] || '00'} ${timeMatch[3].toUpperCase()}`;
     }
   }
-  
+
   // For weekly schedules (like "Sunday 7pm")
   if (schedule.toLowerCase().includes('sunday')) {
     return 'Next Sunday 7:00 PM MT';
@@ -70,13 +71,16 @@ function calculateNextRun(agentId: string, schedule: string): string | null {
   if (schedule.toLowerCase().includes('wednesday')) {
     return 'Next Wednesday';
   }
-  
+
   // Default: just return the schedule
   return schedule;
 }
 
 export async function GET() {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     const agentIds = Object.keys(AGENT_SCHEDULES);
 
     // Batch: 2 queries instead of 18
@@ -105,14 +109,14 @@ export async function GET() {
     const activeTasks = activeResult.data ?? [];
     const completedTasks = completedResult.data ?? [];
 
-    const agents: AgentStatusResponse[] = agentIds.map(agentId => {
-      const activeTask = activeTasks.find(t => t.assigned_agent === agentId);
-      const lastCompleted = completedTasks.find(t => t.assigned_agent === agentId);
+    const agents: AgentStatusResponse[] = agentIds.map((agentId) => {
+      const activeTask = activeTasks.find((t) => t.assigned_agent === agentId);
+      const lastCompleted = completedTasks.find((t) => t.assigned_agent === agentId);
 
       const schedule = AGENT_SCHEDULES[agentId] || 'Unknown';
       return {
         id: agentId,
-        status: activeTask ? 'active' as const : 'idle' as const,
+        status: activeTask ? ('active' as const) : ('idle' as const),
         currentTask: activeTask?.title ?? null,
         lastRun: lastCompleted ? formatRelativeTime(new Date(lastCompleted.updated_at)) : null,
         nextRun: calculateNextRun(agentId, schedule),
@@ -125,9 +129,6 @@ export async function GET() {
     });
   } catch (error) {
     console.error('[AgentStatus] Error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch agent status', agents: [] },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch agent status', agents: [] }, { status: 500 });
   }
 }

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -22,8 +22,8 @@ interface MoverTeam {
 
 async function getMoversData(ageGroup?: string, gender?: string, limit: number = 5) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
   const supabase = createClient(supabaseUrl, supabaseKey);
 
   // Get climbers
@@ -75,108 +75,145 @@ export async function GET(request: Request) {
   const isStory = platform === 'story';
 
   return new ImageResponse(
-    (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          background: `linear-gradient(135deg, ${BRAND_COLORS.forestGreen} 0%, ${BRAND_COLORS.darkGreen} 100%)`,
-          padding: isStory ? 60 : 50,
-          fontFamily: 'Arial, sans-serif',
-        }}
-      >
-        {/* Header */}
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: 30 }}>
-          <div style={{ fontSize: isStory ? 28 : 24, color: BRAND_COLORS.gold, fontWeight: 'bold', letterSpacing: 4 }}>
-            PITCHRANK
-          </div>
-          <div style={{ fontSize: isStory ? 48 : isSquare ? 42 : 36, color: BRAND_COLORS.brightWhite, fontWeight: 'bold', marginTop: 10 }}>
-            BIGGEST MOVERS
-          </div>
-          <div style={{ fontSize: isStory ? 22 : 18, color: 'rgba(255,255,255,0.8)', marginTop: 8 }}>
-            {ageLabel} {genderLabel} • Week of {dateStr}
-          </div>
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: `linear-gradient(135deg, ${BRAND_COLORS.forestGreen} 0%, ${BRAND_COLORS.darkGreen} 100%)`,
+        padding: isStory ? 60 : 50,
+        fontFamily: 'Arial, sans-serif',
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: 30 }}>
+        <div style={{ fontSize: isStory ? 28 : 24, color: BRAND_COLORS.gold, fontWeight: 'bold', letterSpacing: 4 }}>
+          PITCHRANK
         </div>
-
-        {/* Content */}
-        <div style={{ display: 'flex', flexDirection: isStory ? 'column' : 'row', flex: 1, gap: 30 }}>
-          {/* Climbers */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-            <div style={{ fontSize: isStory ? 26 : 22, color: BRAND_COLORS.climberGreen, fontWeight: 'bold', marginBottom: 16, display: 'flex', alignItems: 'center' }}>
-              🚀 CLIMBERS
-            </div>
-            {climbers.map((team, i) => (
-              <div
-                key={i}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  background: 'rgba(76, 175, 80, 0.15)',
-                  borderLeft: `4px solid ${BRAND_COLORS.climberGreen}`,
-                  borderRadius: 8,
-                  padding: '12px 16px',
-                  marginBottom: 10,
-                }}
-              >
-                <div style={{ fontSize: isStory ? 28 : 24, fontWeight: 'bold', color: BRAND_COLORS.climberGreen, marginRight: 16, minWidth: 70 }}>
-                  +{team.rank_change}
-                </div>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
-                    {team.team_name}
-                  </div>
-                  <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                    {team.club_name} • {team.state_code} • #{team.current_rank}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Fallers */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-            <div style={{ fontSize: isStory ? 26 : 22, color: BRAND_COLORS.fallerRed, fontWeight: 'bold', marginBottom: 16, display: 'flex', alignItems: 'center' }}>
-              📉 FALLERS
-            </div>
-            {fallers.map((team, i) => (
-              <div
-                key={i}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  background: 'rgba(244, 67, 54, 0.15)',
-                  borderLeft: `4px solid ${BRAND_COLORS.fallerRed}`,
-                  borderRadius: 8,
-                  padding: '12px 16px',
-                  marginBottom: 10,
-                }}
-              >
-                <div style={{ fontSize: isStory ? 28 : 24, fontWeight: 'bold', color: BRAND_COLORS.fallerRed, marginRight: 16, minWidth: 70 }}>
-                  {team.rank_change}
-                </div>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
-                    {team.team_name}
-                  </div>
-                  <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                    {team.club_name} • {team.state_code} • #{team.current_rank}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+        <div
+          style={{
+            fontSize: isStory ? 48 : isSquare ? 42 : 36,
+            color: BRAND_COLORS.brightWhite,
+            fontWeight: 'bold',
+            marginTop: 10,
+          }}
+        >
+          BIGGEST MOVERS
         </div>
-
-        {/* Footer */}
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 20 }}>
-          <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>
-            pitchrank.io • #YouthSoccer #Rankings
-          </div>
+        <div style={{ fontSize: isStory ? 22 : 18, color: 'rgba(255,255,255,0.8)', marginTop: 8 }}>
+          {ageLabel} {genderLabel} • Week of {dateStr}
         </div>
       </div>
-    ),
+
+      {/* Content */}
+      <div style={{ display: 'flex', flexDirection: isStory ? 'column' : 'row', flex: 1, gap: 30 }}>
+        {/* Climbers */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              fontSize: isStory ? 26 : 22,
+              color: BRAND_COLORS.climberGreen,
+              fontWeight: 'bold',
+              marginBottom: 16,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            🚀 CLIMBERS
+          </div>
+          {climbers.map((team, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                background: 'rgba(76, 175, 80, 0.15)',
+                borderLeft: `4px solid ${BRAND_COLORS.climberGreen}`,
+                borderRadius: 8,
+                padding: '12px 16px',
+                marginBottom: 10,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: isStory ? 28 : 24,
+                  fontWeight: 'bold',
+                  color: BRAND_COLORS.climberGreen,
+                  marginRight: 16,
+                  minWidth: 70,
+                }}
+              >
+                +{team.rank_change}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
+                  {team.team_name}
+                </div>
+                <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
+                  {team.club_name} • {team.state_code} • #{team.current_rank}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Fallers */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              fontSize: isStory ? 26 : 22,
+              color: BRAND_COLORS.fallerRed,
+              fontWeight: 'bold',
+              marginBottom: 16,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            📉 FALLERS
+          </div>
+          {fallers.map((team, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                background: 'rgba(244, 67, 54, 0.15)',
+                borderLeft: `4px solid ${BRAND_COLORS.fallerRed}`,
+                borderRadius: 8,
+                padding: '12px 16px',
+                marginBottom: 10,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: isStory ? 28 : 24,
+                  fontWeight: 'bold',
+                  color: BRAND_COLORS.fallerRed,
+                  marginRight: 16,
+                  minWidth: 70,
+                }}
+              >
+                {team.rank_change}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
+                  {team.team_name}
+                </div>
+                <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
+                  {team.club_name} • {team.state_code} • #{team.current_rank}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: 20 }}>
+        <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>pitchrank.io • #YouthSoccer #Rankings</div>
+      </div>
+    </div>,
     {
       width: dimensions.width,
       height: dimensions.height,

--- a/frontend/app/api/mission-control/status/route.ts
+++ b/frontend/app/api/mission-control/status/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { execSync } from 'child_process';
 import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
@@ -21,16 +20,19 @@ interface AgentStatus {
   alerts: string[];
 }
 
-const AGENTS_CONFIG: Record<string, { 
-  name: string; 
-  emoji: string; 
-  role: string; 
-  model: 'Haiku' | 'Sonnet' | 'Opus';
-  description: string;
-  schedule: string;
-  collaborates: string[];
-  spawns: string[];
-}> = {
+const AGENTS_CONFIG: Record<
+  string,
+  {
+    name: string;
+    emoji: string;
+    role: string;
+    model: 'Haiku' | 'Sonnet' | 'Opus';
+    description: string;
+    schedule: string;
+    collaborates: string[];
+    spawns: string[];
+  }
+> = {
   orchestrator: {
     name: 'Orchestrator',
     emoji: '🎯',
@@ -41,80 +43,86 @@ const AGENTS_CONFIG: Record<string, {
     collaborates: ['All agents'],
     spawns: ['Codey', 'Watchy', 'Cleany', 'Ranky', 'Movy', 'Scrappy', 'Socialy'],
   },
-  cleany: { 
-    name: 'Cleany', 
-    emoji: '🧹', 
-    role: 'Data Hygiene', 
+  cleany: {
+    name: 'Cleany',
+    emoji: '🧹',
+    role: 'Data Hygiene',
     model: 'Haiku',
-    description: 'Normalizes club names, team names, and merges duplicate teams. Keeps the database clean so rankings are accurate.',
+    description:
+      'Normalizes club names, team names, and merges duplicate teams. Keeps the database clean so rankings are accurate.',
     schedule: 'Sunday 7pm MT',
     collaborates: ['Ranky'],
     spawns: ['Codey'],
   },
-  watchy: { 
-    name: 'Watchy', 
-    emoji: '👁️', 
-    role: 'System Monitor', 
+  watchy: {
+    name: 'Watchy',
+    emoji: '👁️',
+    role: 'System Monitor',
     model: 'Haiku',
-    description: 'Daily health checks on quarantine queues, rankings freshness, and data quality. First line of defense.',
+    description:
+      'Daily health checks on quarantine queues, rankings freshness, and data quality. First line of defense.',
     schedule: 'Daily 8am MT',
     collaborates: [],
     spawns: ['Codey'],
   },
-  compy: { 
-    name: 'Compy', 
-    emoji: '🧠', 
-    role: 'Meta-Learning', 
+  compy: {
+    name: 'Compy',
+    emoji: '🧠',
+    role: 'Meta-Learning',
     model: 'Sonnet',
-    description: 'Reviews all agent sessions nightly, extracts patterns and gotchas, updates learning files. Makes every agent smarter over time.',
+    description:
+      'Reviews all agent sessions nightly, extracts patterns and gotchas, updates learning files. Makes every agent smarter over time.',
     schedule: 'Nightly 10:30pm MT',
     collaborates: ['All agents'],
     spawns: [],
   },
-  scrappy: { 
-    name: 'Scrappy', 
-    emoji: '🕷️', 
-    role: 'Data Acquisition', 
+  scrappy: {
+    name: 'Scrappy',
+    emoji: '🕷️',
+    role: 'Data Acquisition',
     model: 'Haiku',
-    description: 'Monitors GitHub Actions scrapes, fetches future games for preview content. Ensures fresh data flows in.',
+    description:
+      'Monitors GitHub Actions scrapes, fetches future games for preview content. Ensures fresh data flows in.',
     schedule: 'Monday 10am, Wednesday 6am MT',
     collaborates: ['Ranky', 'Movy'],
     spawns: ['Codey'],
   },
-  ranky: { 
-    name: 'Ranky', 
-    emoji: '📊', 
-    role: 'Rankings Engine', 
+  ranky: {
+    name: 'Ranky',
+    emoji: '📊',
+    role: 'Rankings Engine',
     model: 'Haiku',
     description: 'Runs the v53e PowerScore algorithm with ML adjustments. Calculates rankings for 90k+ teams.',
     schedule: 'Monday 12pm MT',
     collaborates: ['Scrappy', 'Movy'],
     spawns: ['Codey'],
   },
-  movy: { 
-    name: 'Movy', 
-    emoji: '📈', 
-    role: 'Content & Analytics', 
+  movy: {
+    name: 'Movy',
+    emoji: '📈',
+    role: 'Content & Analytics',
     model: 'Haiku',
-    description: 'Generates weekly movers reports and weekend previews. Creates social content with narrative commentary.',
+    description:
+      'Generates weekly movers reports and weekend previews. Creates social content with narrative commentary.',
     schedule: 'Tuesday 10am, Wednesday 11am MT',
     collaborates: ['Ranky', 'Scrappy', 'Socialy'],
     spawns: ['Codey'],
   },
-  codey: { 
-    name: 'Codey', 
-    emoji: '💻', 
-    role: 'Engineering', 
+  codey: {
+    name: 'Codey',
+    emoji: '💻',
+    role: 'Engineering',
     model: 'Sonnet',
-    description: 'On-demand engineer spawned by other agents to fix issues, build features, and investigate errors. Escalates to Opus for complex tasks.',
+    description:
+      'On-demand engineer spawned by other agents to fix issues, build features, and investigate errors. Escalates to Opus for complex tasks.',
     schedule: 'On-demand',
     collaborates: ['All agents'],
     spawns: [],
   },
-  socialy: { 
-    name: 'Socialy', 
-    emoji: '📱', 
-    role: 'SEO & Growth', 
+  socialy: {
+    name: 'Socialy',
+    emoji: '📱',
+    role: 'SEO & Growth',
     model: 'Haiku',
     description: 'Analyzes Google Search Console data, identifies SEO opportunities, and coordinates content creation.',
     schedule: 'Wednesday 9am MT',
@@ -136,7 +144,7 @@ function formatRelativeTime(date: Date): string {
   if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
   if (diffDays === 1) return 'Yesterday';
   if (diffDays < 7) return `${diffDays} days ago`;
-  
+
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
@@ -152,145 +160,87 @@ function calculateNextRun(schedule: string): string | null {
       return `Tomorrow at ${timeMatch[1]}:${timeMatch[2] || '00'} ${timeMatch[3].toUpperCase()}`;
     }
   }
-  
+
   if (schedule.toLowerCase().includes('sunday')) return 'Next Sunday 7:00 PM MT';
   if (schedule.toLowerCase().includes('monday')) return 'Next Monday';
   if (schedule.toLowerCase().includes('tuesday')) return 'Next Tuesday';
   if (schedule.toLowerCase().includes('wednesday')) return 'Next Wednesday';
-  
+
   return schedule;
 }
 
-// Fetch live status from database
-async function fetchAgentLiveStatus(agentId: string): Promise<Partial<AgentStatus>> {
-  try {
-    // Check for active (in_progress) tasks
-    const { data: activeTasks } = await supabase
-      .from('agent_tasks')
-      .select('*')
-      .eq('assigned_agent', agentId)
-      .eq('status', 'in_progress')
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    const isActive = activeTasks && activeTasks.length > 0;
-    const currentTask = isActive ? activeTasks[0].title : null;
-
-    // Get last completed task for lastRun
-    const { data: completedTasks } = await supabase
-      .from('agent_tasks')
-      .select('*')
-      .eq('assigned_agent', agentId)
-      .in('status', ['done', 'review'])
-      .order('updated_at', { ascending: false })
-      .limit(1);
-
-    const lastRun = completedTasks && completedTasks.length > 0
-      ? formatRelativeTime(new Date(completedTasks[0].updated_at))
-      : null;
-
-    // Check for blocked tasks (assigned but not started)
-    const { data: blockedTasks } = await supabase
-      .from('agent_tasks')
-      .select('title')
-      .eq('assigned_agent', agentId)
-      .eq('status', 'assigned')
-      .order('created_at', { ascending: false })
-      .limit(3);
-
-    // Assigned tasks are NOT blockers - they're just queued work
-    // Only show as blocked if there's an actual blocker (not implemented yet)
-    const assignedTasks = blockedTasks && blockedTasks.length > 0
-      ? blockedTasks.map(t => t.title)
-      : [];
-
-    return {
-      // Active if working, otherwise idle (blocked would need explicit blocker flag)
-      status: isActive ? 'active' : 'idle',
-      currentTask,
-      lastRun,
-      blockers: [], // No blockers for now - assigned tasks are just queued work
-      alerts: [], // Could be populated from task comments if needed
-    };
-  } catch (error) {
-    console.error(`Error fetching status for ${agentId}:`, error);
-    return {
-      status: 'error',
-      currentTask: null,
-      lastRun: null,
-      blockers: [],
-      alerts: ['Failed to fetch status'],
-    };
-  }
-}
-
-function getRecentCommits(): { message: string; time: string; author: string }[] {
-  try {
-    const output = execSync(
-      'git log --oneline --format="%s|%cr|%an" -10',
-      { cwd: process.cwd(), encoding: 'utf-8' }
-    );
-    return output.trim().split('\n').map(line => {
-      const [message, time, author] = line.split('|');
-      return { message, time, author };
-    });
-  } catch {
-    return [];
-  }
-}
-
 export async function GET() {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
+  try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
 
-  const agents: AgentStatus[] = [];
+    const agentIds = Object.keys(AGENTS_CONFIG);
 
-  // Fetch live status for each agent from database
-  for (const [id, config] of Object.entries(AGENTS_CONFIG)) {
-    const liveStatus = await fetchAgentLiveStatus(id);
-    const nextRun = calculateNextRun(config.schedule);
+    // Batch: 2 queries instead of 27 sequential ones
+    const [activeResult, completedResult] = await Promise.all([
+      supabase
+        .from('agent_tasks')
+        .select('assigned_agent, title, created_at')
+        .in('assigned_agent', agentIds)
+        .eq('status', 'in_progress')
+        .order('created_at', { ascending: false }),
+      supabase
+        .from('agent_tasks')
+        .select('assigned_agent, updated_at')
+        .in('assigned_agent', agentIds)
+        .in('status', ['done', 'review'])
+        .order('updated_at', { ascending: false }),
+    ]);
 
-    agents.push({
-      id,
-      name: config.name,
-      emoji: config.emoji,
-      role: config.role,
-      model: config.model,
-      description: config.description,
-      schedule: config.schedule,
-      collaborates: config.collaborates,
-      spawns: config.spawns,
-      status: liveStatus.status || 'idle',
-      currentTask: liveStatus.currentTask || null,
-      lastRun: liveStatus.lastRun || null,
-      nextRun,
-      blockers: liveStatus.blockers || [],
-      alerts: liveStatus.alerts || [],
+    if (activeResult.error) {
+      console.error('Error querying active tasks:', activeResult.error);
+    }
+    if (completedResult.error) {
+      console.error('Error querying completed tasks:', completedResult.error);
+    }
+
+    const activeTasks = activeResult.data ?? [];
+    const completedTasks = completedResult.data ?? [];
+
+    const agents: AgentStatus[] = agentIds.map((id) => {
+      const config = AGENTS_CONFIG[id];
+      const activeTask = activeTasks.find((t) => t.assigned_agent === id);
+      const lastCompleted = completedTasks.find((t) => t.assigned_agent === id);
+
+      return {
+        id,
+        name: config.name,
+        emoji: config.emoji,
+        role: config.role,
+        model: config.model,
+        description: config.description,
+        schedule: config.schedule,
+        collaborates: config.collaborates,
+        spawns: config.spawns,
+        status: activeTask ? ('active' as const) : ('idle' as const),
+        currentTask: activeTask?.title ?? null,
+        lastRun: lastCompleted ? formatRelativeTime(new Date(lastCompleted.updated_at)) : null,
+        nextRun: calculateNextRun(config.schedule),
+        blockers: [],
+        alerts: [],
+      };
     });
+
+    const stats = {
+      active: agents.filter((a) => a.status === 'active').length,
+      idle: agents.filter((a) => a.status === 'idle').length,
+      blocked: agents.filter((a) => a.status === 'blocked').length,
+      error: agents.filter((a) => a.status === 'error').length,
+    };
+
+    return NextResponse.json({
+      agents,
+      commits: [],
+      stats,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[Mission Control] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch mission control status' }, { status: 500 });
   }
-
-  const commits = getRecentCommits();
-
-  const stats = {
-    active: agents.filter(a => a.status === 'active').length,
-    idle: agents.filter(a => a.status === 'idle').length,
-    blocked: agents.filter(a => a.status === 'blocked').length,
-    error: agents.filter(a => a.status === 'error').length,
-  };
-
-  // Verify blockers and alerts are always arrays
-  const agentsWithDefaults = agents.map(agent => ({
-    ...agent,
-    blockers: Array.isArray(agent.blockers) ? agent.blockers : [],
-    alerts: Array.isArray(agent.alerts) ? agent.alerts : [],
-  }));
-
-  console.log('[Mission Control] Response agents sample:', agentsWithDefaults[0]);
-
-  return NextResponse.json({
-    agents: agentsWithDefaults,
-    commits,
-    stats,
-    timestamp: new Date().toISOString(),
-  });
 }

--- a/frontend/app/api/notifications/preferences/route.ts
+++ b/frontend/app/api/notifications/preferences/route.ts
@@ -66,6 +66,9 @@ export async function PATCH(request: NextRequest) {
         if (field === 'digest_frequency' && !validFrequencies.includes(body[field])) {
           return NextResponse.json({ error: `Invalid digest_frequency: ${body[field]}` }, { status: 400 });
         }
+        if ((field === 'push_enabled' || field === 'email_digest_enabled') && typeof body[field] !== 'boolean') {
+          return NextResponse.json({ error: `${field} must be a boolean` }, { status: 400 });
+        }
         updates[field] = body[field];
       }
     }
@@ -74,10 +77,7 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
     }
 
-    const { error } = await supabase
-      .from('user_profiles')
-      .update(updates)
-      .eq('id', user.id);
+    const { error } = await supabase.from('user_profiles').update(updates).eq('id', user.id);
 
     if (error) {
       return NextResponse.json({ error: 'Failed to update preferences' }, { status: 500 });

--- a/frontend/app/api/notifications/subscribe/route.ts
+++ b/frontend/app/api/notifications/subscribe/route.ts
@@ -25,17 +25,15 @@ export async function POST(request: NextRequest) {
     }
 
     // Upsert push subscription
-    const { error } = await supabase
-      .from('push_subscriptions')
-      .upsert(
-        {
-          user_id: user.id,
-          endpoint,
-          p256dh: keys.p256dh,
-          auth: keys.auth,
-        },
-        { onConflict: 'user_id,endpoint' }
-      );
+    const { error } = await supabase.from('push_subscriptions').upsert(
+      {
+        user_id: user.id,
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      },
+      { onConflict: 'user_id,endpoint' }
+    );
 
     if (error) {
       console.error('Failed to save push subscription:', error);
@@ -43,10 +41,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Enable push in profile
-    await supabase
-      .from('user_profiles')
-      .update({ push_enabled: true })
-      .eq('id', user.id);
+    await supabase.from('user_profiles').update({ push_enabled: true }).eq('id', user.id);
 
     return NextResponse.json({ success: true });
   } catch (error) {
@@ -75,18 +70,18 @@ export async function DELETE(request: NextRequest) {
     const { endpoint } = body;
 
     if (endpoint) {
-      await supabase
-        .from('push_subscriptions')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('endpoint', endpoint);
+      await supabase.from('push_subscriptions').delete().eq('user_id', user.id).eq('endpoint', endpoint);
     }
 
-    // Disable push in profile
-    await supabase
-      .from('user_profiles')
-      .update({ push_enabled: false })
-      .eq('id', user.id);
+    // Only disable push if no remaining subscriptions
+    const { count } = await supabase
+      .from('push_subscriptions')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id);
+
+    if (count === 0 || count === null) {
+      await supabase.from('user_profiles').update({ push_enabled: false }).eq('id', user.id);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/frontend/app/api/process-missing-games/route.ts
+++ b/frontend/app/api/process-missing-games/route.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 /**
  * API Route to process missing game requests
  * This can be called by Vercel Cron Jobs to run automatically
- * 
+ *
  * To set up Vercel Cron:
  * 1. Add to vercel.json:
  *    {
@@ -14,7 +14,7 @@ import { createClient } from '@supabase/supabase-js';
  *      }]
  *    }
  * 2. Or use Vercel Dashboard → Settings → Cron Jobs
- * 
+ *
  * Note: Processing is handled by GitHub Actions workflow, not this endpoint
  */
 export async function GET(request: NextRequest) {
@@ -22,30 +22,21 @@ export async function GET(request: NextRequest) {
     // Verify this is a cron request (optional security check)
     const authHeader = request.headers.get('authorization');
     const cronSecret = process.env.CRON_SECRET;
-    
-    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const serviceKey = process.env.SUPABASE_SERVICE_KEY;
     if (!serviceKey) {
       console.error('[process-missing-games] Missing SUPABASE_SERVICE_KEY');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     if (!supabaseUrl) {
       console.error('[process-missing-games] Missing NEXT_PUBLIC_SUPABASE_URL');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     // Create Supabase client with service key
@@ -62,10 +53,7 @@ export async function GET(request: NextRequest) {
 
     if (fetchError) {
       console.error('[process-missing-games] Error fetching requests:', fetchError);
-      return NextResponse.json(
-        { error: 'Failed to fetch requests' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch requests' }, { status: 500 });
     }
 
     if (!pendingRequests || pendingRequests.length === 0) {
@@ -92,10 +80,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('[process-missing-games] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }
-

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,6 +1,6 @@
-import { stripe } from "@/lib/stripe/server";
-import { createServerSupabase } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+import { stripe } from '@/lib/stripe/server';
+import { createServerSupabase } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
   try {
@@ -10,37 +10,31 @@ export async function POST(req: Request) {
     } = await supabase.auth.getUser();
 
     if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
     const { priceId } = await req.json();
 
     // Basic validation - ensure it looks like a Stripe price ID
-    if (!priceId || typeof priceId !== "string" || !priceId.startsWith("price_")) {
-      return NextResponse.json({ error: "Invalid price ID" }, { status: 400 });
+    if (!priceId || typeof priceId !== 'string' || !priceId.startsWith('price_')) {
+      return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
     }
 
     // Get user profile
     const { data: profile, error: profileError } = await supabase
-      .from("user_profiles")
-      .select("*")
-      .eq("id", user.id)
+      .from('user_profiles')
+      .select('*')
+      .eq('id', user.id)
       .single();
 
     if (profileError) {
-      console.error("Error fetching profile:", profileError);
-      return NextResponse.json(
-        { error: "Failed to fetch user profile" },
-        { status: 500 }
-      );
+      console.error('Error fetching profile:', profileError);
+      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
     }
 
-    // Check if user already has active subscription
-    if (profile?.plan === "premium" && profile?.subscription_status === "active") {
-      return NextResponse.json(
-        { error: "You already have an active subscription" },
-        { status: 400 }
-      );
+    // Check if user already has active or trialing subscription
+    if (profile?.subscription_status === 'active' || profile?.subscription_status === 'trialing') {
+      return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
     }
 
     let customerId = profile?.stripe_customer_id;
@@ -58,22 +52,29 @@ export async function POST(req: Request) {
 
       // Save customer ID to profile - this MUST succeed for webhooks to work
       const { error: updateError } = await supabase
-        .from("user_profiles")
+        .from('user_profiles')
         .update({ stripe_customer_id: customerId })
-        .eq("id", user.id);
+        .eq('id', user.id);
 
       if (updateError) {
-        console.error("Error saving customer ID to profile:", updateError);
-        return NextResponse.json(
-          { error: "Failed to link billing account. Please try again." },
-          { status: 500 }
-        );
+        console.error('Error saving customer ID to profile:', updateError);
+        return NextResponse.json({ error: 'Failed to link billing account. Please try again.' }, { status: 500 });
       }
+    }
+
+    // Belt-and-suspenders: check Stripe directly for existing subscriptions
+    const existingSubs = await stripe.subscriptions.list({
+      customer: customerId,
+      limit: 10,
+    });
+    const activeSub = existingSubs.data.find((s) => s.status === 'active' || s.status === 'trialing');
+    if (activeSub) {
+      return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
     }
 
     // Create Stripe checkout session with 7-day free trial
     const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
+      mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`,
@@ -85,22 +86,19 @@ export async function POST(req: Request) {
         },
       },
       allow_promotion_codes: true,
-      billing_address_collection: "auto",
+      billing_address_collection: 'auto',
       customer_update: {
-        address: "auto",
-        name: "auto",
+        address: 'auto',
+        name: 'auto',
       },
     });
 
     return NextResponse.json({ url: session.url });
   } catch (error) {
-    console.error("Checkout session error:", error);
+    console.error('Checkout session error:', error);
 
-    // Return more specific error message for debugging
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json(
-      { error: `Failed to create checkout session: ${errorMessage}` },
-      { status: 500 }
-    );
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Checkout session detail:', errorMessage);
+    return NextResponse.json({ error: 'Failed to create checkout session' }, { status: 500 });
   }
 }

--- a/frontend/app/api/team-aliases/[teamId]/route.ts
+++ b/frontend/app/api/team-aliases/[teamId]/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '@/lib/supabase/admin';
 
 /**
  * Get all aliases for a team from team_alias_map
  * Returns provider info and alias details
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ teamId: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ teamId: string }> }) {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     const { teamId } = await params;
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -17,10 +18,7 @@ export async function GET(
 
     if (!supabaseUrl || !supabaseAnonKey) {
       console.error('[team-aliases] Missing environment variables');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     const supabase = createClient(supabaseUrl, supabaseAnonKey);
@@ -29,7 +27,8 @@ export async function GET(
     // Include division field for MLS NEXT HD/AD differentiation
     const { data: aliases, error } = await supabase
       .from('team_alias_map')
-      .select(`
+      .select(
+        `
         id,
         provider_team_id,
         match_method,
@@ -38,17 +37,15 @@ export async function GET(
         division,
         created_at,
         provider:providers(id, name)
-      `)
+      `
+      )
       .eq('team_id_master', teamId)
       .eq('review_status', 'approved')
       .order('created_at', { ascending: false });
 
     if (error) {
       console.error('[team-aliases] Error fetching aliases:', error);
-      return NextResponse.json(
-        { error: 'Failed to fetch team aliases' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch team aliases' }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -57,9 +54,6 @@ export async function GET(
     });
   } catch (error) {
     console.error('[team-aliases] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/frontend/app/api/team-merge/list/route.ts
+++ b/frontend/app/api/team-merge/list/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '@/lib/supabase/admin';
 
 /**
  * GET /api/team-merge/list
@@ -8,14 +9,14 @@ import { createClient } from '@supabase/supabase-js';
  */
 export async function GET() {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseAnonKey) {
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     const supabase = createClient(supabaseUrl, supabaseAnonKey);
@@ -29,10 +30,7 @@ export async function GET() {
 
     if (error) {
       console.error('[team-merge/list] Error fetching merges:', error);
-      return NextResponse.json(
-        { error: 'Failed to fetch merges' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch merges' }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -41,9 +39,6 @@ export async function GET() {
     });
   } catch (error) {
     console.error('[team-merge/list] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/frontend/app/api/team-merge/route.ts
+++ b/frontend/app/api/team-merge/route.ts
@@ -30,10 +30,7 @@ export async function POST(request: NextRequest) {
 
     if (!serviceKey || !supabaseUrl) {
       console.error('[team-merge] Missing environment variables');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     // Parse request body
@@ -41,20 +38,11 @@ export async function POST(request: NextRequest) {
     try {
       requestBody = await request.json();
     } catch {
-      return NextResponse.json(
-        { error: 'Invalid request body' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    const {
-      deprecatedTeamId,
-      canonicalTeamId,
-      mergedBy,
-      mergeReason,
-      confidenceScore,
-      suggestionSignals,
-    } = requestBody;
+    const { deprecatedTeamId, canonicalTeamId, mergedBy, mergeReason, confidenceScore, suggestionSignals } =
+      requestBody;
 
     // Validate required fields
     if (!deprecatedTeamId || !canonicalTeamId || !mergedBy) {
@@ -67,18 +55,12 @@ export async function POST(request: NextRequest) {
     // Validate UUIDs
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(deprecatedTeamId) || !uuidRegex.test(canonicalTeamId)) {
-      return NextResponse.json(
-        { error: 'Invalid team ID format' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
     // Prevent self-merge
     if (deprecatedTeamId === canonicalTeamId) {
-      return NextResponse.json(
-        { error: 'Cannot merge a team with itself' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Cannot merge a team with itself' }, { status: 400 });
     }
 
     const supabase = createClient(supabaseUrl, serviceKey);
@@ -98,10 +80,7 @@ export async function POST(request: NextRequest) {
       const message = error.message || 'Unknown error';
 
       if (message.includes('already deprecated') || message.includes('already merged')) {
-        return NextResponse.json(
-          { error: 'This team has already been merged' },
-          { status: 409 }
-        );
+        return NextResponse.json({ error: 'This team has already been merged' }, { status: 409 });
       }
 
       if (message.includes('circular merge') || message.includes('chain')) {
@@ -112,16 +91,10 @@ export async function POST(request: NextRequest) {
       }
 
       if (message.includes('does not exist')) {
-        return NextResponse.json(
-          { error: 'One or both team IDs do not exist' },
-          { status: 404 }
-        );
+        return NextResponse.json({ error: 'One or both team IDs do not exist' }, { status: 404 });
       }
 
-      return NextResponse.json(
-        { error: `Merge failed: ${message}` },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: `Merge failed: ${message}` }, { status: 500 });
     }
 
     // If confidence score and signals were provided (from Option 8), update the merge record
@@ -141,8 +114,8 @@ export async function POST(request: NextRequest) {
       .select('team_id_master, team_name')
       .in('team_id_master', [deprecatedTeamId, canonicalTeamId]);
 
-    const deprecatedTeam = teams?.find(t => t.team_id_master === deprecatedTeamId);
-    const canonicalTeam = teams?.find(t => t.team_id_master === canonicalTeamId);
+    const deprecatedTeam = teams?.find((t) => t.team_id_master === deprecatedTeamId);
+    const canonicalTeam = teams?.find((t) => t.team_id_master === canonicalTeamId);
 
     return NextResponse.json({
       success: true,
@@ -155,10 +128,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('[team-merge] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }
 
@@ -180,10 +150,7 @@ export async function DELETE(request: NextRequest) {
 
     if (!serviceKey || !supabaseUrl) {
       console.error('[team-merge] Missing environment variables');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     // Parse request body
@@ -191,29 +158,20 @@ export async function DELETE(request: NextRequest) {
     try {
       requestBody = await request.json();
     } catch {
-      return NextResponse.json(
-        { error: 'Invalid request body' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
     const { deprecatedTeamId, revertedBy, revertReason } = requestBody;
 
     // Validate required fields
     if (!deprecatedTeamId || !revertedBy) {
-      return NextResponse.json(
-        { error: 'Missing required fields: deprecatedTeamId, revertedBy' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing required fields: deprecatedTeamId, revertedBy' }, { status: 400 });
     }
 
     // Validate UUID
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(deprecatedTeamId)) {
-      return NextResponse.json(
-        { error: 'Invalid team ID format' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
     const supabase = createClient(supabaseUrl, serviceKey);
@@ -238,16 +196,10 @@ export async function DELETE(request: NextRequest) {
       const message = error.message || 'Unknown error';
 
       if (message.includes('not found') || message.includes('not merged')) {
-        return NextResponse.json(
-          { error: 'This team is not currently merged' },
-          { status: 404 }
-        );
+        return NextResponse.json({ error: 'This team is not currently merged' }, { status: 404 });
       }
 
-      return NextResponse.json(
-        { error: `Revert failed: ${message}` },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: `Revert failed: ${message}` }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -258,10 +210,7 @@ export async function DELETE(request: NextRequest) {
     });
   } catch (error) {
     console.error('[team-merge] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }
 
@@ -272,33 +221,27 @@ export async function DELETE(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseAnonKey) {
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     const { searchParams } = new URL(request.url);
     const teamId = searchParams.get('teamId');
 
     if (!teamId) {
-      return NextResponse.json(
-        { error: 'Missing teamId query parameter' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing teamId query parameter' }, { status: 400 });
     }
 
     // Validate UUID
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(teamId)) {
-      return NextResponse.json(
-        { error: 'Invalid team ID format' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
     const supabase = createClient(supabaseUrl, supabaseAnonKey);
@@ -311,10 +254,7 @@ export async function GET(request: NextRequest) {
       .single();
 
     if (teamError || !team) {
-      return NextResponse.json(
-        { error: 'Team not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
     }
 
     if (!team.is_deprecated) {
@@ -341,9 +281,6 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('[team-merge] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/frontend/app/api/team-merge/suggestions/route.ts
+++ b/frontend/app/api/team-merge/suggestions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from '@/lib/supabase/admin';
 
 /**
  * GET /api/team-merge/suggestions
@@ -59,15 +60,15 @@ interface MergeSuggestion {
 
 // Signal weights
 const WEIGHTS = {
-  opponentOverlap: 0.40,
+  opponentOverlap: 0.4,
   scheduleAlignment: 0.25,
-  nameSimilarity: 0.20,
-  geography: 0.10,
+  nameSimilarity: 0.2,
+  geography: 0.1,
   performance: 0.05,
 };
 
 // Minimum confidence threshold - only show high-quality suggestions
-const MIN_CONFIDENCE_THRESHOLD = 0.90;
+const MIN_CONFIDENCE_THRESHOLD = 0.9;
 
 /**
  * Detects distinguishing markers in team names that indicate different teams
@@ -86,11 +87,50 @@ function hasDistinguishingMarkers(nameA: string, nameB: string): { isDifferent: 
 
   // Common location codes used in youth soccer (3-4 letter codes)
   const locationCodes = [
-    'clw', 'lwr', 'tpa', 'orl', 'jax', 'mia', 'ftl', 'pbg', 'srq', 'tam',  // Florida
-    'atl', 'dal', 'hou', 'aus', 'san', 'phx', 'den', 'sea', 'por', 'lax',  // Other cities
-    'north', 'south', 'east', 'west', 'central', 'metro', 'coastal',       // Directional
-    'mv', 'tem', 'sv', 'cv', 'pv', 'rv', 'ev', 'wv', 'nv',                 // Valley codes
-    'sc', 'fc', 'cf', 'ac', 'bc', 'cc', 'dc', 'ec',                        // Club type codes
+    'clw',
+    'lwr',
+    'tpa',
+    'orl',
+    'jax',
+    'mia',
+    'ftl',
+    'pbg',
+    'srq',
+    'tam', // Florida
+    'atl',
+    'dal',
+    'hou',
+    'aus',
+    'san',
+    'phx',
+    'den',
+    'sea',
+    'por',
+    'lax', // Other cities
+    'north',
+    'south',
+    'east',
+    'west',
+    'central',
+    'metro',
+    'coastal', // Directional
+    'mv',
+    'tem',
+    'sv',
+    'cv',
+    'pv',
+    'rv',
+    'ev',
+    'wv',
+    'nv', // Valley codes
+    'sc',
+    'fc',
+    'cf',
+    'ac',
+    'bc',
+    'cc',
+    'dc',
+    'ec', // Club type codes
   ];
 
   // Extract potential location codes from names
@@ -110,19 +150,22 @@ function hasDistinguishingMarkers(nameA: string, nameB: string): { isDifferent: 
 
   // If both have different location codes, they're different teams
   if (locationA && locationB && locationA !== locationB) {
-    return { isDifferent: true, reason: `Different locations: ${locationA.toUpperCase()} vs ${locationB.toUpperCase()}` };
+    return {
+      isDifferent: true,
+      reason: `Different locations: ${locationA.toUpperCase()} vs ${locationB.toUpperCase()}`,
+    };
   }
 
   // Detect team number suffixes: -1, -2, "2", "II", "1st", "2nd", etc.
   // Also handles numbers embedded in name like "EDP 1" or "Mahe1"
   const numberPatterns = [
-    /[-\s](\d+)$/,                    // Ends with -1, -2, " 1", " 2"
-    /\s(\d+)$/,                       // Ends with space + number
-    /[a-z](\d+)$/i,                   // Number directly after letter: Mahe1, Team2
-    /[-\s](i{1,3}|iv|v)$/i,           // Roman numerals I, II, III, IV, V
-    /(\d+)(st|nd|rd|th)$/i,           // 1st, 2nd, 3rd, 4th
-    /\steam\s*(\d+)/i,                // "team 1", "team 2"
-    /\s(one|two|three|four|five)$/i,  // Written numbers
+    /[-\s](\d+)$/, // Ends with -1, -2, " 1", " 2"
+    /\s(\d+)$/, // Ends with space + number
+    /[a-z](\d+)$/i, // Number directly after letter: Mahe1, Team2
+    /[-\s](i{1,3}|iv|v)$/i, // Roman numerals I, II, III, IV, V
+    /(\d+)(st|nd|rd|th)$/i, // 1st, 2nd, 3rd, 4th
+    /\steam\s*(\d+)/i, // "team 1", "team 2"
+    /\s(one|two|three|four|five)$/i, // Written numbers
     /\b(edp|ecnl|ga|mls)\s+(\d+)\b/i, // League + number: "EDP 1", "ECNL 2"
   ];
 
@@ -229,8 +272,7 @@ function hasDistinguishingMarkers(nameA: string, nameB: string): { isDifferent: 
 
   if (nickA && nickB) {
     // Same age group but different nicknames
-    if (nickA[1].toLowerCase() === nickB[1].toLowerCase() &&
-        nickA[2].toLowerCase() !== nickB[2].toLowerCase()) {
+    if (nickA[1].toLowerCase() === nickB[1].toLowerCase() && nickA[2].toLowerCase() !== nickB[2].toLowerCase()) {
       return { isDifferent: true, reason: `Different team names: ${nickA[2]} vs ${nickB[2]}` };
     }
   }
@@ -240,14 +282,14 @@ function hasDistinguishingMarkers(nameA: string, nameB: string): { isDifferent: 
 
 export async function GET(request: NextRequest) {
   try {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseAnonKey) {
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -281,10 +323,7 @@ export async function GET(request: NextRequest) {
 
     if (teamsError) {
       console.error('[suggestions] Error fetching teams:', teamsError);
-      return NextResponse.json(
-        { error: 'Failed to fetch teams' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch teams' }, { status: 500 });
     }
 
     if (!teams || teams.length < 2) {
@@ -392,7 +431,7 @@ export async function GET(request: NextRequest) {
             teamBId: teamB.team_id_master,
             teamBName: teamB.team_name,
             confidenceScore: Math.round(confidence * 1000) / 1000,
-            recommendation: confidence >= 0.95 ? 'high' : confidence >= 0.90 ? 'medium' : 'low',
+            recommendation: confidence >= 0.95 ? 'high' : confidence >= 0.9 ? 'medium' : 'low',
             signals,
             details,
           });
@@ -412,10 +451,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('[suggestions] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }
 
@@ -423,12 +459,12 @@ export async function GET(request: NextRequest) {
 function calcOpponentOverlap(gamesA: GameData[], gamesB: GameData[]): number {
   if (!gamesA.length || !gamesB.length) return 0;
 
-  const opponentsA = new Set(gamesA.map(g => g.opponent_id).filter(Boolean));
-  const opponentsB = new Set(gamesB.map(g => g.opponent_id).filter(Boolean));
+  const opponentsA = new Set(gamesA.map((g) => g.opponent_id).filter(Boolean));
+  const opponentsB = new Set(gamesB.map((g) => g.opponent_id).filter(Boolean));
 
   if (!opponentsA.size || !opponentsB.size) return 0;
 
-  const intersection = [...opponentsA].filter(id => opponentsB.has(id)).length;
+  const intersection = [...opponentsA].filter((id) => opponentsB.has(id)).length;
   const union = new Set([...opponentsA, ...opponentsB]).size;
 
   return union > 0 ? intersection / union : 0;
@@ -437,10 +473,10 @@ function calcOpponentOverlap(gamesA: GameData[], gamesB: GameData[]): number {
 function getOpponentOverlapDetail(gamesA: GameData[], gamesB: GameData[]): string {
   if (!gamesA.length || !gamesB.length) return 'Insufficient game data';
 
-  const opponentsA = new Set(gamesA.map(g => g.opponent_id).filter(Boolean));
-  const opponentsB = new Set(gamesB.map(g => g.opponent_id).filter(Boolean));
+  const opponentsA = new Set(gamesA.map((g) => g.opponent_id).filter(Boolean));
+  const opponentsB = new Set(gamesB.map((g) => g.opponent_id).filter(Boolean));
 
-  const intersection = [...opponentsA].filter(id => opponentsB.has(id)).length;
+  const intersection = [...opponentsA].filter((id) => opponentsB.has(id)).length;
   const union = new Set([...opponentsA, ...opponentsB]).size;
 
   return `${intersection} shared opponents out of ${union} total`;
@@ -449,8 +485,8 @@ function getOpponentOverlapDetail(gamesA: GameData[], gamesB: GameData[]): strin
 function calcScheduleAlignment(gamesA: GameData[], gamesB: GameData[]): number {
   if (!gamesA.length || !gamesB.length) return 0;
 
-  const datesA = new Set(gamesA.map(g => g.game_date?.split('T')[0]).filter(Boolean));
-  const datesB = new Set(gamesB.map(g => g.game_date?.split('T')[0]).filter(Boolean));
+  const datesA = new Set(gamesA.map((g) => g.game_date?.split('T')[0]).filter(Boolean));
+  const datesB = new Set(gamesB.map((g) => g.game_date?.split('T')[0]).filter(Boolean));
 
   if (!datesA.size || !datesB.size) return 0;
 
@@ -474,8 +510,8 @@ function calcScheduleAlignment(gamesA: GameData[], gamesB: GameData[]): number {
 function getScheduleAlignmentDetail(gamesA: GameData[], gamesB: GameData[]): string {
   if (!gamesA.length || !gamesB.length) return 'Insufficient game data';
 
-  const datesA = new Set(gamesA.map(g => g.game_date?.split('T')[0]).filter(Boolean));
-  const datesB = new Set(gamesB.map(g => g.game_date?.split('T')[0]).filter(Boolean));
+  const datesA = new Set(gamesA.map((g) => g.game_date?.split('T')[0]).filter(Boolean));
+  const datesB = new Set(gamesB.map((g) => g.game_date?.split('T')[0]).filter(Boolean));
 
   let closeMatches = 0;
   for (const dateA of datesA) {
@@ -584,10 +620,10 @@ function getPerformanceDetail(gamesA: GameData[], gamesB: GameData[]): string {
 }
 
 function calcStats(games: GameData[]) {
-  const valid = games.filter(g => g.goals_for !== null && g.goals_against !== null);
+  const valid = games.filter((g) => g.goals_for !== null && g.goals_against !== null);
   if (!valid.length) return null;
 
-  const wins = valid.filter(g => g.goals_for! > g.goals_against!).length;
+  const wins = valid.filter((g) => g.goals_for! > g.goals_against!).length;
   const gf = valid.reduce((sum, g) => sum + (g.goals_for || 0), 0);
   const ga = valid.reduce((sum, g) => sum + (g.goals_against || 0), 0);
 
@@ -614,11 +650,7 @@ function levenshteinSimilarity(a: string, b: string): number {
   for (let i = 1; i <= a.length; i++) {
     for (let j = 1; j <= b.length; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      matrix[i][j] = Math.min(
-        matrix[i - 1][j] + 1,
-        matrix[i][j - 1] + 1,
-        matrix[i - 1][j - 1] + cost
-      );
+      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost);
     }
   }
 

--- a/frontend/app/api/watchlist/add/route.ts
+++ b/frontend/app/api/watchlist/add/route.ts
@@ -1,5 +1,5 @@
-import { createServerSupabase } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+import { createServerSupabase } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
 /**
  * POST /api/watchlist/add
@@ -19,100 +19,91 @@ export async function POST(req: Request) {
       error: authError,
     } = await supabase.auth.getUser();
 
-    console.log("[Watchlist Add] Auth check:", user?.id || "no user", authError?.message || "no error");
+    console.log('[Watchlist Add] Auth check:', user?.id || 'no user', authError?.message || 'no error');
 
     if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
     // Get user profile to check premium status
     const { data: profile, error: profileError } = await supabase
-      .from("user_profiles")
-      .select("plan")
-      .eq("id", user.id)
+      .from('user_profiles')
+      .select('plan')
+      .eq('id', user.id)
       .single();
 
-    console.log("[Watchlist Add] Profile check:", profile?.plan || "no profile", profileError?.message || "no error");
+    console.log('[Watchlist Add] Profile check:', profile?.plan || 'no profile', profileError?.message || 'no error');
 
     if (profileError) {
-      console.error("[Watchlist Add] Error fetching profile:", profileError);
-      return NextResponse.json(
-        { error: "Failed to fetch user profile" },
-        { status: 500 }
-      );
+      console.error('[Watchlist Add] Error fetching profile:', profileError);
+      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
     }
 
     // Check if profile exists (user may not have a profile row yet)
     if (!profile) {
-      console.log("[Watchlist Add] No profile found for user");
-      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+      console.log('[Watchlist Add] No profile found for user');
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
     }
 
     // Enforce premium access
-    if (profile.plan !== "premium" && profile.plan !== "admin") {
-      console.log("[Watchlist Add] User not premium:", profile.plan);
-      return NextResponse.json({ error: "Premium required" }, { status: 403 });
+    if (profile.plan !== 'premium' && profile.plan !== 'admin') {
+      console.log('[Watchlist Add] User not premium:', profile.plan);
+      return NextResponse.json({ error: 'Premium required' }, { status: 403 });
     }
 
     // Parse request body
     const body = await req.json();
     const { teamIdMaster } = body;
-    console.log("[Watchlist Add] Team ID:", teamIdMaster);
+    console.log('[Watchlist Add] Team ID:', teamIdMaster);
 
-    if (!teamIdMaster || typeof teamIdMaster !== "string") {
-      return NextResponse.json(
-        { error: "teamIdMaster is required" },
-        { status: 400 }
-      );
+    if (!teamIdMaster || typeof teamIdMaster !== 'string') {
+      return NextResponse.json({ error: 'teamIdMaster is required' }, { status: 400 });
     }
 
     // Validate team exists
     const { data: team, error: teamError } = await supabase
-      .from("teams")
-      .select("team_id_master, team_name")
-      .eq("team_id_master", teamIdMaster)
+      .from('teams')
+      .select('team_id_master, team_name')
+      .eq('team_id_master', teamIdMaster)
       .single();
 
-    console.log("[Watchlist Add] Team lookup:", team?.team_name || "not found", teamError?.message || "no error");
+    console.log('[Watchlist Add] Team lookup:', team?.team_name || 'not found', teamError?.message || 'no error');
 
     if (teamError || !team) {
-      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
     }
 
     // Get or create default watchlist
     let watchlistId: string;
 
     let { data: existingWatchlist, error: fetchError } = await supabase
-      .from("watchlists")
-      .select("id")
-      .eq("user_id", user.id)
-      .eq("is_default", true)
+      .from('watchlists')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('is_default', true)
       .single();
 
-    console.log("[Watchlist Add] Existing watchlist:", existingWatchlist?.id || "none", fetchError?.code || "no error");
+    console.log('[Watchlist Add] Existing watchlist:', existingWatchlist?.id || 'none', fetchError?.code || 'no error');
 
-    if (fetchError && fetchError.code !== "PGRST116") {
-      console.error("[Watchlist Add] Error fetching watchlist:", fetchError);
-      return NextResponse.json(
-        { error: "Failed to fetch watchlist" },
-        { status: 500 }
-      );
+    if (fetchError && fetchError.code !== 'PGRST116') {
+      console.error('[Watchlist Add] Error fetching watchlist:', fetchError);
+      return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
     }
 
     // If no default watchlist found, use most recent watchlist (fallback)
     // This prevents creating duplicate watchlists when is_default flag is missing
-    if (!existingWatchlist && fetchError?.code === "PGRST116") {
-      console.log("[Watchlist Add] No default watchlist found, trying most recent");
+    if (!existingWatchlist && fetchError?.code === 'PGRST116') {
+      console.log('[Watchlist Add] No default watchlist found, trying most recent');
       const { data: watchlists, error: listError } = await supabase
-        .from("watchlists")
-        .select("id")
-        .eq("user_id", user.id)
-        .order("created_at", { ascending: false })
+        .from('watchlists')
+        .select('id')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
         .limit(1);
-      
+
       if (!listError && watchlists && watchlists.length > 0) {
         existingWatchlist = watchlists[0];
-        console.log("[Watchlist Add] Using most recent watchlist as fallback:", existingWatchlist.id);
+        console.log('[Watchlist Add] Using most recent watchlist as fallback:', existingWatchlist.id);
       }
     }
 
@@ -120,88 +111,77 @@ export async function POST(req: Request) {
       watchlistId = existingWatchlist.id;
     } else {
       // Create default watchlist
-      console.log("[Watchlist Add] Creating new watchlist for user:", user.id);
+      console.log('[Watchlist Add] Creating new watchlist for user:', user.id);
       const { data: newWatchlist, error: createError } = await supabase
-        .from("watchlists")
+        .from('watchlists')
         .insert({
           user_id: user.id,
-          name: "My Watchlist",
+          name: 'My Watchlist',
           is_default: true,
         })
-        .select("id")
+        .select('id')
         .single();
 
-      console.log("[Watchlist Add] New watchlist:", newWatchlist?.id || "failed", createError?.message || "no error");
+      console.log('[Watchlist Add] New watchlist:', newWatchlist?.id || 'failed', createError?.message || 'no error');
 
       if (createError || !newWatchlist) {
-        console.error("[Watchlist Add] Error creating watchlist:", createError);
-        return NextResponse.json(
-          { error: "Failed to create watchlist" },
-          { status: 500 }
-        );
+        console.error('[Watchlist Add] Error creating watchlist:', createError);
+        return NextResponse.json({ error: 'Failed to create watchlist' }, { status: 500 });
       }
 
       watchlistId = newWatchlist.id;
     }
 
     // Add team to watchlist (upsert to handle duplicates gracefully)
-    console.log("[Watchlist Add] Upserting item:", watchlistId, teamIdMaster);
-    const { data: upsertData, error: addError } = await supabase.from("watchlist_items").upsert(
-      {
-        watchlist_id: watchlistId,
-        team_id_master: teamIdMaster,
-      },
-      {
-        onConflict: "watchlist_id,team_id_master",
-        ignoreDuplicates: false, // Changed to false to see if item was actually inserted
-      }
-    ).select();
+    console.log('[Watchlist Add] Upserting item:', watchlistId, teamIdMaster);
+    const { data: upsertData, error: addError } = await supabase
+      .from('watchlist_items')
+      .upsert(
+        {
+          watchlist_id: watchlistId,
+          team_id_master: teamIdMaster,
+        },
+        {
+          onConflict: 'watchlist_id,team_id_master',
+          ignoreDuplicates: false, // Changed to false to see if item was actually inserted
+        }
+      )
+      .select();
 
-    console.log("[Watchlist Add] Upsert result:", {
+    console.log('[Watchlist Add] Upsert result:', {
       data: upsertData,
       error: addError?.message,
       errorCode: addError?.code,
     });
 
     if (addError) {
-      console.error("[Watchlist Add] Error adding team to watchlist:", addError);
-      return NextResponse.json(
-        { error: "Failed to add team to watchlist" },
-        { status: 500 }
-      );
+      console.error('[Watchlist Add] Error adding team to watchlist:', addError);
+      return NextResponse.json({ error: 'Failed to add team to watchlist' }, { status: 500 });
     }
 
     // Verify the item was actually added
     const { data: verifyItem, error: verifyError } = await supabase
-      .from("watchlist_items")
-      .select("*")
-      .eq("watchlist_id", watchlistId)
-      .eq("team_id_master", teamIdMaster)
+      .from('watchlist_items')
+      .select('*')
+      .eq('watchlist_id', watchlistId)
+      .eq('team_id_master', teamIdMaster)
       .single();
 
-    console.log("[Watchlist Add] Verification query:", {
+    console.log('[Watchlist Add] Verification query:', {
       found: !!verifyItem,
       item: verifyItem,
       error: verifyError?.message,
     });
 
-    console.log("[Watchlist Add] Success! Added", team.team_name);
+    console.log('[Watchlist Add] Success! Added', team.team_name);
     return NextResponse.json({
       success: true,
       message: `Added ${team.team_name} to watchlist`,
       teamIdMaster,
       watchlistId,
-      debug: {
-        upsertData: upsertData ? { count: upsertData.length, items: upsertData } : null,
-        verifyItem: verifyItem ? { found: true, teamId: verifyItem.team_id_master } : { found: false },
-        verifyError: verifyError?.message || null,
-      },
     });
   } catch (error) {
-    console.error("Watchlist add error:", error);
-    return NextResponse.json(
-      { error: "Failed to add team to watchlist" },
-      { status: 500 }
-    );
+    console.error('Watchlist add error:', error);
+    return NextResponse.json({ error: 'Failed to add team to watchlist' }, { status: 500 });
   }
 }


### PR DESCRIPTION
Addresses 8 groups of findings from the 2026-03-27 API route audit. All changes are frontend API routes only, no rankings engine code touched.

**Auth gaps closed (6 GET endpoints):** Added `requireAdmin()` to agent-activity, agent-status, team-aliases, team-merge (GET/list/suggestions). These were exposing admin data without authentication while their sibling POST/DELETE handlers already had auth.

**Security hardening:**
- Stripe checkout no longer leaks internal error messages to the client
- Removed `SUPABASE_SERVICE_ROLE_KEY` from the infographic movers edge runtime endpoint
- `process-missing-games` now fails closed when `CRON_SECRET` is unset (was silently skipping auth)
- Removed `debug` objects from agent-activity and watchlist/add error responses

**Bug fixes:**
- Push notification DELETE no longer disables `push_enabled` when other subscriptions remain
- Notification preferences PATCH now validates boolean field types
- Stripe checkout subscription check uses proper list params to catch all active/trialing subs

**Performance:**
- Mission control status endpoint batches agent task queries (2 parallel queries instead of 27 sequential). Also removed `execSync('git log')` which blocks the event loop and fails silently on Vercel.