### PR TITLE
fix: webhook error handling + cancel_at_period_end tracking

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1582,7 +1582,7 @@ elif section == "🆕 New Accounts":
         try:
             account_rows = fetch_all_rows(
                 db.table('user_profiles')
-                .select('id, email, plan, subscription_status, subscription_period_end, stripe_customer_id, created_at, updated_at')
+                .select('id, email, plan, subscription_status, subscription_period_end, stripe_customer_id, cancel_at_period_end, created_at, updated_at')
                 .order('created_at', desc=True)
             )
             accounts_df = pd.DataFrame(account_rows)
@@ -1639,6 +1639,7 @@ elif section == "🆕 New Accounts":
             accounts_df['subscription_status'] = accounts_df.get('subscription_status', '').fillna('').astype(str).str.lower()
             accounts_df['subscription_period_end'] = pd.to_datetime(accounts_df.get('subscription_period_end'), errors='coerce', utc=True)
             accounts_df['stripe_customer_id'] = accounts_df.get('stripe_customer_id', '').fillna('')
+            accounts_df['cancel_at_period_end'] = accounts_df.get('cancel_at_period_end', False).fillna(False).astype(bool)
             accounts_df['created_at_ts'] = pd.to_datetime(accounts_df.get('created_at'), errors='coerce', utc=True)
             accounts_df['updated_at_ts'] = pd.to_datetime(accounts_df.get('updated_at'), errors='coerce', utc=True)
 
@@ -1647,9 +1648,12 @@ elif section == "🆕 New Accounts":
                 p = row['plan']
                 ss = row['subscription_status']
                 has_stripe = bool(row.get('stripe_customer_id'))
+                canceling = bool(row.get('cancel_at_period_end'))
                 if p == 'admin':
                     return 'admin'
                 if p == 'premium':
+                    if canceling:
+                        return 'paid (canceling)'
                     if ss == 'trialing':
                         return 'trial'
                     if ss == 'past_due':

--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -23,6 +23,11 @@ vi.mock('@/lib/stripe/server', () => ({
     INVOICE_PAID: 'invoice.paid',
     INVOICE_PAYMENT_FAILED: 'invoice.payment_failed',
   },
+  extractPeriodEnd: vi.fn(() => new Date().toISOString()),
+  mapStatusToPlan: vi.fn((status: string) =>
+    status === 'active' || status === 'trialing' || status === 'past_due' ? 'premium' : 'free',
+  ),
+  updateUserProfile: vi.fn().mockResolvedValue([{ id: '1' }]),
 }));
 
 // Mock @supabase/supabase-js (used directly in webhook route for admin client)
