### PR TITLE
feat: Free Team Report Card lead magnet

### DIFF
--- a/campaigns/free-team-report-card/brief.md
+++ b/campaigns/free-team-report-card/brief.md
@@ -1,0 +1,69 @@
+# Campaign: Free Team Report Card
+
+## Goal
+Capture parent emails by offering a personalized, data-driven team report card that showcases PitchRank's data depth. Target: 1,000 email captures in first 90 days.
+
+## Format
+Auto-generated PDF via email — personalized per team using live PitchRank data.
+
+## Hook
+"See How Your Team Stacks Up — Get Your Free Season Report Card"
+
+## Target Audience
+Proud parents of competitive youth soccer players (U10-U19). 90% parents, 10% coaches/DOCs. Suburban, $100K+ HH, 35-50. They check rankings obsessively and want shareable proof their team is good.
+
+## Bridge to Paid Offer
+Free Report Card shows the highlights (rank, trend, SOS, recent results). Premium unlocks:
+- Full head-to-head comparisons
+- Predictive matchup analytics
+- Historical trend deep-dives
+- Club comparison tools
+- Weekly ranking alerts with analysis
+
+The report card creates the "taste" — parents see what the data CAN tell them and want more.
+
+## Paid Offer
+- Premium Monthly: $6.99/mo
+- Premium Annual: $69.99/yr ($5.83/mo)
+- 7-day free trial available
+
+## Competitive Differentiation
+- NO competitor offers personalized, data-driven team reports
+- GotSoccer has raw data but no parent-friendly presentation
+- TopDrawerSoccer is $109/yr and recruiting-focused
+- Soccer Rankings App is $9.99/yr but basic algorithm, no reports
+- This is a first-mover advantage — only PitchRank has the data + ML to generate these
+
+## Distribution Plan
+1. **On-site:** CTA on every team profile page ("Get your free report card")
+2. **SEO:** Embed in state ranking pages and blog content
+3. **Social:** "Your team's report card is ready" shareable previews on Twitter/X, Instagram
+4. **Tryout season:** "Before you switch clubs, see where your team really stands"
+5. **Viral loop:** Report cards designed to be screenshot-worthy and shared in parent group chats
+6. **Forums:** Share in SoCal Soccer, BigSoccer, GA Soccer Forum (not spam — genuine value)
+
+## Email Segmentation Data Captured
+- Team name → ties to specific team in PitchRank DB
+- Age group → U10-U19 segmentation
+- Parent email → primary contact
+- State/region → geographic targeting
+- Current league (if detectable from team data) → league-specific content
+
+## Funnel Flow
+```
+Parent finds PitchRank (SEO, social, referral)
+  → Sees team rankings (free tier)
+  → CTA: "Get your free team report card"
+  → Enters: team name + age group + email
+  → Receives: PDF report card via email (immediate)
+  → Enters: Email sequence based on plan tier
+    → Free user → nurture toward trial
+    → Trial user → convert to paid before 7 days
+    → Paid user → onboard, reduce churn, upsell annual
+```
+
+## Status
+draft
+
+## Voice Notes
+Report card copy should match PitchRank voice: direct, data-forward, parent-respectful. No hype. Let the numbers speak. Make it feel like an insider document — something only PitchRank can generate.

