### PR TITLE
refactor: extract shared constants and API utilities

### DIFF
--- a/frontend/app/api/create-team/route.ts
+++ b/frontend/app/api/create-team/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
 
 /**
  * Create a new team and link it to an unknown opponent
@@ -12,23 +13,18 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<{
+      gameId: string;
+      opponentProviderId: string;
+      teamName: string;
+      clubName?: string;
+      ageGroup: string;
+      gender: string;
+      stateCode?: string;
+    }>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[create-team] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    // Parse request body
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { gameId, opponentProviderId, teamName, clubName, ageGroup, gender, stateCode } = requestBody;
+    const { gameId, opponentProviderId, teamName, clubName, ageGroup, gender, stateCode } = body.data;
 
     // Validate required fields
     if (!gameId || !opponentProviderId || !teamName || !ageGroup || !gender) {
@@ -48,7 +44,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Age group must be in format like "u10", "u11", etc.' }, { status: 400 });
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // 1. Get the provider_id from the game
     const { data: game, error: gameError } = await supabase

--- a/frontend/app/api/link-opponent/preview/route.ts
+++ b/frontend/app/api/link-opponent/preview/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createServiceSupabase } from '@/lib/supabase/service';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
 
 /**
  * Preview API for linking unknown opponent
@@ -7,29 +8,16 @@ import { createClient } from '@supabase/supabase-js';
  */
 export async function POST(request: NextRequest) {
   try {
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<Record<string, string>>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[link-opponent/preview] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    // Parse request body
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { gameId, opponentProviderId } = requestBody;
+    const { gameId, opponentProviderId } = body.data;
 
     if (!gameId || !opponentProviderId) {
       return NextResponse.json({ error: 'Missing required fields: gameId and opponentProviderId' }, { status: 400 });
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // Get the provider_id from the game
     const { data: game, error: gameError } = await supabase

--- a/frontend/app/api/link-opponent/preview/route.ts
+++ b/frontend/app/api/link-opponent/preview/route.ts
@@ -8,7 +8,7 @@ import { parseJsonBody } from '@/lib/api/parseJsonBody';
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await parseJsonBody<Record<string, string>>(request);
+    const body = await parseJsonBody<{ gameId: string; opponentProviderId: string }>(request);
     if (body.error) return body.error;
 
     const { gameId, opponentProviderId } = body.data;

--- a/frontend/app/api/link-opponent/route.ts
+++ b/frontend/app/api/link-opponent/route.ts
@@ -12,7 +12,12 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const body = await parseJsonBody<Record<string, string>>(request);
+    const body = await parseJsonBody<{
+      gameId: string;
+      opponentProviderId: string;
+      teamIdMaster: string;
+      applyToAllGames?: boolean;
+    }>(request);
     if (body.error) return body.error;
 
     const { gameId, opponentProviderId, teamIdMaster, applyToAllGames = true } = body.data;

--- a/frontend/app/api/link-opponent/route.ts
+++ b/frontend/app/api/link-opponent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
 
 /**
  * Link unknown opponent to a team
@@ -11,23 +12,10 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<Record<string, string>>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[link-opponent] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    // Parse request body
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { gameId, opponentProviderId, teamIdMaster, applyToAllGames = true } = requestBody;
+    const { gameId, opponentProviderId, teamIdMaster, applyToAllGames = true } = body.data;
 
     if (!gameId || !opponentProviderId || !teamIdMaster) {
       return NextResponse.json(
@@ -36,7 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // 1. Validate that the team exists
     const { data: team, error: teamError } = await supabase

--- a/frontend/app/api/notifications/preferences/route.ts
+++ b/frontend/app/api/notifications/preferences/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requireAuth } from '@/lib/api/requireAuth';
 
 /**
  * GET /api/notifications/preferences
@@ -7,15 +7,9 @@ import { createServerSupabase } from '@/lib/supabase/server';
  */
 export async function GET() {
   try {
-    const supabase = await createServerSupabase();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const { data: profile, error } = await supabase
       .from('user_profiles')
@@ -44,15 +38,9 @@ export async function GET() {
  */
 export async function PATCH(request: NextRequest) {
   try {
-    const supabase = await createServerSupabase();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const body = await request.json();
 

--- a/frontend/app/api/notifications/subscribe/route.ts
+++ b/frontend/app/api/notifications/subscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requireAuth } from '@/lib/api/requireAuth';
 
 /**
  * POST /api/notifications/subscribe
@@ -7,15 +7,9 @@ import { createServerSupabase } from '@/lib/supabase/server';
  */
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createServerSupabase();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const body = await request.json();
     const { endpoint, keys } = body;
@@ -56,15 +50,9 @@ export async function POST(request: NextRequest) {
  */
 export async function DELETE(request: NextRequest) {
   try {
-    const supabase = await createServerSupabase();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const body = await request.json();
     const { endpoint } = body;

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,17 +1,12 @@
 import { stripe, getStripePriceIds } from '@/lib/stripe/server';
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requireAuth } from '@/lib/api/requireAuth';
 import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
   try {
-    const supabase = await createServerSupabase();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const { priceId } = await req.json();
 

--- a/frontend/app/api/stripe/portal/route.ts
+++ b/frontend/app/api/stripe/portal/route.ts
@@ -1,5 +1,5 @@
 import { stripe } from '@/lib/stripe/server';
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requireAuth } from '@/lib/api/requireAuth';
 import { NextResponse } from 'next/server';
 
 /**
@@ -8,14 +8,9 @@ import { NextResponse } from 'next/server';
  */
 export async function POST() {
   try {
-    const supabase = await createServerSupabase();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     // Get user profile with Stripe customer ID
     const { data: profile, error: profileError } = await supabase

--- a/frontend/app/api/stripe/sync/route.ts
+++ b/frontend/app/api/stripe/sync/route.ts
@@ -1,5 +1,5 @@
 import { stripe, extractPeriodEnd, mapStatusToPlan } from '@/lib/stripe/server';
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requireAuth } from '@/lib/api/requireAuth';
 import { NextResponse } from 'next/server';
 
 /**
@@ -13,14 +13,9 @@ import { NextResponse } from 'next/server';
  */
 export async function POST(req: Request) {
   try {
-    const supabase = await createServerSupabase();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
+    const auth = await requireAuth();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     const { sessionId } = await req.json();
     if (!sessionId || typeof sessionId !== 'string') {

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -105,13 +105,13 @@ export async function POST(req: Request) {
       // No matching user — retrying won't help. Acknowledge so Stripe stops.
       console.warn(`[webhook] Permanent error, returning 200 to stop retries`);
       return NextResponse.json(
-        { received: true, error: 'Permanent webhook error', detail: errorMessage },
+        { received: true, error: 'Permanent webhook error', details: errorMessage },
         { status: 200 }
       );
     }
 
     // Transient error (DB timeout, network issue) — return 500 so Stripe retries
-    return NextResponse.json({ error: 'Webhook handler failed', detail: errorMessage }, { status: 500 });
+    return NextResponse.json({ error: 'Webhook handler failed', details: errorMessage }, { status: 500 });
   }
 }
 

--- a/frontend/app/api/team-merge/route.ts
+++ b/frontend/app/api/team-merge/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
 
 /**
  * Team Merge API Endpoints
@@ -25,24 +27,10 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<Record<string, string>>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[team-merge] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    // Parse request body
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { deprecatedTeamId, canonicalTeamId, mergedBy, mergeReason, confidenceScore, suggestionSignals } =
-      requestBody;
+    const { deprecatedTeamId, canonicalTeamId, mergedBy, mergeReason, confidenceScore, suggestionSignals } = body.data;
 
     // Validate required fields
     if (!deprecatedTeamId || !canonicalTeamId || !mergedBy) {
@@ -63,7 +51,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Cannot merge a team with itself' }, { status: 400 });
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // Execute the merge via PostgreSQL function
     const { data: mergeId, error } = await supabase.rpc('execute_team_merge', {
@@ -145,23 +133,10 @@ export async function DELETE(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<Record<string, string>>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[team-merge] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    // Parse request body
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { deprecatedTeamId, revertedBy, revertReason } = requestBody;
+    const { deprecatedTeamId, revertedBy, revertReason } = body.data;
 
     // Validate required fields
     if (!deprecatedTeamId || !revertedBy) {
@@ -174,7 +149,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // Get the team name before reverting
     const { data: team } = await supabase

--- a/frontend/app/api/team-merge/route.ts
+++ b/frontend/app/api/team-merge/route.ts
@@ -27,7 +27,14 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const body = await parseJsonBody<Record<string, string>>(request);
+    const body = await parseJsonBody<{
+      deprecatedTeamId: string;
+      canonicalTeamId: string;
+      mergedBy: string;
+      mergeReason?: string;
+      confidenceScore?: number;
+      suggestionSignals?: Record<string, unknown>;
+    }>(request);
     if (body.error) return body.error;
 
     const { deprecatedTeamId, canonicalTeamId, mergedBy, mergeReason, confidenceScore, suggestionSignals } = body.data;
@@ -133,7 +140,11 @@ export async function DELETE(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const body = await parseJsonBody<Record<string, string>>(request);
+    const body = await parseJsonBody<{
+      deprecatedTeamId: string;
+      revertedBy: string;
+      revertReason?: string;
+    }>(request);
     if (body.error) return body.error;
 
     const { deprecatedTeamId, revertedBy, revertReason } = body.data;

--- a/frontend/app/api/unlink-opponent/route.ts
+++ b/frontend/app/api/unlink-opponent/route.ts
@@ -12,7 +12,12 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const body = await parseJsonBody<Record<string, string>>(request);
+    const body = await parseJsonBody<{
+      gameId: string;
+      opponentProviderId: string;
+      teamIdMaster: string;
+      unlinkAllGames?: boolean;
+    }>(request);
     if (body.error) return body.error;
 
     const { gameId, opponentProviderId, teamIdMaster, unlinkAllGames = true } = body.data;

--- a/frontend/app/api/unlink-opponent/route.ts
+++ b/frontend/app/api/unlink-opponent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
 
 /**
  * Unlink an incorrectly linked opponent from a game
@@ -11,22 +12,10 @@ export async function POST(request: NextRequest) {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
 
-    const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const body = await parseJsonBody<Record<string, string>>(request);
+    if (body.error) return body.error;
 
-    if (!serviceKey || !supabaseUrl) {
-      console.error('[unlink-opponent] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    let requestBody;
-    try {
-      requestBody = await request.json();
-    } catch {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
-    }
-
-    const { gameId, opponentProviderId, teamIdMaster, unlinkAllGames = true } = requestBody;
+    const { gameId, opponentProviderId, teamIdMaster, unlinkAllGames = true } = body.data;
 
     if (!gameId || !opponentProviderId || !teamIdMaster) {
       return NextResponse.json(
@@ -35,7 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createServiceSupabase();
 
     // 1. Get the game to determine which side the opponent is on
     const { data: game, error: gameError } = await supabase

--- a/frontend/app/api/watchlist/add/route.ts
+++ b/frontend/app/api/watchlist/add/route.ts
@@ -1,4 +1,4 @@
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requirePremium } from '@/lib/api/requirePremium';
 import { NextResponse } from 'next/server';
 
 /**
@@ -11,39 +11,9 @@ import { NextResponse } from 'next/server';
  */
 export async function POST(req: Request) {
   try {
-    const supabase = await createServerSupabase();
-
-    // Get authenticated user
-    const {
-      data: { user },
-      error: _authError,
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    // Get user profile to check premium status
-    const { data: profile, error: profileError } = await supabase
-      .from('user_profiles')
-      .select('plan')
-      .eq('id', user.id)
-      .single();
-
-    if (profileError) {
-      console.error('[Watchlist Add] Error fetching profile:', profileError);
-      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
-    }
-
-    // Check if profile exists (user may not have a profile row yet)
-    if (!profile) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
-    }
-
-    // Enforce premium access
-    if (profile.plan !== 'premium' && profile.plan !== 'admin') {
-      return NextResponse.json({ error: 'Premium required' }, { status: 403 });
-    }
+    const auth = await requirePremium();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     // Parse request body
     const body = await req.json();

--- a/frontend/app/api/watchlist/route.ts
+++ b/frontend/app/api/watchlist/route.ts
@@ -1,4 +1,4 @@
-import { createServerSupabase } from '@/lib/supabase/server';
+import { requirePremium } from '@/lib/api/requirePremium';
 import { NextResponse } from 'next/server';
 
 /**
@@ -52,38 +52,9 @@ export interface WatchlistResponse {
  */
 export async function GET() {
   try {
-    const supabase = await createServerSupabase();
-
-    // Get authenticated user
-    const {
-      data: { user },
-      error: _authError,
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-    }
-
-    // Get user profile to check premium status
-    const { data: profile, error: profileError } = await supabase
-      .from('user_profiles')
-      .select('plan')
-      .eq('id', user.id)
-      .single();
-
-    if (profileError) {
-      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
-    }
-
-    // Check if profile exists (user may not have a profile row yet)
-    if (!profile) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
-    }
-
-    // Enforce premium access
-    if (profile.plan !== 'premium' && profile.plan !== 'admin') {
-      return NextResponse.json({ error: 'Premium required' }, { status: 403 });
-    }
+    const auth = await requirePremium();
+    if (auth.error) return auth.error;
+    const { user, supabase } = auth;
 
     // Get user's default watchlist
     // First try to find default watchlist

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import { getBlogPost, getAllBlogSlugs } from '@/lib/blog';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { BASE_URL } from '@/lib/constants';
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -23,16 +24,14 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
   const { slug } = await params;
   const post = getBlogPost(slug);
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-
   if (!post) {
     return {
       title: 'Post Not Found',
     };
   }
 
-  const canonicalUrl = `${baseUrl}/blog/${slug}`;
-  const heroImage = post.image ? `${baseUrl}${post.image}` : `${baseUrl}/opengraph-image.png`;
+  const canonicalUrl = `${BASE_URL}/blog/${slug}`;
+  const heroImage = post.image ? `${BASE_URL}${post.image}` : `${BASE_URL}/opengraph-image.png`;
 
   return {
     title: post.title,

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -4,21 +4,20 @@ import { NewsletterSubscribe } from '@/components/NewsletterSubscribe';
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import type { Metadata } from 'next';
 import { getAllBlogPosts } from '@/lib/blog';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Blog',
   description:
     'Learn about youth soccer rankings, our algorithm methodology, and how PitchRank helps teams, coaches, and parents understand competitive soccer.',
   alternates: {
-    canonical: `${baseUrl}/blog`,
+    canonical: `${BASE_URL}/blog`,
   },
   openGraph: {
     title: 'Blog | PitchRank',
     description:
       'Educational content about youth soccer rankings, algorithm methodology, and competitive soccer insights.',
-    url: `${baseUrl}/blog`,
+    url: `${BASE_URL}/blog`,
     siteName: 'PitchRank',
     type: 'website',
     images: [

--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -7,7 +7,7 @@ const ComparePanel = dynamic(() => import('@/components/ComparePanel').then((mod
   loading: () => <CardSkeleton />,
 });
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Compare/Predict Teams',
@@ -19,13 +19,13 @@ export const metadata: Metadata = {
     follow: false,
   },
   alternates: {
-    canonical: `${baseUrl}/compare`,
+    canonical: `${BASE_URL}/compare`,
   },
   openGraph: {
     title: 'Compare/Predict Teams | PitchRank',
     description:
       'Compare multiple youth soccer teams side-by-side to see their rankings, statistics, and performance metrics.',
-    url: `${baseUrl}/compare`,
+    url: `${BASE_URL}/compare`,
     siteName: 'PitchRank',
     type: 'website',
     images: [

--- a/frontend/app/infographics/layout.tsx
+++ b/frontend/app/infographics/layout.tsx
@@ -1,18 +1,17 @@
 import type { Metadata } from 'next';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Social Media Infographics',
   description:
     'Generate shareable youth soccer rankings graphics for Instagram, Twitter, and Facebook. Create top 10 leaderboards, team spotlights, and more.',
   alternates: {
-    canonical: `${baseUrl}/infographics`,
+    canonical: `${BASE_URL}/infographics`,
   },
   openGraph: {
     title: 'Social Media Infographics | PitchRank',
     description: 'Generate shareable youth soccer rankings graphics for social media.',
-    url: `${baseUrl}/infographics`,
+    url: `${BASE_URL}/infographics`,
     siteName: 'PitchRank',
     type: 'website',
   },

--- a/frontend/app/infographics/page.tsx
+++ b/frontend/app/infographics/page.tsx
@@ -20,7 +20,7 @@ import { renderStoryTemplateToCanvas, STORY_TYPES } from '@/components/infograph
 import { renderCoverImageToCanvas, COVER_PLATFORMS } from '@/components/infographics/coverImageRenderer';
 import { useRankings } from '@/hooks/useRankings';
 import { useInstagramHandles, collectHandlesForCaption } from '@/hooks/useInstagramHandles';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, AGE_GROUP_OPTIONS, GENDER_OPTIONS } from '@/lib/constants';
 import {
   Download,
   Share2,
@@ -70,22 +70,9 @@ const INFOGRAPHIC_TYPES: { id: InfographicType; label: string; icon: React.React
   { id: 'covers', label: 'Cover Images', icon: <ImageIcon size={18} />, description: 'Social media headers' },
 ];
 
-const AGE_GROUPS = [
-  { value: 'u10', label: 'U10' },
-  { value: 'u11', label: 'U11' },
-  { value: 'u12', label: 'U12' },
-  { value: 'u13', label: 'U13' },
-  { value: 'u14', label: 'U14' },
-  { value: 'u15', label: 'U15' },
-  { value: 'u16', label: 'U16' },
-  { value: 'u17', label: 'U17' },
-  { value: 'u19', label: 'U19' },
-];
+const AGE_GROUPS = AGE_GROUP_OPTIONS;
 
-const GENDERS = [
-  { value: 'M' as const, label: 'Boys' },
-  { value: 'F' as const, label: 'Girls' },
-];
+const GENDERS = GENDER_OPTIONS;
 
 type GenderType = 'M' | 'F';
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,6 +8,7 @@ import { StructuredData } from '@/components/StructuredData';
 import { Footer } from '@/components/Footer';
 import { GoogleAnalytics } from '@/components/GoogleAnalytics';
 import { WebVitalsReporter } from '@/components/WebVitalsReporter';
+import { BASE_URL_WWW } from '@/lib/constants';
 
 // Athletic Editorial Typography
 const oswald = Oswald({
@@ -35,7 +36,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchrank.io'),
+  metadataBase: new URL(BASE_URL_WWW),
   title: {
     default: 'PitchRank — Youth Soccer Rankings',
     template: '%s | PitchRank',
@@ -74,7 +75,7 @@ export const metadata: Metadata = {
     apple: '/logos/apple-touch-icon.png',
   },
   alternates: {
-    canonical: process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchrank.io',
+    canonical: BASE_URL_WWW,
   },
   openGraph: {
     type: 'website',

--- a/frontend/app/methodology/page.tsx
+++ b/frontend/app/methodology/page.tsx
@@ -2,21 +2,20 @@ import { PageHeader } from '@/components/PageHeader';
 import { MethodologySection } from '@/components/MethodologySection';
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import type { Metadata } from 'next';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Methodology',
   description:
     'Learn how PitchRank calculates youth soccer team rankings and power scores using cross-age game support, unified scoring, and data-driven analytics.',
   alternates: {
-    canonical: `${baseUrl}/methodology`,
+    canonical: `${BASE_URL}/methodology`,
   },
   openGraph: {
     title: 'Ranking Methodology | PitchRank',
     description:
       'Learn how PitchRank calculates youth soccer team rankings and power scores using data-driven analytics.',
-    url: `${baseUrl}/methodology`,
+    url: `${BASE_URL}/methodology`,
     siteName: 'PitchRank',
     type: 'website',
     images: [

--- a/frontend/app/privacy-policy/page.tsx
+++ b/frontend/app/privacy-policy/page.tsx
@@ -3,19 +3,18 @@ import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy',
   description: 'Privacy Policy for PitchRank.io — how we collect, use, and protect your information.',
   alternates: {
-    canonical: `${baseUrl}/privacy-policy`,
+    canonical: `${BASE_URL}/privacy-policy`,
   },
   openGraph: {
     title: 'Privacy Policy | PitchRank',
     description: 'Privacy Policy for PitchRank.io — how we collect, use, and protect your information.',
-    url: `${baseUrl}/privacy-policy`,
+    url: `${BASE_URL}/privacy-policy`,
     siteName: 'PitchRank',
     type: 'website',
   },

--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -1,6 +1,6 @@
 import { RankingsPageContent } from '@/components/RankingsPageContent';
 import type { Metadata } from 'next';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, BASE_URL, formatGender } from '@/lib/constants';
 import BreadcrumbSchema from '@/components/BreadcrumbSchema';
 
 // Revalidate every hour for ISR caching
@@ -22,20 +22,6 @@ function formatAgeGroup(ageGroup: string): string {
 }
 
 /**
- * Format gender for display (e.g., "male" -> "Boys", "female" -> "Girls")
- */
-const VALID_GENDERS: Record<string, string> = {
-  male: 'Boys',
-  female: 'Girls',
-  boys: 'Boys',
-  girls: 'Girls',
-};
-
-function formatGender(gender: string): string {
-  return VALID_GENDERS[gender.toLowerCase()] ?? 'Unknown';
-}
-
-/**
  * Get state name from code
  */
 function getStateName(stateCode: string): string {
@@ -52,8 +38,7 @@ export async function generateMetadata({ params }: RankingsPageProps): Promise<M
     const resolvedParams = await params;
     const { region, ageGroup, gender } = resolvedParams;
 
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-    const canonicalUrl = `${baseUrl}/rankings/${region}/${ageGroup}/${gender}`;
+    const canonicalUrl = `${BASE_URL}/rankings/${region}/${ageGroup}/${gender}`;
 
     const formattedAgeGroup = formatAgeGroup(ageGroup);
     const formattedGender = formatGender(gender);

--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -112,7 +112,7 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
     '@type': 'RankingTable',
     name: `${locationText} ${formattedAgeGroup} ${formattedGender} Soccer Rankings`,
     description: 'Youth soccer team rankings by PowerScore rating, updated weekly',
-    url: `https://pitchrank.io/rankings/${safeRegion}/${safeAgeGroup}/${safeGender}`,
+    url: `${BASE_URL}/rankings/${safeRegion}/${safeAgeGroup}/${safeGender}`,
   };
 
   // Escape </script> sequences to prevent XSS in JSON-LD structured data

--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -2,14 +2,12 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, AGE_GROUPS, BASE_URL } from '@/lib/constants';
 import { api } from '@/lib/api';
 import { formatPowerScore } from '@/lib/utils';
 
 // Revalidate every hour for ISR caching
 export const revalidate = 3600;
-
-const AGE_GROUPS = ['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'];
 
 interface StateOverviewPageProps {
   params: Promise<{
@@ -39,8 +37,7 @@ export async function generateMetadata({ params }: StateOverviewPageProps): Prom
     return { title: 'Not Found | PitchRank' };
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-  const canonicalUrl = `${baseUrl}/rankings/${region.toLowerCase()}`;
+  const canonicalUrl = `${BASE_URL}/rankings/${region.toLowerCase()}`;
   const isNational = region.toLowerCase() === 'national';
 
   const title = isNational

--- a/frontend/app/rankings/age/[ageGroup]/page.tsx
+++ b/frontend/app/rankings/age/[ageGroup]/page.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, AGE_GROUPS_ALL, BASE_URL } from '@/lib/constants';
 import { api } from '@/lib/api';
 
 // Revalidate every hour for ISR caching
 export const revalidate = 3600;
 
-const VALID_AGE_GROUPS = ['u8', 'u9', 'u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u18', 'u19'];
+const VALID_AGE_GROUPS = AGE_GROUPS_ALL;
 
 // Popular states to highlight
 const POPULAR_STATES = ['CA', 'TX', 'FL', 'NY', 'GA', 'PA', 'IL', 'NC', 'AZ', 'WA', 'NJ', 'CO'];
@@ -24,7 +24,7 @@ interface AgeGroupPageProps {
  */
 function validateAgeGroup(ageGroup: string): string | null {
   const normalized = ageGroup.toLowerCase();
-  if (VALID_AGE_GROUPS.includes(normalized)) {
+  if ((VALID_AGE_GROUPS as readonly string[]).includes(normalized)) {
     return normalized;
   }
   return null;
@@ -43,8 +43,7 @@ export async function generateMetadata({ params }: AgeGroupPageProps): Promise<M
   }
 
   const ageDisplay = validAge.toUpperCase();
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-  const canonicalUrl = `${baseUrl}/rankings/age/${validAge}`;
+  const canonicalUrl = `${BASE_URL}/rankings/age/${validAge}`;
 
   const title = `${ageDisplay} Youth Soccer Rankings - National | PitchRank`;
   const description = `National ${ageDisplay} youth soccer rankings. View top boys and girls soccer teams in the ${ageDisplay} age group across all states. Updated weekly with PowerScore ratings.`;
@@ -142,7 +141,7 @@ export default async function AgeGroupPage({ params }: AgeGroupPageProps) {
   }
 
   // Adjacent age groups for navigation
-  const currentIdx = VALID_AGE_GROUPS.indexOf(validAge);
+  const currentIdx = (VALID_AGE_GROUPS as readonly string[]).indexOf(validAge);
   const prevAge = currentIdx > 0 ? VALID_AGE_GROUPS[currentIdx - 1] : null;
   const nextAge = currentIdx < VALID_AGE_GROUPS.length - 1 ? VALID_AGE_GROUPS[currentIdx + 1] : null;
 

--- a/frontend/app/rankings/layout.tsx
+++ b/frontend/app/rankings/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 /**
  * Layout for rankings pages
@@ -14,13 +13,13 @@ export const metadata: Metadata = {
   description:
     'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from 726,730+ real game results. No fluff, just data.',
   alternates: {
-    canonical: `${baseUrl}/rankings`,
+    canonical: `${BASE_URL}/rankings`,
   },
   openGraph: {
     title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams',
     description:
       'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from real game results.',
-    url: `${baseUrl}/rankings`,
+    url: `${BASE_URL}/rankings`,
     siteName: 'PitchRank',
     type: 'website',
   },

--- a/frontend/app/report-card/page.tsx
+++ b/frontend/app/report-card/page.tsx
@@ -1,20 +1,19 @@
 import type { Metadata } from 'next';
 import { ReportCardForm } from '@/components/ReportCardForm';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Free Team Report Card',
   description:
     "Get your team's free season report card — rankings, trends, and insights powered by PitchRank's 13-layer algorithm. 25,000+ teams. Updated weekly.",
   alternates: {
-    canonical: `${baseUrl}/report-card`,
+    canonical: `${BASE_URL}/report-card`,
   },
   openGraph: {
     title: 'Free Team Report Card | PitchRank',
     description:
       'See how your team stacks up. Rankings, strength profile, and recent results — powered by 25K+ teams and a 13-layer algorithm.',
-    url: `${baseUrl}/report-card`,
+    url: `${BASE_URL}/report-card`,
     siteName: 'PitchRank',
     type: 'website',
   },

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, AGE_GROUPS, BASE_URL_WWW } from '@/lib/constants';
 import { getAllBlogSlugs } from '@/lib/blog';
 
 /**
@@ -11,10 +11,10 @@ import { getAllBlogSlugs } from '@/lib/blog';
  * This causes "Page with redirect" issues in Search Console.
  */
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchrank.io';
+  const baseUrl = BASE_URL_WWW;
 
   // Age groups available in the system
-  const ageGroups = ['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'];
+  const ageGroups = AGE_GROUPS;
 
   // Genders (URL format)
   const genders = ['male', 'female'];

--- a/frontend/app/teams/[id]/page.tsx
+++ b/frontend/app/teams/[id]/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 import { Suspense } from 'react';
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
+import { BASE_URL } from '@/lib/constants';
 
 interface TeamPageProps {
   params: Promise<{
@@ -43,8 +44,7 @@ export async function generateMetadata({ params }: TeamPageProps): Promise<Metad
       return { title: 'Team Not Found | PitchRank' };
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-    const teamUrl = `${baseUrl}/teams/${resolvedParams.id}`;
+    const teamUrl = `${BASE_URL}/teams/${resolvedParams.id}`;
     const title = `${team.team_name}${team.state_code ? ` (${team.state_code})` : ''} | PitchRank`;
     const description = `View rankings, trajectory, momentum, and full profile for ${team.team_name}${team.club_name ? ` from ${team.club_name}` : ''}.`;
 

--- a/frontend/app/terms-of-service/page.tsx
+++ b/frontend/app/terms-of-service/page.tsx
@@ -3,19 +3,18 @@ import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Terms of Service',
   description: 'Terms of Service for PitchRank.io — youth soccer team rankings and analytics platform.',
   alternates: {
-    canonical: `${baseUrl}/terms-of-service`,
+    canonical: `${BASE_URL}/terms-of-service`,
   },
   openGraph: {
     title: 'Terms of Service | PitchRank',
     description: 'Terms of Service for PitchRank.io — youth soccer team rankings and analytics platform.',
-    url: `${baseUrl}/terms-of-service`,
+    url: `${BASE_URL}/terms-of-service`,
     siteName: 'PitchRank',
     type: 'website',
   },

--- a/frontend/components/BlogPostSchema.tsx
+++ b/frontend/components/BlogPostSchema.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BASE_URL } from '@/lib/constants';
 
 interface BlogPostSchemaProps {
   title: string;
@@ -30,9 +31,8 @@ export function BlogPostSchema({
   image,
   articleSection,
 }: BlogPostSchemaProps) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-  const postUrl = `${baseUrl}/blog/${slug}`;
-  const imageUrl = image ? (image.startsWith('http') ? image : `${baseUrl}${image}`) : `${baseUrl}/opengraph-image.png`;
+  const postUrl = `${BASE_URL}/blog/${slug}`;
+  const imageUrl = image ? (image.startsWith('http') ? image : `${BASE_URL}${image}`) : `${BASE_URL}/opengraph-image.png`;
 
   const schema = {
     '@context': 'https://schema.org',
@@ -51,7 +51,7 @@ export function BlogPostSchema({
       name: 'PitchRank',
       logo: {
         '@type': 'ImageObject',
-        url: `${baseUrl}/logos/pitchrank-wordmark.svg`,
+        url: `${BASE_URL}/logos/pitchrank-wordmark.svg`,
       },
     },
     image: imageUrl,

--- a/frontend/components/BreadcrumbSchema.tsx
+++ b/frontend/components/BreadcrumbSchema.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BASE_URL } from '@/lib/constants';
 
 export interface BreadcrumbItem {
   name: string;
@@ -15,8 +16,6 @@ interface BreadcrumbSchemaProps {
  * @see https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
  */
 export function BreadcrumbSchema({ items }: BreadcrumbSchemaProps) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
@@ -24,7 +23,7 @@ export function BreadcrumbSchema({ items }: BreadcrumbSchemaProps) {
       '@type': 'ListItem',
       position: index + 1,
       name: item.name,
-      item: `${baseUrl}${item.href}`,
+      item: `${BASE_URL}${item.href}`,
     })),
   };
 

--- a/frontend/components/Breadcrumbs.tsx
+++ b/frontend/components/Breadcrumbs.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ChevronRight, Home } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useMemo } from 'react';
+import { BASE_URL } from '@/lib/constants';
 
 interface BreadcrumbItem {
   label: string;
@@ -134,11 +135,6 @@ export function Breadcrumbs({ items, showHomeIcon = true }: BreadcrumbsProps) {
 
   // Generate structured data (BreadcrumbList schema)
   const structuredData = useMemo(() => {
-    const baseUrl =
-      typeof window !== 'undefined'
-        ? `${window.location.protocol}//${window.location.host}`
-        : process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-
     return {
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
@@ -146,7 +142,7 @@ export function Breadcrumbs({ items, showHomeIcon = true }: BreadcrumbsProps) {
         '@type': 'ListItem',
         position: index + 1,
         name: crumb.label,
-        item: `${baseUrl}${crumb.href}`,
+        item: `${BASE_URL}${crumb.href}`,
       })),
     };
   }, [breadcrumbs]);

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { AGE_GROUPS } from '@/lib/constants';
 import { Twitter, Instagram, Facebook, Linkedin } from '@/components/ui/brand-icons';
 
 /**
@@ -53,7 +54,7 @@ export function Footer() {
   ];
 
   // Age groups for internal linking
-  const ageGroups = ['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'];
+  const ageGroups = AGE_GROUPS;
 
   const footerLinks = {
     Rankings: [

--- a/frontend/components/GlobalSearch.tsx
+++ b/frontend/components/GlobalSearch.tsx
@@ -11,6 +11,7 @@ import { Search, X } from 'lucide-react';
 import { useTeamSearch } from '@/hooks/useTeamSearch';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackSearchUsed, trackSearchResultClicked } from '@/lib/events';
+import { formatGender } from '@/lib/constants';
 
 /**
  * Escape special regex characters in a string
@@ -247,7 +248,7 @@ export function GlobalSearch() {
                       {team.rank_in_cohort_final && <span> • Rank #{team.rank_in_cohort_final}</span>}
                       {team.age != null && team.gender && (
                         <span className={team.club_name || team.state || team.rank_in_cohort_final ? ' • ' : ''}>
-                          U{team.age} {team.gender === 'M' ? 'Boys' : team.gender === 'F' ? 'Girls' : team.gender}
+                          U{team.age} {formatGender(team.gender)}
                         </span>
                       )}
                     </div>

--- a/frontend/components/RankingsPageContent.tsx
+++ b/frontend/components/RankingsPageContent.tsx
@@ -7,7 +7,7 @@ import { RankingsTable } from '@/components/RankingsTable';
 import { RankingsTableSkeleton } from '@/components/skeletons/RankingsTableSkeleton';
 import { ShareButtons } from '@/components/ShareButtons';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, formatGender } from '@/lib/constants';
 import { RelatedRankings } from '@/components/RelatedRankings';
 
 interface RankingsPageContentProps {
@@ -32,7 +32,7 @@ export function RankingsPageContent({ region, ageGroup, gender }: RankingsPageCo
   const ageGroupDisplay = ageGroup.toUpperCase();
 
   // Format gender for display
-  const genderDisplay = gender === 'male' ? 'Boys' : 'Girls';
+  const genderDisplay = formatGender(gender);
 
   // Create share title
   const shareTitle = `🏆 Check out the ${ageGroupDisplay} ${genderDisplay} ${stateName} soccer rankings on PitchRank!`;

--- a/frontend/components/RankingsSchema.tsx
+++ b/frontend/components/RankingsSchema.tsx
@@ -1,3 +1,5 @@
+import { BASE_URL, formatGender } from '@/lib/constants';
+
 interface RankedTeam {
   teamName: string;
   clubName?: string | null;
@@ -20,8 +22,7 @@ interface RankingsSchemaProps {
  * Helps Google understand ranking information for rich results
  */
 export function RankingsSchema({ region, ageGroup, gender, topTeams, totalTeams, lastUpdated }: RankingsSchemaProps) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-  const genderDisplay = gender === 'male' ? 'Boys' : 'Girls';
+  const genderDisplay = formatGender(gender);
   const regionDisplay = region === 'national' ? 'National' : region.toUpperCase();
   const ageDisplay = ageGroup.toUpperCase();
 
@@ -31,7 +32,7 @@ export function RankingsSchema({ region, ageGroup, gender, topTeams, totalTeams,
     '@type': 'ItemList',
     name: `${ageDisplay} ${genderDisplay} Soccer Rankings - ${regionDisplay}`,
     description: `Top ${ageDisplay} ${genderDisplay.toLowerCase()} soccer team rankings ${region === 'national' ? 'nationally' : `in ${regionDisplay}`}`,
-    url: `${baseUrl}/rankings/${region}/${ageGroup}/${gender}`,
+    url: `${BASE_URL}/rankings/${region}/${ageGroup}/${gender}`,
     numberOfItems: totalTeams || topTeams.length,
     itemListElement: topTeams.slice(0, 10).map((team, index) => {
       const item: Record<string, unknown> = {
@@ -76,11 +77,11 @@ export function RankingsSchema({ region, ageGroup, gender, topTeams, totalTeams,
     '@type': 'WebPage',
     name: `${ageDisplay} ${genderDisplay} Soccer Rankings - ${regionDisplay}`,
     description: `Comprehensive ${ageDisplay} ${genderDisplay.toLowerCase()} soccer team rankings with PowerScores and performance metrics`,
-    url: `${baseUrl}/rankings/${region}/${ageGroup}/${gender}`,
+    url: `${BASE_URL}/rankings/${region}/${ageGroup}/${gender}`,
     isPartOf: {
       '@type': 'WebSite',
       name: 'PitchRank',
-      url: baseUrl,
+      url: BASE_URL,
     },
     about: {
       '@type': 'Thing',

--- a/frontend/components/RelatedRankings.tsx
+++ b/frontend/components/RelatedRankings.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { US_STATES } from '@/lib/constants';
+import { US_STATES, AGE_GROUPS, formatGender } from '@/lib/constants';
 
 interface RelatedRankingsProps {
   currentRegion: string;
@@ -7,14 +7,12 @@ interface RelatedRankingsProps {
   currentGender: string;
 }
 
-const AGE_GROUPS = ['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'];
-
 /**
  * Internal linking component for SEO
  * Shows related rankings pages to improve crawlability and user navigation
  */
 export function RelatedRankings({ currentRegion, currentAgeGroup, currentGender }: RelatedRankingsProps) {
-  const genderDisplay = currentGender === 'male' ? 'Boys' : 'Girls';
+  const genderDisplay = formatGender(currentGender);
   const ageDisplay = currentAgeGroup.toUpperCase();
   const isNational = currentRegion === 'national';
 
@@ -22,7 +20,7 @@ export function RelatedRankings({ currentRegion, currentAgeGroup, currentGender 
   const currentState = US_STATES.find((s) => s.code.toLowerCase() === currentRegion.toLowerCase());
 
   // Get neighboring age groups
-  const currentAgeIndex = AGE_GROUPS.indexOf(currentAgeGroup.toLowerCase());
+  const currentAgeIndex = (AGE_GROUPS as readonly string[]).indexOf(currentAgeGroup.toLowerCase());
   const neighboringAges = AGE_GROUPS.filter((_, i) => Math.abs(i - currentAgeIndex) <= 2 && i !== currentAgeIndex);
 
   // Get nearby states (simplified - just show a few popular ones + national)
@@ -33,7 +31,7 @@ export function RelatedRankings({ currentRegion, currentAgeGroup, currentGender 
 
   // Opposite gender
   const oppositeGender = currentGender === 'male' ? 'female' : 'male';
-  const oppositeGenderDisplay = oppositeGender === 'male' ? 'Boys' : 'Girls';
+  const oppositeGenderDisplay = formatGender(oppositeGender);
 
   return (
     <div className="mt-8 pt-6 border-t border-border">

--- a/frontend/components/StructuredData.tsx
+++ b/frontend/components/StructuredData.tsx
@@ -1,17 +1,17 @@
+import { BASE_URL } from '@/lib/constants';
+
 /**
  * Structured Data (Schema.org JSON-LD) component
  * Provides rich metadata for search engines
  */
 export function StructuredData() {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
-
   // Organization Schema
   const organizationSchema = {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: 'PitchRank',
-    url: baseUrl,
-    logo: `${baseUrl}/logos/pitchrank-logo-dark.png`,
+    url: BASE_URL,
+    logo: `${BASE_URL}/logos/pitchrank-logo-dark.png`,
     description: 'Data-powered youth soccer team rankings and performance analytics',
     sameAs: [
       'https://twitter.com/pitchrank',
@@ -31,13 +31,13 @@ export function StructuredData() {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: 'PitchRank',
-    url: baseUrl,
+    url: BASE_URL,
     description: 'Youth soccer team rankings with cross-age and cross-state support',
     potentialAction: {
       '@type': 'SearchAction',
       target: {
         '@type': 'EntryPoint',
-        urlTemplate: `${baseUrl}/rankings?q={search_term_string}`,
+        urlTemplate: `${BASE_URL}/rankings?q={search_term_string}`,
       },
       'query-input': 'required name=search_term_string',
     },
@@ -49,7 +49,7 @@ export function StructuredData() {
     '@type': 'SportsOrganization',
     name: 'PitchRank',
     sport: 'Soccer',
-    url: baseUrl,
+    url: BASE_URL,
     description: 'Comprehensive ranking system for youth soccer teams across the United States',
     memberOf: {
       '@type': 'Organization',

--- a/frontend/components/UnknownOpponentLink.tsx
+++ b/frontend/components/UnknownOpponentLink.tsx
@@ -23,6 +23,7 @@ import type Fuse from 'fuse.js';
 import type { RankingRow } from '@/types/RankingRow';
 import type { GameWithTeams } from '@/lib/types';
 import { formatGameDate } from '@/lib/dateUtils';
+import { AGE_GROUPS_ALL, formatGender } from '@/lib/constants';
 
 interface UnknownOpponentLinkProps {
   game: GameWithTeams;
@@ -135,7 +136,7 @@ const US_STATES = [
 ];
 
 // Age groups for dropdown
-const AGE_GROUPS = ['u8', 'u9', 'u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u18', 'u19'];
+const AGE_GROUPS = AGE_GROUPS_ALL;
 
 export function UnknownOpponentLink({
   game,
@@ -549,8 +550,7 @@ export function UnknownOpponentLink({
                                 )}
                                 {team.age != null && team.gender && (
                                   <span className={team.club_name || team.state ? ' • ' : ''}>
-                                    U{team.age}{' '}
-                                    {team.gender === 'M' ? 'Boys' : team.gender === 'F' ? 'Girls' : team.gender}
+                                    U{team.age} {formatGender(team.gender)}
                                   </span>
                                 )}
                               </div>
@@ -677,7 +677,7 @@ export function UnknownOpponentLink({
                     {selectedTeam.club_name && `${selectedTeam.club_name} • `}
                     {selectedTeam.state?.toUpperCase()}
                     {selectedTeam.age != null && ` • U${selectedTeam.age}`}
-                    {selectedTeam.gender && ` ${selectedTeam.gender === 'M' ? 'Boys' : 'Girls'}`}
+                    {selectedTeam.gender && ` ${formatGender(selectedTeam.gender)}`}
                   </p>
                 </div>
               </div>

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,3 +1,4 @@
+export { requireAuth } from './requireAuth';
 export { requirePremium } from './requirePremium';
 export { validatePagination } from './validatePagination';
 export { parseJsonBody } from './parseJsonBody';

--- a/frontend/lib/api/requireAuth.ts
+++ b/frontend/lib/api/requireAuth.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+/**
+ * Verify the request is from an authenticated user (any plan).
+ * Returns the user and supabase client if authenticated,
+ * or a NextResponse error.
+ *
+ * Usage in route handlers:
+ *   const auth = await requireAuth();
+ *   if (auth.error) return auth.error;
+ *   const { user, supabase } = auth;
+ */
+export async function requireAuth(): Promise<
+  | {
+      user: { id: string; email?: string };
+      supabase: SupabaseClient;
+      error: null;
+    }
+  | { user: null; supabase: null; error: NextResponse }
+> {
+  try {
+    const supabase = await createServerSupabase();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return {
+        user: null,
+        supabase: null,
+        error: NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+      };
+    }
+
+    return { user, supabase, error: null };
+  } catch {
+    return {
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Authentication failed' }, { status: 500 }),
+    };
+  }
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -62,9 +62,9 @@ export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.i
 
 /**
  * Base URL with www prefix, used by root layout metadataBase and sitemap.
- * Matches the www redirect rule in middleware.
+ * Derived from BASE_URL to ensure the www variant stays in sync.
  */
-export const BASE_URL_WWW = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchrank.io';
+export const BASE_URL_WWW = BASE_URL.replace('https://', 'https://www.');
 
 // --- Age Groups ---
 

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -54,3 +54,75 @@ export const US_STATES = [
   { code: 'wi', name: 'Wisconsin' },
   { code: 'wy', name: 'Wyoming' },
 ] as const;
+
+// --- Site URL ---
+
+/** Base URL without www prefix, used by most pages for canonical URLs and OG metadata. */
+export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+
+/**
+ * Base URL with www prefix, used by root layout metadataBase and sitemap.
+ * Matches the www redirect rule in middleware.
+ */
+export const BASE_URL_WWW = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchrank.io';
+
+// --- Age Groups ---
+
+/** Standard ranked age groups (excludes u18 which has no rankings cohort). */
+export const AGE_GROUPS = ['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'] as const;
+
+/** Extended age groups including u8, u9, u18 — used for validation and team creation forms. */
+export const AGE_GROUPS_ALL = [
+  'u8',
+  'u9',
+  'u10',
+  'u11',
+  'u12',
+  'u13',
+  'u14',
+  'u15',
+  'u16',
+  'u17',
+  'u18',
+  'u19',
+] as const;
+
+/** Age groups as value/label pairs for select dropdowns. */
+export const AGE_GROUP_OPTIONS = AGE_GROUPS.map((ag) => ({
+  value: ag,
+  label: ag.toUpperCase(),
+}));
+
+// --- Gender ---
+
+export type GenderCode = 'M' | 'F' | 'B' | 'G';
+
+/** Map single-letter gender codes to display labels. */
+export const GENDER_LABELS: Record<string, string> = {
+  M: 'Boys',
+  F: 'Girls',
+  B: 'Boys',
+  G: 'Girls',
+};
+
+/** Map URL-slug gender strings to display labels. */
+export const GENDER_SLUG_LABELS: Record<string, string> = {
+  male: 'Boys',
+  female: 'Girls',
+  boys: 'Boys',
+  girls: 'Girls',
+};
+
+/**
+ * Format a gender code or slug to a display label.
+ * Handles M/F/B/G, male/female, Male/Female, boys/girls.
+ */
+export function formatGender(gender: string): string {
+  return GENDER_LABELS[gender] ?? GENDER_SLUG_LABELS[gender.toLowerCase()] ?? 'Unknown';
+}
+
+/** Gender options for select dropdowns. */
+export const GENDER_OPTIONS = [
+  { value: 'M' as const, label: 'Boys' },
+  { value: 'F' as const, label: 'Girls' },
+];

--- a/frontend/lib/insights/seasonTruth.ts
+++ b/frontend/lib/insights/seasonTruth.ts
@@ -22,6 +22,7 @@
  */
 
 import type { InsightInputData, SeasonTruthInsight, FormSignal, RankTrajectory, PlayStyle } from './types';
+import { formatGender } from '@/lib/constants';
 
 /**
  * Determines rank trajectory based on recent form (perf_centered)
@@ -175,7 +176,7 @@ function buildCohortContext(
   const rank = ranking.rank_in_cohort_final;
   if (rank === null || cohortStats.totalTeams <= 1) return null;
 
-  const genderLabel = team.gender === 'M' || team.gender === 'B' ? 'Boys' : 'Girls';
+  const genderLabel = formatGender(team.gender);
   const ageLabel = team.age ? `U${team.age}` : null;
 
   const cohortLabel = ageLabel ? `${genderLabel} ${ageLabel}` : genderLabel;

--- a/frontend/lib/pdf/TeamReportCard.tsx
+++ b/frontend/lib/pdf/TeamReportCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Document, Page, View, Text, Link, StyleSheet, Font } from '@react-pdf/renderer';
+import { formatGender } from '@/lib/constants';
 
 // Register fonts via Google Fonts CDN
 Font.register({
@@ -414,7 +415,7 @@ export function TeamReportCard({
   generatedDate,
 }: ReportCardProps) {
   const percentile = Math.round((1 - ranking.rank_in_cohort_final / cohortTotal) * 100);
-  const genderLabel = team.gender === 'M' || team.gender === 'B' ? 'Boys' : 'Girls';
+  const genderLabel = formatGender(team.gender);
   const winPct =
     ranking.win_percentage != null
       ? `${Math.round(ranking.win_percentage)}%`

--- a/frontend/lib/supabase/service.ts
+++ b/frontend/lib/supabase/service.ts
@@ -1,0 +1,18 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Create a Supabase client with the service-role key for admin operations.
+ * Use in API routes that need to bypass RLS (e.g., create-team, link-opponent).
+ *
+ * Throws if environment variables are missing (caught by route-level try/catch).
+ */
+export function createServiceSupabase(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error(`Missing Supabase service environment variables (url=${!!supabaseUrl}, key=${!!serviceKey})`);
+  }
+
+  return createClient(supabaseUrl, serviceKey);
+}


### PR DESCRIPTION
## Summary
- Extract `BASE_URL`, `AGE_GROUPS`, `AGE_GROUPS_ALL`, `formatGender()`, and dropdown option arrays into `lib/constants.ts`, replacing 20+ inline copies across pages and components
- Create `requireAuth()` utility for auth-only API routes (notifications, stripe checkout/portal/sync), standardizing error messages to "Not authenticated"
- Create `createServiceSupabase()` factory for admin routes, eliminating 5 duplicated env-var-check + `createClient` blocks
- Adopt existing `requirePremium()` in watchlist routes, replacing ~35 lines of manual auth+plan checking per route
- Adopt existing `parseJsonBody()` in admin routes, replacing duplicated try/catch JSON parsing
- Standardize webhook error shape: `detail` → `details` (plural) for consistency

**45 files changed, 302 insertions, 367 deletions (net -65 lines)**

## Test plan
- [x] `next build` passes (TypeScript compilation, no type errors)
- [x] `npm run test` passes (12/12 Vitest tests including stripe webhook)
- [x] ESLint clean on new utility files
- [x] Prettier formatted
- [ ] Verify `/rankings/national/u12/male` renders correctly in preview
- [ ] Verify watchlist add/remove still works (premium gating via `requirePremium()`)
- [ ] Verify admin routes (team-merge, link-opponent) still work with `createServiceSupabase()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)