@@ -40,7 +45,7 @@ vi.mock('@supabase/supabase-js', () => ({
 
 import { POST } from '../route';
 import { headers } from 'next/headers';
-import { stripe } from '@/lib/stripe/server';
+import { stripe, updateUserProfile } from '@/lib/stripe/server';
 
 function makeRequest(body = ''): Request {
   return new Request('http://localhost/api/stripe/webhook', {
@@ -129,6 +134,100 @@ describe('POST /api/stripe/webhook', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.received).toBe(true);
+  });
+
+  it('returns 500 on transient errors so Stripe retries', async () => {
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<
+        ReturnType<typeof headers>
+      >,
+    );
+
+    const fakeEvent = {
+      id: 'evt_transient',
+      type: 'customer.subscription.deleted',
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_123',
+          status: 'canceled',
+        } as unknown as Stripe.Subscription,
+      },
+    } as Stripe.Event;
+
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(fakeEvent);
+    vi.mocked(updateUserProfile).mockRejectedValueOnce(new Error('DB connection timeout'));
+
+    const res = await POST(makeRequest('valid body'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Webhook handler failed');
+  });
+
+  it('returns 200 on permanent errors (missing user) to stop retries', async () => {
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<
+        ReturnType<typeof headers>
+      >,
+    );
+
+    const fakeEvent = {
+      id: 'evt_permanent',
+      type: 'customer.subscription.deleted',
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_orphan',
+          status: 'canceled',
+        } as unknown as Stripe.Subscription,
+      },
+    } as Stripe.Event;
+
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(fakeEvent);
+    vi.mocked(updateUserProfile).mockRejectedValueOnce(
+      new Error('No user profile found for Stripe customer cus_orphan'),
+    );
+
+    const res = await POST(makeRequest('valid body'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.error).toBe('Permanent webhook error');
+  });
+
+  it('tracks cancel_at_period_end on subscription updates', async () => {
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<
+        ReturnType<typeof headers>
+      >,
+    );
+
+    const fakeEvent = {
+      id: 'evt_cancel_pending',
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_123',
+          status: 'active',
+          cancel_at_period_end: true,
+          items: { data: [{ current_period_end: 1735689600 }] },
+        } as unknown as Stripe.Subscription,
+      },
+    } as Stripe.Event;
+
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(fakeEvent);
+    vi.mocked(updateUserProfile).mockResolvedValueOnce([{ id: '1' }]);
+
+    const res = await POST(makeRequest('valid body'));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(updateUserProfile)).toHaveBeenCalledWith(
+      expect.anything(),
+      'cus_123',
+      expect.objectContaining({ cancel_at_period_end: true }),
+    );
   });
 
   it('returns 200 for unknown event types (acknowledge receipt)', async () => {

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -20,6 +20,15 @@ function getSupabaseAdmin(): SupabaseClient {
   return supabaseAdmin;
 }
 
+/**
+ * Permanent errors that won't resolve on retry — return 200 so Stripe
+ * stops retrying. Everything else returns 500 so Stripe retries.
+ */
+function isPermanentError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes('No user profile found for Stripe customer');
+}
+
 export async function POST(req: Request) {
   const body = await req.text();
   const headersList = await headers();
@@ -45,6 +54,8 @@ export async function POST(req: Request) {
     console.error(`Webhook signature verification failed: ${message}`);
     return NextResponse.json({ error: 'Webhook signature verification failed' }, { status: 400 });
   }
+
+  console.log(`[webhook] Received ${event.type} (${event.id})`);
 
   try {
     switch (event.type) {
@@ -79,20 +90,24 @@ export async function POST(req: Request) {
       }
 
       default:
-        console.log(`Unhandled event type: ${event.type}`);
+        console.log(`[webhook] Unhandled event type: ${event.type}`);
     }
 
     return NextResponse.json({ received: true });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorStack = error instanceof Error ? error.stack : undefined;
-    console.error(`Webhook handler error for ${event.type}: ${errorMessage}`);
+    console.error(`[webhook] Handler error for ${event.type}: ${errorMessage}`);
     if (errorStack) console.error(errorStack);
-    // Return 200 to acknowledge receipt and prevent Stripe from retrying
-    // for up to 72 hours. Permanent errors (missing user, bad data) won't
-    // resolve on retry. Transient errors (DB timeout) are rare and can be
-    // reprocessed manually if needed.
-    return NextResponse.json({ received: true, error: 'Webhook handler failed', detail: errorMessage }, { status: 200 });
+
+    if (isPermanentError(error)) {
+      // No matching user — retrying won't help. Acknowledge so Stripe stops.
+      console.warn(`[webhook] Permanent error, returning 200 to stop retries`);
+      return NextResponse.json({ received: true, error: 'Permanent webhook error', detail: errorMessage }, { status: 200 });
+    }
+
+    // Transient error (DB timeout, network issue) — return 500 so Stripe retries
+    return NextResponse.json({ error: 'Webhook handler failed', detail: errorMessage }, { status: 500 });
   }
 }
 
@@ -104,7 +119,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const subscriptionId = session.subscription as string;
 
   if (!customerId || !subscriptionId) {
-    console.error('Missing customer or subscription ID in checkout session');
+    console.error('[webhook] Missing customer or subscription ID in checkout session');
     return;
   }
 
@@ -117,11 +132,12 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       subscription_status: subscription.status,
       plan: mapStatusToPlan(subscription.status),
       subscription_period_end: extractPeriodEnd(subscription),
+      cancel_at_period_end: false,
     }),
     stripe.customers.retrieve(customerId),
   ]);
 
-  console.log(`Subscription activated for customer ${customerId}`);
+  console.log(`[webhook] Subscription activated for customer ${customerId}`);
 
   // Notify admin of new signup
   const customerName = (customer as Stripe.Customer).name ?? 'Unknown';
