### PR TITLE
fix: ranking pipeline integrity — final rank, ML floor, league SCF

### DIFF
--- a/frontend/app/api/insights/[teamId]/route.ts
+++ b/frontend/app/api/insights/[teamId]/route.ts
@@ -112,7 +112,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     // Fetch ranking history
     const { data: rankingHistory, error: historyError } = await supabase
       .from('ranking_history')
-      .select('snapshot_date, rank_in_cohort, power_score_final')
+      .select('snapshot_date, rank_in_cohort, rank_in_cohort_ml, rank_in_cohort_final, power_score_final')
       .eq('team_id', teamId)
       .order('snapshot_date', { ascending: false })
       .limit(30);
@@ -199,6 +199,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
       }),
       rankingHistory: ((rankingHistory || []) as RankingHistoryRow[]).map((h: RankingHistoryRow) => ({
         snapshot_date: h.snapshot_date,
+        rank_in_cohort_final: h.rank_in_cohort_final,
+        rank_in_cohort_ml: h.rank_in_cohort_ml,
         rank_in_cohort: h.rank_in_cohort,
         power_score_final: h.power_score_final,
       })),

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -174,8 +174,13 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
           break;
         case 'powerScore':
           // Use power_score_final (ML-adjusted score) - primary sort field
+          // Canonical tie-break: team_id ASC (matches stored rank ordering)
           aValue = a.power_score_final ?? 0;
           bValue = b.power_score_final ?? 0;
+          if (aValue === bValue) {
+            aValue = b.team_id_master || '';
+            bValue = a.team_id_master || '';
+          }
           break;
         case 'sosRank':
           // Use computed SOS rank from filtered data

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -91,7 +91,10 @@ export const api = {
         query = query.eq('gender', gender);
       }
 
-      query = query.order('power_score_final', { ascending: false }).range(offset, offset + batchSize - 1);
+      query = query
+        .order('power_score_final', { ascending: false })
+        .order('team_id_master', { ascending: true })
+        .range(offset, offset + batchSize - 1);
 
       const { data, error } = await query;
 
