### PR TITLE
Tighten Glicko ranking guardrails

### DIFF
--- a/frontend/app/api/rankings/national/route.ts
+++ b/frontend/app/api/rankings/national/route.ts
@@ -62,7 +62,9 @@ export async function GET(request: NextRequest) {
       .in('status', ['Active', 'Not Enough Ranked Games'])
       .eq('age', normalizedAge)
       .eq('gender', gender)
-      .order('power_score_final', { ascending: false })
+      // Use the published cohort rank from the engine instead of re-sorting by score.
+      .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
+      .order('team_id_master', { ascending: true })
       .range(offset, offset + limit - 1);
 
     if (error) {

--- a/frontend/app/embed/club/[clubId]/page.tsx
+++ b/frontend/app/embed/club/[clubId]/page.tsx
@@ -55,7 +55,8 @@ export default async function ClubEmbedPage({ params }: ClubEmbedPageProps) {
         .ilike('club_name', clubName)
         .order('age', { ascending: true })
         .order('gender', { ascending: true })
-        .order('power_score_final', { ascending: false });
+        .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
+        .order('team_id_master', { ascending: true });
 
       if (!dbError && data) {
         teams = data as typeof teams;

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -101,60 +101,22 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     }
   }, [rankings, region, ageGroup, gender]);
 
-  // Use pre-calculated SOS ranks from database
-  // sos_rank_national for national view, sos_rank_state for state view
-
-  // Compute position-based ranks from the filtered data.
-  // The database views compute ranks using ROW_NUMBER() over ALL teams (including inactive),
-  // but this page only shows Active/Not Enough Ranked Games teams.
-  // This causes rank gaps (e.g., #1, #2, #5, #18 instead of #1, #2, #3, #4).
-  // Fix: compute sequential ranks from the filtered data sorted by power_score_final.
-  const computedRanks = useMemo(() => {
-    if (!rankings) return null;
-    const map = new Map<string, number>();
-    // Only rank Active teams (8+ games) — teams with "Not Enough Ranked Games" get no rank
-    const activeTeams = rankings.filter((t) => t.status === 'Active');
-    const sorted = [...activeTeams].sort((a, b) => {
-      const diff = (b.power_score_final ?? 0) - (a.power_score_final ?? 0);
-      if (diff !== 0) return diff;
-      // Tie-break by SOS (higher = better)
-      const aSos = region ? (a.sos_norm_state ?? a.sos_norm ?? 0) : (a.sos_norm ?? 0);
-      const bSos = region ? (b.sos_norm_state ?? b.sos_norm ?? 0) : (b.sos_norm ?? 0);
-      return bSos - aSos;
-    });
-    sorted.forEach((team, index) => {
-      map.set(team.team_id_master, index + 1);
-    });
-    return map;
-  }, [region, rankings]);
-
-  // Compute position-based SOS ranks from filtered data.
-  // Same issue: DB SOS ranks include inactive teams, causing inconsistency with the filtered count.
-  const computedSosRanks = useMemo(() => {
-    if (!rankings) return null;
-    const map = new Map<string, number>();
-    // Only rank Active teams for SOS — same gate as power score ranks
-    const activeTeams = rankings.filter((t) => t.status === 'Active');
-    const sorted = [...activeTeams].sort((a, b) => {
-      const aSos = region ? (a.sos_norm_state ?? a.sos_norm ?? 0) : (a.sos_norm ?? 0);
-      const bSos = region ? (b.sos_norm_state ?? b.sos_norm ?? 0) : (b.sos_norm ?? 0);
-      return bSos - aSos; // Higher SOS = tougher schedule = lower rank number
-    });
-    sorted.forEach((team, index) => {
-      map.set(team.team_id_master, index + 1);
-    });
-    return map;
-  }, [region, rankings]);
-
-  // Helper to get the correct rank for display
+  // Use published ranks from the backend contract.
   const getDisplayRank = useCallback(
     (team: RankingRow): number | null | undefined => {
-      return computedRanks?.get(team.team_id_master) ?? null;
+      return region ? (team.rank_in_state_final ?? null) : (team.rank_in_cohort_final ?? null);
     },
-    [computedRanks]
+    [region]
   );
 
-  // Sort rankings based on selected field with SOS tie-breaking
+  const getDisplaySosRank = useCallback(
+    (team: RankingRow): number | null | undefined => {
+      return region ? (team.sos_rank_state ?? null) : (team.sos_rank_national ?? null);
+    },
+    [region]
+  );
+
+  // Sort rankings using published ranks and deterministic fallbacks.
   const sortedRankings = useMemo(() => {
     if (!rankings) return [];
 
@@ -164,28 +126,20 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
 
       switch (sortField) {
         case 'rank':
-          // Use computed position-based ranks (sequential, gap-free)
-          aValue = computedRanks?.get(a.team_id_master) ?? Infinity;
-          bValue = computedRanks?.get(b.team_id_master) ?? Infinity;
+          aValue = getDisplayRank(a) ?? Infinity;
+          bValue = getDisplayRank(b) ?? Infinity;
           break;
         case 'team':
           aValue = a.team_name.toLowerCase();
           bValue = b.team_name.toLowerCase();
           break;
         case 'powerScore':
-          // Use power_score_final (ML-adjusted score) - primary sort field
-          // Canonical tie-break: team_id ASC (matches stored rank ordering)
           aValue = a.power_score_final ?? 0;
           bValue = b.power_score_final ?? 0;
-          if (aValue === bValue) {
-            aValue = b.team_id_master || '';
-            bValue = a.team_id_master || '';
-          }
           break;
         case 'sosRank':
-          // Use computed SOS rank from filtered data
-          aValue = computedSosRanks?.get(a.team_id_master) ?? Infinity;
-          bValue = computedSosRanks?.get(b.team_id_master) ?? Infinity;
+          aValue = getDisplaySosRank(a) ?? Infinity;
+          bValue = getDisplaySosRank(b) ?? Infinity;
           break;
         default:
           return 0;
@@ -198,18 +152,21 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
       const primaryCompare =
         sortDirection === 'asc' ? (aValue as number) - (bValue as number) : (bValue as number) - (aValue as number);
 
-      // If primary values are equal, use SOS as tie-breaker (higher SOS = harder schedule = better)
-      if (primaryCompare === 0 && (sortField === 'rank' || sortField === 'powerScore')) {
-        const aSos = region ? (a.sos_norm_state ?? a.sos_norm ?? 0) : (a.sos_norm ?? 0);
-        const bSos = region ? (b.sos_norm_state ?? b.sos_norm ?? 0) : (b.sos_norm ?? 0);
-        return bSos - aSos; // Higher SOS ranks higher (tie-breaker always descending)
+      if (primaryCompare !== 0) {
+        return primaryCompare;
       }
 
-      return primaryCompare;
+      const aRank = getDisplayRank(a) ?? Number.POSITIVE_INFINITY;
+      const bRank = getDisplayRank(b) ?? Number.POSITIVE_INFINITY;
+      if (aRank !== bRank) {
+        return aRank - bRank;
+      }
+
+      return a.team_id_master.localeCompare(b.team_id_master);
     });
 
     return sorted;
-  }, [rankings, sortField, sortDirection, region, computedRanks, computedSosRanks]);
+  }, [getDisplayRank, getDisplaySosRank, rankings, sortField, sortDirection]);
 
   // Virtualizer for rendering only visible rows
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -337,7 +294,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
   const topTeamsForSchema = sortedRankings.slice(0, 10).map((team, index) => ({
     teamName: team.team_name,
     clubName: team.club_name ?? undefined,
-    rank: computedRanks?.get(team.team_id_master) ?? index + 1,
+    rank: getDisplayRank(team) ?? index + 1,
     powerScore: team.power_score_final ?? undefined,
     state: team.state ?? undefined,
   }));
