### PR TITLE
Refactor analytics dashboard: extract shared utils, fix font class, cache auth

### DIFF
--- a/frontend/app/api/analytics/funnel/route.ts
+++ b/frontend/app/api/analytics/funnel/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { getAnalyticsDataClient } from '@/lib/google-auth';
+import { getDateRange } from '@/lib/analytics-utils';
 import type { FunnelData, FunnelStep, ConversionRates } from '@/types/analytics';
 
 const FUNNEL_EVENTS = [
@@ -9,28 +10,6 @@ const FUNNEL_EVENTS = [
   { event: 'checkout_initiated', label: 'Checkout Started' },
   { event: 'subscription_completed', label: 'Subscribed' },
 ] as const;
-
-function getDateRange(range: string): { startDate: string; endDate: string } {
-  const end = new Date();
-  end.setDate(end.getDate() - 1);
-  const start = new Date(end);
-
-  switch (range) {
-    case '7d':
-      start.setDate(start.getDate() - 7);
-      break;
-    case '90d':
-      start.setDate(start.getDate() - 90);
-      break;
-    default:
-      start.setDate(start.getDate() - 28);
-  }
-
-  return {
-    startDate: start.toISOString().split('T')[0],
-    endDate: end.toISOString().split('T')[0],
-  };
-}
 
 export async function GET(req: Request) {
   const auth = await requireAdmin();

--- a/frontend/app/api/analytics/search-console/route.ts
+++ b/frontend/app/api/analytics/search-console/route.ts
@@ -1,29 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { getSearchConsoleClient } from '@/lib/google-auth';
+import { getDateRange } from '@/lib/analytics-utils';
 import type { SearchConsoleData, SearchConsoleRow, SearchConsolePageRow } from '@/types/analytics';
-
-function getDateRange(range: string): { startDate: string; endDate: string } {
-  const end = new Date();
-  end.setDate(end.getDate() - 1); // GSC data has ~2 day lag
-  const start = new Date(end);
-
-  switch (range) {
-    case '7d':
-      start.setDate(start.getDate() - 7);
-      break;
-    case '90d':
-      start.setDate(start.getDate() - 90);
-      break;
-    default:
-      start.setDate(start.getDate() - 28);
-  }
-
-  return {
-    startDate: start.toISOString().split('T')[0],
-    endDate: end.toISOString().split('T')[0],
-  };
-}
 
 export async function GET(req: Request) {
   const auth = await requireAdmin();

--- a/frontend/app/api/analytics/traffic/route.ts
+++ b/frontend/app/api/analytics/traffic/route.ts
@@ -1,29 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { getAnalyticsDataClient } from '@/lib/google-auth';
+import { getDateRange } from '@/lib/analytics-utils';
 import type { TrafficData, ReferralSource, PageMetric } from '@/types/analytics';
-
-function getDateRange(range: string): { startDate: string; endDate: string } {
-  const end = new Date();
-  end.setDate(end.getDate() - 1);
-  const start = new Date(end);
-
-  switch (range) {
-    case '7d':
-      start.setDate(start.getDate() - 7);
-      break;
-    case '90d':
-      start.setDate(start.getDate() - 90);
-      break;
-    default:
-      start.setDate(start.getDate() - 28);
-  }
-
-  return {
-    startDate: start.toISOString().split('T')[0],
-    endDate: end.toISOString().split('T')[0],
-  };
-}
 
 export async function GET(req: Request) {
   const auth = await requireAdmin();

--- a/frontend/app/mission-control/page.tsx
+++ b/frontend/app/mission-control/page.tsx
@@ -16,7 +16,7 @@ export default function MissionControlPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="font-heading text-3xl font-bold tracking-tight">Mission Control</h1>
+            <h1 className="font-display text-3xl font-bold tracking-tight">Mission Control</h1>
             <p className="mt-1 text-sm text-gray-400">Traffic, search performance, and conversion analytics</p>
           </div>
           <DateRangeSelector value={range} onChange={setRange} />

--- a/frontend/components/analytics/FunnelTab.tsx
+++ b/frontend/components/analytics/FunnelTab.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import { useFunnelData } from '@/hooks/useAnalytics';
+import { formatPercent } from '@/lib/analytics-utils';
 import { MetricCard } from './MetricCard';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 
 const FUNNEL_COLORS = ['#22c55e', '#3b82f6', '#f59e0b', '#ef4444'];
-
-function formatPercent(rate: number): string {
-  return `${(rate * 100).toFixed(1)}%`;
-}
 
 interface FunnelTabProps {
   range: string;
@@ -113,7 +110,11 @@ export function FunnelTab({ range }: FunnelTabProps) {
               key={step.event}
               title={step.label}
               value={step.count.toLocaleString()}
-              subtitle={i > 0 ? `${formatPercent(step.count / data.funnel[0].count)} of views` : undefined}
+              subtitle={
+                i > 0 && data.funnel[0].count > 0
+                  ? `${formatPercent(step.count / data.funnel[0].count)} of views`
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/frontend/components/analytics/SearchConsoleTab.tsx
+++ b/frontend/components/analytics/SearchConsoleTab.tsx
@@ -1,17 +1,10 @@
 'use client';
 
 import { useSearchConsole } from '@/hooks/useAnalytics';
+import { formatPercent, formatPosition } from '@/lib/analytics-utils';
 import { MetricCard } from './MetricCard';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
-
-function formatCtr(ctr: number): string {
-  return `${(ctr * 100).toFixed(1)}%`;
-}
-
-function formatPosition(pos: number): string {
-  return pos.toFixed(1);
-}
 
 function TableSkeleton() {
   return (
@@ -44,7 +37,7 @@ export function SearchConsoleTab({ range }: SearchConsoleTabProps) {
           value={data ? data.totals.impressions.toLocaleString() : '—'}
           loading={isLoading}
         />
-        <MetricCard title="Average CTR" value={data ? formatCtr(data.totals.ctr) : '—'} loading={isLoading} />
+        <MetricCard title="Average CTR" value={data ? formatPercent(data.totals.ctr) : '—'} loading={isLoading} />
         <MetricCard
           title="Average Position"
           value={data ? formatPosition(data.totals.position) : '—'}
@@ -75,7 +68,7 @@ export function SearchConsoleTab({ range }: SearchConsoleTabProps) {
                     <TableCell className="text-white">{row.query}</TableCell>
                     <TableCell className="text-right text-gray-300">{row.clicks.toLocaleString()}</TableCell>
                     <TableCell className="text-right text-gray-300">{row.impressions.toLocaleString()}</TableCell>
-                    <TableCell className="text-right text-gray-300">{formatCtr(row.ctr)}</TableCell>
+                    <TableCell className="text-right text-gray-300">{formatPercent(row.ctr)}</TableCell>
                     <TableCell className="text-right text-gray-300">{formatPosition(row.position)}</TableCell>
                   </TableRow>
                 ))}
@@ -117,7 +110,7 @@ export function SearchConsoleTab({ range }: SearchConsoleTabProps) {
                     </TableCell>
                     <TableCell className="text-right text-gray-300">{row.clicks.toLocaleString()}</TableCell>
                     <TableCell className="text-right text-gray-300">{row.impressions.toLocaleString()}</TableCell>
-                    <TableCell className="text-right text-gray-300">{formatCtr(row.ctr)}</TableCell>
+                    <TableCell className="text-right text-gray-300">{formatPercent(row.ctr)}</TableCell>
                     <TableCell className="text-right text-gray-300">{formatPosition(row.position)}</TableCell>
                   </TableRow>
                 ))}

--- a/frontend/lib/analytics-utils.ts
+++ b/frontend/lib/analytics-utils.ts
@@ -1,0 +1,31 @@
+export type DateRangeKey = '7d' | '28d' | '90d';
+
+export function getDateRange(range: string): { startDate: string; endDate: string } {
+  const end = new Date();
+  end.setDate(end.getDate() - 1);
+  const start = new Date(end);
+
+  switch (range) {
+    case '7d':
+      start.setDate(start.getDate() - 7);
+      break;
+    case '90d':
+      start.setDate(start.getDate() - 90);
+      break;
+    default:
+      start.setDate(start.getDate() - 28);
+  }
+
+  return {
+    startDate: start.toISOString().split('T')[0],
+    endDate: end.toISOString().split('T')[0],
+  };
+}
+
+export function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+export function formatPosition(pos: number): string {
+  return pos.toFixed(1);
+}

--- a/frontend/lib/google-auth.ts
+++ b/frontend/lib/google-auth.ts
@@ -1,16 +1,18 @@
 import { google } from 'googleapis';
+import type { JWT } from 'google-auth-library';
 
-function getCredentials() {
+let _auth: JWT | null = null;
+
+function getAuth(): JWT {
+  if (_auth) return _auth;
+
   const json = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
   if (!json) {
     throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set');
   }
-  return JSON.parse(json);
-}
 
-function getAuth() {
-  const credentials = getCredentials();
-  return new google.auth.JWT({
+  const credentials = JSON.parse(json);
+  _auth = new google.auth.JWT({
     email: credentials.client_email,
     key: credentials.private_key,
     scopes: [
@@ -18,6 +20,8 @@ function getAuth() {
       'https://www.googleapis.com/auth/analytics.readonly',
     ],
   });
+
+  return _auth;
 }
 
 export function getSearchConsoleClient() {


### PR DESCRIPTION
Clean up the Mission Control analytics dashboard code. Extract the duplicated getDateRange function and percent/position formatters into a shared analytics-utils.ts module. Cache the Google service account JWT at module level instead of re-parsing credentials on every API call. Fix font-heading (doesn't exist) to font-display (Oswald). Guard against division by zero in the funnel event count display.