@@ -1113,7 +1116,7 @@ export const api = {
 
     const { data, error } = await supabase
       .from('ranking_history')
-      .select('snapshot_date, rank_in_cohort, rank_in_cohort_ml')
+      .select('snapshot_date, rank_in_cohort, rank_in_cohort_ml, rank_in_cohort_final')
       .eq('team_id', id)
       .gte('snapshot_date', cutoffStr)
       .order('snapshot_date', { ascending: true });
@@ -1133,6 +1136,7 @@ export const api = {
       snapshot_date: string;
       rank_in_cohort: number;
       rank_in_cohort_ml: number | null;
+      rank_in_cohort_final: number | null;
     }>) {
       // Find the Monday of this snapshot's week
       const d = new Date(row.snapshot_date + 'T00:00:00');
@@ -1146,7 +1150,7 @@ export const api = {
 
       points.push({
         snapshot_date: mondayKey,
-        rank: row.rank_in_cohort_ml ?? row.rank_in_cohort,
+        rank: row.rank_in_cohort_final ?? row.rank_in_cohort_ml ?? row.rank_in_cohort,
       });
     }
 

--- a/frontend/lib/insights/seasonTruth.ts
+++ b/frontend/lib/insights/seasonTruth.ts
@@ -138,7 +138,11 @@ function computeRankVelocity(rankingHistory: InsightInputData['rankingHistory'])
   const latest = rankingHistory[0];
   const oldest = rankingHistory[rankingHistory.length - 1];
 
-  const rankChange = oldest.rank_in_cohort - latest.rank_in_cohort; // positive = improved
+  // 3-level fallback: final → ML → raw (handles pre-migration snapshots)
+  const getRank = (h: InsightInputData['rankingHistory'][0]) =>
+    h.rank_in_cohort_final ?? h.rank_in_cohort_ml ?? h.rank_in_cohort;
+
+  const rankChange = getRank(oldest) - getRank(latest); // positive = improved
   const daySpan = Math.round(
     (new Date(latest.snapshot_date).getTime() - new Date(oldest.snapshot_date).getTime()) / (1000 * 60 * 60 * 24)
   );
@@ -148,8 +152,8 @@ function computeRankVelocity(rankingHistory: InsightInputData['rankingHistory'])
   const weeks = Math.round(daySpan / 7);
 
   // Check for sustained top-10 hold
-  if (latest.rank_in_cohort <= 10) {
-    const allTopTen = rankingHistory.every((h) => h.rank_in_cohort <= 10);
+  if (getRank(latest) <= 10) {
+    const allTopTen = rankingHistory.every((h) => getRank(h) <= 10);
     if (allTopTen && rankingHistory.length >= 8) {
       return `Held a top-10 position for ${weeks}+ weeks`;
     }

--- a/frontend/lib/insights/types.ts
+++ b/frontend/lib/insights/types.ts
@@ -148,6 +148,8 @@ export interface InsightInputData {
   }>;
   rankingHistory: Array<{
     snapshot_date: string;
+    rank_in_cohort_final?: number;
+    rank_in_cohort_ml?: number;
     rank_in_cohort: number;
     power_score_final: number | null;
   }>;

--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -218,7 +218,7 @@ async def save_rankings_to_supabase(
                             record["national_rank"] = None
 
                         # Optional fields
-                        record["games_played"] = int(row.get("gp", 0)) if pd.notna(row.get("gp")) else 0
+                        record["games_played"] = int(row.get("games_played", row.get("gp", 0))) if pd.notna(row.get("games_played", row.get("gp"))) else 0
                         record["wins"] = int(row.get("wins", 0)) if pd.notna(row.get("wins")) else 0
                         record["losses"] = int(row.get("losses", 0)) if pd.notna(row.get("losses")) else 0
                         record["draws"] = int(row.get("draws", 0)) if pd.notna(row.get("draws")) else 0

--- a/src/etl/glicko_config.py
+++ b/src/etl/glicko_config.py
@@ -77,6 +77,12 @@ class GlickoConfig:
     MIN_BRIDGE_GAMES: int = 3
     ISOLATION_SOS_CAP: float = 0.60
 
+    # League-aware SCF: detect closed-league bubbles
+    SCF_LEAGUE_DIVERSITY_DIVISOR: float = 2.0   # Opponents from 2+ known leagues → max league_scf
+    SCF_LEAGUE_FLOOR: float = 0.5               # Minimum league_scf
+    SCF_LEAGUE_CONCENTRATION_THRESHOLD: float = 0.75  # >75% same league → penalty
+    SCF_MIN_UNIQUE_LEAGUES: int = 2             # Below this → league-isolated
+
     # ML
     ML_ALPHA: float = 0.08
 

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -609,24 +609,28 @@ def compute_scf(
     team_ratings: Dict[str, Tuple[float, float, float]],
     cfg: GlickoConfig,
     team_games: Optional[Dict[str, pd.DataFrame]] = None,
+    tier_league_map: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Dict]:
     """Compute Schedule Connectivity Factor for each team.
 
-    Detects teams playing in isolated regional bubbles (e.g., 3 Idaho teams
-    only playing each other inflate each other's ratings) and assigns a
-    diversity score that can dampen their SOS toward neutral.
+    Detects teams playing in isolated bubbles — either regional (state-based)
+    or league-based (e.g., cross-state ECNL_RL play). Assigns a diversity
+    score that can dampen SOS and mu toward neutral.
 
     Args:
         games_df: DataFrame with columns team_id, opp_id plus standard game cols.
         team_state_map: Dict mapping team_id -> state abbreviation (e.g. 'ID').
         team_ratings: Dict of {team_id: (mu, sigma, volatility)}.
-        cfg: GlickoConfig with SCF_ENABLED, SCF_DIVERSITY_DIVISOR, SCF_FLOOR,
-             MIN_BRIDGE_GAMES, SCF_MIN_UNIQUE_STATES.
+        cfg: GlickoConfig with SCF and league-SCF settings.
         team_games: Optional pre-filtered games dict from run_glicko2_cohort.
+        tier_league_map: Optional dict of team_id -> league string for league diversity.
 
     Returns:
-        Dict[team_id, {scf, unique_states, bridge_games, is_isolated, quality_boosted}]
+        Dict[team_id, {scf, unique_states, bridge_games, is_isolated, quality_boosted,
+                        unique_leagues, league_scf, dominant_opp_league, dominant_opp_league_share}]
     """
+    from collections import Counter
+
     result: Dict[str, Dict] = {}
 
     for team_id in team_ratings:
@@ -637,6 +641,10 @@ def compute_scf(
                 "bridge_games": 0,
                 "is_isolated": False,
                 "quality_boosted": False,
+                "unique_leagues": 0,
+                "league_scf": 1.0,
+                "dominant_opp_league": None,
+                "dominant_opp_league_share": 0.0,
             }
             continue
 
@@ -646,11 +654,12 @@ def compute_scf(
         else:
             tg = games_df[games_df["team_id"] == team_id]
 
-        # Vectorized state lookup
+        # State diversity (filter unknown states)
         opp_ids = tg["opp_id"].values
         opp_states = [team_state_map.get(o, "") for o in opp_ids]
-        bridge_count = sum(1 for s in opp_states if s and s != team_state)
-        unique_states = len(set(s for s in opp_states if s))
+        valid_states = [s for s in opp_states if s and s != "UNKNOWN"]
+        bridge_count = sum(1 for s in valid_states if s != team_state)
+        unique_states = len(set(valid_states))
 
         # SCF score: diversity of opponent states
         scf_raw = min(unique_states / cfg.SCF_DIVERSITY_DIVISOR, 1.0)
@@ -658,12 +667,48 @@ def compute_scf(
 
         is_isolated = bridge_count < cfg.MIN_BRIDGE_GAMES or unique_states < cfg.SCF_MIN_UNIQUE_STATES
 
+        # League diversity (only when tier_league_map provided)
+        unique_leagues = 0
+        dominant_league = None
+        dominant_share = 0.0
+        league_scf = 1.0
+
+        if tier_league_map:
+            opp_leagues_known = [
+                tier_league_map[str(o)] for o in opp_ids if str(o) in tier_league_map
+            ]
+
+            if opp_leagues_known:
+                unique_leagues = len(set(opp_leagues_known))
+                # Count-based: need opponents from N+ leagues
+                league_count_scf = min(unique_leagues / cfg.SCF_LEAGUE_DIVERSITY_DIVISOR, 1.0)
+
+                # Concentration-based: penalty if dominant league > threshold
+                league_counts = Counter(opp_leagues_known)
+                dominant_league, dominant_count = league_counts.most_common(1)[0]
+                dominant_share = dominant_count / len(opp_leagues_known)
+                if dominant_share > cfg.SCF_LEAGUE_CONCENTRATION_THRESHOLD:
+                    concentration_penalty = 1.0 - (dominant_share - cfg.SCF_LEAGUE_CONCENTRATION_THRESHOLD)
+                else:
+                    concentration_penalty = 1.0
+
+                league_scf_raw = min(league_count_scf, concentration_penalty)
+                league_scf = max(cfg.SCF_LEAGUE_FLOOR, league_scf_raw)
+
+            # Final SCF: most restrictive dimension wins
+            scf = min(scf, league_scf)
+            is_isolated = is_isolated or unique_leagues < cfg.SCF_MIN_UNIQUE_LEAGUES
+
         result[team_id] = {
             "scf": scf,
             "unique_states": unique_states,
             "bridge_games": bridge_count,
             "is_isolated": is_isolated,
             "quality_boosted": False,
+            "unique_leagues": unique_leagues,
+            "league_scf": league_scf,
+            "dominant_opp_league": dominant_league,
+            "dominant_opp_league_share": round(dominant_share, 3),
         }
 
     return result
@@ -830,6 +875,9 @@ def apply_scf_dampening(
     df["is_isolated"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("is_isolated", False))
     df["unique_opp_states"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("unique_states", 0))
     df["quality_boosted"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("quality_boosted", False))
+    df["unique_opp_leagues"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("unique_leagues", 0))
+    df["dominant_opp_league"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("dominant_opp_league"))
+    df["dominant_opp_league_share"] = df["team_id"].map(lambda t: scf_data.get(t, {}).get("dominant_opp_league_share", 0.0))
 
     # Cap isolated teams' SOS before dampening
     max_sos = df["sos_raw"].max()
@@ -1159,7 +1207,10 @@ def compute_rankings_v2(
 
     # 6. Apply SCF (if team_state_map provided and SCF_ENABLED)
     if cfg.SCF_ENABLED and team_state_map:
-        scf_data = compute_scf(games_df, team_state_map, team_ratings, cfg, team_games=team_games)
+        scf_data = compute_scf(
+            games_df, team_state_map, team_ratings, cfg,
+            team_games=team_games, tier_league_map=tier_league_map,
+        )
         team_df = apply_scf_dampening(team_df, scf_data, cfg)
 
     # 7. Normalize to 0-1 via sigmoid z-score
@@ -1282,8 +1333,14 @@ def compute_rankings_v2(
 
     logger.info(f"Glicko-2 engine complete{label}: {len(team_df)} teams ranked")
 
+    # Collect the actual games used by Glicko-2 (union of per-team select_games)
+    used_indices: set = set()
+    for tg in team_games.values():
+        used_indices.update(tg.index.tolist())
+    games_used = games_df.loc[games_df.index.isin(used_indices)] if used_indices else games_df
+
     return {
         "teams": team_df,
-        "games_used": games_df,
+        "games_used": games_used,
         "game_explainability": game_explain_df,
     }

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -216,15 +216,65 @@ async def compute_rankings_with_ml(
     cache_dir = Path("data/cache")
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    # Generate hash key from ALL game IDs (not just first 1000 - that caused stale cache issues)
-    # Include merge_version to invalidate cache when team merges change
+    # Generate hash key from game IDs + full config fingerprint
+    # Changing any tuning param (engine, Glicko config, ML config, tier multipliers) invalidates cache
     game_ids = games_df["game_id"].astype(str).tolist() if "game_id" in games_df.columns else []
     hash_input = "".join(sorted(game_ids)) + str(lookback_days) + (provider_filter or "")
-    # Only include merge_version when merges actually exist (not "no_merges")
-    # This ensures cache key stays identical when no merges are configured
     if merge_version and merge_version != "no_merges":
         hash_input += f"_merge_{merge_version}"
-    cache_key = hashlib.md5(hash_input.encode()).hexdigest()  # MD5 for cache key only (not security)
+
+    # Config fingerprint: serialize actual engine + ML + tier config
+    import json as _json
+
+    from src.etl.glicko_config import GlickoConfig as _GCfg
+    from src.rankings.constants import (
+        LEAGUE_MULTIPLIER_FEMALE as _LMF,
+    )
+    from src.rankings.constants import (
+        LEAGUE_MULTIPLIER_MALE as _LMM,
+    )
+    from src.rankings.constants import (
+        NEGATIVE_ML_FLOOR as _NMF,
+    )
+    from src.rankings.constants import (
+        SOS_ML_THRESHOLD_HIGH as _SMH,
+    )
+    from src.rankings.constants import (
+        SOS_ML_THRESHOLD_LOW as _SML,
+    )
+    from src.rankings.constants import (
+        UNAFFILIATED_MULTIPLIER_FEMALE as _UMF,
+    )
+    from src.rankings.constants import (
+        UNAFFILIATED_MULTIPLIER_MALE as _UMM,
+    )
+
+    _ecfg = _GCfg() if use_glicko else v53_cfg
+    _ml = layer13_cfg or Layer13Config(lookback_days=_ecfg.WINDOW_DAYS if hasattr(_ecfg, "WINDOW_DAYS") else 365)
+    _cfg_dict = {
+        "engine": "glicko" if use_glicko else "v53e",
+        "min_games": _ecfg.MIN_GAMES_PROVISIONAL,
+        "window": getattr(_ecfg, "WINDOW_DAYS", 365),
+        "scf": getattr(_ecfg, "SCF_ENABLED", True),
+        "scf_lf": getattr(_ecfg, "SCF_LEAGUE_FLOOR", None),
+        "scf_lc": getattr(_ecfg, "SCF_LEAGUE_CONCENTRATION_THRESHOLD", None),
+        "ml_a": _ml.alpha,
+        "ml_nm": _ml.norm_mode,
+        "ml_mg": _ml.min_team_games_for_residual,
+        "ml_rd": _ml.recency_decay_lambda,
+        "ml_rc": getattr(_ml, "residual_clip_goals", 6),
+        "nmf": _NMF,
+        "sml": _SML,
+        "smh": _SMH,
+        "tm": sorted(_LMM.items()),
+        "tf": sorted(_LMF.items()),
+        "um": _UMM,
+        "uf": _UMF,
+    }
+    _cfg_fp = hashlib.md5(_json.dumps(_cfg_dict, sort_keys=True, default=str).encode()).hexdigest()[:12]
+    hash_input += f"_cfg_{_cfg_fp}"
+
+    cache_key = hashlib.md5(hash_input.encode()).hexdigest()
     cache_file_teams = cache_dir / f"rankings_{cache_key}_teams.parquet"
     cache_file_games = cache_dir / f"rankings_{cache_key}_games.parquet"
 
@@ -331,7 +381,7 @@ async def compute_rankings_with_ml(
         teams_with_ml, game_residuals = await apply_predictive_adjustment(
             supabase_client=supabase_client,
             teams_df=teams_base,
-            games_used_df=games_df,  # Use original games with full columns (id, home_team_master_id)
+            games_used_df=base.get("games_used", games_df),  # Use Glicko-2 filtered games
             cfg=ml_cfg,
             return_game_residuals=True,  # Request per-game residuals
         )
@@ -565,7 +615,9 @@ async def compute_all_cohorts(
             league_counts: Dict[str, int] = {}
             for lg in tier_league_map.values():
                 league_counts[lg] = league_counts.get(lg, 0) + 1
-            logger.info(f"✅ Fetched league for {len(tier_league_map):,} teams. Distribution: {dict(sorted(league_counts.items(), key=lambda x: -x[1])[:5])}")
+            logger.info(
+                f"✅ Fetched league for {len(tier_league_map):,} teams. Distribution: {dict(sorted(league_counts.items(), key=lambda x: -x[1])[:5])}"
+            )
         else:
             logger.warning("⚠️ No team IDs found for league metadata fetch")
 
@@ -654,10 +706,12 @@ async def compute_all_cohorts(
                 global_strength_map.update(strength_dict)
             # Cache converged Glicko-2 ratings for warm-starting Pass 2
             if use_glicko and all(c in teams_df.columns for c in ("mu", "sigma", "volatility")):
-                pass1_glicko_ratings[i] = dict(zip(
-                    teams_df["team_id"].astype(str),
-                    zip(teams_df["mu"], teams_df["sigma"], teams_df["volatility"]),
-                ))
+                pass1_glicko_ratings[i] = dict(
+                    zip(
+                        teams_df["team_id"].astype(str),
+                        zip(teams_df["mu"], teams_df["sigma"], teams_df["volatility"]),
+                    )
+                )
         # Cache pre-SOS state keyed by cohort index (v53e only; Glicko-2 has none)
         if not use_glicko and result.get("pre_sos_state"):
             pass1_pre_sos_states[i] = result["pre_sos_state"]
@@ -923,7 +977,7 @@ async def compute_all_cohorts(
 
     # ---- Final age-anchor scaling for PowerScore ----
     if not teams_combined.empty:
-        from src.rankings.constants import AGE_TO_ANCHOR, NEGATIVE_ML_FLOOR, SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
+        from src.rankings.constants import AGE_TO_ANCHOR, SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
         from src.rankings.shared import sos_ml_blend
 
         if "age_num" not in teams_combined.columns:
@@ -981,11 +1035,11 @@ async def compute_all_cohorts(
                         (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)
                     ).clip(0.0, 1.0)
 
-                    # Asymmetric gate: negative ML corrections (marking overrated teams down)
-                    # get at least NEGATIVE_ML_FLOOR authority regardless of SOS.
+                    # Negative ML corrections always apply at full authority.
                     # Positive corrections (inflation) are still fully gated by SOS.
                     import numpy as _np
-                    ml_scale_effective = _np.where(ml_delta >= 0, ml_scale, _np.maximum(ml_scale, NEGATIVE_ML_FLOOR))
+
+                    ml_scale_effective = _np.where(ml_delta >= 0, ml_scale, 1.0)
 
                     # Step 4: Final score = baseline + SOS-scaled ML adjustment
                     base = (ps_adj + ml_delta * ml_scale_effective).clip(0.0, 1.0)
@@ -1116,6 +1170,31 @@ async def compute_all_cohorts(
                     # Overwrite power_score_final to guarantee monotonicity
                     teams_combined.loc[grp.index, "power_score_final"] = psf_recomputed
                     logger.info(f"  {age_val} {gender}: {len(grp)} teams, monotonicity enforced ✅")
+
+            # === PUBLISHED RANK: canonical ordering by power_score_true DESC, team_id ASC ===
+            # power_score_true is unanchored, so within an (age, gender) cohort it produces
+            # the same ordering as power_score_final (anchor is a constant multiplier).
+            # team_id ASC is the deterministic tie-break (matches UI sort behavior).
+            #
+            # NOTE: The SQL views remap age 18 → 19 (U19 encompasses 2007+2008 birth years).
+            # The calculator ranks by raw age_num (before remap), so U18 and U19 are ranked
+            # as separate cohorts here. The view layer merges them for display.
+            if "power_score_true" in teams_combined.columns:
+                teams_combined["rank_in_cohort_final"] = pd.array([pd.NA] * len(teams_combined), dtype="Int64")
+                active_mask = teams_combined["status"] == "Active"
+                if active_mask.any():
+                    for (age_val, gender), grp in teams_combined[active_mask].groupby(["age_num", "gender"]):
+                        ranked = grp.sort_values(
+                            ["power_score_true", "team_id"],
+                            ascending=[False, True],
+                        )
+                        ranks = pd.Series(
+                            range(1, len(ranked) + 1),
+                            index=ranked.index,
+                            dtype="Int64",
+                        )
+                        teams_combined.loc[ranks.index, "rank_in_cohort_final"] = ranks
+                    logger.info(f"  Published rank_in_cohort_final computed for {active_mask.sum()} Active teams")
 
             # === Anchor integrity sample (top 3 per age group) ===
             if "power_score_true" in teams_combined.columns:

--- a/src/rankings/constants.py
+++ b/src/rankings/constants.py
@@ -49,10 +49,9 @@ FEMALE_AGE_ANCHORS: dict[int, float] = {
 SOS_ML_THRESHOLD_LOW = 0.45
 SOS_ML_THRESHOLD_HIGH = 0.60
 
-# Asymmetric ML gate: minimum authority for negative ML corrections.
-# Positive corrections are fully gated by SOS; negative corrections
-# (marking overrated teams down) get at least this much authority.
-NEGATIVE_ML_FLOOR = 0.5
+# Negative ML corrections always apply at full authority.
+# Weak schedule should never shield a team from being marked as overrated.
+NEGATIVE_ML_FLOOR = 1.0
 
 # ── League Tier System ──────────────────────────────────────────────────
 # Per-league opponent strength multiplier applied during Glicko-2

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -864,6 +864,14 @@ def v53e_to_rankings_full_format(
     else:
         rankings_df["rank_in_cohort"] = pd.array([pd.NA] * len(rankings_df), dtype="Int64")
 
+    # Preserve NULL rank_in_cohort_final for non-Active teams
+    if "rank_in_cohort_final" in rankings_df.columns:
+        rankings_df["rank_in_cohort_final"] = pd.to_numeric(rankings_df["rank_in_cohort_final"], errors="coerce").astype(
+            "Int64"
+        )
+    else:
+        rankings_df["rank_in_cohort_final"] = pd.array([pd.NA] * len(rankings_df), dtype="Int64")
+
     # National/state/global ranks will be computed in views, but store rank_in_cohort values
     # Set these to None initially - they'll be computed dynamically in views
     rankings_df["national_rank"] = None
@@ -969,6 +977,7 @@ def v53e_to_rankings_full_format(
         "powerscore_ml",
         "rank_in_cohort_ml",
         "rank_in_cohort",
+        "rank_in_cohort_final",
         "national_rank",
         "state_rank",
         "global_rank",

--- a/src/rankings/ranking_history.py
+++ b/src/rankings/ranking_history.py
@@ -57,14 +57,10 @@ async def save_ranking_snapshot(
             df["age_group"] = df["age"].apply(lambda x: f"u{int(float(x))}" if pd.notna(x) else "")
 
     # Calculate state ranks within each (state_code, age_group, gender) cohort
-    # Only Active teams get state ranks — consistent with v53e and state_rankings_view
+    # Only Active teams get state ranks — consistent with state_rankings_view
     if "state_code" in df.columns and "power_score_final" in df.columns:
-        # Use ML score if available, otherwise fall back to power_score_final
-        score_col = (
-            "powerscore_ml"
-            if "powerscore_ml" in df.columns and df["powerscore_ml"].notna().any()
-            else "power_score_final"
-        )
+        # Use power_score_final (canonical score) for state rank computation
+        score_col = "power_score_final"
 
         # Initialize all state ranks as NULL
         df["rank_in_state"] = pd.array([pd.NA] * len(df), dtype="Int64")
@@ -109,6 +105,7 @@ async def save_ranking_snapshot(
             "gender": str(row.get("gender", "")),
             "rank_in_cohort": int(row.get("rank_in_cohort")) if pd.notna(row.get("rank_in_cohort")) else None,
             "rank_in_cohort_ml": int(row.get("rank_in_cohort_ml")) if pd.notna(row.get("rank_in_cohort_ml")) else None,
+            "rank_in_cohort_final": int(row.get("rank_in_cohort_final")) if pd.notna(row.get("rank_in_cohort_final")) else None,
             "power_score_final": float(row.get("power_score_final"))
             if pd.notna(row.get("power_score_final"))
             else None,
@@ -234,7 +231,7 @@ async def get_historical_ranks(
                 # Query snapshots within date range for this batch
                 response = (
                     supabase_client.table("ranking_history")
-                    .select("team_id, snapshot_date, rank_in_cohort, rank_in_cohort_ml")
+                    .select("team_id, snapshot_date, rank_in_cohort, rank_in_cohort_ml, rank_in_cohort_final")
                     .in_("team_id", batch)
                     .gte("snapshot_date", date_range_start.isoformat())
                     .lte("snapshot_date", date_range_end.isoformat())
@@ -262,8 +259,10 @@ async def get_historical_ranks(
         for record in all_records:
             team_id = record["team_id"]
             snapshot_date = date.fromisoformat(record["snapshot_date"])
+            # 3-level fallback: final → ML → raw (handles pre-migration snapshots)
+            final_rank = record.get("rank_in_cohort_final")
             ml_rank = record.get("rank_in_cohort_ml")
-            rank = ml_rank if ml_rank is not None else record.get("rank_in_cohort")
+            rank = final_rank if final_rank is not None else (ml_rank if ml_rank is not None else record.get("rank_in_cohort"))
 
             # Calculate date distance
             distance = abs((snapshot_date - target_date).days)
@@ -500,9 +499,13 @@ async def calculate_rank_changes(
     def calculate_change(row) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         team_id = row["team_id"]
 
-        # Use ML rank if available, otherwise use cohort rank
+        # Use published final rank, with 3-level fallback for pre-migration data
+        final_rank = row.get("rank_in_cohort_final")
         ml_rank = row.get("rank_in_cohort_ml")
-        current_national_rank = ml_rank if not pd.isna(ml_rank) else row.get("rank_in_cohort")
+        current_national_rank = (
+            final_rank if pd.notna(final_rank)
+            else (ml_rank if pd.notna(ml_rank) else row.get("rank_in_cohort"))
+        )
         current_state_rank = row.get("current_state_rank")
 
         # National rank changes

--- a/src/rankings/shared.py
+++ b/src/rankings/shared.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from src.rankings.constants import NEGATIVE_ML_FLOOR, SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
+from src.rankings.constants import SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
 
 
 def sos_ml_blend(ps_adj: float, ps_ml: float, sos_norm: float) -> float:
@@ -13,12 +13,12 @@ def sos_ml_blend(ps_adj: float, ps_ml: float, sos_norm: float) -> float:
     Returns a score in [0, 1] where ML authority scales linearly from 0 to 1
     as sos_norm moves from SOS_ML_THRESHOLD_LOW to SOS_ML_THRESHOLD_HIGH.
 
-    Asymmetric gate: negative ML corrections (overrated teams) get at least
-    NEGATIVE_ML_FLOOR authority regardless of SOS.
+    Negative ML corrections (overrated teams) always apply at full authority.
+    Positive corrections (inflation) are fully gated by SOS.
     """
     ml_scale = max(0.0, min(1.0, (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW)))
     ml_delta = ps_ml - ps_adj
-    effective_scale = ml_scale if ml_delta >= 0 else max(ml_scale, NEGATIVE_ML_FLOOR)
+    effective_scale = ml_scale if ml_delta >= 0 else 1.0
     return max(0.0, min(1.0, ps_adj + ml_delta * effective_scale))
 
 

--- a/supabase/migrations/20260404000000_add_rank_in_cohort_final.sql
+++ b/supabase/migrations/20260404000000_add_rank_in_cohort_final.sql
@@ -1,0 +1,5 @@
+-- Add rank_in_cohort_final: the published rank computed from power_score_final ordering
+-- Computed in calculator.py after power_score_true is set, using canonical order:
+-- power_score_true DESC, team_id ASC. Active teams only; NULL for non-Active.
+ALTER TABLE rankings_full ADD COLUMN IF NOT EXISTS rank_in_cohort_final INTEGER;
+COMMENT ON COLUMN rankings_full.rank_in_cohort_final IS 'Published cohort rank from power_score_true DESC, team_id ASC. Active teams only; NULL for non-Active.';

--- a/supabase/migrations/20260404000001_update_views_use_rank_final.sql
+++ b/supabase/migrations/20260404000001_update_views_use_rank_final.sql
@@ -1,0 +1,447 @@
+-- Migration: Switch views to use stored rank_in_cohort_final
+-- Date: 2026-04-04
+-- Purpose: Replace COALESCE(rank_in_cohort_ml, rank_in_cohort) with the published
+--          rank_in_cohort_final computed from power_score_final ordering.
+--          Uses status-aware fallback during transition (NULL column until first recalc).
+--          Fixes state_rankings_view to use active-only CTE + join-back pattern so
+--          non-Active teams remain visible with NULL state rank.
+
+-- =====================================================
+-- Step 1: Drop existing views (state depends on rankings)
+-- =====================================================
+
+DROP VIEW IF EXISTS state_rankings_view CASCADE;
+DROP VIEW IF EXISTS rankings_view CASCADE;
+
+-- =====================================================
+-- Step 2: Recreate rankings_view with rank_in_cohort_final
+-- =====================================================
+
+CREATE VIEW rankings_view
+WITH (security_invoker = true)
+AS
+SELECT
+    t.team_id_master,
+    t.team_name,
+    t.club_name,
+    t.state_code AS state,
+    -- Age extraction with U18->U19 remap
+    CASE
+      WHEN (
+        CASE
+          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+          ELSE NULL
+        END
+      ) = 18 THEN 19
+      ELSE
+        CASE
+          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+          ELSE NULL
+        END
+    END AS age,
+    CASE
+      WHEN rf.gender = 'Male' THEN 'M'
+      WHEN rf.gender = 'Female' THEN 'F'
+      WHEN rf.gender = 'Boys' THEN 'M'
+      WHEN rf.gender = 'Girls' THEN 'F'
+      WHEN rf.gender = 'M' THEN 'M'
+      WHEN rf.gender = 'F' THEN 'F'
+      ELSE rf.gender
+    END AS gender,
+
+    COALESCE(rf.games_played, cr.games_played) AS games_played,
+    COALESCE(rf.wins, cr.wins) AS wins,
+    COALESCE(rf.losses, cr.losses) AS losses,
+    COALESCE(rf.draws, cr.draws) AS draws,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+       AND g.is_excluded = FALSE
+    ) AS total_games_played,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score > g.away_score)
+            OR (g.away_team_master_id = t.team_id_master AND g.away_score > g.home_score))
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+       AND g.is_excluded = FALSE
+    ) AS total_wins,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score < g.away_score)
+            OR (g.away_team_master_id = t.team_id_master AND g.away_score < g.home_score))
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+       AND g.is_excluded = FALSE
+    ) AS total_losses,
+
+    (SELECT COUNT(*)
+     FROM games g
+     WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+       AND g.home_score = g.away_score
+       AND g.home_score IS NOT NULL
+       AND g.away_score IS NOT NULL
+       AND g.is_excluded = FALSE
+    ) AS total_draws,
+
+    CASE
+      WHEN (SELECT COUNT(*)
+            FROM games g
+            WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+              AND g.home_score IS NOT NULL
+              AND g.away_score IS NOT NULL
+              AND g.is_excluded = FALSE) > 0
+      THEN (
+        (
+          (SELECT COUNT(*)::NUMERIC
+           FROM games g
+           WHERE ((g.home_team_master_id = t.team_id_master AND g.home_score > g.away_score)
+                  OR (g.away_team_master_id = t.team_id_master AND g.away_score > g.home_score))
+             AND g.home_score IS NOT NULL
+             AND g.away_score IS NOT NULL
+             AND g.is_excluded = FALSE)
+          +
+          (SELECT COUNT(*)::NUMERIC
+           FROM games g
+           WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+             AND g.home_score = g.away_score
+             AND g.home_score IS NOT NULL
+             AND g.away_score IS NOT NULL
+             AND g.is_excluded = FALSE) * 0.5
+        ) /
+        (SELECT COUNT(*)::NUMERIC
+         FROM games g
+         WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+           AND g.home_score IS NOT NULL
+           AND g.away_score IS NOT NULL
+           AND g.is_excluded = FALSE)
+      ) * 100
+      ELSE NULL
+    END AS win_percentage,
+
+    rf.power_score_final,
+    rf.sos_norm,
+    rf.sos_norm_state,
+    rf.off_norm AS offense_norm,
+    rf.def_norm AS defense_norm,
+    rf.perf_centered,
+
+    -- Published rank: status-aware fallback until first recalc populates rank_in_cohort_final
+    CASE WHEN rf.status = 'Active'
+        THEN COALESCE(rf.rank_in_cohort_final, rf.rank_in_cohort_ml, rf.rank_in_cohort)
+        ELSE NULL
+    END AS rank_in_cohort_final,
+
+    rf.sos_rank_national,
+    rf.sos_rank_state,
+
+    rf.rank_change_7d,
+    rf.rank_change_30d,
+    rf.rank_change_state_7d,
+    rf.rank_change_state_30d,
+
+    rf.status,
+    rf.last_game,
+    rf.last_calculated
+
+FROM teams t
+LEFT JOIN rankings_full rf ON t.team_id_master = rf.team_id
+LEFT JOIN current_rankings cr ON t.team_id_master = cr.team_id
+WHERE (rf.power_score_final IS NOT NULL OR cr.national_power_score IS NOT NULL)
+  AND t.is_deprecated IS NOT TRUE;
+
+COMMENT ON VIEW rankings_view IS 'National rankings view. Uses stored rank_in_cohort_final (with status-aware fallback to rank_in_cohort_ml/rank_in_cohort during transition). Age 18 remapped to 19. Excludes deprecated teams.';
+
+-- =====================================================
+-- Step 3: Recreate state_rankings_view with active-only CTE + join-back
+-- =====================================================
+-- Active teams get a state rank via ROW_NUMBER in a CTE.
+-- Non-active teams remain visible with NULL rank_in_state_final via LEFT JOIN.
+
+CREATE VIEW state_rankings_view
+WITH (security_invoker = true)
+AS
+WITH active_state_ranks AS (
+    SELECT
+        rv.team_id_master,
+        ROW_NUMBER() OVER (
+            PARTITION BY rv.state, rv.age, rv.gender
+            ORDER BY rv.power_score_final DESC, rv.team_id_master ASC
+        ) AS rank_in_state_final
+    FROM rankings_view rv
+    WHERE rv.state IS NOT NULL
+      AND rv.status = 'Active'
+)
+SELECT
+    rv.team_id_master,
+    rv.team_name,
+    rv.club_name,
+    rv.state AS state,
+    rv.age AS age,
+    rv.gender,
+
+    rv.games_played,
+    rv.wins,
+    rv.losses,
+    rv.draws,
+
+    rv.total_games_played,
+    rv.total_wins,
+    rv.total_losses,
+    rv.total_draws,
+    rv.win_percentage,
+
+    rv.power_score_final,
+    rv.sos_norm,
+    rv.sos_norm_state,
+    rv.offense_norm,
+    rv.defense_norm,
+
+    rv.perf_centered,
+
+    rv.rank_in_cohort_final,
+
+    asr.rank_in_state_final,
+
+    rv.sos_rank_national,
+    rv.sos_rank_state,
+
+    rv.rank_change_7d,
+    rv.rank_change_30d,
+
+    rv.status,
+    rv.last_game,
+    rv.last_calculated
+
+FROM rankings_view rv
+LEFT JOIN active_state_ranks asr ON rv.team_id_master = asr.team_id_master
+WHERE rv.state IS NOT NULL
+  AND rv.status IN ('Active', 'Not Enough Ranked Games');
+
+COMMENT ON VIEW state_rankings_view IS 'State rankings view. Active teams get rank_in_state_final via active-only CTE (power_score_final DESC, team_id ASC). Non-active teams visible with NULL state rank.';
+
+-- =====================================================
+-- Step 4: Update get_state_rankings RPC to use rank_in_cohort_final
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_state_rankings(
+    p_state TEXT,
+    p_age TEXT,
+    p_gender TEXT,
+    p_limit INT DEFAULT 1000,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    team_id_master UUID,
+    team_name TEXT,
+    club_name TEXT,
+    state TEXT,
+    age INT,
+    gender TEXT,
+    games_played INT,
+    wins INT,
+    losses INT,
+    draws INT,
+    total_games_played INT,
+    total_wins INT,
+    total_losses INT,
+    total_draws INT,
+    win_percentage NUMERIC,
+    power_score_final FLOAT8,
+    sos_norm FLOAT8,
+    sos_norm_state FLOAT8,
+    offense_norm FLOAT8,
+    defense_norm FLOAT8,
+    perf_centered FLOAT8,
+    rank_in_cohort_final INT,
+    rank_in_state_final BIGINT,
+    sos_rank_national INT,
+    sos_rank_state INT,
+    rank_change_7d INT,
+    rank_change_30d INT,
+    rank_change_state_7d INT,
+    rank_change_state_30d INT,
+    status TEXT,
+    last_game TIMESTAMPTZ,
+    last_calculated TIMESTAMPTZ
+) LANGUAGE sql STABLE AS $$
+    WITH
+    gender_norm AS (
+        SELECT CASE
+            WHEN p_gender IN ('M', 'B') THEN 'Male'
+            WHEN p_gender IN ('F', 'G') THEN 'Female'
+            ELSE p_gender
+        END AS gender_val
+    ),
+    cohort AS (
+        SELECT
+            t.team_id_master,
+            t.team_name,
+            t.club_name,
+            rf.state_code,
+            rf.age_group,
+            rf.gender AS raw_gender,
+            COALESCE(rf.games_played, cr.games_played) AS games_played,
+            COALESCE(rf.wins, cr.wins) AS wins,
+            COALESCE(rf.losses, cr.losses) AS losses,
+            COALESCE(rf.draws, cr.draws) AS draws,
+            COALESCE(rf.total_games_played, 0) AS total_games_played,
+            COALESCE(rf.total_wins, 0) AS total_wins,
+            COALESCE(rf.total_losses, 0) AS total_losses,
+            COALESCE(rf.total_draws, 0) AS total_draws,
+            rf.power_score_final,
+            rf.sos_norm,
+            rf.sos_norm_state,
+            rf.off_norm,
+            rf.def_norm,
+            rf.perf_centered,
+            -- Status-aware fallback for rank_in_cohort_final
+            CASE WHEN rf.status = 'Active'
+                THEN COALESCE(rf.rank_in_cohort_final, rf.rank_in_cohort_ml, rf.rank_in_cohort)
+                ELSE NULL
+            END AS rank_in_cohort_final,
+            rf.sos_rank_national,
+            rf.sos_rank_state,
+            rf.rank_change_7d,
+            rf.rank_change_30d,
+            rf.rank_change_state_7d,
+            rf.rank_change_state_30d,
+            rf.status,
+            rf.last_game,
+            rf.last_calculated
+        FROM teams t
+        JOIN rankings_full rf ON t.team_id_master = rf.team_id
+        LEFT JOIN current_rankings cr ON t.team_id_master = cr.team_id
+        CROSS JOIN gender_norm gn
+        WHERE rf.state_code = UPPER(p_state)
+          AND (
+              CASE
+                  WHEN (
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
+                  ) = 18 THEN 19
+                  ELSE
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
+              END
+          ) = CASE WHEN p_age::INTEGER = 18 THEN 19 ELSE p_age::INTEGER END
+          AND rf.gender = gn.gender_val
+          AND rf.status IN ('Active', 'Not Enough Ranked Games')
+          AND t.is_deprecated IS NOT TRUE
+          AND rf.power_score_final IS NOT NULL
+    ),
+    active_ranked AS (
+        SELECT
+            c.team_id_master,
+            ROW_NUMBER() OVER (ORDER BY c.power_score_final DESC, c.team_id_master ASC) AS rank_in_state
+        FROM cohort c
+        WHERE c.status = 'Active'
+    )
+    SELECT
+        c.team_id_master,
+        c.team_name,
+        c.club_name,
+        c.state_code AS state,
+        CASE WHEN p_age::INTEGER = 18 THEN 19 ELSE p_age::INTEGER END AS age,
+        CASE
+            WHEN c.raw_gender = 'Male' THEN 'M'
+            WHEN c.raw_gender = 'Female' THEN 'F'
+            WHEN c.raw_gender = 'Boys' THEN 'M'
+            WHEN c.raw_gender = 'Girls' THEN 'F'
+            WHEN c.raw_gender = 'M' THEN 'M'
+            WHEN c.raw_gender = 'F' THEN 'F'
+            ELSE c.raw_gender
+        END AS gender,
+        c.games_played,
+        c.wins,
+        c.losses,
+        c.draws,
+        c.total_games_played,
+        c.total_wins,
+        c.total_losses,
+        c.total_draws,
+        CASE
+            WHEN c.total_games_played > 0
+            THEN ((c.total_wins::NUMERIC + c.total_draws::NUMERIC * 0.5)
+                  / c.total_games_played::NUMERIC) * 100
+            ELSE NULL
+        END AS win_percentage,
+        c.power_score_final,
+        c.sos_norm,
+        c.sos_norm_state,
+        c.off_norm AS offense_norm,
+        c.def_norm AS defense_norm,
+        c.perf_centered,
+        c.rank_in_cohort_final,
+        ar.rank_in_state AS rank_in_state_final,
+        c.sos_rank_national,
+        c.sos_rank_state,
+        c.rank_change_7d,
+        c.rank_change_30d,
+        c.rank_change_state_7d,
+        c.rank_change_state_30d,
+        c.status,
+        c.last_game,
+        c.last_calculated
+    FROM cohort c
+    LEFT JOIN active_ranked ar ON c.team_id_master = ar.team_id_master
+    ORDER BY c.power_score_final DESC
+    LIMIT p_limit
+    OFFSET p_offset;
+$$;
+
+COMMENT ON FUNCTION get_state_rankings IS 'Paginated state rankings RPC. Uses stored rank_in_cohort_final (with status-aware fallback). State rank via active-only CTE with canonical ordering (power_score_final DESC, team_id ASC). Age 18 remapped to 19.';
+
+-- =====================================================
+-- Step 5: Update get_team_state_rank RPC with canonical ordering
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_team_state_rank(p_team_id UUID)
+RETURNS TABLE (
+    state_rank BIGINT,
+    sos_rank_state BIGINT
+) LANGUAGE sql STABLE AS $$
+    WITH team_info AS (
+        SELECT team_id, state_code, age_group, gender, power_score_final, sos_norm_state, status
+        FROM rankings_full WHERE team_id = p_team_id
+    )
+    SELECT
+        (SELECT COUNT(*) + 1 FROM rankings_full rf
+         WHERE rf.state_code = ti.state_code
+           AND rf.age_group = ti.age_group
+           AND rf.gender = ti.gender
+           AND rf.status = 'Active'
+           AND (rf.power_score_final > ti.power_score_final
+                OR (rf.power_score_final = ti.power_score_final AND rf.team_id < ti.team_id))
+        )::BIGINT AS state_rank,
+        (SELECT COUNT(*) + 1 FROM rankings_full rf
+         WHERE rf.state_code = ti.state_code
+           AND rf.age_group = ti.age_group
+           AND rf.gender = ti.gender
+           AND rf.status = 'Active'
+           AND rf.sos_norm_state IS NOT NULL
+           AND ti.sos_norm_state IS NOT NULL
+           AND rf.sos_norm_state > ti.sos_norm_state
+        )::BIGINT AS sos_rank_state
+    FROM team_info ti
+    WHERE ti.status = 'Active';
+$$;
+
+COMMENT ON FUNCTION get_team_state_rank IS 'Single-team state rank RPC. Counts Active teams with higher power_score_final (tie-break: team_id ASC). Only returns for Active teams.';

--- a/supabase/migrations/20260404000002_add_rank_final_to_history.sql
+++ b/supabase/migrations/20260404000002_add_rank_final_to_history.sql
@@ -1,0 +1,3 @@
+-- Add rank_in_cohort_final to ranking_history for published final rank tracking
+ALTER TABLE ranking_history ADD COLUMN IF NOT EXISTS rank_in_cohort_final INTEGER;
+COMMENT ON COLUMN ranking_history.rank_in_cohort_final IS 'Published final rank from power_score_final ordering. Replaces COALESCE(rank_in_cohort_ml, rank_in_cohort) as the canonical historical rank.';

--- a/tests/unit/test_league_bubble_scf.py
+++ b/tests/unit/test_league_bubble_scf.py
@@ -1,0 +1,150 @@
+"""
+Tests for league-aware SCF bubble detection in Glicko-2 engine.
+
+Verifies that compute_scf() detects closed-league ecosystems (e.g., cross-state
+ECNL_RL play) and dampens mu/SOS accordingly.
+"""
+
+import pandas as pd
+import pytest
+
+from src.etl.glicko_config import GlickoConfig
+from src.etl.glicko_engine import compute_scf
+
+
+def _make_games(team_id: str, opp_ids: list[str]) -> pd.DataFrame:
+    """Build a simple games DataFrame for one team."""
+    rows = []
+    for i, opp in enumerate(opp_ids):
+        rows.append({"team_id": team_id, "opp_id": opp, "gf": 3, "ga": 1})
+        rows.append({"team_id": opp, "opp_id": team_id, "gf": 1, "ga": 3})
+    return pd.DataFrame(rows)
+
+
+class TestLeagueBubbleSCF:
+    """Verify league diversity affects SCF."""
+
+    def test_single_league_opponents_get_low_scf(self):
+        """Team with all opponents in one league → league_scf = 0.5."""
+        cfg = GlickoConfig()
+        opps = [f"opp_{i}" for i in range(10)]
+        games = _make_games("team_a", opps)
+
+        team_state_map = {"team_a": "NE"}
+        for i, opp in enumerate(opps):
+            # Spread across 5 states to ensure state_scf is high
+            team_state_map[opp] = ["CT", "MA", "NY", "PA", "NJ"][i % 5]
+
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a"] + opps}
+
+        # All opponents in ECNL_RL
+        tier_league_map = {opp: "ECNL_RL" for opp in opps}
+
+        scf_data = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=tier_league_map)
+        team_scf = scf_data["team_a"]
+
+        assert team_scf["unique_leagues"] == 1
+        assert team_scf["league_scf"] == cfg.SCF_LEAGUE_FLOOR  # 0.5
+        assert team_scf["scf"] <= 0.5  # league_scf restricts overall
+        assert team_scf["dominant_opp_league"] == "ECNL_RL"
+        assert team_scf["dominant_opp_league_share"] == 1.0
+
+    def test_diverse_league_opponents_get_high_scf(self):
+        """Team with opponents from 3+ leagues → league_scf = 1.0."""
+        cfg = GlickoConfig()
+        opps = ["opp_ecnl", "opp_ga", "opp_dpl"]
+        games = _make_games("team_a", opps)
+
+        team_state_map = {"team_a": "AZ", "opp_ecnl": "CA", "opp_ga": "TX", "opp_dpl": "FL"}
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a"] + opps}
+        tier_league_map = {"opp_ecnl": "ECNL", "opp_ga": "GA", "opp_dpl": "DPL"}
+
+        scf_data = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=tier_league_map)
+        team_scf = scf_data["team_a"]
+
+        assert team_scf["unique_leagues"] == 3
+        assert team_scf["league_scf"] == 1.0
+
+    def test_concentration_penalty(self):
+        """Team with 80%+ same league → concentration penalty kicks in."""
+        cfg = GlickoConfig()
+        opps = [f"opp_{i}" for i in range(10)]
+        games = _make_games("team_a", opps)
+
+        team_state_map = {"team_a": "AZ"}
+        for i, opp in enumerate(opps):
+            team_state_map[opp] = ["CA", "TX", "FL", "NY", "GA"][i % 5]
+
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a"] + opps}
+
+        # 9/10 ECNL_RL, 1 ECNL → 90% concentration
+        tier_league_map = {opp: "ECNL_RL" for opp in opps[:9]}
+        tier_league_map[opps[9]] = "ECNL"
+
+        scf_data = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=tier_league_map)
+        team_scf = scf_data["team_a"]
+
+        assert team_scf["unique_leagues"] == 2
+        assert team_scf["dominant_opp_league_share"] == 0.9
+        # Concentration penalty: 1.0 - (0.9 - 0.75) = 0.85
+        # league_count_scf: 2/2 = 1.0
+        # league_scf = max(0.5, min(1.0, 0.85)) = 0.85
+        assert team_scf["league_scf"] == pytest.approx(0.85, abs=0.01)
+
+    def test_no_tier_league_map_backward_compatible(self):
+        """Without tier_league_map, SCF is state-only (unchanged)."""
+        cfg = GlickoConfig()
+        opps = ["opp_1", "opp_2"]
+        games = _make_games("team_a", opps)
+
+        team_state_map = {"team_a": "AZ", "opp_1": "CA", "opp_2": "TX"}
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a", "opp_1", "opp_2"]}
+
+        scf_with = compute_scf(games, team_state_map, ratings, cfg, tier_league_map={})
+        scf_without = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=None)
+
+        assert scf_with["team_a"]["scf"] == scf_without["team_a"]["scf"]
+        assert scf_without["team_a"]["league_scf"] == 1.0
+
+    def test_null_league_opponents_dont_inflate_diversity(self):
+        """Opponents with no league in tier_league_map don't count as a unique league."""
+        cfg = GlickoConfig()
+        opps = ["opp_rl_1", "opp_rl_2", "opp_unknown"]
+        games = _make_games("team_a", opps)
+
+        team_state_map = {"team_a": "AZ", "opp_rl_1": "CA", "opp_rl_2": "TX", "opp_unknown": "FL"}
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a"] + opps}
+
+        # Only 2 opponents have known leagues, both ECNL_RL
+        tier_league_map = {"opp_rl_1": "ECNL_RL", "opp_rl_2": "ECNL_RL"}
+
+        scf_data = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=tier_league_map)
+        team_scf = scf_data["team_a"]
+
+        # opp_unknown not in tier_league_map → excluded from league diversity
+        assert team_scf["unique_leagues"] == 1
+        assert team_scf["league_scf"] == cfg.SCF_LEAGUE_FLOOR  # 0.5
+
+    def test_league_scf_restricts_state_scf(self):
+        """When state_scf = 1.0 but league_scf = 0.5, final scf = 0.5."""
+        cfg = GlickoConfig()
+        opps = [f"opp_{i}" for i in range(8)]
+        games = _make_games("team_a", opps)
+
+        # 8 different states → state_scf = min(8/4, 1.0) = 1.0
+        states = ["CT", "MA", "NY", "PA", "NJ", "OH", "IL", "MI"]
+        team_state_map = {"team_a": "NE"}
+        for opp, st in zip(opps, states):
+            team_state_map[opp] = st
+
+        ratings = {t: (1500.0, 200.0, 0.06) for t in ["team_a"] + opps}
+
+        # All same league → league_scf = 0.5
+        tier_league_map = {opp: "ECNL_RL" for opp in opps}
+
+        scf_data = compute_scf(games, team_state_map, ratings, cfg, tier_league_map=tier_league_map)
+        team_scf = scf_data["team_a"]
+
+        assert team_scf["unique_states"] >= 4  # state_scf would be 1.0
+        assert team_scf["league_scf"] == 0.5
+        assert team_scf["scf"] == 0.5  # min(1.0, 0.5)

--- a/tests/unit/test_ml_layer13_sos_scaling.py
+++ b/tests/unit/test_ml_layer13_sos_scaling.py
@@ -12,10 +12,9 @@ Formula:
   final = powerscore_adj + ml_scale * (powerscore_ml - powerscore_adj)
 """
 
-import pytest
 import numpy as np
 import pandas as pd
-
+import pytest
 
 # ---------------------------------------------------------------------------
 # Constants (matching calculator.py)
@@ -26,31 +25,28 @@ SOS_ML_THRESHOLD_HIGH = 0.60
 
 def ml_scale_formula(sos_norm):
     """Replicate the SOS-conditioned ML scaling formula."""
-    return np.clip(
-        (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW),
-        0.0, 1.0
-    )
+    return np.clip((sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW), 0.0, 1.0)
 
 
-NEGATIVE_ML_FLOOR = 0.5
+NEGATIVE_ML_FLOOR = 1.0
 
 
 def final_score(ps_adj, ps_ml, sos_norm):
     """Compute final score using SOS-conditioned ML scaling.
 
-    Asymmetric gate: negative ML corrections get a floor of NEGATIVE_ML_FLOOR
-    authority even when SOS is below the low threshold. Positive ML corrections
-    are still fully gated by SOS.
+    Negative ML corrections always apply at full authority (1.0).
+    Positive ML corrections are still fully gated by SOS.
     """
     scale = ml_scale_formula(sos_norm)
     ml_delta = ps_ml - ps_adj
-    effective_scale = np.where(ml_delta >= 0, scale, np.maximum(scale, NEGATIVE_ML_FLOOR))
+    effective_scale = np.where(ml_delta >= 0, scale, 1.0)
     return np.clip(ps_adj + ml_delta * effective_scale, 0.0, 1.0)
 
 
 # ===========================================================================
 # Unit tests for ml_scale formula
 # ===========================================================================
+
 
 class TestMLScaleFormula:
     """Test the SOS → ml_scale mapping."""
@@ -99,6 +95,7 @@ class TestMLScaleFormula:
 # Final score computation
 # ===========================================================================
 
+
 class TestFinalScoreComputation:
     """Test the full SOS-conditioned ML blending."""
 
@@ -126,20 +123,17 @@ class TestFinalScoreComputation:
         assert result == pytest.approx(expected, abs=1e-9)
 
     def test_negative_ml_delta_with_weak_schedule(self):
-        """ML saying team is WORSE should still partially apply with weak schedule.
+        """ML saying team is WORSE applies at FULL authority regardless of SOS.
 
-        Changed from original behavior: negative ML corrections now get a floor
-        of NEGATIVE_ML_FLOOR (0.5) authority even when SOS is below the low
-        threshold. This prevents overrated teams with weak schedules from being
-        shielded from ML corrections (e.g., ECNL RL teams going 15-0 against
-        weak opponents).
+        Negative ML corrections always get 1.0 authority. Weak schedule should
+        never shield a team from being marked as overrated.
         """
         ps_adj = 0.7
         ps_ml = 0.4  # ML says team is worse
         result = final_score(ps_adj, ps_ml, sos_norm=0.30)
         ml_delta = ps_ml - ps_adj  # -0.3
-        # With floor of 0.5, effective scale = max(0.0, 0.5) = 0.5
-        expected = np.clip(ps_adj + ml_delta * 0.5, 0.0, 1.0)  # 0.7 + (-0.3)*0.5 = 0.55
+        # Full authority (1.0): 0.7 + (-0.3)*1.0 = 0.4
+        expected = np.clip(ps_adj + ml_delta * 1.0, 0.0, 1.0)
         assert result == pytest.approx(expected, abs=1e-9)
 
     def test_negative_ml_delta_with_strong_schedule(self):
@@ -165,18 +159,16 @@ class TestFinalScoreComputation:
         """Reproduces FC Arizona ECNL RL: 15-0 vs weak opponents, high mu,
         strong negative ML signal, but SOS=0.39 blocks correction.
 
-        With the floored asymmetric gate, the negative ML correction should
-        partially apply, reducing the inflated score.
+        Negative ML correction applies at full authority regardless of SOS.
         """
-        ps_adj = 0.88   # high mu from undefeated record
-        ps_ml = 0.85    # ML says overrated (negative delta)
+        ps_adj = 0.88  # high mu from undefeated record
+        ps_ml = 0.85  # ML says overrated (negative delta)
         sos_norm = 0.39  # below 0.45 threshold
 
         result = final_score(ps_adj, ps_ml, sos_norm=sos_norm)
-        # Without fix: result would equal ps_adj (0.88) — ML blocked
-        # With fix: negative correction partially applied
-        assert result < ps_adj, (
-            f"Negative ML correction should reduce score from {ps_adj}, got {result}"
+        # Full authority: 0.88 + (0.85 - 0.88) * 1.0 = 0.85
+        assert result == pytest.approx(ps_ml, abs=1e-9), (
+            f"Negative ML correction should fully apply: expected {ps_ml}, got {result}"
         )
 
     def test_bounds_clamping(self):
@@ -193,6 +185,7 @@ class TestFinalScoreComputation:
 # ===========================================================================
 # ML Layer 13 blending formula
 # ===========================================================================
+
 
 class TestLayer13BlendFormula:
     """Test the ML Layer 13 blending formula:
@@ -227,10 +220,7 @@ class TestLayer13BlendFormula:
         for ps_adj in [0.0, 0.2, 0.5, 0.8, 1.0]:
             for ml_norm in [-0.5, -0.25, 0.0, 0.25, 0.5]:
                 ps_ml = np.clip((ps_adj + alpha * ml_norm) / MAX_ML, 0.0, 1.0)
-                assert 0.0 <= ps_ml <= 1.0, (
-                    f"ps_ml={ps_ml:.4f} out of bounds with "
-                    f"ps_adj={ps_adj}, ml_norm={ml_norm}"
-                )
+                assert 0.0 <= ps_ml <= 1.0, f"ps_ml={ps_ml:.4f} out of bounds with ps_adj={ps_adj}, ml_norm={ml_norm}"
 
     def test_max_ml_contribution(self):
         """Maximum ML adjustment: alpha * 0.5 = 0.05 (with alpha=0.10)."""
@@ -250,6 +240,7 @@ class TestLayer13BlendFormula:
 # Vectorized SOS-conditioned scaling (matching calculator.py)
 # ===========================================================================
 
+
 class TestVectorizedSOSScaling:
     """Test the vectorized version of SOS-conditioned scaling as used in calculator.py."""
 
@@ -263,25 +254,19 @@ class TestVectorizedSOSScaling:
 
         # Vectorized (pandas-style, as in calculator.py — with asymmetric gate)
         ml_delta = ps_ml - ps_adj
-        ml_scale = np.clip(
-            (sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW),
-            0.0, 1.0
-        )
+        ml_scale = np.clip((sos_norm - SOS_ML_THRESHOLD_LOW) / (SOS_ML_THRESHOLD_HIGH - SOS_ML_THRESHOLD_LOW), 0.0, 1.0)
         effective_scale = np.where(ml_delta >= 0, ml_scale, np.maximum(ml_scale, NEGATIVE_ML_FLOOR))
         vec_result = np.clip(ps_adj + ml_delta * effective_scale, 0.0, 1.0)
 
         # Scalar
-        scalar_result = np.array([
-            final_score(pa, pm, sn)
-            for pa, pm, sn in zip(ps_adj, ps_ml, sos_norm)
-        ])
+        scalar_result = np.array([final_score(pa, pm, sn) for pa, pm, sn in zip(ps_adj, ps_ml, sos_norm)])
 
         np.testing.assert_allclose(vec_result, scalar_result, atol=1e-10)
 
     def test_sos_nan_fills_to_half(self):
         """When sos_norm is NaN, it should be filled to 0.5 (within transition zone)."""
         sos_norm = pd.Series([np.nan, 0.5, np.nan])
-        filled = sos_norm.fillna(0.5)
+        sos_norm.fillna(0.5, inplace=True)
         expected_scale = ml_scale_formula(0.5)
         # 0.5 is between 0.45 and 0.60 → partial authority
         assert expected_scale == pytest.approx(1.0 / 3.0, abs=0.01)


### PR DESCRIPTION
## Summary

- **Published rank now matches power_score_final.** Added `rank_in_cohort_final` computed from canonical ordering (`power_score_true DESC, team_id ASC`) in `calculator.py`. Views use status-aware fallback during transition. State rankings use active-only CTE + join-back pattern (non-Active teams visible with NULL state rank).
- **Negative ML corrections apply at full authority.** `NEGATIVE_ML_FLOOR` set to 1.0 — weak schedules no longer shield overrated teams from ML penalties. Penn Fusion (SOS 0.925) and ECNL RL teams (SOS 0.49) now get equal negative correction authority.
- **League-aware SCF detects closed-league bubbles.** `compute_scf()` now checks league diversity alongside state diversity. Cross-state ECNL_RL play no longer bypasses bubble detection. Uses dual-signal: unique league count + dominant-league concentration threshold. `final_scf = min(state_scf, league_scf)`.
- **Ranking history uses published final rank.** 3-level fallback (`final -> ml -> raw`) for backward compatibility with pre-migration snapshots. All frontend consumers updated.
- **Cache key hashes full config.** Engine choice, Glicko config, ML config, and tier multipliers all included. Layer 13 receives Glicko-2 filtered `games_used`, not raw input.

## Test plan

- [x] 132 unit tests passing (tier multiplier, ML scaling, Glicko engine, league bubble SCF)
- [x] 6 new league-bubble SCF tests
- [x] ML scaling tests updated for full negative authority
- [ ] Apply migrations to Supabase
- [ ] Run backfill_team_leagues.py
- [ ] Trigger full ranking recalculation
- [ ] Verify Penn Fusion ranks above Mercurial and Sunrise in U17F
- [ ] Spot-check top-25 in U14M, U15F, U17M for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)