@@ -547,7 +504,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                                   age: team.age,
                                   gender: team.gender,
                                   rank_in_cohort_final: team.rank_in_cohort_final,
-                                  rank_in_state_final: getDisplayRank(team) ?? undefined,
+                                  rank_in_state_final: team.rank_in_state_final ?? undefined,
                                 })
                               }
                               className="font-medium hover:text-primary transition-colors duration-300 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer inline-block text-xs sm:text-sm truncate block w-full"
@@ -566,7 +523,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                           </div>
                           <div className="px-1.5 sm:px-4 py-2 sm:py-3 text-right flex items-center justify-end text-xs sm:text-sm min-w-0 overflow-hidden">
                             {(() => {
-                              const sosRank = computedSosRanks?.get(team.team_id_master);
+                              const sosRank = getDisplaySosRank(team);
                               if (!sosRank) return <span className="truncate">—</span>;
                               const totalTeams = sortedRankings.length;
                               const pct = totalTeams > 0 ? Math.round((1 - (sosRank - 1) / totalTeams) * 100) : null;

--- a/frontend/components/RecentMovers.tsx
+++ b/frontend/components/RecentMovers.tsx
@@ -57,21 +57,6 @@ export function RecentMovers({
     localStorage.setItem('recentMoversTimeWindow', timeWindow);
   }, [timeWindow]);
 
-  // Compute sequential national ranks from filtered data (avoids gaps from inactive teams)
-  const computedNationalRanks = useMemo(() => {
-    if (!rankings?.length) return new Map<string, number>();
-    const map = new Map<string, number>();
-    const sorted = [...rankings].sort((a, b) => {
-      const diff = (b.power_score_final ?? 0) - (a.power_score_final ?? 0);
-      if (diff !== 0) return diff;
-      return (b.sos_norm ?? 0) - (a.sos_norm ?? 0);
-    });
-    sorted.forEach((team, index) => {
-      map.set(team.team_id_master, index + 1);
-    });
-    return map;
-  }, [rankings]);
-
   // Calculate recent movers based on real historical rank change data
   const recentMovers = useMemo(() => {
     if (!rankings?.length) return [];
@@ -166,7 +151,7 @@ export function RecentMovers({
                         </div>
                         <div className="text-xs text-muted-foreground flex items-center gap-1.5">
                           <span className="font-mono">
-                            #{computedNationalRanks.get(team.team_id_master) ?? team.rank_in_cohort_final}
+                            {team.rank_in_cohort_final != null ? `#${team.rank_in_cohort_final}` : '—'}
                           </span>
                           {team.state && (
                             <>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -92,7 +92,7 @@ export const api = {
       }
 
       query = query
-        .order('power_score_final', { ascending: false })
+        .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
         .order('team_id_master', { ascending: true })
         .range(offset, offset + batchSize - 1);
 

--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -23,6 +23,7 @@ from supabase.lib.client_options import SyncClientOptions
 
 from src.rankings.calculator import compute_all_cohorts, compute_rankings_v53e_only
 from src.rankings.data_adapter import v53e_to_rankings_full_format, v53e_to_supabase_format
+from src.rankings.layer13_predictive_adjustment import Layer13Config
 from src.utils.merge_resolver import MergeResolver
 from supabase import create_client
 
@@ -218,7 +219,11 @@ async def save_rankings_to_supabase(
                             record["national_rank"] = None
 
                         # Optional fields
-                        record["games_played"] = int(row.get("games_played", row.get("gp", 0))) if pd.notna(row.get("games_played", row.get("gp"))) else 0
+                        record["games_played"] = (
+                            int(row.get("games_played", row.get("gp", 0)))
+                            if pd.notna(row.get("games_played", row.get("gp")))
+                            else 0
+                        )
                         record["wins"] = int(row.get("wins", 0)) if pd.notna(row.get("wins")) else 0
                         record["losses"] = int(row.get("losses", 0)) if pd.notna(row.get("losses")) else 0
                         record["draws"] = int(row.get("draws", 0)) if pd.notna(row.get("draws")) else 0
@@ -612,16 +617,30 @@ async def main():
                 use_glicko=(args.engine == "glicko"),
             )
         else:
-            result = await compute_rankings_v53e_only(
-                supabase_client=supabase,
-                today=None,
-                fetch_from_supabase=True,
-                lookback_days=args.lookback_days,
-                provider_filter=args.provider,
-                force_rebuild=args.force_rebuild,
-                merge_resolver=merge_resolver,
-                timing_report=timing_report,
-            )
+            if args.engine == "glicko":
+                result = await compute_all_cohorts(
+                    supabase_client=supabase,
+                    today=None,
+                    layer13_cfg=Layer13Config(enabled=False),
+                    fetch_from_supabase=True,
+                    lookback_days=args.lookback_days,
+                    provider_filter=args.provider,
+                    force_rebuild=args.force_rebuild,
+                    merge_resolver=merge_resolver,
+                    timing_report=timing_report,
+                    use_glicko=True,
+                )
+            else:
+                result = await compute_rankings_v53e_only(
+                    supabase_client=supabase,
+                    today=None,
+                    fetch_from_supabase=True,
+                    lookback_days=args.lookback_days,
+                    provider_filter=args.provider,
+                    force_rebuild=args.force_rebuild,
+                    merge_resolver=merge_resolver,
+                    timing_report=timing_report,
+                )
 
         teams_df = result["teams"]
 
@@ -637,8 +656,8 @@ async def main():
             )
             if "age_group" in teams_df.columns:
                 # Extract age and check max per age
-                age_nums = teams_df['age_group'].astype(str).str.extract(r'(\d+)')[0].astype(int)
-                max_by_age = teams_df.groupby(age_nums)['power_score_final'].max()
+                age_nums = teams_df["age_group"].astype(str).str.extract(r"(\d+)")[0].astype(int)
+                max_by_age = teams_df.groupby(age_nums)["power_score_final"].max()
                 console.print("[dim]Max power_score_final by age:[/dim]")
                 for age, max_ps in max_by_age.items():
                     console.print(f"[dim]  Age {age}: {max_ps:.4f}[/dim]")

--- a/src/etl/glicko_config.py
+++ b/src/etl/glicko_config.py
@@ -96,5 +96,5 @@ class GlickoConfig:
     # ML
     ML_ALPHA: float = 0.08
 
-    # Provisional
-    MIN_GAMES_PROVISIONAL: int = 9
+    # Provisional/publication floor
+    MIN_GAMES_PROVISIONAL: int = 12

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -1257,12 +1257,13 @@ def compute_rankings_v2(
             1.0 + cfg.SOS_ADJ_STRONG_MAX,
         )
         mu_sos = cfg.INITIAL_MU + (team_df["mu"] - cfg.INITIAL_MU) * sos_scale
-        team_df["powerscore_adj"] = sigmoid_zscore_normalize(mu_sos)
+        team_df["powerscore_core"] = sigmoid_zscore_normalize(mu_sos)
     else:
-        team_df["powerscore_adj"] = sigmoid_zscore_normalize(team_df["mu"])
+        team_df["powerscore_core"] = sigmoid_zscore_normalize(team_df["mu"])
 
     # 8. Provisional multiplier from sigma
     team_df["provisional_mult"] = np.clip(1.0 - (team_df["sigma"] / cfg.INITIAL_SIGMA) ** 2, 0.0, 1.0)
+    team_df["powerscore_adj"] = (team_df["powerscore_core"] * team_df["provisional_mult"]).clip(0.0, 1.0)
 
     # 9. Status and rankings
     cutoff = today - pd.Timedelta(days=cfg.INACTIVE_DAYS)
@@ -1327,8 +1328,7 @@ def compute_rankings_v2(
     team_df["abs_strength"] = sigmoid_zscore_normalize(team_df["mu"])
 
     # Power scores
-    team_df["power_presos"] = team_df["powerscore_adj"]
-    team_df["powerscore_core"] = team_df["powerscore_adj"]
+    team_df["power_presos"] = team_df["powerscore_core"]
     team_df["anchor"] = 0.5
 
     # Performance residuals (placeholder -- ML layer computes these)

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -376,7 +376,7 @@ async def compute_rankings_with_ml(
         lookback_days=v53_cfg.WINDOW_DAYS,
         alpha=0.08,  # Tuned via weight simulator grid search: 0.08 optimal (quality 14→19/23)
         norm_mode="zscore",
-        min_team_games_for_residual=6,
+        min_team_games_for_residual=12,
         recency_decay_lambda=0.06,  # Short-term form focus; tune later after stability verified
         table_name="games",
         provider_filter=provider_filter,

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -609,8 +609,12 @@ def v53e_to_supabase_format(teams_df: pd.DataFrame) -> pd.DataFrame:
     else:
         rankings_df["national_power_score"] = 0.0
 
-    # Map rank with proper defaults and dtype
-    if "rank_in_cohort_ml" in rankings_df.columns:
+    # Map rank with proper defaults and dtype.
+    # current_rankings is backward-compat only, but it should still reflect the
+    # published final rank ordering when that column is available.
+    if "rank_in_cohort_final" in rankings_df.columns:
+        rankings_df["national_rank"] = rankings_df["rank_in_cohort_final"]
+    elif "rank_in_cohort_ml" in rankings_df.columns:
         rankings_df["national_rank"] = rankings_df["rank_in_cohort_ml"]
     elif "rank_in_cohort" in rankings_df.columns:
         rankings_df["national_rank"] = rankings_df["rank_in_cohort"]
@@ -866,9 +870,9 @@ def v53e_to_rankings_full_format(
 
     # Preserve NULL rank_in_cohort_final for non-Active teams
     if "rank_in_cohort_final" in rankings_df.columns:
-        rankings_df["rank_in_cohort_final"] = pd.to_numeric(rankings_df["rank_in_cohort_final"], errors="coerce").astype(
-            "Int64"
-        )
+        rankings_df["rank_in_cohort_final"] = pd.to_numeric(
+            rankings_df["rank_in_cohort_final"], errors="coerce"
+        ).astype("Int64")
     else:
         rankings_df["rank_in_cohort_final"] = pd.array([pd.NA] * len(rankings_df), dtype="Int64")
 

--- a/src/rankings/layer13_predictive_adjustment.py
+++ b/src/rankings/layer13_predictive_adjustment.py
@@ -47,7 +47,7 @@ class Layer13Config:
 
     # residual aggregation
     recency_decay_lambda: float = 0.06  # exp(-lambda * (recency-1)); short-term form focus
-    min_team_games_for_residual: int = 6
+    min_team_games_for_residual: int = 12
     residual_clip_goals: float = 3.5  # guardrail on residual outliers
     min_training_rows: int = 30  # Minimum rows to enable ML (prevents leakage)
 
@@ -395,6 +395,7 @@ async def apply_predictive_adjustment(
     if "ml_overperf" in out.columns:
         out = out.drop(columns=["ml_overperf"])
     out = out.merge(team_resid, on=["team_id", "age", "gender"], how="left")
+    out["ml_game_count"] = out["ml_game_count"].fillna(0).astype(int)
     out["ml_overperf"] = (
         out["ml_overperf"].fillna(0.0).clip(lower=-cfg.residual_clip_goals, upper=cfg.residual_clip_goals)
     )
@@ -403,6 +404,8 @@ async def apply_predictive_adjustment(
     )
     # Use .reindex() to align by index, not positional order (groupby may reorder rows)
     out["ml_norm"] = normalized["__tmp__"].reindex(out.index).values - 0.5
+    eligible_ml_mask = out["ml_game_count"] >= cfg.min_team_games_for_residual
+    out.loc[~eligible_ml_mask, "ml_norm"] = 0.0
 
     # 6) Blend into PowerScore and rerank
     #
@@ -411,6 +414,7 @@ async def apply_predictive_adjustment(
     # With alpha=0.08 this means ±0.04 — well within [0, 1] for valid base scores.
     # We clamp afterward to guarantee bounds without compressing the score range.
     out["powerscore_ml"] = out[base_power_col] + cfg.alpha * out["ml_norm"]
+    out.loc[~eligible_ml_mask, "powerscore_ml"] = out.loc[~eligible_ml_mask, base_power_col]
     out["powerscore_ml"] = out["powerscore_ml"].clip(0.0, 1.0)
     out["rank_in_cohort_ml"] = _rank_active_only(out, cfg.cohort_key_cols, "powerscore_ml")
 
@@ -627,7 +631,7 @@ def _aggregate_team_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.Dat
     )
     agg = agg.drop(columns=["weighted_sum", "weight_sum"])
     if agg.empty:
-        return pd.DataFrame(columns=["team_id", "age", "gender", "ml_overperf"])
+        return pd.DataFrame(columns=["team_id", "age", "gender", "ml_overperf", "ml_game_count"])
 
     # require a minimum number of games to avoid yo-yo
     counts = (
@@ -637,12 +641,13 @@ def _aggregate_team_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.Dat
     )
     merged = agg.merge(counts, on=[team_id_col, age_col, gender_col], how="left")
     merged.loc[merged["game_count"] < cfg.min_team_games_for_residual, "ml_overperf"] = 0.0
+    merged = merged.rename(columns={"game_count": "ml_game_count"})
 
     # Ensure team_id column name for merging (v53e uses 'team_id')
     if team_id_col != "team_id":
         merged = merged.rename(columns={team_id_col: "team_id"})
 
-    return merged[["team_id", "age", "gender", "ml_overperf"]]
+    return merged[["team_id", "age", "gender", "ml_overperf", "ml_game_count"]]
 
 
 def _normalize_by_cohort(

--- a/tests/unit/test_glicko_engine.py
+++ b/tests/unit/test_glicko_engine.py
@@ -969,6 +969,19 @@ class TestComputeRankingsV2:
         for _, row in teams.iterrows():
             assert 0.0 <= row["provisional_mult"] <= 1.0
 
+    def test_powerscore_adj_uses_provisional_multiplier(self):
+        """Glicko published baseline should apply the provisional multiplier."""
+        rows = self._make_game("A", "B", 2, 1, "2026-03-01")
+        games = pd.DataFrame(rows)
+        cfg = GlickoConfig(MIN_GAMES_PROVISIONAL=1)
+        result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"), cfg=cfg)
+        teams = result["teams"]
+
+        for _, row in teams.iterrows():
+            expected = row["powerscore_core"] * row["provisional_mult"]
+            assert row["powerscore_adj"] == pytest.approx(expected, abs=1e-9)
+            assert row["power_presos"] == pytest.approx(row["powerscore_core"], abs=1e-9)
+
 
 class TestGameExplainability:
     """Tests for compute_game_explainability post-hoc breakdown."""

--- a/tests/unit/test_ml_layer13_sos_scaling.py
+++ b/tests/unit/test_ml_layer13_sos_scaling.py
@@ -272,5 +272,75 @@ class TestVectorizedSOSScaling:
         assert expected_scale == pytest.approx(1.0 / 3.0, abs=0.01)
 
 
+@pytest.mark.asyncio
+async def test_low_sample_ml_rows_stay_neutral_after_normalization(monkeypatch):
+    """Teams below the ML residual floor must stay at the base score."""
+    from src.rankings.layer13_predictive_adjustment import Layer13Config, apply_predictive_adjustment
+    import src.rankings.layer13_predictive_adjustment as layer13
+
+    monkeypatch.setattr(layer13, "_HAS_ML", True)
+
+    feats = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2026-01-01", "2026-01-10", "2026-03-31"]),
+            "team_id": ["A", "B", "B"],
+            "opp_id": ["B", "A", "A"],
+            "age": [14, 14, 14],
+            "gender": ["M", "M", "M"],
+            "goal_margin": [0.0, 0.0, 0.0],
+            "team_power": [0.8, 0.7, 0.7],
+            "opp_power": [0.7, 0.8, 0.8],
+            "power_diff": [0.1, -0.1, -0.1],
+            "age_gap": [0, 0, 0],
+            "cross_gender": [0, 0, 0],
+            "rank_recency": [1.0, 2.0, 1.0],
+            "residual": [0.0, -1.0, -1.0],
+        }
+    )
+
+    monkeypatch.setattr(layer13, "_build_features", lambda *args, **kwargs: feats.copy())
+    monkeypatch.setattr(layer13, "_fit_and_residualize", lambda built, train_feats, cfg: built.copy())
+
+    teams_df = pd.DataFrame(
+        {
+            "team_id": ["A", "B"],
+            "age": [14, 14],
+            "gender": ["M", "M"],
+            "powerscore_adj": [0.80, 0.70],
+            "status": ["Active", "Active"],
+        }
+    )
+    games_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2026-01-01", "2026-01-10", "2026-03-31"]),
+            "team_id": ["A", "B", "B"],
+            "opp_id": ["B", "A", "A"],
+            "gf": [1, 0, 0],
+            "ga": [1, 1, 1],
+            "age": [14, 14, 14],
+            "gender": ["M", "M", "M"],
+            "opp_age": [14, 14, 14],
+            "opp_gender": ["M", "M", "M"],
+        }
+    )
+    cfg = Layer13Config(min_team_games_for_residual=2, min_training_rows=1, norm_mode="zscore")
+
+    out = await apply_predictive_adjustment(
+        supabase_client=None,
+        teams_df=teams_df,
+        games_used_df=games_df,
+        cfg=cfg,
+    )
+
+    low_sample = out[out["team_id"] == "A"].iloc[0]
+    eligible = out[out["team_id"] == "B"].iloc[0]
+
+    assert low_sample["ml_game_count"] == 1
+    assert low_sample["ml_norm"] == pytest.approx(0.0, abs=1e-9)
+    assert low_sample["powerscore_ml"] == pytest.approx(low_sample["powerscore_adj"], abs=1e-9)
+    assert eligible["ml_game_count"] == 2
+    assert pd.notna(eligible["ml_norm"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- apply Glicko provisional shrink to the published baseline score path
- require 12 games for Glicko publication and Layer 13 residual authority
- keep frontend ranking displays aligned to published rank fields
- preserve Glicko when rerunning without ML from the rankings script

## Verification
- python -m pytest tests/unit/test_ml_layer13_sos_scaling.py tests/unit/test_glicko_engine.py tests/integration/test_glicko_full_pipeline.py -q
- python -m pytest tests/unit/test_active_only_ranking.py -k "layer13_rank_active_only_handles_mixed_statuses or calculator_values_alignment" -q
- npx eslint app/api/rankings/national/route.ts app/embed/club/[clubId]/page.tsx components/RankingsTable.tsx components/RecentMovers.tsx lib/api.ts