@@ -141,21 +157,28 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 }
 
 /**
- * Handle subscription updates (plan changes, renewals)
+ * Handle subscription updates (plan changes, renewals, cancellation intent)
+ *
+ * When a user cancels via Customer Portal, Stripe sets cancel_at_period_end=true
+ * but keeps status as "active" until the period ends. We track this flag so the
+ * dashboard can show the user as "canceling" rather than misleadingly "active".
  */
 async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   const customerId = subscription.customer as string;
   const status = subscription.status;
   const plan = mapStatusToPlan(status);
+  const canceling = subscription.cancel_at_period_end ?? false;
 
   await updateUserProfile(getSupabaseAdmin(), customerId, {
     stripe_subscription_id: subscription.id,
     subscription_status: status,
     plan,
     subscription_period_end: extractPeriodEnd(subscription),
+    cancel_at_period_end: canceling,
   });
 
-  console.log(`Subscription updated for customer ${customerId}: ${status}`);
+  const label = canceling ? `${status} (canceling at period end)` : status;
+  console.log(`[webhook] Subscription updated for customer ${customerId}: ${label}`);
 }
 
 /**
@@ -169,9 +192,10 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
     subscription_status: 'canceled',
     plan: 'free',
     subscription_period_end: null,
+    cancel_at_period_end: false,
   });
 
-  console.log(`Subscription canceled for customer ${customerId}`);
+  console.log(`[webhook] Subscription canceled for customer ${customerId}`);
 }
 
 /**
@@ -199,9 +223,10 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
     subscription_status: subscriptionData.status,
     plan: mapStatusToPlan(subscriptionData.status),
     subscription_period_end: extractPeriodEnd(subscriptionData),
+    cancel_at_period_end: subscriptionData.cancel_at_period_end ?? false,
   });
 
-  console.log(`Invoice paid for customer ${customerId}`);
+  console.log(`[webhook] Invoice paid for customer ${customerId}`);
 }
 
 /**
@@ -214,5 +239,5 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
     subscription_status: 'past_due',
   });
 
-  console.log(`Payment failed for customer ${customerId}`);
+  console.log(`[webhook] Payment failed for customer ${customerId}`);
 }

--- a/frontend/components/subscription/SubscriptionStatus.tsx
+++ b/frontend/components/subscription/SubscriptionStatus.tsx
@@ -29,7 +29,10 @@ function formatDate(dateString: string | null): string {
   });
 }
 
-function getStatusColor(status: string | null): string {
+function getStatusColor(status: string | null, canceling?: boolean): string {
+  if (canceling && (status === "active" || status === "trialing")) {
+    return "bg-orange-500/10 text-orange-600 border-orange-500/20";
+  }
   switch (status) {
     case "active":
     case "trialing":
@@ -41,6 +44,13 @@ function getStatusColor(status: string | null): string {
     default:
       return "bg-muted text-muted-foreground";
   }
+}
+
+function getStatusLabel(profile: UserProfile): string {
+  if (profile.cancel_at_period_end && profile.subscription_status === "active") {
+    return "Canceling";
+  }
+  return profile.subscription_status || "Unknown";
 }
 
 export function SubscriptionStatus({ profile }: SubscriptionStatusProps) {
@@ -116,8 +126,8 @@ export function SubscriptionStatus({ profile }: SubscriptionStatusProps) {
             <Crown className="w-5 h-5 text-primary" />
             PitchRank+ Subscription
           </CardTitle>
-          <Badge className={getStatusColor(profile.subscription_status)}>
-            {profile.subscription_status || "Unknown"}
+          <Badge className={getStatusColor(profile.subscription_status, profile.cancel_at_period_end)}>
+            {getStatusLabel(profile)}
           </Badge>
         </div>
         <CardDescription>
@@ -142,6 +152,22 @@ export function SubscriptionStatus({ profile }: SubscriptionStatusProps) {
             </div>
           )}
         </div>
+
+        {/* Canceling notice */}
+        {profile.cancel_at_period_end && profile.subscription_status === "active" && (
+          <div className="flex items-start gap-3 p-3 rounded-lg bg-orange-500/10 border border-orange-500/20">
+            <AlertCircle className="w-5 h-5 text-orange-600 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-medium text-orange-600">
+                Subscription Canceling
+              </p>
+              <p className="text-xs text-orange-600/80 mt-1">
+                Your access continues until {formatDate(profile.subscription_period_end)}.
+                You can resubscribe anytime from the billing portal.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Past due warning */}
         {profile.subscription_status === "past_due" && (

--- a/frontend/hooks/useUser.ts
+++ b/frontend/hooks/useUser.ts
@@ -16,6 +16,7 @@ export interface UserProfile {
   stripe_subscription_id: string | null;
   subscription_status: string | null;
   subscription_period_end: string | null;
+  cancel_at_period_end: boolean;
 }
 
 /**

--- a/scripts/reconcile_stripe_subscriptions.py
+++ b/scripts/reconcile_stripe_subscriptions.py
@@ -90,6 +90,7 @@ def check_stripe_subscription(customer_id: str):
         "status": sub.status,
         "subscription_id": sub.id,
         "period_end": period_end,
+        "cancel_at_period_end": bool(sub.cancel_at_period_end),
     }
 
 
@@ -124,12 +125,14 @@ def reconcile(supabase, dry_run: bool):
             stripe_status = sub_data["status"]
             stripe_sub_id = sub_data["subscription_id"]
             period_end = sub_data["period_end"]
+            cancel_at_period_end = sub_data["cancel_at_period_end"]
         else:
             # No subscription in Stripe
             expected_plan = "free"
             stripe_status = None
             stripe_sub_id = None
             period_end = None
+            cancel_at_period_end = False
 
         db_plan = row.get("plan") or "free"
         db_status = row.get("subscription_status")
@@ -172,6 +175,7 @@ def reconcile(supabase, dry_run: bool):
                 "plan": expected_plan,
                 "subscription_status": stripe_status,
                 "stripe_subscription_id": stripe_sub_id,
+                "cancel_at_period_end": cancel_at_period_end,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
             if period_end:

--- a/supabase/migrations/20260330000000_add_cancel_at_period_end.sql
+++ b/supabase/migrations/20260330000000_add_cancel_at_period_end.sql
@@ -1,0 +1,10 @@
+-- Add cancel_at_period_end flag to track pending cancellations
+-- When a user cancels via Stripe Customer Portal, status stays "active"
+-- but cancel_at_period_end becomes true. Without this flag, the dashboard
+-- shows them as a happy paid subscriber when they've actually cancelled.
+
+alter table public.user_profiles
+  add column if not exists cancel_at_period_end boolean not null default false;
+
+comment on column public.user_profiles.cancel_at_period_end is
+  'True when user has cancelled but subscription remains active until period end';


### PR DESCRIPTION
## Summary
- **Return 500 on transient webhook errors** so Stripe retries (DB timeouts, network issues). Previously all errors returned 200, silently losing events forever.
- **Return 200 only for permanent errors** (missing user profile) where retrying won't help.
- **Track `cancel_at_period_end`** — new DB column + webhook/reconciliation/dashboard/frontend support so "canceling" users show correctly instead of misleading "active" status.

Fixes the root cause of jodiraebarrett@gmail.com (and 2 other users) showing as active subscribers after cancellation. Profiles were already corrected via manual reconciliation run.

## Changes
| File | What |
|------|------|
| `webhook/route.ts` | Transient vs permanent error handling, `cancel_at_period_end` in all handlers, structured logging |
| `webhook/__tests__/route.test.ts` | 3 new tests: transient retry, permanent stop, cancel tracking |
| `hooks/useUser.ts` | Added `cancel_at_period_end` to `UserProfile` interface |
| `SubscriptionStatus.tsx` | Orange "Canceling" badge + notice for pending cancellations |
| `dashboard.py` | "paid (canceling)" display plan category |
| `reconcile_stripe_subscriptions.py` | Syncs `cancel_at_period_end` from Stripe |
| `migrations/20260330000000_add_cancel_at_period_end.sql` | New boolean column on `user_profiles` |

## Test plan
- [x] All 8 webhook tests pass
- [x] TypeScript compiles clean
- [ ] Run migration against Supabase after merge
- [ ] Verify webhook deliveries in Stripe Dashboard (Developers > Webhooks)
- [ ] Trigger a test cancellation and confirm "Canceling" badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)