--- a/campaigns/free-team-report-card/lead-magnet.md
+++ b/campaigns/free-team-report-card/lead-magnet.md
@@ -1,0 +1,412 @@
+---
+title: "Free Team Report Card"
+subtitle: "See How Your Team Stacks Up"
+format: auto-generated PDF
+hook: "Get your team's free season report card — rankings, trends, and insights powered by PitchRank's 13-layer algorithm."
+bridge_to: "PitchRank Premium ($6.99/mo or $69.99/yr)"
+target_audience: "Parents of competitive youth soccer players (U10-U19)"
+estimated_consumption_time: "2 min to read, instant delivery"
+status: draft
+created_by: /lead-magnet
+created_date: 2026-03-29
+---
+
+# Free Team Report Card — Full Specification
+
+## Overview
+
+A personalized, auto-generated PDF report card for any team in PitchRank's database (25,000+). Delivered instantly via email after the parent enters their team name, age group, and email address. Designed to be screenshot-worthy and shareable.
+
+---
+
+## Capture Form
+
+### Fields
+1. **Team name** (autocomplete search against PitchRank DB)
+   - Placeholder: "Start typing your team name..."
+   - Shows: team name, club, state, age group in dropdown
+2. **Email address**
+   - Placeholder: "Where should we send it?"
+3. **Optional: Your role** (dropdown)
+   - Parent / Coach / Club Director / Other
+   - Used for email segmentation, not required
+
+### Form Copy
+**Headline:** "Your team's report card is ready."
+**Subhead:** "Rankings, trends, and insights — powered by 25K+ teams and a 13-layer algorithm. Free. Delivered in seconds."
+**CTA button:** "Send My Report Card"
+**Below button:** "Free. No credit card. Unsubscribe anytime."
+
+### Post-Submit
+**Confirmation page:** "Check your inbox — your report card is on its way."
+**Fallback:** "Don't see it? Check your spam folder or [click here to view online]."
+
+---
+
+## PDF Report Card — Layout Specification
+
+### Page 1: The Report Card
+
+**Design:** Clean, branded. Forest Green (#0B5345) + Electric Yellow (#F4D03F) accent. Oswald headlines, DM Sans body. White background. Feels like a premium sports analytics document.
+
+**Dimensions:** US Letter (8.5" x 11") — also works on mobile as a single scroll.
+
+---
+
+#### HEADER
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  [PitchRank Logo]                                        │
+│                                                          │
+│  TEAM REPORT CARD                                        │
+│  ─────────────────                                       │
+│  {Team Name}                                             │
+│  {Club Name} · {State} · {Age Group} · {Gender}          │
+│                                                          │
+│  Generated {Month Day, Year}                             │
+│  Data through {last_game_date}                           │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+#### RANKING OVERVIEW (Hero section — biggest visual impact)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│        NATIONAL RANK          STATE RANK                 │
+│        ┌──────────┐          ┌──────────┐               │
+│        │          │          │          │               │
+│        │   #47    │          │   #12    │               │
+│        │          │          │          │               │
+│        └──────────┘          └──────────┘               │
+│        of {N} teams           of {N} in {State}          │
+│        {▲3 7d} {▲8 30d}      {▲1 7d} {▲4 30d}          │
+│                                                          │
+│        POWERSCORE                                        │
+│        ┌──────────────────────────────────┐              │
+│        │ ████████████████░░░░  0.72       │              │
+│        └──────────────────────────────────┘              │
+│        Top {percentile}% nationally                      │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Data fields used:**
+- `rank_in_cohort_final` (national rank)
+- `rank_in_state_final` (state rank)
+- `power_score_final` (PowerScore, displayed as 0.00-1.00)
+- `rank_change_7d`, `rank_change_30d` (trend arrows)
+- `rank_change_state_7d`, `rank_change_state_30d`
+- Total teams in cohort (for "of N teams")
+- Percentile calculation: `(1 - rank/total) × 100`
+
+**Design notes:**
+- Rank numbers are LARGE (48pt+ Oswald). This is the hero.
+- Green arrows (▲) for rank improvements, red (▼) for drops
+- PowerScore bar is Forest Green fill on gray background
+- Percentile text: "Top 15% nationally" — this is the bragging stat
+
+---
+
+#### STRENGTH PROFILE (3-bar visual)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  STRENGTH PROFILE                                        │
+│                                                          │
+│  Offense     ██████████████░░░░░░  0.71                  │
+│  Defense     ████████████████░░░░  0.82                  │
+│  Schedule    ██████████░░░░░░░░░░  0.54                  │
+│                                                          │
+│  Your team plays a harder schedule than {SOS_pct}%       │
+│  of teams in your age group.                             │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Data fields used:**
+- `off_norm` (offensive strength, 0-1)
+- `def_norm` (defensive strength, 0-1)
+- `sos_norm` (strength of schedule, 0-1)
+- `sos_rank_national` (for percentile calculation)
+
+**Design notes:**
+- Bars are horizontal, filled proportionally
+- Color: Forest Green for all bars, Electric Yellow for the highest bar
+- SOS context sentence makes the number meaningful
+
+---
+
+#### SEASON RECORD
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  SEASON RECORD                                           │
+│                                                          │
+│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐       │
+│  │  {GP}  │  │  {W}   │  │  {L}   │  │  {D}   │       │
+│  │ Games  │  │  Wins  │  │ Losses │  │ Draws  │       │
+│  └────────┘  └────────┘  └────────┘  └────────┘       │
+│                                                          │
+│  Win Rate: {win_pct}%                                    │
+│  Career Record: {total_W}-{total_L}-{total_D}            │
+│                                                          │
+│  Form: {perf_centered indicator}                         │
+│  {▲ Overperforming / ● On Track / ▼ Underperforming}    │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Data fields used:**
+- `games_played`, `wins`, `losses`, `draws` (30-day window)
+- `win_percentage`
+- `total_games_played`, `total_wins`, `total_losses`, `total_draws`
+- `perf_centered` (form indicator: positive = overperforming)
+
+**Design notes:**
+- 4 big number boxes in a row
+- Win rate as a bold percentage
+- Form indicator uses color: green (overperforming), gray (on track), red (underperforming)
+
+---
+
+#### RECENT RESULTS (Last 5 games)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  RECENT RESULTS                                          │
+│                                                          │
+│  {Date}  vs {Opponent}           {Score}  {W/L/D}       │
+│  {Date}  vs {Opponent}           {Score}  {W/L/D}       │
+│  {Date}  vs {Opponent}           {Score}  {W/L/D}       │
+│  {Date}  vs {Opponent}           {Score}  {W/L/D}       │
+│  {Date}  vs {Opponent}           {Score}  {W/L/D}       │
+│                                                          │
+│  ── See all {N} games at pitchrank.io/{team_slug} ──    │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Data fields used:**
+- Last 5 entries from `getTeamGames()` API
+- `game_date`, opponent `team_name`, `home_score`/`away_score`, result (W/L/D)
+- `competition` or `division_name` (shown as small text under opponent if space allows)
+
+**Design notes:**
+- W = green badge, L = red badge, D = gray badge
+- Opponent names truncated if too long
+- Link to full game list drives traffic to the site
+
+---
+
+#### PREMIUM TEASER (Bridge to paid)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  WANT THE FULL PICTURE?                    [PitchRank]   │
+│                                                          │
+│  Your free report card shows the highlights.             │
+│  Premium shows you everything:                           │
+│                                                          │
+│  ✓ Head-to-head team comparisons                        │
+│  ✓ Predictive matchup analytics                         │
+│  ✓ 90-day ranking trend charts                          │
+│  ✓ Strength of schedule deep-dives                      │
+│  ✓ Weekly ranking alerts for your team                  │
+│  ✓ Club comparison tools                                │
+│                                                          │
+│  ┌──────────────────────────────────────────┐           │
+│  │   Start Your Free Trial → pitchrank.io   │           │
+│  └──────────────────────────────────────────┘           │
+│                                                          │
+│  7 days free · $6.99/mo · Cancel anytime                │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Design notes:**
+- This is a soft pitch, not a hard sell
+- Forest Green background with white text for the CTA section
+- Electric Yellow CTA button
+- "7 days free" is the key reassurance
+- Keep it to 1/4 of the page max — this is a lead magnet, not a sales page
+
+---
+
+#### FOOTER
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  Rankings powered by PitchRank's 13-layer algorithm      │
+│  25,000+ teams · Updated weekly · pitchrank.io           │
+│                                                          │
+│  Data through {last_calculated_date}                     │
+│  © 2026 PitchRank. All rights reserved.                  │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Delivery Email
+
+**Subject line variants:**
+
+① "Your team's report card is inside"                    ★ recommended
+→ Safe bet: Direct, matches expectation set at opt-in
+→ Preview: "{Team Name} — rank, trends, and insights"
+
+② "{Team Name} is ranked #{rank} nationally"
+→ Bold play: Puts the ranking right in the subject line. Opens with the data parents crave.
+→ Preview: "Your free report card is attached"
+
+③ "here's how {Team Name} stacks up"
+→ Personal: Lowercase, conversational, uses the team name
+→ Preview: "Rankings, strength profile, and recent results"
+
+**Recommended A/B test:** ① vs ②
+**Reason:** Tests whether parents respond to the promise ("report card is inside") or the data ("ranked #47"). Result tells us whether to lead with curiosity or specificity in the welcome sequence.
+
+---
+
+**Email body:**
+
+```
+Your team's report card is ready.
+
+[DOWNLOAD REPORT CARD — PDF]
+
+Here's the quick version:
+
+{Team Name} — {Age Group} {Gender}
+National Rank: #{rank} (▲{change} this month)
+State Rank: #{state_rank} in {State}
+PowerScore: {score} (top {percentile}% nationally)
+Record: {W}-{L}-{D}
+
+The full report card has your strength profile,
+recent results, and schedule difficulty breakdown.
+It is attached above.
+
+Over the next few days, I will send you a few
+emails about what these numbers mean and how
+to use them. Rankings are more useful when you
+know what to look for.
+
+Quick question: What are you most curious about —
+how your team compares to others, or where
+they are trending?
+
+Hit reply and let me know.
+
+— PitchRank
+
+
+P.S. Want the full picture? Head-to-head comparisons,
+predictive analytics, and weekly alerts are available
+with Premium. Try it free for 7 days:
+pitchrank.io/upgrade
+```
+
+---
+
+## Shareability Features
+
+The report card is designed to be shared. Key decisions:
+
+1. **Screenshot-worthy layout:** The ranking overview section (national rank, state rank, PowerScore) fits cleanly in a phone screenshot crop
+2. **No sensitive data:** Nothing on the report card is private — it is all publicly derivable from game results
+3. **Brand watermark:** PitchRank logo and URL visible in every section so shares drive traffic
+4. **Social preview image:** When the team profile URL is shared on social media, the OG image shows the team's rank and PowerScore — auto-generated from the same data
+5. **"Share your report card" CTA** in the email: Direct links to share on Twitter/X ("My team is ranked #47 nationally on @PitchRank"), Facebook, and copy-link
+
+---
+
+## Data Requirements for Generation
+
+### Minimum data to generate a report card:
+- Team exists in PitchRank DB ✓
+- Has a `power_score_final` (not null) ✓
+- Has `rank_in_cohort_final` ✓
+- Has at least 1 game in the system ✓
+
+### Graceful degradation:
+- **No recent games (30-day window empty):** Show career record only, note "No recent games in the ranking window"
+- **No state rank:** Show national rank only
+- **No SOS data:** Omit strength of schedule section
+- **No predictive data:** Omit prediction section (this is Premium-only anyway)
+- **Team is "Inactive":** Still generate, but note "This team has not played recently. Rankings reflect last known data."
+
+### Teams that CANNOT get a report card:
+- Team not in PitchRank DB (show "Team not found — [suggest adding]")
+- Team has zero games (show "Not enough data yet — check back after their first game")
+
+---
+
+## Technical Implementation Notes
+
+### PDF Generation Options
+1. **React-PDF (@react-pdf/renderer)** — Already in the Next.js ecosystem. Generate server-side.
+2. **Puppeteer/Playwright** — Render an HTML template, screenshot to PDF. More design flexibility.
+3. **API route** — `POST /api/report-card/generate` accepts team_id + email, queries DB, generates PDF, sends via email service.
+
+### Email Delivery
+- **Transactional email** (not marketing) — use Resend, SendGrid, or Postmark
+- PDF attached OR hosted link (hosted is better for tracking opens/clicks)
+- Trigger: immediate on form submission
+- Fallback: if email fails, show PDF inline on confirmation page
+
+### Caching
+- Report cards can be cached per team per week (since rankings update weekly)
+- Invalidate cache on Monday after rankings recalculation
+- Cache key: `report-card:{team_id}:{ranking_week}`
+
+### Analytics to Track
+- Form submissions (total captures)
+- Email open rate on delivery email
+- PDF download/view rate
+- Click-through to pitchrank.io from PDF
+- Click-through to Premium upgrade CTA
+- Share actions (Twitter, Facebook, copy-link)
+- Time from report card to trial start
+- Time from report card to Premium conversion
+
+---
+
+## Funnel Integration
+
+### How this feeds the 3 email sequences:
+
+```
+Parent downloads report card
+  │
+  ├── Already has PitchRank account?
+  │   ├── Free user → FREE EMAIL SEQUENCE
+  │   │   (nurture toward trial: show what Premium reveals)
+  │   ├── Trial user → TRIAL EMAIL SEQUENCE
+  │   │   (convert before 7 days: deepen engagement)
+  │   └── Paid user → PAID EMAIL SEQUENCE
+  │       (onboard, reduce churn, upsell annual)
+  │
+  └── No account yet → FREE EMAIL SEQUENCE
+      (welcome → value → bridge → trial CTA)
+```
+
+### Email sequence entry points:
+- **Email 1 (Day 0):** Report card delivery (this document)
+- **Email 2 (Day 2):** "What your PowerScore actually means" (education)
+- **Email 3 (Day 4):** "How your team compares to [rival]" (comparison teaser)
+- **Email 4 (Day 6):** "3 things your report card doesn't show" (bridge to Premium)
+- **Email 5 (Day 8):** "Try Premium free for 7 days" (soft pitch)
+
+These will be built out fully in `/email-sequences`.

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -1,0 +1,216 @@
+import { createServerSupabase } from '@/lib/supabase/server';
+import { sendReportCardEmail } from '@/lib/email';
+import { checkRateLimit } from '@/lib/api/rateLimit';
+import { NextRequest, NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { TeamReportCard } from '@/lib/pdf';
+import type { ReportCardGame } from '@/lib/pdf';
+import React from 'react';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(request: NextRequest) {
+  try {
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    if (!checkRateLimit(ip, 3, 60000)) {
+      return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
+    }
+
+    const body = await request.json();
+    const { teamId, email, role } = body;
+
+    // Validate inputs
+    if (!teamId || typeof teamId !== 'string' || !UUID_REGEX.test(teamId)) {
+      return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
+    }
+    if (!email || typeof email !== 'string' || !EMAIL_REGEX.test(email)) {
+      return NextResponse.json({ error: 'Please enter a valid email address' }, { status: 400 });
+    }
+
+    const normalizedEmail = email.toLowerCase().trim();
+    const supabase = await createServerSupabase();
+
+    // Fetch team data
+    const { data: team, error: teamError } = await supabase
+      .from('teams')
+      .select('team_id_master, team_name, club_name, state_code, age_group, gender')
+      .eq('team_id_master', teamId)
+      .single();
+
+    if (teamError || !team) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+    }
+
+    // Fetch ranking data (includes rank_change_*, perf_centered, offense_norm, defense_norm)
+    const { data: ranking, error: rankingError } = await supabase
+      .from('rankings_view')
+      .select('*')
+      .eq('team_id_master', teamId)
+      .single();
+
+    if (rankingError || !ranking || ranking.power_score_final == null) {
+      return NextResponse.json(
+        { error: 'Not enough ranking data for this team. Check back after they have played more games.' },
+        { status: 400 },
+      );
+    }
+
+    // Fetch last 5 games with opponent names
+    const { data: rawGames } = await supabase
+      .from('games')
+      .select('game_date, home_team_master_id, away_team_master_id, home_score, away_score')
+      .or(`home_team_master_id.eq.${teamId},away_team_master_id.eq.${teamId}`)
+      .eq('is_excluded', false)
+      .not('home_score', 'is', null)
+      .not('away_score', 'is', null)
+      .order('game_date', { ascending: false })
+      .limit(5);
+
+    // Resolve opponent names
+    const games: ReportCardGame[] = [];
+    if (rawGames && rawGames.length > 0) {
+      const opponentIds = rawGames.map((g) =>
+        g.home_team_master_id === teamId ? g.away_team_master_id : g.home_team_master_id,
+      ).filter(Boolean) as string[];
+
+      const { data: opponents } = await supabase
+        .from('teams')
+        .select('team_id_master, team_name')
+        .in('team_id_master', [...new Set(opponentIds)]);
+
+      const nameMap = new Map<string, string>();
+      opponents?.forEach((t) => nameMap.set(t.team_id_master, t.team_name));
+
+      for (const g of rawGames) {
+        const isHome = g.home_team_master_id === teamId;
+        const opId = isHome ? g.away_team_master_id : g.home_team_master_id;
+        const teamScore = isHome ? g.home_score : g.away_score;
+        const oppScore = isHome ? g.away_score : g.home_score;
+        let result: 'W' | 'L' | 'D' | 'U' = 'U';
+        if (teamScore != null && oppScore != null) {
+          if (teamScore > oppScore) result = 'W';
+          else if (teamScore < oppScore) result = 'L';
+          else result = 'D';
+        }
+        games.push({
+          game_date: g.game_date ? new Date(g.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '—',
+          opponent_name: (opId ? nameMap.get(opId) : null) || 'Unknown',
+          score: `${teamScore ?? 0}-${oppScore ?? 0}`,
+          result,
+        });
+      }
+    }
+
+    // Fetch cohort totals for percentile calculation
+    const ageNum = parseInt(team.age_group?.replace('u', '') || '0', 10);
+    const genderCode = team.gender === 'Male' ? 'M' : team.gender === 'Female' ? 'F' : team.gender;
+
+    const { count: cohortTotal } = await supabase
+      .from('rankings_view')
+      .select('*', { count: 'exact', head: true })
+      .eq('age', ageNum)
+      .eq('gender', genderCode)
+      .eq('status', 'Active');
+
+    const { count: stateCohortTotal } = await supabase
+      .from('rankings_view')
+      .select('*', { count: 'exact', head: true })
+      .eq('age', ageNum)
+      .eq('gender', genderCode)
+      .eq('state', team.state_code)
+      .eq('status', 'Active');
+
+    const totalNational = cohortTotal ?? 1;
+    const totalState = stateCohortTotal ?? 1;
+
+    // Generate PDF
+    const generatedDate = new Date().toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+    const pdfElement = React.createElement(TeamReportCard, {
+        team: {
+          team_name: team.team_name,
+          club_name: team.club_name,
+          state: team.state_code,
+          age: ageNum,
+          gender: genderCode,
+        },
+        ranking: {
+          power_score_final: ranking.power_score_final,
+          rank_in_cohort_final: ranking.rank_in_cohort_final,
+          rank_in_state_final: ranking.rank_in_state_final ?? null,
+          offense_norm: ranking.offense_norm ?? null,
+          defense_norm: ranking.defense_norm ?? null,
+          sos_norm: ranking.sos_norm ?? 0,
+          rank_change_7d: ranking.rank_change_7d ?? null,
+          rank_change_30d: ranking.rank_change_30d ?? null,
+          rank_change_state_7d: ranking.rank_change_state_7d ?? null,
+          rank_change_state_30d: ranking.rank_change_state_30d ?? null,
+          perf_centered: ranking.perf_centered ?? null,
+          wins: ranking.wins ?? 0,
+          losses: ranking.losses ?? 0,
+          draws: ranking.draws ?? 0,
+          games_played: ranking.games_played ?? 0,
+          total_wins: ranking.total_wins ?? 0,
+          total_losses: ranking.total_losses ?? 0,
+          total_draws: ranking.total_draws ?? 0,
+          total_games_played: ranking.total_games_played ?? 0,
+          win_percentage: ranking.win_percentage ?? null,
+        },
+        games,
+        cohortTotal: totalNational,
+        stateCohortTotal: totalState,
+        generatedDate,
+      });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pdfBuffer = await renderToBuffer(pdfElement as any);
+
+    // Save lead to database (non-blocking pattern)
+    supabase
+      .from('report_card_leads')
+      .insert([{
+        email: normalizedEmail,
+        team_id: teamId,
+        team_name: team.team_name,
+        role: role || null,
+        source: 'report-card',
+      }])
+      .then(({ error: insertError }) => {
+        if (insertError) console.error('Failed to save report card lead:', insertError);
+      });
+
+    // Send email with PDF attachment (non-blocking)
+    const record = `${ranking.total_wins ?? ranking.wins}-${ranking.total_losses ?? ranking.losses}-${ranking.total_draws ?? ranking.draws}`;
+    const percentile = Math.round((1 - ranking.rank_in_cohort_final / totalNational) * 100);
+
+    sendReportCardEmail(
+      normalizedEmail,
+      team.team_name,
+      ranking.rank_in_cohort_final,
+      ranking.rank_in_state_final ?? null,
+      team.state_code,
+      ranking.power_score_final,
+      percentile > 0 ? percentile : 1,
+      record,
+      ranking.rank_change_30d ?? null,
+      Buffer.from(pdfBuffer),
+    ).catch((err) => {
+      console.error('Failed to send report card email:', err);
+    });
+
+    return NextResponse.json(
+      { success: true, message: 'Report card sent! Check your inbox.' },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error('Report card API error:', error);
+    return NextResponse.json(
+      { error: 'An unexpected error occurred. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/app/report-card/page.tsx
+++ b/frontend/app/report-card/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next';
+import { ReportCardForm } from '@/components/ReportCardForm';
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+
+export const metadata: Metadata = {
+  title: 'Free Team Report Card',
+  description:
+    "Get your team's free season report card — rankings, trends, and insights powered by PitchRank's 13-layer algorithm. 25,000+ teams. Updated weekly.",
+  alternates: {
+    canonical: `${baseUrl}/report-card`,
+  },
+  openGraph: {
+    title: 'Free Team Report Card | PitchRank',
+    description:
+      "See how your team stacks up. Rankings, strength profile, and recent results — powered by 25K+ teams and a 13-layer algorithm.",
+    url: `${baseUrl}/report-card`,
+    siteName: 'PitchRank',
+    type: 'website',
+  },
+};
+
+export default function ReportCardPage() {
+  return (
+    <main className="min-h-screen bg-background">
+      {/* Hero section */}
+      <section className="bg-[#0B5345] py-16 px-4">
+        <div className="max-w-2xl mx-auto text-center">
+          <h1 className="font-oswald text-4xl md:text-5xl font-bold text-[#F4D03F] mb-4 tracking-wide">
+            Your team&apos;s report card is ready.
+          </h1>
+          <p className="text-white/90 text-lg md:text-xl max-w-xl mx-auto">
+            Rankings, trends, and insights — powered by 25K+ teams and a 13-layer algorithm. Free. Delivered in seconds.
+          </p>
+        </div>
+      </section>
+
+      {/* Form section */}
+      <section className="px-4 -mt-8">
+        <div className="max-w-md mx-auto">
+          <ReportCardForm />
+        </div>
+      </section>
+
+      {/* Social proof / info */}
+      <section className="max-w-2xl mx-auto px-4 py-12 text-center">
+        <div className="grid grid-cols-3 gap-6 mb-8">
+          <div>
+            <p className="font-oswald text-2xl font-bold text-foreground">25,000+</p>
+            <p className="text-sm text-muted-foreground">Teams ranked</p>
+          </div>
+          <div>
+            <p className="font-oswald text-2xl font-bold text-foreground">13</p>
+            <p className="text-sm text-muted-foreground">Algorithm layers</p>
+          </div>
+          <div>
+            <p className="font-oswald text-2xl font-bold text-foreground">Weekly</p>
+            <p className="text-sm text-muted-foreground">Updates</p>
+          </div>
+        </div>
+        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+          Your report card includes national rank, state rank, PowerScore, strength profile, season record, and recent results. All from real game data.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/frontend/components/ReportCardForm.tsx
+++ b/frontend/components/ReportCardForm.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { TeamSelector } from '@/components/TeamSelector';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import type { RankingRow } from '@/types/RankingRow';
+
+type FormState = 'idle' | 'loading' | 'success' | 'error';
+
+export function ReportCardForm() {
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<RankingRow | null>(null);
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState('');
+  const [formState, setFormState] = useState<FormState>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleTeamChange = (teamId: string | null, team: RankingRow | null) => {
+    setSelectedTeamId(teamId);
+    setSelectedTeam(team);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedTeamId || !email) return;
+
+    setFormState('loading');
+    setErrorMessage('');
+
+    try {
+      const res = await fetch('/api/reports/team-card', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          teamId: selectedTeamId,
+          email: email.trim(),
+          role: role || undefined,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setFormState('error');
+        setErrorMessage(data.error || 'Something went wrong. Please try again.');
+        return;
+      }
+
+      setFormState('success');
+    } catch {
+      setFormState('error');
+      setErrorMessage('Network error. Please check your connection and try again.');
+    }
+  };
+
+  if (formState === 'success') {
+    return (
+      <Card className="shadow-xl border-0">
+        <CardContent className="p-8 text-center">
+          <div className="text-4xl mb-4">⚽</div>
+          <h2 className="text-xl font-bold mb-2">Check your inbox!</h2>
+          <p className="text-muted-foreground mb-1">
+            Your report card for <span className="font-semibold text-foreground">{selectedTeam?.team_name}</span> is on its way.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Don&apos;t see it? Check your spam folder.
+          </p>
+          <Button
+            variant="outline"
+            className="mt-6"
+            onClick={() => {
+              setFormState('idle');
+              setSelectedTeamId(null);
+              setSelectedTeam(null);
+              setEmail('');
+              setRole('');
+            }}
+          >
+            Get another report card
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-xl border-0">
+      <CardContent className="p-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <TeamSelector
+            label="Find your team"
+            value={selectedTeamId}
+            onChange={handleTeamChange}
+          />
+
+          <div>
+            <label htmlFor="report-card-email" className="text-sm font-medium mb-2 block">
+              Email address
+            </label>
+            <Input
+              id="report-card-email"
+              type="email"
+              placeholder="Where should we send it?"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="report-card-role" className="text-sm font-medium mb-2 block">
+              Your role <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <select
+              id="report-card-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <option value="">Select...</option>
+              <option value="parent">Parent</option>
+              <option value="coach">Coach</option>
+              <option value="director">Club Director</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+
+          {formState === 'error' && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full bg-[#0B5345] hover:bg-[#1a6b5c] text-white font-semibold"
+            disabled={!selectedTeamId || !email || formState === 'loading'}
+          >
+            {formState === 'loading' ? 'Generating...' : 'Send My Report Card'}
+          </Button>
+
+          <p className="text-xs text-center text-muted-foreground">
+            Free. No credit card. Unsubscribe anytime.
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/email/index.ts
+++ b/frontend/lib/email/index.ts
@@ -1,2 +1,3 @@
 export { resend } from './resend';
 export { sendWelcomeEmail } from './welcome';
+export { sendReportCardEmail } from './report-card';

--- a/frontend/lib/email/report-card.ts
+++ b/frontend/lib/email/report-card.ts
@@ -1,0 +1,132 @@
+import { resend } from './resend';
+
+function buildReportCardHtml(
+  teamName: string,
+  rankNational: number | null,
+  rankState: number | null,
+  state: string | null,
+  powerScore: number | null,
+  percentile: number,
+  record: string,
+  rankChange30d: number | null,
+): string {
+  const rankChangeText = rankChange30d != null && rankChange30d !== 0
+    ? rankChange30d > 0
+      ? `<span style="color: #10B981;">▲${rankChange30d} this month</span>`
+      : `<span style="color: #EF4444;">▼${Math.abs(rankChange30d)} this month</span>`
+    : '';
+
+  const stateRankLine = rankState != null && state
+    ? `State Rank: <strong>#${rankState}</strong> in ${state.toUpperCase()}<br>`
+    : '';
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Team Report Card</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #1a1a1a; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background-color: #0B5345; padding: 16px 24px; border-radius: 8px 8px 0 0;">
+    <h1 style="color: #F4D03F; margin: 0; font-size: 22px; letter-spacing: 2px;">PITCHRANK</h1>
+  </div>
+
+  <div style="background-color: #f9fafb; padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+    <p style="margin: 0 0 16px 0; font-size: 16px;">Your team's report card is ready.</p>
+
+    <div style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 6px; padding: 16px; margin-bottom: 16px;">
+      <p style="margin: 0 0 4px 0; font-weight: bold; font-size: 15px;">${teamName}</p>
+      <p style="margin: 0; font-size: 14px; color: #6B7280;">
+        National Rank: <strong>#${rankNational ?? '—'}</strong> ${rankChangeText}<br>
+        ${stateRankLine}
+        PowerScore: <strong>${powerScore != null ? powerScore.toFixed(2) : '—'}</strong> (top ${percentile}% nationally)<br>
+        Record: <strong>${record}</strong>
+      </p>
+    </div>
+
+    <p style="font-size: 14px; color: #374151;">The full report card has your strength profile, recent results, and schedule difficulty breakdown. It's attached to this email.</p>
+
+    <p style="font-size: 14px; color: #374151;">Over the next few days, I'll send you a few emails about what these numbers mean and how to use them. Rankings are more useful when you know what to look for.</p>
+
+    <p style="font-size: 14px; color: #374151;"><strong>Quick question:</strong> What are you most curious about — how your team compares to others, or where they're trending?</p>
+
+    <p style="font-size: 14px; color: #374151;">Hit reply and let me know.</p>
+
+    <p style="font-size: 14px; color: #374151;">— PitchRank</p>
+  </div>
+
+  <div style="margin-top: 20px; padding: 16px; background-color: #0B5345; border-radius: 6px; text-align: center;">
+    <p style="color: #ffffff; margin: 0 0 8px 0; font-size: 13px;">Want the full picture? Head-to-head comparisons, predictive analytics, and weekly alerts.</p>
+    <a href="https://pitchrank.io/upgrade" style="display: inline-block; background-color: #F4D03F; color: #0B5345; padding: 10px 24px; border-radius: 4px; text-decoration: none; font-weight: bold; font-size: 14px;">Start Your Free Trial</a>
+    <p style="color: #1a6b5c; margin: 8px 0 0 0; font-size: 11px;">7 days free · $6.99/mo · Cancel anytime</p>
+  </div>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;">
+
+  <p style="color: #9ca3af; font-size: 11px; text-align: center;">
+    Rankings powered by PitchRank's 13-layer algorithm · 25,000+ teams · Updated weekly<br>
+    <a href="https://pitchrank.io" style="color: #9ca3af;">pitchrank.io</a>
+  </p>
+</body>
+</html>`;
+}
+
+/**
+ * Send a report card email with PDF attachment.
+ * Returns true if sent successfully, false otherwise.
+ * Errors are logged but not thrown - lead capture should succeed even if email fails.
+ */
+export async function sendReportCardEmail(
+  email: string,
+  teamName: string,
+  rankNational: number | null,
+  rankState: number | null,
+  state: string | null,
+  powerScore: number | null,
+  percentile: number,
+  record: string,
+  rankChange30d: number | null,
+  pdfBuffer: Buffer,
+): Promise<boolean> {
+  if (!resend) {
+    console.warn('Resend not configured - skipping report card email');
+    return false;
+  }
+
+  try {
+    const { error } = await resend.emails.send({
+      from: 'PitchRank <reports@mail.pitchrank.io>',
+      to: email,
+      subject: "Your team's report card is inside",
+      html: buildReportCardHtml(
+        teamName,
+        rankNational,
+        rankState,
+        state,
+        powerScore,
+        percentile,
+        record,
+        rankChange30d,
+      ),
+      attachments: [
+        {
+          filename: `${teamName.replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, '-')}-Report-Card.pdf`,
+          content: pdfBuffer,
+        },
+      ],
+    });
+
+    if (error) {
+      console.error('Failed to send report card email:', error);
+      return false;
+    }
+
+    console.log(`Report card email sent to ${email} for team ${teamName}`);
+    return true;
+  } catch (err) {
+    console.error('Error sending report card email:', err);
+    return false;
+  }
+}

--- a/frontend/lib/pdf/TeamReportCard.tsx
+++ b/frontend/lib/pdf/TeamReportCard.tsx
@@ -1,0 +1,569 @@
+import React from 'react';
+import {
+  Document,
+  Page,
+  View,
+  Text,
+  Link,
+  StyleSheet,
+  Font,
+} from '@react-pdf/renderer';
+
+// Register fonts via Google Fonts CDN
+Font.register({
+  family: 'Oswald',
+  fonts: [
+    {
+      src: 'https://fonts.gstatic.com/s/oswald/v53/TK3_WkUHHAIjg75cFRf3bXL8LICs1_FvsUZiYA.ttf',
+      fontWeight: 400,
+    },
+    {
+      src: 'https://fonts.gstatic.com/s/oswald/v53/TK3_WkUHHAIjg75cFRf3bXL8LICs18NvsUZiYA.ttf',
+      fontWeight: 700,
+    },
+  ],
+});
+
+Font.register({
+  family: 'DM Sans',
+  fonts: [
+    {
+      src: 'https://fonts.gstatic.com/s/dmsans/v15/rP2Hp2ywxg089UriI5-g4vlH9VoD8Cmcqbu0-K4.ttf',
+      fontWeight: 400,
+    },
+    {
+      src: 'https://fonts.gstatic.com/s/dmsans/v15/rP2Hp2ywxg089UriI5-g4vlH9VoD8CmcqbuN_K4.ttf',
+      fontWeight: 700,
+    },
+  ],
+});
+
+// --- Colors (from brand/creative-kit.md) ---
+const C = {
+  forestGreen: '#0B5345',
+  lightGreen: '#1a6b5c',
+  electricYellow: '#F4D03F',
+  white: '#FFFFFF',
+  nearBlack: '#1a1a1a',
+  lightGray: '#F3F4F6',
+  mediumGray: '#6B7280',
+  borderGray: '#E5E7EB',
+  winGreen: '#10B981',
+  lossRed: '#EF4444',
+  drawGray: '#9CA3AF',
+};
+
+// --- Shared styles ---
+const s = StyleSheet.create({
+  page: {
+    fontFamily: 'DM Sans',
+    fontSize: 10,
+    color: C.nearBlack,
+    backgroundColor: C.white,
+    paddingTop: 30,
+    paddingBottom: 30,
+    paddingHorizontal: 36,
+  },
+  // Header
+  headerBar: {
+    backgroundColor: C.forestGreen,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    marginBottom: 16,
+    marginHorizontal: -36,
+    marginTop: -30,
+  },
+  brandName: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 20,
+    color: C.electricYellow,
+    letterSpacing: 2,
+  },
+  headerSubtitle: {
+    fontFamily: 'Oswald',
+    fontWeight: 400,
+    fontSize: 11,
+    color: C.white,
+    marginTop: 2,
+    letterSpacing: 1,
+  },
+  teamNameRow: {
+    marginBottom: 4,
+    marginTop: 12,
+  },
+  teamName: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 22,
+    color: C.forestGreen,
+  },
+  teamMeta: {
+    fontSize: 9,
+    color: C.mediumGray,
+    marginBottom: 14,
+  },
+  // Section
+  sectionTitle: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 11,
+    color: C.forestGreen,
+    letterSpacing: 1,
+    marginBottom: 8,
+    textTransform: 'uppercase' as const,
+  },
+  divider: {
+    borderBottomWidth: 1,
+    borderBottomColor: C.borderGray,
+    marginVertical: 10,
+  },
+  // Ranking Overview
+  rankRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  rankBox: {
+    width: '30%',
+    alignItems: 'center',
+    backgroundColor: C.lightGray,
+    borderRadius: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 6,
+  },
+  rankNumber: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 32,
+    color: C.forestGreen,
+  },
+  rankLabel: {
+    fontSize: 8,
+    color: C.mediumGray,
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  rankChange: {
+    fontSize: 8,
+    marginTop: 2,
+  },
+  // PowerScore bar
+  scoreBarOuter: {
+    height: 14,
+    backgroundColor: C.borderGray,
+    borderRadius: 7,
+    marginTop: 4,
+    marginBottom: 2,
+    overflow: 'hidden',
+  },
+  scoreBarInner: {
+    height: 14,
+    backgroundColor: C.forestGreen,
+    borderRadius: 7,
+  },
+  scoreLabel: {
+    fontSize: 9,
+    color: C.mediumGray,
+  },
+  scoreBold: {
+    fontWeight: 700,
+    color: C.nearBlack,
+  },
+  // Strength bars
+  strengthRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  strengthLabel: {
+    width: 60,
+    fontSize: 9,
+    color: C.mediumGray,
+  },
+  strengthBarOuter: {
+    flex: 1,
+    height: 10,
+    backgroundColor: C.borderGray,
+    borderRadius: 5,
+    overflow: 'hidden',
+    marginRight: 8,
+  },
+  strengthBarInner: {
+    height: 10,
+    borderRadius: 5,
+  },
+  strengthValue: {
+    width: 30,
+    fontSize: 9,
+    fontWeight: 700,
+    textAlign: 'right',
+  },
+  // Record boxes
+  recordRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  recordBox: {
+    width: '23%',
+    alignItems: 'center',
+    backgroundColor: C.lightGray,
+    borderRadius: 4,
+    paddingVertical: 6,
+  },
+  recordNumber: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 18,
+    color: C.nearBlack,
+  },
+  recordLabel: {
+    fontSize: 7,
+    color: C.mediumGray,
+    marginTop: 1,
+    textTransform: 'uppercase' as const,
+  },
+  // Recent results table
+  gameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    borderBottomWidth: 0.5,
+    borderBottomColor: C.borderGray,
+  },
+  gameDate: {
+    width: 60,
+    fontSize: 8,
+    color: C.mediumGray,
+  },
+  gameOpponent: {
+    flex: 1,
+    fontSize: 9,
+  },
+  gameScore: {
+    width: 40,
+    fontSize: 9,
+    fontWeight: 700,
+    textAlign: 'center',
+  },
+  gameBadge: {
+    width: 18,
+    fontSize: 8,
+    fontWeight: 700,
+    textAlign: 'center',
+    borderRadius: 3,
+    paddingVertical: 1,
+    color: C.white,
+  },
+  // Premium CTA
+  ctaBox: {
+    backgroundColor: C.forestGreen,
+    borderRadius: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    marginTop: 12,
+  },
+  ctaTitle: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 12,
+    color: C.electricYellow,
+    marginBottom: 6,
+    letterSpacing: 1,
+  },
+  ctaText: {
+    fontSize: 8.5,
+    color: C.white,
+    lineHeight: 1.5,
+    marginBottom: 2,
+  },
+  ctaButton: {
+    backgroundColor: C.electricYellow,
+    borderRadius: 4,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    alignSelf: 'flex-start',
+    marginTop: 8,
+  },
+  ctaButtonText: {
+    fontFamily: 'Oswald',
+    fontWeight: 700,
+    fontSize: 10,
+    color: C.forestGreen,
+    letterSpacing: 0.5,
+  },
+  ctaSmall: {
+    fontSize: 7,
+    color: C.lightGreen,
+    marginTop: 4,
+  },
+  // Footer
+  footer: {
+    marginTop: 'auto',
+    paddingTop: 8,
+    borderTopWidth: 1,
+    borderTopColor: C.borderGray,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  footerText: {
+    fontSize: 7,
+    color: C.mediumGray,
+  },
+});
+
+// --- Helper components ---
+
+function RankChangeText({ change }: { change: number | null }) {
+  if (change == null || change === 0) return <Text style={[s.rankChange, { color: C.mediumGray }]}>—</Text>;
+  const isUp = change > 0;
+  return (
+    <Text style={[s.rankChange, { color: isUp ? C.winGreen : C.lossRed }]}>
+      {isUp ? `▲${change}` : `▼${Math.abs(change)}`} 30d
+    </Text>
+  );
+}
+
+function StrengthBar({ label, value, color }: { label: string; value: number | null; color?: string }) {
+  const v = value ?? 0;
+  const pct = Math.round(v * 100);
+  return (
+    <View style={s.strengthRow}>
+      <Text style={s.strengthLabel}>{label}</Text>
+      <View style={s.strengthBarOuter}>
+        <View style={[s.strengthBarInner, { width: `${pct}%`, backgroundColor: color || C.forestGreen }]} />
+      </View>
+      <Text style={s.strengthValue}>{v.toFixed(2)}</Text>
+    </View>
+  );
+}
+
+function ResultBadge({ result }: { result: string }) {
+  const colorMap: Record<string, string> = {
+    W: C.winGreen,
+    L: C.lossRed,
+    D: C.drawGray,
+    U: C.mediumGray,
+  };
+  return (
+    <Text style={[s.gameBadge, { backgroundColor: colorMap[result] || C.mediumGray }]}>
+      {result}
+    </Text>
+  );
+}
+
+function FormIndicator({ perf }: { perf: number | null }) {
+  if (perf == null) return null;
+  let label: string;
+  let color: string;
+  if (perf > 0.05) {
+    label = '▲ Overperforming';
+    color = C.winGreen;
+  } else if (perf < -0.05) {
+    label = '▼ Underperforming';
+    color = C.lossRed;
+  } else {
+    label = '● On Track';
+    color = C.mediumGray;
+  }
+  return <Text style={{ fontSize: 8, color, marginTop: 2 }}>{label}</Text>;
+}
+
+// --- Props ---
+
+export interface ReportCardGame {
+  game_date: string;
+  opponent_name: string;
+  score: string;
+  result: 'W' | 'L' | 'D' | 'U';
+}
+
+export interface ReportCardProps {
+  team: {
+    team_name: string;
+    club_name: string | null;
+    state: string | null;
+    age: number;
+    gender: string;
+  };
+  ranking: {
+    power_score_final: number;
+    rank_in_cohort_final: number;
+    rank_in_state_final: number | null;
+    offense_norm: number | null;
+    defense_norm: number | null;
+    sos_norm: number;
+    rank_change_7d: number | null;
+    rank_change_30d: number | null;
+    rank_change_state_7d: number | null;
+    rank_change_state_30d: number | null;
+    perf_centered: number | null;
+    wins: number;
+    losses: number;
+    draws: number;
+    games_played: number;
+    total_wins: number;
+    total_losses: number;
+    total_draws: number;
+    total_games_played: number;
+    win_percentage: number | null;
+  };
+  games: ReportCardGame[];
+  cohortTotal: number;
+  stateCohortTotal: number;
+  generatedDate: string;
+}
+
+// --- Document ---
+
+export function TeamReportCard({
+  team,
+  ranking,
+  games,
+  cohortTotal,
+  stateCohortTotal,
+  generatedDate,
+}: ReportCardProps) {
+  const percentile = Math.round((1 - ranking.rank_in_cohort_final / cohortTotal) * 100);
+  const genderLabel = team.gender === 'M' || team.gender === 'B' ? 'Boys' : 'Girls';
+  const winPct = ranking.win_percentage != null
+    ? `${Math.round(ranking.win_percentage)}%`
+    : ranking.total_games_played > 0
+      ? `${Math.round(((ranking.total_wins + 0.5 * ranking.total_draws) / ranking.total_games_played) * 100)}%`
+      : '—';
+
+  return (
+    <Document>
+      <Page size="LETTER" style={s.page}>
+        {/* Header bar */}
+        <View style={s.headerBar}>
+          <Text style={s.brandName}>PITCHRANK</Text>
+          <Text style={s.headerSubtitle}>TEAM REPORT CARD</Text>
+        </View>
+
+        {/* Team identity */}
+        <View style={s.teamNameRow}>
+          <Text style={s.teamName}>{team.team_name}</Text>
+        </View>
+        <Text style={s.teamMeta}>
+          {team.club_name ? `${team.club_name} · ` : ''}
+          {team.state ? `${team.state.toUpperCase()} · ` : ''}
+          U{team.age} {genderLabel} · Generated {generatedDate}
+        </Text>
+
+        {/* Ranking Overview */}
+        <Text style={s.sectionTitle}>Ranking Overview</Text>
+        <View style={s.rankRow}>
+          <View style={s.rankBox}>
+            <Text style={s.rankNumber}>#{ranking.rank_in_cohort_final}</Text>
+            <Text style={s.rankLabel}>National Rank{'\n'}of {cohortTotal} teams</Text>
+            <RankChangeText change={ranking.rank_change_30d} />
+          </View>
+          {ranking.rank_in_state_final != null && (
+            <View style={s.rankBox}>
+              <Text style={s.rankNumber}>#{ranking.rank_in_state_final}</Text>
+              <Text style={s.rankLabel}>State Rank{'\n'}of {stateCohortTotal} in {team.state?.toUpperCase()}</Text>
+              <RankChangeText change={ranking.rank_change_state_30d} />
+            </View>
+          )}
+          <View style={s.rankBox}>
+            <Text style={[s.rankNumber, { fontSize: 24 }]}>{ranking.power_score_final.toFixed(2)}</Text>
+            <Text style={s.rankLabel}>PowerScore</Text>
+            <Text style={[s.rankChange, { color: C.forestGreen }]}>Top {percentile > 0 ? percentile : 1}%</Text>
+          </View>
+        </View>
+
+        {/* PowerScore bar */}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 2 }}>
+          <Text style={s.scoreLabel}>PowerScore</Text>
+          <Text style={[s.scoreLabel, s.scoreBold]}>{ranking.power_score_final.toFixed(2)}</Text>
+        </View>
+        <View style={s.scoreBarOuter}>
+          <View style={[s.scoreBarInner, { width: `${Math.round(ranking.power_score_final * 100)}%` }]} />
+        </View>
+
+        <View style={s.divider} />
+
+        {/* Strength Profile */}
+        <Text style={s.sectionTitle}>Strength Profile</Text>
+        <StrengthBar label="Offense" value={ranking.offense_norm} />
+        <StrengthBar label="Defense" value={ranking.defense_norm} />
+        <StrengthBar label="Schedule" value={ranking.sos_norm} color={C.lightGreen} />
+
+        <View style={s.divider} />
+
+        {/* Season Record */}
+        <Text style={s.sectionTitle}>Season Record</Text>
+        <View style={s.recordRow}>
+          <View style={s.recordBox}>
+            <Text style={s.recordNumber}>{ranking.games_played}</Text>
+            <Text style={s.recordLabel}>Games</Text>
+          </View>
+          <View style={s.recordBox}>
+            <Text style={[s.recordNumber, { color: C.winGreen }]}>{ranking.wins}</Text>
+            <Text style={s.recordLabel}>Wins</Text>
+          </View>
+          <View style={s.recordBox}>
+            <Text style={[s.recordNumber, { color: C.lossRed }]}>{ranking.losses}</Text>
+            <Text style={s.recordLabel}>Losses</Text>
+          </View>
+          <View style={s.recordBox}>
+            <Text style={s.recordNumber}>{ranking.draws}</Text>
+            <Text style={s.recordLabel}>Draws</Text>
+          </View>
+        </View>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 2 }}>
+          <Text style={{ fontSize: 9 }}>
+            Win Rate: <Text style={{ fontWeight: 700 }}>{winPct}</Text>
+          </Text>
+          <Text style={{ fontSize: 9, color: C.mediumGray }}>
+            Career: {ranking.total_wins}-{ranking.total_losses}-{ranking.total_draws} ({ranking.total_games_played} games)
+          </Text>
+        </View>
+        <FormIndicator perf={ranking.perf_centered} />
+
+        <View style={s.divider} />
+
+        {/* Recent Results */}
+        {games.length > 0 && (
+          <>
+            <Text style={s.sectionTitle}>Recent Results</Text>
+            {games.map((g, i) => (
+              <View key={i} style={s.gameRow}>
+                <Text style={s.gameDate}>{g.game_date}</Text>
+                <Text style={s.gameOpponent}>{g.opponent_name}</Text>
+                <Text style={s.gameScore}>{g.score}</Text>
+                <ResultBadge result={g.result} />
+              </View>
+            ))}
+          </>
+        )}
+
+        {/* Premium CTA */}
+        <View style={s.ctaBox}>
+          <Text style={s.ctaTitle}>WANT THE FULL PICTURE?</Text>
+          <Text style={s.ctaText}>{'✓ Head-to-head team comparisons'}</Text>
+          <Text style={s.ctaText}>{'✓ Predictive matchup analytics'}</Text>
+          <Text style={s.ctaText}>{'✓ 90-day ranking trend charts'}</Text>
+          <Text style={s.ctaText}>{'✓ Strength of schedule deep-dives'}</Text>
+          <Text style={s.ctaText}>{'✓ Weekly ranking alerts for your team'}</Text>
+          <Link src="https://pitchrank.io/upgrade">
+            <View style={s.ctaButton}>
+              <Text style={s.ctaButtonText}>Start Your Free Trial</Text>
+            </View>
+          </Link>
+          <Text style={s.ctaSmall}>7 days free · $6.99/mo · Cancel anytime</Text>
+        </View>
+
+        {/* Footer */}
+        <View style={s.footer}>
+          <Text style={s.footerText}>
+            Rankings powered by PitchRank&apos;s 13-layer algorithm · 25,000+ teams · Updated weekly
+          </Text>
+          <Text style={s.footerText}>pitchrank.io</Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}

--- a/frontend/lib/pdf/index.ts
+++ b/frontend/lib/pdf/index.ts
@@ -1,0 +1,2 @@
+export { TeamReportCard } from './TeamReportCard';
+export type { ReportCardProps, ReportCardGame } from './TeamReportCard';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-pdf/renderer": "^4.3.2",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.81.1",
         "@tanstack/react-query": "^5.90.7",
@@ -256,6 +257,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2080,6 +2090,180 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.4.tgz",
+      "integrity": "sha512-8YtgGtL511txIEc9AjiilpZ7yjid8uCd8OGUl6jaL3LIHnrToUupSN4IzsMQpVTCMYiDLFnDNQzpZsOYtRS/Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^4.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.4.tgz",
+      "integrity": "sha512-z0ogVQE0bKqgXQ5smgzIU857rLV7bMgVdrYsu3UfXDDLSzI7QPvzf6MFTFllX6Dx2rcsF13E01dqKPtJEM799g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/png-js": "^3.0.0",
+        "jay-peg": "^1.1.1"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.2.tgz",
+      "integrity": "sha512-gNu2oh8MiGR+NJZYTJ4c4q0nWCESBI6rKFiodVhE7OeVAjtzZzd6l65wsN7HXdWJqOZD3ttD97iE+tf5SOd/Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.4",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.2",
+        "@react-pdf/textkit": "^6.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.1.0.tgz",
+      "integrity": "sha512-Wm/IOAv0h/U5Ra94c/PltFJGcpTUd/fwVMVeFD6X9tTTPCttIwg0teRG1Lqq617J8K4W7jpL/B0HTH0mjp3QpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^3.0.0",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "linebreak": "^1.1.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
+      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.2.tgz",
+      "integrity": "sha512-el5KYM1sH/PKcO4tRCIm8/AIEmhtraaONbwCrBhFdehoGv6JtgnXiMxHGAvZbI5kEg051GbyP+XIU6f6YbOu6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.2.tgz",
+      "integrity": "sha512-EhPkj35gO9rXIyyx29W3j3axemvVY5RigMmlK4/6Ku0pXB8z9PEE/sz4ZBOShu2uot6V4xiCR3aG+t9IjJJlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.4",
+        "@react-pdf/layout": "^4.4.2",
+        "@react-pdf/pdfkit": "^4.1.0",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.3.2",
+        "@react-pdf/types": "^2.9.2",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.2.tgz",
+      "integrity": "sha512-E3ftGRYUQGKiN3JOgtGsLDo0hGekA6dmkmi/MYACytmPTKxQRBSO3126MebmCq+t1rgU9uRlREIEawJ+8nzSbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.2",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.1.0.tgz",
+      "integrity": "sha512-sFlzDC9CDFrJsnL3B/+NHrk9+Advqk7iJZIStiYQDdskbow8GF/AGYrpIk+vWSnh35YxaGbHkqXq53XOxnyrjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.2.tgz",
+      "integrity": "sha512-dufvpKId9OajLLbgn9q7VLUmyo1Jf+iyGk2ZHmCL8nIDtL8N1Ejh9TH7+pXXrR0tdie1nmnEb5Bz9U7g4hI4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.4",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.2"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -3727,6 +3911,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4084,6 +4274,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -4094,6 +4304,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4118,6 +4337,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -4322,6 +4559,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4348,8 +4594,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -4427,6 +4682,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4717,6 +4978,12 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -4764,6 +5031,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -5470,6 +5743,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5484,7 +5766,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5628,6 +5909,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -6030,6 +6328,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6052,6 +6365,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -6109,6 +6428,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6150,6 +6475,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6528,6 +6859,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -6606,6 +6943,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -6620,7 +6966,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7004,6 +7349,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -7123,7 +7487,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7170,6 +7533,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7409,11 +7778,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7637,6 +8014,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7649,6 +8032,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7780,6 +8169,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7810,7 +8205,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7822,7 +8216,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -7833,6 +8226,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -8065,6 +8467,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -8149,6 +8560,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -8252,6 +8669,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -8530,6 +8967,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -8627,6 +9073,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -8874,6 +9329,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/svix": {
       "version": "1.86.0",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.86.0.tgz",
@@ -8914,6 +9375,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -9197,6 +9664,32 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -9325,6 +9818,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -9436,6 +9935,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite/node_modules/fsevents": {
@@ -9849,6 +10362,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-pdf/renderer": "^4.3.2",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.81.1",
     "@tanstack/react-query": "^5.90.7",

--- a/supabase/migrations/20260329000000_create_report_card_leads.sql
+++ b/supabase/migrations/20260329000000_create_report_card_leads.sql
@@ -1,0 +1,19 @@
+-- Report card lead capture table
+-- Stores email captures from the Free Team Report Card lead magnet
+CREATE TABLE IF NOT EXISTS report_card_leads (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL,
+  team_id UUID NOT NULL,
+  team_name TEXT NOT NULL,
+  role TEXT,
+  source TEXT DEFAULT 'report-card',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_rcl_email ON report_card_leads(email);
+CREATE INDEX idx_rcl_team ON report_card_leads(team_id);
+
+ALTER TABLE report_card_leads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow anonymous inserts" ON report_card_leads
+  FOR INSERT TO anon WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Personalized PDF report card for any of PitchRank's 25K+ teams, delivered via email as a lead magnet
- Parents enter team name + email → receive branded PDF with ranking, strength profile, trends, and recent results
- Bridges to Premium ($6.99/mo) by showing data depth while keeping deep analytics behind the paywall

## What's included
- **PDF generation** (`@react-pdf/renderer`) — Forest Green + Electric Yellow branded layout with ranking overview, strength bars, season record, recent results, and premium CTA
- **API route** (`POST /api/reports/team-card`) — orchestrates data fetch, PDF generation, lead capture, and email delivery with rate limiting
- **Email template** — Resend delivery with inline data summary + PDF attachment
- **Capture form** (`/report-card`) — public landing page with TeamSelector autocomplete + email input
- **Database migration** — `report_card_leads` table for lead capture with RLS
- **Campaign docs** — brief and full lead magnet spec

## Test plan
- [ ] Run Supabase migration for `report_card_leads` table
- [ ] Visit `/report-card`, search for a known team, enter email, submit
- [ ] Verify PDF arrives via email with correct data and branding
- [ ] Verify `report_card_leads` row was inserted in Supabase
- [ ] Test with non-existent team ID (expect 404)
- [ ] Test with team lacking ranking data (expect 400)
- [ ] Test rate limiting (4th request in 1 min should be rejected)
- [ ] Test mobile responsiveness of capture form

🤖 Generated with [Claude Code](https://claude.com/claude-code)