### PR TITLE
Fix P2 logic bugs: batched queries, null guards, validation

### DIFF
--- a/frontend/app/api/agent-webhook/route.ts
+++ b/frontend/app/api/agent-webhook/route.ts
@@ -3,10 +3,10 @@ import { supabase } from '@/lib/supabaseClient';
 
 /**
  * Agent Webhook API
- * 
+ *
  * Receives notifications from OpenClaw agent sessions about task lifecycle events.
  * Used to automatically track sub-agent tasks in Mission Control.
- * 
+ *
  * Actions:
  * - spawn: Create a new in-progress task when an agent starts
  * - progress: Update task with progress info (optional)
@@ -21,6 +21,16 @@ interface WebhookPayload {
   task: string;
   result?: string;
   error?: string;
+}
+
+/** Find the task_id associated with a session key via task_comments */
+async function findTaskBySession(sessionKey: string): Promise<string | null> {
+  const { data: comments } = await supabase
+    .from('task_comments')
+    .select('task_id')
+    .like('content', `%Session: ${sessionKey}%`)
+    .limit(1);
+  return comments?.[0]?.task_id ?? null;
 }
 
 // Agent emoji mapping
@@ -79,14 +89,12 @@ export async function POST(request: NextRequest) {
     switch (action) {
       case 'spawn': {
         // Create agent session record for live status tracking
-        const { error: sessionError } = await supabase
-          .from('agent_sessions')
-          .insert({
-            session_key: sessionKey,
-            agent_name: agentName,
-            task_description: task,
-            status: 'active',
-          });
+        const { error: sessionError } = await supabase.from('agent_sessions').insert({
+          session_key: sessionKey,
+          agent_name: agentName,
+          task_description: task,
+          status: 'active',
+        });
 
         if (sessionError) {
           console.error('[AgentWebhook] Failed to create session:', sessionError);
@@ -97,7 +105,7 @@ export async function POST(request: NextRequest) {
 
         // Create new task in in_progress status
         const title = task.length > 100 ? task.substring(0, 97) + '...' : task;
-        
+
         const { data: newTask, error: createError } = await supabase
           .from('agent_tasks')
           .insert({
@@ -135,35 +143,30 @@ export async function POST(request: NextRequest) {
           message_type: 'spawn',
         });
 
-        return NextResponse.json({ 
-          success: true, 
-          taskId: newTask.id,
-          message: 'Task created' 
-        }, { status: 201 });
+        return NextResponse.json(
+          {
+            success: true,
+            taskId: newTask.id,
+            message: 'Task created',
+          },
+          { status: 201 }
+        );
       }
 
       case 'progress': {
         // Update session's updated_at (keeps it "active" in the 5-minute window)
         await supabase
           .from('agent_sessions')
-          .update({ 
+          .update({
             updated_at: new Date().toISOString(),
             task_description: result || task, // Update task description with progress
           })
           .eq('session_key', sessionKey);
 
-        // Find the task by session key in comments
-        const { data: comments } = await supabase
-          .from('task_comments')
-          .select('task_id')
-          .like('content', `%Session: ${sessionKey}%`)
-          .limit(1);
-
-        if (!comments || comments.length === 0) {
+        const taskId = await findTaskBySession(sessionKey);
+        if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }
-
-        const taskId = comments[0].task_id;
 
         // Add progress comment
         await supabase.from('task_comments').insert({
@@ -181,31 +184,20 @@ export async function POST(request: NextRequest) {
         // Update agent session to completed
         await supabase
           .from('agent_sessions')
-          .update({ 
+          .update({
             status: 'completed',
             completed_at: new Date().toISOString(),
             result: result || 'Task finished successfully',
           })
           .eq('session_key', sessionKey);
 
-        // Find the task by session key in comments
-        const { data: comments } = await supabase
-          .from('task_comments')
-          .select('task_id')
-          .like('content', `%Session: ${sessionKey}%`)
-          .limit(1);
-
-        if (!comments || comments.length === 0) {
+        const taskId = await findTaskBySession(sessionKey);
+        if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }
 
-        const taskId = comments[0].task_id;
-
         // Update task status to review (needs verification before done)
-        const { error: updateError } = await supabase
-          .from('agent_tasks')
-          .update({ status: 'review' })
-          .eq('id', taskId);
+        const { error: updateError } = await supabase.from('agent_tasks').update({ status: 'review' }).eq('id', taskId);
 
         if (updateError) {
           console.error('Error updating task:', updateError);
@@ -239,31 +231,20 @@ export async function POST(request: NextRequest) {
         // Update agent session to error
         await supabase
           .from('agent_sessions')
-          .update({ 
+          .update({
             status: 'error',
             completed_at: new Date().toISOString(),
             result: errorMsg || 'Task failed - needs retry',
           })
           .eq('session_key', sessionKey);
 
-        // Find the task by session key in comments
-        const { data: comments } = await supabase
-          .from('task_comments')
-          .select('task_id')
-          .like('content', `%Session: ${sessionKey}%`)
-          .limit(1);
-
-        if (!comments || comments.length === 0) {
+        const taskId = await findTaskBySession(sessionKey);
+        if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }
 
-        const taskId = comments[0].task_id;
-
         // Update task status back to inbox (needs retry)
-        const { error: updateError } = await supabase
-          .from('agent_tasks')
-          .update({ status: 'inbox' })
-          .eq('id', taskId);
+        const { error: updateError } = await supabase.from('agent_tasks').update({ status: 'inbox' }).eq('id', taskId);
 
         if (updateError) {
           console.error('Error updating task:', updateError);
@@ -304,9 +285,9 @@ export async function POST(request: NextRequest) {
 
 // GET endpoint for health check
 export async function GET() {
-  return NextResponse.json({ 
-    status: 'ok', 
+  return NextResponse.json({
+    status: 'ok',
     endpoint: 'agent-webhook',
-    actions: ['spawn', 'progress', 'complete', 'error']
+    actions: ['spawn', 'progress', 'complete', 'error'],
   });
 }

--- a/frontend/app/api/link-opponent/preview/route.ts
+++ b/frontend/app/api/link-opponent/preview/route.ts
@@ -12,10 +12,7 @@ export async function POST(request: NextRequest) {
 
     if (!serviceKey || !supabaseUrl) {
       console.error('[link-opponent/preview] Missing environment variables');
-      return NextResponse.json(
-        { error: 'Server configuration error' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
     // Parse request body
@@ -23,19 +20,13 @@ export async function POST(request: NextRequest) {
     try {
       requestBody = await request.json();
     } catch {
-      return NextResponse.json(
-        { error: 'Invalid request body' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
     const { gameId, opponentProviderId } = requestBody;
 
     if (!gameId || !opponentProviderId) {
-      return NextResponse.json(
-        { error: 'Missing required fields: gameId and opponentProviderId' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing required fields: gameId and opponentProviderId' }, { status: 400 });
     }
 
     const supabase = createClient(supabaseUrl, serviceKey);
@@ -49,10 +40,11 @@ export async function POST(request: NextRequest) {
 
     if (gameError || !game) {
       console.error('[link-opponent/preview] Game not found:', gameError);
-      return NextResponse.json(
-        { error: 'Game not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+
+    if (!game.provider_id) {
+      return NextResponse.json({ error: 'Game has no provider' }, { status: 400 });
     }
 
     // Get the provider name for display
@@ -90,10 +82,7 @@ export async function POST(request: NextRequest) {
 
     if (homeError || awayError) {
       console.error('[link-opponent/preview] Query error:', homeError || awayError);
-      return NextResponse.json(
-        { error: 'Failed to query games' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to query games' }, { status: 500 });
     }
 
     // Get team names for the affected games to show context
@@ -132,14 +121,16 @@ export async function POST(request: NextRequest) {
     const formatGame = (g: GameRecord, isHome: boolean) => ({
       id: g.id,
       gameDate: g.game_date,
-      score: g.home_score !== null && g.away_score !== null
-        ? `${g.home_score} - ${g.away_score}`
-        : 'No score',
+      score: g.home_score !== null && g.away_score !== null ? `${g.home_score} - ${g.away_score}` : 'No score',
       competition: g.competition || 'Unknown',
       opponentPosition: isHome ? 'home' : 'away',
       otherTeam: isHome
-        ? (g.away_team_master_id ? teamNames[g.away_team_master_id] || 'Unknown' : 'Unknown')
-        : (g.home_team_master_id ? teamNames[g.home_team_master_id] || 'Unknown' : 'Unknown'),
+        ? g.away_team_master_id
+          ? teamNames[g.away_team_master_id] || 'Unknown'
+          : 'Unknown'
+        : g.home_team_master_id
+          ? teamNames[g.home_team_master_id] || 'Unknown'
+          : 'Unknown',
     });
 
     const affectedGames = [
@@ -174,9 +165,6 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('[link-opponent/preview] Unexpected error:', error);
-    return NextResponse.json(
-      { error: 'An unexpected error occurred' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
   }
 }

--- a/frontend/app/api/notifications/subscribe/route.ts
+++ b/frontend/app/api/notifications/subscribe/route.ts
@@ -25,17 +25,15 @@ export async function POST(request: NextRequest) {
     }
 
     // Upsert push subscription
-    const { error } = await supabase
-      .from('push_subscriptions')
-      .upsert(
-        {
-          user_id: user.id,
-          endpoint,
-          p256dh: keys.p256dh,
-          auth: keys.auth,
-        },
-        { onConflict: 'user_id,endpoint' }
-      );
+    const { error } = await supabase.from('push_subscriptions').upsert(
+      {
+        user_id: user.id,
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      },
+      { onConflict: 'user_id,endpoint' }
+    );
 
     if (error) {
       console.error('Failed to save push subscription:', error);
@@ -43,10 +41,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Enable push in profile
-    await supabase
-      .from('user_profiles')
-      .update({ push_enabled: true })
-      .eq('id', user.id);
+    await supabase.from('user_profiles').update({ push_enabled: true }).eq('id', user.id);
 
     return NextResponse.json({ success: true });
   } catch (error) {
@@ -74,19 +69,14 @@ export async function DELETE(request: NextRequest) {
     const body = await request.json();
     const { endpoint } = body;
 
-    if (endpoint) {
-      await supabase
-        .from('push_subscriptions')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('endpoint', endpoint);
+    if (!endpoint || typeof endpoint !== 'string') {
+      return NextResponse.json({ error: 'endpoint is required' }, { status: 400 });
     }
 
+    await supabase.from('push_subscriptions').delete().eq('user_id', user.id).eq('endpoint', endpoint);
+
     // Disable push in profile
-    await supabase
-      .from('user_profiles')
-      .update({ push_enabled: false })
-      .eq('id', user.id);
+    await supabase.from('user_profiles').update({ push_enabled: false }).eq('id', user.id);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,6 +1,6 @@
-import { stripe } from "@/lib/stripe/server";
-import { createServerSupabase } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+import { stripe } from '@/lib/stripe/server';
+import { createServerSupabase } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
   try {
@@ -10,37 +10,41 @@ export async function POST(req: Request) {
     } = await supabase.auth.getUser();
 
     if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
     const { priceId } = await req.json();
 
     // Basic validation - ensure it looks like a Stripe price ID
-    if (!priceId || typeof priceId !== "string" || !priceId.startsWith("price_")) {
-      return NextResponse.json({ error: "Invalid price ID" }, { status: 400 });
+    if (!priceId || typeof priceId !== 'string' || !priceId.startsWith('price_')) {
+      return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
+    }
+
+    // Validate against known price IDs from env vars
+    const VALID_PRICE_IDS = [
+      process.env.NEXT_PUBLIC_STRIPE_MONTHLY_PRICE_ID,
+      process.env.NEXT_PUBLIC_STRIPE_YEARLY_PRICE_ID,
+    ].filter(Boolean);
+
+    if (VALID_PRICE_IDS.length > 0 && !VALID_PRICE_IDS.includes(priceId)) {
+      return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
     }
 
     // Get user profile
     const { data: profile, error: profileError } = await supabase
-      .from("user_profiles")
-      .select("*")
-      .eq("id", user.id)
+      .from('user_profiles')
+      .select('*')
+      .eq('id', user.id)
       .single();
 
     if (profileError) {
-      console.error("Error fetching profile:", profileError);
-      return NextResponse.json(
-        { error: "Failed to fetch user profile" },
-        { status: 500 }
-      );
+      console.error('Error fetching profile:', profileError);
+      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
     }
 
     // Check if user already has active subscription
-    if (profile?.plan === "premium" && profile?.subscription_status === "active") {
-      return NextResponse.json(
-        { error: "You already have an active subscription" },
-        { status: 400 }
-      );
+    if (profile?.plan === 'premium' && profile?.subscription_status === 'active') {
+      return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
     }
 
     let customerId = profile?.stripe_customer_id;
@@ -58,22 +62,19 @@ export async function POST(req: Request) {
 
       // Save customer ID to profile - this MUST succeed for webhooks to work
       const { error: updateError } = await supabase
-        .from("user_profiles")
+        .from('user_profiles')
         .update({ stripe_customer_id: customerId })
-        .eq("id", user.id);
+        .eq('id', user.id);
 
       if (updateError) {
-        console.error("Error saving customer ID to profile:", updateError);
-        return NextResponse.json(
-          { error: "Failed to link billing account. Please try again." },
-          { status: 500 }
-        );
+        console.error('Error saving customer ID to profile:', updateError);
+        return NextResponse.json({ error: 'Failed to link billing account. Please try again.' }, { status: 500 });
       }
     }
 
     // Create Stripe checkout session with 7-day free trial
     const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
+      mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`,
@@ -85,22 +86,19 @@ export async function POST(req: Request) {
         },
       },
       allow_promotion_codes: true,
-      billing_address_collection: "auto",
+      billing_address_collection: 'auto',
       customer_update: {
-        address: "auto",
-        name: "auto",
+        address: 'auto',
+        name: 'auto',
       },
     });
 
     return NextResponse.json({ url: session.url });
   } catch (error) {
-    console.error("Checkout session error:", error);
+    console.error('Checkout session error:', error);
 
     // Return more specific error message for debugging
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json(
-      { error: `Failed to create checkout session: ${errorMessage}` },
-      { status: 500 }
-    );
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: `Failed to create checkout session: ${errorMessage}` }, { status: 500 });
   }
 }

--- a/frontend/app/api/unlink-opponent/route.ts
+++ b/frontend/app/api/unlink-opponent/route.ts
@@ -49,6 +49,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Game not found' }, { status: 404 });
     }
 
+    if (!game.provider_id) {
+      return NextResponse.json({ error: 'Game has no provider' }, { status: 400 });
+    }
+
     const providerTeamIdStr = String(opponentProviderId);
     const isOpponentHome = String(game.home_provider_id) === providerTeamIdStr;
     const isOpponentAway = String(game.away_provider_id) === providerTeamIdStr;

--- a/frontend/app/api/watchlist/route.ts
+++ b/frontend/app/api/watchlist/route.ts
@@ -1,5 +1,5 @@
-import { createServerSupabase } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+import { createServerSupabase } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
 /**
  * Watchlist item with team data and insights preview
@@ -10,7 +10,7 @@ export interface WatchlistTeam {
   club_name: string | null;
   state: string | null;
   age: number | null;
-  gender: "M" | "F" | "B" | "G";
+  gender: 'M' | 'F' | 'B' | 'G';
   // Rankings
   rank_in_cohort_final: number | null;
   rank_in_state_final: number | null;
@@ -61,52 +61,49 @@ export async function GET() {
     } = await supabase.auth.getUser();
 
     if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
     // Get user profile to check premium status
     const { data: profile, error: profileError } = await supabase
-      .from("user_profiles")
-      .select("plan")
-      .eq("id", user.id)
+      .from('user_profiles')
+      .select('plan')
+      .eq('id', user.id)
       .single();
 
     if (profileError) {
-      return NextResponse.json(
-        { error: "Failed to fetch user profile" },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
     }
 
     // Check if profile exists (user may not have a profile row yet)
     if (!profile) {
-      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
     }
 
     // Enforce premium access
-    if (profile.plan !== "premium" && profile.plan !== "admin") {
-      return NextResponse.json({ error: "Premium required" }, { status: 403 });
+    if (profile.plan !== 'premium' && profile.plan !== 'admin') {
+      return NextResponse.json({ error: 'Premium required' }, { status: 403 });
     }
 
     // Get user's default watchlist
     // First try to find default watchlist
     let { data: watchlist, error: watchlistError } = await supabase
-      .from("watchlists")
-      .select("*")
-      .eq("user_id", user.id)
-      .eq("is_default", true)
+      .from('watchlists')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('is_default', true)
       .single();
 
     // If no default watchlist found, get the most recent watchlist (fallback)
     // This handles cases where watchlists exist but is_default flag is missing
-    if (!watchlist && watchlistError?.code === "PGRST116") {
+    if (!watchlist && watchlistError?.code === 'PGRST116') {
       const { data: watchlists, error: listError } = await supabase
-        .from("watchlists")
-        .select("*")
-        .eq("user_id", user.id)
-        .order("created_at", { ascending: false })
+        .from('watchlists')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
         .limit(1);
-      
+
       if (listError) {
         watchlistError = listError;
       } else if (watchlists && watchlists.length > 0) {
@@ -114,48 +111,41 @@ export async function GET() {
       }
     }
 
-    if (watchlistError && watchlistError.code !== "PGRST116") {
-      console.error("Error fetching watchlist:", watchlistError);
-      return NextResponse.json(
-        { error: "Failed to fetch watchlist" },
-        { status: 500 }
-      );
+    if (watchlistError && watchlistError.code !== 'PGRST116') {
+      console.error('Error fetching watchlist:', watchlistError);
+      return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
     }
 
     // No watchlist exists - return empty response with proper structure
     if (!watchlist) {
       // Try to find ANY watchlist for this user (not just default) for debugging
       const { data: anyWatchlist, error: anyError } = await supabase
-        .from("watchlists")
-        .select("*")
-        .eq("user_id", user.id)
+        .from('watchlists')
+        .select('*')
+        .eq('user_id', user.id)
         .limit(5);
-      
+
       return NextResponse.json({
         watchlist: {
-          id: "",
-          name: "",
+          id: '',
+          name: '',
           is_default: true,
-          created_at: "",
-          updated_at: "",
+          created_at: '',
+          updated_at: '',
         },
         teams: [],
       });
     }
 
-
     // Get watchlist items for the found watchlist
     const { data: items, error: itemsError } = await supabase
-      .from("watchlist_items")
-      .select("team_id_master, created_at")
-      .eq("watchlist_id", watchlist.id);
+      .from('watchlist_items')
+      .select('team_id_master, created_at')
+      .eq('watchlist_id', watchlist.id);
 
     if (itemsError) {
-      console.error("[Watchlist API] Error fetching watchlist items:", itemsError);
-      return NextResponse.json(
-        { error: "Failed to fetch watchlist items" },
-        { status: 500 }
-      );
+      console.error('[Watchlist API] Error fetching watchlist items:', itemsError);
+      return NextResponse.json({ error: 'Failed to fetch watchlist items' }, { status: 500 });
     }
 
     // Define types for database responses
@@ -205,9 +195,7 @@ export async function GET() {
     // Get team IDs
     const typedItems = items as WatchlistItem[];
     const teamIds = typedItems.map((item: WatchlistItem) => item.team_id_master);
-    const itemMap = new Map(
-      typedItems.map((item: WatchlistItem) => [item.team_id_master, item.created_at])
-    );
+    const itemMap = new Map(typedItems.map((item: WatchlistItem) => [item.team_id_master, item.created_at]));
 
     // Guard against empty teamIds array
     if (teamIds.length === 0) {
@@ -226,46 +214,40 @@ export async function GET() {
     // First fetch basic team data from teams table (this has ALL teams)
     // This ensures we return all watched teams, even those without rankings
     const { data: teamsData, error: teamsError } = await supabase
-      .from("teams")
-      .select("team_id_master, team_name, club_name, state, age_group, gender")
-      .in("team_id_master", teamIds);
+      .from('teams')
+      .select('team_id_master, team_name, club_name, state, age_group, gender')
+      .in('team_id_master', teamIds);
 
     if (teamsError) {
-      console.error("Error fetching teams:", teamsError.message);
-      return NextResponse.json(
-        { error: "Failed to fetch team data", details: teamsError.message },
-        { status: 500 }
-      );
+      console.error('Error fetching teams:', teamsError.message);
+      return NextResponse.json({ error: 'Failed to fetch team data', details: teamsError.message }, { status: 500 });
     }
-
 
     // Fetch ranking data from rankings_view (may not have all teams)
     // Filter by status to match rankings pages (only active teams)
     const { data: rankingsData, error: rankingsError } = await supabase
-      .from("rankings_view")
-      .select("*")
-      .in("team_id_master", teamIds)
-      .in("status", ["Active", "Not Enough Ranked Games"]);
+      .from('rankings_view')
+      .select('*')
+      .in('team_id_master', teamIds)
+      .in('status', ['Active', 'Not Enough Ranked Games']);
 
     if (rankingsError) {
-      console.error("Error fetching rankings:", rankingsError);
+      console.error('Error fetching rankings:', rankingsError);
       // Continue with partial data - teams can still be shown without rankings
     }
 
     // Create a map of rankings by team_id_master for quick lookup
-    const rankingsMap = new Map(
-      ((rankingsData || []) as RankingRow[]).map((r: RankingRow) => [r.team_id_master, r])
-    );
+    const rankingsMap = new Map(((rankingsData || []) as RankingRow[]).map((r: RankingRow) => [r.team_id_master, r]));
 
     // Fetch state rankings for state rank (with status filter)
     const { data: stateRankingsData, error: stateRankingsError } = await supabase
-      .from("state_rankings_view")
-      .select("team_id_master, rank_in_state_final")
-      .in("team_id_master", teamIds)
-      .in("status", ["Active", "Not Enough Ranked Games"]);
+      .from('state_rankings_view')
+      .select('team_id_master, rank_in_state_final')
+      .in('team_id_master', teamIds)
+      .in('status', ['Active', 'Not Enough Ranked Games']);
 
     if (stateRankingsError) {
-      console.error("Error fetching state rankings:", stateRankingsError);
+      console.error('Error fetching state rankings:', stateRankingsError);
     }
 
     const stateRankMap = new Map(
@@ -278,21 +260,34 @@ export async function GET() {
     // Calculate new games count (last 7 days) for each team
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-    const sevenDaysAgoStr = sevenDaysAgo.toISOString().split("T")[0];
+    const sevenDaysAgoStr = sevenDaysAgo.toISOString().split('T')[0];
 
-    // Get recent games for all teams in one query
-    const { data: recentGames, error: recentGamesError } = await supabase
-      .from("games")
-      .select("home_team_master_id, away_team_master_id, game_date")
-      .or(
-        teamIds
-          .map(
-            (id) =>
-              `home_team_master_id.eq.${id},away_team_master_id.eq.${id}`
-          )
-          .join(",")
-      )
-      .gte("game_date", sevenDaysAgoStr);
+    // Get recent games for all teams using parallel .in() queries
+    // (avoids unbounded .or() that can exceed URL length limits)
+    const [homeRecentResult, awayRecentResult] = await Promise.all([
+      supabase
+        .from('games')
+        .select('home_team_master_id, away_team_master_id, game_date')
+        .in('home_team_master_id', teamIds)
+        .gte('game_date', sevenDaysAgoStr),
+      supabase
+        .from('games')
+        .select('home_team_master_id, away_team_master_id, game_date')
+        .in('away_team_master_id', teamIds)
+        .gte('game_date', sevenDaysAgoStr),
+    ]);
+
+    const recentGamesError = homeRecentResult.error || awayRecentResult.error;
+
+    // Merge and deduplicate by composite key (no unique id on select)
+    const recentGamesRaw = [...(homeRecentResult.data || []), ...(awayRecentResult.data || [])];
+    const recentGamesSeen = new Set<string>();
+    const recentGames = recentGamesRaw.filter((g) => {
+      const key = `${g.home_team_master_id}|${g.away_team_master_id}|${g.game_date}`;
+      if (recentGamesSeen.has(key)) return false;
+      recentGamesSeen.add(key);
+      return true;
+    });
 
     // Count new games per team
     const newGamesMap = new Map<string, number>();
@@ -321,23 +316,35 @@ export async function GET() {
     }
 
     // Also get last game date for teams with no recent games
-    const teamsWithoutRecentGames = teamIds.filter(
-      (id: string) => !lastGameMap.has(id)
-    );
+    const teamsWithoutRecentGames = teamIds.filter((id: string) => !lastGameMap.has(id));
     if (teamsWithoutRecentGames.length > 0) {
-      const { data: lastGames, error: lastGamesError } = await supabase
-        .from("games")
-        .select("home_team_master_id, away_team_master_id, game_date")
-        .or(
-          teamsWithoutRecentGames
-            .map(
-              (id: string) =>
-                `home_team_master_id.eq.${id},away_team_master_id.eq.${id}`
-            )
-            .join(",")
-        )
-        .order("game_date", { ascending: false })
-        .limit(teamsWithoutRecentGames.length * 3); // Get a few recent games per team
+      const perTeamLimit = teamsWithoutRecentGames.length * 3;
+      const [homeLastResult, awayLastResult] = await Promise.all([
+        supabase
+          .from('games')
+          .select('home_team_master_id, away_team_master_id, game_date')
+          .in('home_team_master_id', teamsWithoutRecentGames)
+          .order('game_date', { ascending: false })
+          .limit(perTeamLimit),
+        supabase
+          .from('games')
+          .select('home_team_master_id, away_team_master_id, game_date')
+          .in('away_team_master_id', teamsWithoutRecentGames)
+          .order('game_date', { ascending: false })
+          .limit(perTeamLimit),
+      ]);
+
+      const lastGamesError = homeLastResult.error || awayLastResult.error;
+
+      // Merge and deduplicate
+      const lastGamesRaw = [...(homeLastResult.data || []), ...(awayLastResult.data || [])];
+      const lastGamesSeen = new Set<string>();
+      const lastGames = lastGamesRaw.filter((g) => {
+        const key = `${g.home_team_master_id}|${g.away_team_master_id}|${g.game_date}`;
+        if (lastGamesSeen.has(key)) return false;
+        lastGamesSeen.add(key);
+        return true;
+      });
 
       if (!lastGamesError && lastGames) {
         for (const game of lastGames) {
@@ -388,7 +395,7 @@ export async function GET() {
     // Then enrich with ranking data where available
     const teams: WatchlistTeam[] = ((teamsData || []) as TeamRow[]).map((team: TeamRow) => {
       const ranking = rankingsMap.get(team.team_id_master);
-      
+
       // Use age from rankings_view if available (more accurate), otherwise convert from age_group
       const age = ranking?.age ?? ageGroupToAge(team.age_group);
 
@@ -398,7 +405,7 @@ export async function GET() {
         club_name: team.club_name,
         state: team.state,
         age,
-        gender: team.gender as "M" | "F" | "B" | "G",
+        gender: team.gender as 'M' | 'F' | 'B' | 'G',
         // Ranking data (may be null if team has no rankings yet)
         rank_in_cohort_final: ranking?.rank_in_cohort_final ?? null,
         rank_in_state_final: stateRankMap.get(team.team_id_master) ?? null,
@@ -414,7 +421,7 @@ export async function GET() {
         win_percentage: ranking?.win_percentage ?? null,
         new_games_count: newGamesMap.get(team.team_id_master) || 0,
         last_game_date: lastGameMap.get(team.team_id_master) || null,
-        watchlist_added_at: itemMap.get(team.team_id_master) || "",
+        watchlist_added_at: itemMap.get(team.team_id_master) || '',
       };
     });
 
@@ -429,11 +436,8 @@ export async function GET() {
       teams,
     } satisfies WatchlistResponse);
   } catch (error) {
-    console.error("Watchlist GET error:", error);
+    console.error('Watchlist GET error:', error);
     const errorMessage = error instanceof Error ? error.message : String(error);
-    return NextResponse.json(
-      { error: "Failed to fetch watchlist" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
   }
 }


### PR DESCRIPTION
Addresses P2 correctness findings from the 2026-03-27 audit.

**Watchlist unbounded .or():** Replaced two `.or()` calls that built massive filter strings (2 conditions per team ID) with parallel `.in()` queries via `Promise.all`. Prevents URL length limit failures for large watchlists.

**Null provider_id guards:** Added early-return guards in link-opponent/preview and unlink-opponent routes when `game.provider_id` is null. Previously, `.eq('provider_id', null)` silently matched zero rows.

**DELETE unsubscribe validation:** Now returns 400 when endpoint is missing instead of silently succeeding with no deletion.

**Agent-webhook dedup:** Extracted the LIKE-based session key lookup (repeated 3 times) into a `findTaskBySession()` helper.

**Stripe priceId allowlist:** Validates priceId against known price IDs from env vars, not just the `price_` prefix.