### PR TITLE
Security hardening and CI typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,22 @@ jobs:
       - run: npm ci
       - run: npx prettier --check .
 
+  frontend-typecheck:
+    name: Frontend Typecheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd frontend && npx lint-staged

--- a/frontend/app/mission-control/page.tsx
+++ b/frontend/app/mission-control/page.tsx
@@ -1,14 +1,47 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
 import { DateRangeSelector } from '@/components/analytics/DateRangeSelector';
 import { SearchConsoleTab } from '@/components/analytics/SearchConsoleTab';
 import { TrafficTab } from '@/components/analytics/TrafficTab';
 import { FunnelTab } from '@/components/analytics/FunnelTab';
+import { useUser, hasAdminAccess } from '@/hooks/useUser';
 
 export default function MissionControlPage() {
+  const { user, profile, isLoading: userLoading } = useUser();
   const [range, setRange] = useState('28d');
+
+  if (userLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black">
+        <div className="container mx-auto p-6">
+          <div className="animate-pulse space-y-6">
+            <div className="h-12 bg-white/5 rounded-xl w-64" />
+            <div className="h-96 bg-white/5 rounded-xl" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || !hasAdminAccess(profile)) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container px-4 py-16">
+          <div className="text-center max-w-md mx-auto">
+            <h1 className="text-2xl font-display mb-3">Page Not Found</h1>
+            <p className="text-muted-foreground mb-6">The page you are looking for does not exist.</p>
+            <Link href="/">
+              <Button size="lg">Go Home</Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">

--- a/frontend/hooks/useUser.ts
+++ b/frontend/hooks/useUser.ts
@@ -28,6 +28,14 @@ export function hasPremiumAccess(profile: UserProfile | null): boolean {
 }
 
 /**
+ * Check if user has admin access
+ */
+export function hasAdminAccess(profile: UserProfile | null): boolean {
+  if (!profile) return false;
+  return profile.plan === 'admin';
+}
+
+/**
  * Check if subscription is active
  */
 export function isSubscriptionActive(profile: UserProfile | null): boolean {

--- a/frontend/lib/confidenceEngine.ts
+++ b/frontend/lib/confidenceEngine.ts
@@ -18,6 +18,7 @@
 
 import type { TeamWithRanking } from './types';
 import type { Game } from './types';
+import { isNetworkError } from './errors';
 
 // Confidence calibration v2 parameters
 interface ConfidenceParametersV2 {
@@ -36,6 +37,8 @@ interface ConfidenceParametersV2 {
 
 let confidenceParamsV2: ConfidenceParametersV2 | null = null;
 let confidenceParamsV2Loading: Promise<void> | null = null;
+let confidenceRetries = 0;
+const MAX_PARAM_RETRIES = 3;
 
 /**
  * Load confidence calibration v2 parameters from JSON file
@@ -60,9 +63,12 @@ async function loadConfidenceParametersV2(): Promise<ConfidenceParametersV2 | nu
         // File not found - will use defaults
         confidenceParamsV2 = null;
       }
-    } catch (_error) {
-      // Fallback to defaults on error
-      confidenceParamsV2 = null;
+    } catch (error) {
+      if (isNetworkError(error) && confidenceRetries < MAX_PARAM_RETRIES) {
+        confidenceRetries++;
+        confidenceParamsV2Loading = null; // Allow future retry
+      }
+      // Non-network or exhausted retries: stay null, use defaults
     }
   })();
 

--- a/frontend/lib/matchPredictor.ts
+++ b/frontend/lib/matchPredictor.ts
@@ -46,6 +46,7 @@ import type { TeamWithRanking } from './types';
 import type { Game } from './types';
 import { computeConfidence } from './confidenceEngine';
 import { extractAgeFromTeamName } from './utils';
+import { isNetworkError } from './errors';
 
 // Age group parameters (loaded from JSON, fallback to defaults)
 interface AgeGroupParameters {
@@ -74,6 +75,10 @@ let probabilityParams: ProbabilityParameters | null = null;
 let probabilityParamsLoading: Promise<void> | null = null;
 let marginParamsV2: MarginParametersV2 | null = null;
 let marginParamsV2Loading: Promise<void> | null = null;
+let ageGroupRetries = 0;
+let probabilityRetries = 0;
+let marginV2Retries = 0;
+const MAX_PARAM_RETRIES = 3;
 
 /**
  * Load age group parameters from JSON file
@@ -98,8 +103,12 @@ async function loadAgeGroupParameters(): Promise<Record<string, AgeGroupParamete
         // Fallback to defaults if file not found
         ageGroupParams = {};
       }
-    } catch (_error) {
-      // Fallback to defaults on error
+    } catch (error) {
+      if (isNetworkError(error) && ageGroupRetries < MAX_PARAM_RETRIES) {
+        ageGroupRetries++;
+        ageGroupParamsLoading = null; // Allow future retry
+      }
+      // Always set fallback so callers don't get null through non-null assertion
       ageGroupParams = {};
     }
   })();
@@ -131,9 +140,12 @@ async function loadProbabilityParameters(): Promise<ProbabilityParameters | null
         // File not found - will use defaults
         probabilityParams = null;
       }
-    } catch (_error) {
-      // Fallback to defaults on error
-      probabilityParams = null;
+    } catch (error) {
+      if (isNetworkError(error) && probabilityRetries < MAX_PARAM_RETRIES) {
+        probabilityRetries++;
+        probabilityParamsLoading = null; // Allow future retry
+      }
+      // Non-network or exhausted retries: stay null, use defaults
     }
   })();
 
@@ -164,9 +176,12 @@ async function loadMarginParametersV2(): Promise<MarginParametersV2 | null> {
         // File not found - will use defaults
         marginParamsV2 = null;
       }
-    } catch (_error) {
-      // Fallback to defaults on error
-      marginParamsV2 = null;
+    } catch (error) {
+      if (isNetworkError(error) && marginV2Retries < MAX_PARAM_RETRIES) {
+        marginV2Retries++;
+        marginParamsV2Loading = null; // Allow future retry
+      }
+      // Non-network or exhausted retries: stay null, use defaults
     }
   })();
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,13 +1,14 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 
-// Routes that require authentication (currently all are also premium-gated)
-const PROTECTED_ROUTES = ['/watchlist', '/compare', '/teams'];
+// Routes that require premium subscription
+const PREMIUM_ROUTES = ['/watchlist', '/compare', '/teams'];
 
-// Routes that require premium subscription (subset of protected routes)
-// NOTE: Currently identical to PROTECTED_ROUTES. To add auth-only (non-premium)
-// routes, add them to PROTECTED_ROUTES only.
-const PREMIUM_ROUTES: string[] = PROTECTED_ROUTES;
+// Routes that require admin plan
+const ADMIN_ROUTES = ['/mission-control'];
+
+// All routes requiring authentication (derived to prevent list drift)
+const PROTECTED_ROUTES = [...PREMIUM_ROUTES, ...ADMIN_ROUTES];
 
 // Auth routes (login/signup pages)
 const AUTH_ROUTES = ['/login', '/signup'];
@@ -75,6 +76,7 @@ export async function middleware(request: NextRequest) {
 
   const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
   const isPremiumRoute = PREMIUM_ROUTES.some((route) => pathname.startsWith(route));
+  const isAdminRoute = ADMIN_ROUTES.some((route) => pathname.startsWith(route));
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
 
   // Redirect unauthenticated users from protected routes
@@ -94,25 +96,33 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Check premium status for premium routes
-  if (isPremiumRoute && user) {
+  // Check plan-gated routes (single profile fetch for premium + admin checks)
+  if ((isPremiumRoute || isAdminRoute) && user) {
     const { data: profile, error: profileError } = await supabase
       .from('user_profiles')
       .select('plan')
       .eq('id', user.id)
       .single();
 
-    // If profile fetch failed or profile doesn't exist, redirect to upgrade
-    // This prevents users from bypassing premium check when profile is null
-    if (profileError || !profile) {
-      console.warn('[Middleware] Profile not found or error:', profileError?.message);
-      return NextResponse.redirect(new URL('/upgrade', request.url));
+    if (isPremiumRoute) {
+      // If profile fetch failed or profile doesn't exist, redirect to upgrade
+      // This prevents users from bypassing premium check when profile is null
+      if (profileError || !profile) {
+        console.warn('[Middleware] Profile not found or error:', profileError?.message);
+        return NextResponse.redirect(new URL('/upgrade', request.url));
+      }
+
+      // Redirect free users to upgrade page
+      // Allow admin and premium users through
+      if (profile.plan !== 'premium' && profile.plan !== 'admin') {
+        return NextResponse.redirect(new URL('/upgrade', request.url));
+      }
     }
 
-    // Redirect free users to upgrade page
-    // Allow admin and premium users through
-    if (profile.plan !== 'premium' && profile.plan !== 'admin') {
-      return NextResponse.redirect(new URL('/upgrade', request.url));
+    if (isAdminRoute) {
+      if (!profile || profile.plan !== 'admin') {
+        return NextResponse.redirect(new URL('/', request.url));
+      }
     }
   }
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -51,6 +51,9 @@ const nextConfig: NextConfig = {
 
   // Security headers
   async headers() {
+    // unsafe-eval is needed for Next.js dev mode (HMR/source maps) but not production
+    const cspUnsafeEval = process.env.NODE_ENV === 'production' ? '' : " 'unsafe-eval'";
+
     return [
       {
         source: '/(.*)',
@@ -77,8 +80,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'none';",
+            value: `default-src 'self'; script-src 'self' 'unsafe-inline'${cspUnsafeEval} https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'none';`,
           },
         ],
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "analyze": "cross-env ANALYZE=true next build --webpack",
     "test:e2e": "playwright test",
     "test:e2e:api": "playwright test --project=api",


### PR DESCRIPTION
Removes `'unsafe-eval'` from the production CSP (kept for dev HMR), gates `/mission-control` behind admin-only auth in both middleware and client, adds network retry logic to the confidence/predictor parameter loaders so transient failures don't permanently cache null, and adds a `tsc --noEmit` job to CI so type errors get caught before merge.

Also fixes the pre-commit hook to run lint-staged from the frontend directory (was failing because prettier/eslint weren't on PATH at repo root), and derives `PROTECTED_ROUTES` from `PREMIUM_ROUTES + ADMIN_ROUTES` to prevent list drift.