### PR TITLE
Clarify Glicko SOS role and tune weak SOS penalty

### DIFF
--- a/.github/workflows/calculate-rankings.yml
+++ b/.github/workflows/calculate-rankings.yml
@@ -114,7 +114,7 @@ jobs:
           fi
 
       # ---------------------------------------------------------------
-      # 7. RUN THE RANKINGS ENGINE (Iterative SOS + ML)
+      # 7. RUN THE ACTIVE RANKINGS ENGINE (Glicko-2 + ML + post-convergence SOS/SCF)
       # ---------------------------------------------------------------
       - name: Calculate Rankings
         env:
@@ -125,7 +125,7 @@ jobs:
           PYTHONUNBUFFERED: "1"  # Force Python to output logs immediately
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
-          echo "⚽ Running PitchRank Rankings Engine with ML + Iterative SOS"
+          echo "⚽ Running PitchRank Rankings Engine (Glicko-2 + ML + post-convergence SOS/SCF)"
           echo "Python version: $(python --version)"
           echo "Current directory: $(pwd)"
           echo "SUPABASE_URL configured: $([[ -n "$SUPABASE_URL" ]] && echo 'Yes' || echo 'No')"

--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Calculate team rankings using v53e engine with optional ML layer
+Calculate team rankings using the active Glicko-2 engine with optional ML layer.
 """
 
 import argparse
@@ -604,7 +604,8 @@ async def main():
         console.print("")  # Blank line for spacing
 
         if args.ml:
-            # Use compute_all_cohorts for two-pass SOS + national/state normalization
+            # Use compute_all_cohorts for the two-pass cross-age strength flow
+            # plus national/state SOS normalization for display metrics.
             result = await compute_all_cohorts(
                 supabase_client=supabase,
                 today=None,

--- a/src/etl/glicko_config.py
+++ b/src/etl/glicko_config.py
@@ -87,10 +87,13 @@ class GlickoConfig:
     SCF_MIN_UNIQUE_LEAGUES: int = 2  # Below this unique families → league-isolated
 
     # SOS post-hoc adjustment (asymmetric scaling of mu before normalization)
+    # Weak schedules get a larger shrinkage than strong schedules get a reward.
+    # This is intentional: it reins in inflated ratings from soft schedules
+    # without double-counting opponent quality inside the core Glicko update.
     SOS_ADJ_ENABLED: bool = True
     SOS_ADJ_WEAK_THRESHOLD: float = 0.45      # Dead zone lower edge (sos_norm scale)
     SOS_ADJ_STRONG_THRESHOLD: float = 0.60     # Dead zone upper edge (sos_norm scale)
-    SOS_ADJ_WEAK_MAX: float = 0.10             # Max 10% penalty for weakest SOS
+    SOS_ADJ_WEAK_MAX: float = 0.16             # Max 16% penalty for weakest SOS
     SOS_ADJ_STRONG_MAX: float = 0.03           # Max 3% reward for strongest SOS
 
     # ML

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -1133,7 +1133,7 @@ def run_glicko2_cohort(
 
 
 # =========================================================
-# Main entry point — drop-in replacement for v53e.compute_rankings
+# Main Glicko-2 ranking entry point
 # =========================================================
 def compute_rankings_v2(
     games_df: pd.DataFrame,
@@ -1145,13 +1145,13 @@ def compute_rankings_v2(
     initial_ratings: Optional[Dict[str, Tuple[float, float, float]]] = None,
     tier_league_map: Optional[Dict[str, str]] = None,
 ) -> Dict[str, pd.DataFrame]:
-    """Drop-in replacement for v53e.compute_rankings.
+    """Run the full Glicko-2 ranking pipeline.
 
     Runs the full Glicko-2 pipeline:
     1. Run Glicko-2 convergence for the cohort
     2. Derive offense/defense from game residuals
     3. Compute SOS with repeat cap and trim
-    4. Apply SCF bubble detection (if team_state_map provided)
+    4. Apply post-convergence SCF dampening to SOS and published mu (if team_state_map provided)
     5. Normalize all metrics via sigmoid z-score
     6. Compute rankings and status
     7. Map to full rankings_full schema
@@ -1197,7 +1197,7 @@ def compute_rankings_v2(
         cohort_gender=_cohort_gender,
     )
 
-    # 3. Build ratings dict for derived metrics
+    # 3. Build the converged ratings dict for all downstream derived metrics
     team_ratings: Dict[str, Tuple[float, float, float]] = dict(
         zip(team_df["team_id"], zip(team_df["mu"], team_df["sigma"], team_df["volatility"]))
     )
@@ -1228,7 +1228,7 @@ def compute_rankings_v2(
         global_rating_map=global_rating_map,
     )
 
-    # 6. Apply SCF (if team_state_map provided and SCF_ENABLED)
+    # 6. Apply SCF post-convergence dampening (if team_state_map provided and SCF_ENABLED)
     if cfg.SCF_ENABLED and team_state_map:
         scf_data = compute_scf(
             games_df,

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -159,24 +159,24 @@ async def compute_rankings_with_ml(
     provider_filter: Optional[str] = None,
     force_rebuild: bool = False,
     save_snapshot: bool = True,  # Set to False when called from compute_all_cohorts
-    global_strength_map: Optional[Dict] = None,  # For cross-age SOS lookups
+    global_strength_map: Optional[Dict] = None,  # For cross-age opponent-strength lookups in Pass 2
     merge_version: Optional[str] = None,  # For cache invalidation when merges change
     team_state_map: Optional[Dict[str, str]] = None,  # For SCF regional bubble detection
     tier_league_map: Optional[Dict[str, str]] = None,  # For tier-based SOS discounting
     timing_report: Optional["TimingReport"] = None,
     pass_label: Optional[str] = None,  # "Pass1" or "Pass2" for log disambiguation
     pre_sos_state: Optional[Dict] = None,  # Cached state from Pass 1 for two-pass optimization
-    use_glicko: bool = True,  # True = Glicko-2 engine, False = v53e engine
+    use_glicko: bool = True,  # True = Glicko-2 engine, False = legacy v53e engine
     initial_ratings: Optional[Dict] = None,  # Warm-start Glicko-2 Pass 2 from Pass 1 converged ratings
 ) -> Dict[str, pd.DataFrame]:
     """
-    Runs your deterministic v53E engine, then applies the Supabase-aware ML adjustment.
+    Run the selected rankings engine, then apply the Supabase-aware ML adjustment.
 
     Args:
         supabase_client: Supabase client instance
-        games_df: Optional pre-fetched games DataFrame (in v53e format)
+        games_df: Optional pre-fetched games DataFrame in the shared rankings input shape
         today: Reference date for rankings
-        v53_cfg: v53e configuration
+        v53_cfg: Legacy v53e configuration (ignored in Glicko mode except for shared downstream steps)
         layer13_cfg: ML layer configuration
         fetch_from_supabase: If True and games_df is None, fetch from Supabase
         lookback_days: Days to look back for rankings
@@ -513,19 +513,20 @@ async def compute_all_cohorts(
     force_rebuild: bool = False,
     merge_resolver=None,  # Optional MergeResolver for team merge resolution
     timing_report: Optional["TimingReport"] = None,
-    use_glicko: bool = True,  # True = Glicko-2 engine, False = v53e engine
+    use_glicko: bool = True,  # True = Glicko-2 engine, False = legacy v53e engine
 ) -> Dict[str, pd.DataFrame]:
     """
     Compute rankings for all cohorts using two-pass architecture.
 
-    Pass 1: Run each cohort to get initial abs_strength values
-    Pass 2: Re-run with global_strength_map for accurate cross-age SOS
+    Pass 1: Run each cohort to get initial cohort strength values
+    Pass 2: Re-run with a global strength map for accurate cross-age opponent lookups
 
-    This ensures cross-age opponents get their real strength instead of 0.35.
+    In Glicko mode, Pass 2 reuses cohort `mu` values for cross-age opponent ratings.
+    Legacy v53e uses `abs_strength` for its cross-age SOS path.
 
     Args:
         merge_resolver: Optional MergeResolver instance for resolving merged teams
-        use_glicko: If True, use Glicko-2 engine; if False, use v53e engine
+        use_glicko: If True, use Glicko-2 engine; if False, use legacy v53e engine
     """
     # Default config if not provided
     v53_cfg = v53_cfg or V53EConfig()
@@ -663,7 +664,7 @@ async def compute_all_cohorts(
 
     # Group by (age, gender) cohorts
     cohorts = list(games_df.groupby(["age", "gender"]))
-    logger.info(f"🔄 Two-pass SOS: Processing {len(cohorts)} cohorts")
+    logger.info(f"🔄 Two-pass cross-age strength flow: processing {len(cohorts)} cohorts")
 
     # ========== PASS 1: Get initial strengths from all cohorts ==========
     logger.info("📊 Pass 1: Computing initial strengths for all cohorts...")
@@ -692,8 +693,8 @@ async def compute_all_cohorts(
     with _section(timing_report, "pass1_all_cohorts"):
         pass1_results = await asyncio.gather(*pass1_tasks)
 
-    # Build global strength map and collect pre-SOS state from Pass 1
-    # Glicko-2 uses mu (raw rating) for cross-age lookups; v53e uses abs_strength
+    # Build the Pass 2 global strength map.
+    # Glicko-2 uses `mu` for cross-age opponent lookups; legacy v53e uses `abs_strength`.
     strength_col = "mu" if use_glicko else "abs_strength"
     global_strength_map = {}
     pass1_pre_sos_states = {}
@@ -723,14 +724,14 @@ async def compute_all_cohorts(
 
     logger.info(
         f"🌍 Built global strength map with {len(global_strength_map):,} teams "
-        f"(col={strength_col}), cached {len(pass1_pre_sos_states)} pre-SOS states"
+        f"(source={strength_col}), cached {len(pass1_pre_sos_states)} legacy pre-SOS states"
     )
 
     # ========== PASS 2: Re-run with global strength map ==========
-    # v53e: Uses cached pre-SOS state from Pass 1 to skip layers 1-5 (~50% speedup)
-    # Glicko-2: Warm-starts from Pass 1 converged ratings (converges in 2-5 iterations)
+    # Legacy v53e reuses cached pre-SOS state from Pass 1 to skip layers 1-5.
+    # Glicko-2 warm-starts from Pass 1 converged ratings.
     skip_note = " (skipping layers 1-5)" if not use_glicko else " (warm-start from Pass 1)"
-    logger.info(f"📊 Pass 2: Re-computing SOS with global strength map{skip_note}...")
+    logger.info(f"📊 Pass 2: Re-running cohorts with global strength map{skip_note}...")
     pass2_tasks = []
     for i, ((age, gender), cohort_games) in enumerate(cohorts):
         task = compute_rankings_with_ml(
@@ -1238,6 +1239,6 @@ async def compute_all_cohorts(
         logger.info("💾 Saving combined ranking snapshot for all cohorts...")
         await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_combined)
 
-    logger.info(f"✅ Two-pass SOS complete: {len(teams_combined):,} teams ranked")
+    logger.info(f"✅ Two-pass rankings flow complete: {len(teams_combined):,} teams ranked")
 
     return {"teams": teams_combined, "games_used": games_used_combined}

--- a/tests/unit/test_glicko_sos_role.py
+++ b/tests/unit/test_glicko_sos_role.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.etl.glicko_config import GlickoConfig
+from src.etl.glicko_engine import compute_rankings_v2
+from src.etl.glicko_engine import run_glicko2_cohort
+from src.rankings import calculator
+
+
+def _make_game_pair(
+    team_a: str,
+    team_b: str,
+    gf: int,
+    ga: int,
+    date: str,
+    *,
+    age: str = "14",
+    gender: str = "male",
+    opp_age: str | None = None,
+    opp_gender: str | None = None,
+) -> list[dict]:
+    opp_age = opp_age or age
+    opp_gender = opp_gender or gender
+    ts = pd.Timestamp(date)
+    return [
+        {
+            "team_id": team_a,
+            "opp_id": team_b,
+            "gf": gf,
+            "ga": ga,
+            "date": ts,
+            "age": age,
+            "gender": gender,
+            "opp_age": opp_age,
+            "opp_gender": opp_gender,
+        },
+        {
+            "team_id": team_b,
+            "opp_id": team_a,
+            "gf": ga,
+            "ga": gf,
+            "date": ts,
+            "age": opp_age,
+            "gender": opp_gender,
+            "opp_age": age,
+            "opp_gender": gender,
+        },
+    ]
+
+
+def _align(df: pd.DataFrame) -> pd.DataFrame:
+    return df.sort_values("team_id").set_index("team_id")
+
+
+def _core_cols(df: pd.DataFrame) -> pd.DataFrame:
+    aligned = _align(df)
+    return aligned[["mu", "sigma", "volatility", "rank_in_cohort"]]
+
+
+def _convergence_cols(df: pd.DataFrame) -> pd.DataFrame:
+    aligned = _align(df)
+    return aligned[["mu", "sigma", "volatility"]]
+
+
+def _assert_core_fields_unchanged(left: pd.DataFrame, right: pd.DataFrame) -> None:
+    left_core = _core_cols(left)
+    right_core = _core_cols(right)
+    np.testing.assert_allclose(left_core["mu"], right_core["mu"], atol=1e-9)
+    np.testing.assert_allclose(left_core["sigma"], right_core["sigma"], atol=1e-9)
+    np.testing.assert_allclose(left_core["volatility"], right_core["volatility"], atol=1e-12)
+    np.testing.assert_allclose(left_core["rank_in_cohort"], right_core["rank_in_cohort"], atol=0.0)
+
+
+def _assert_convergence_fields_unchanged(left: pd.DataFrame, right: pd.DataFrame) -> None:
+    left_conv = _convergence_cols(left)
+    right_conv = _convergence_cols(right)
+    np.testing.assert_allclose(left_conv["mu"], right_conv["mu"], atol=1e-9)
+    np.testing.assert_allclose(left_conv["sigma"], right_conv["sigma"], atol=1e-9)
+    np.testing.assert_allclose(left_conv["volatility"], right_conv["volatility"], atol=1e-12)
+
+
+def _max_abs_diff(left: pd.DataFrame, right: pd.DataFrame, column: str) -> float:
+    left_aligned = _align(left)[column].astype(float)
+    right_aligned = _align(right)[column].astype(float)
+    return float((left_aligned - right_aligned).abs().max())
+
+
+def _run_glicko(
+    games_df: pd.DataFrame,
+    cfg: GlickoConfig,
+    *,
+    team_state_map: dict[str, str] | None = None,
+    tier_league_map: dict[str, str] | None = None,
+    global_rating_map: dict[str, float] | None = None,
+) -> pd.DataFrame:
+    result = compute_rankings_v2(
+        games_df,
+        today=pd.Timestamp("2026-03-31"),
+        cfg=cfg,
+        team_state_map=team_state_map,
+        tier_league_map=tier_league_map,
+        global_rating_map=global_rating_map,
+    )
+    return result["teams"]
+
+
+def _build_round_robin_cohort() -> pd.DataFrame:
+    rows: list[dict] = []
+    rows += _make_game_pair("A", "B", 4, 0, "2026-03-01")
+    rows += _make_game_pair("A", "C", 4, 1, "2026-03-02")
+    rows += _make_game_pair("A", "D", 5, 0, "2026-03-03")
+    rows += _make_game_pair("B", "C", 2, 0, "2026-03-04")
+    rows += _make_game_pair("B", "D", 3, 1, "2026-03-05")
+    rows += _make_game_pair("C", "D", 2, 1, "2026-03-06")
+    return pd.DataFrame(rows)
+
+
+def _build_repeat_cap_fixture() -> pd.DataFrame:
+    rows: list[dict] = []
+    for i in range(8):
+        rows += _make_game_pair("A", "Elite", 1, 2, f"2026-02-{i + 1:02d}")
+    for i in range(2):
+        rows += _make_game_pair("A", "Weak", 4, 0, f"2026-03-{i + 1:02d}")
+    for i in range(2):
+        rows += _make_game_pair("Elite", "Weak", 3, 0, f"2026-03-{i + 10:02d}")
+    return pd.DataFrame(rows)
+
+
+def _build_isolated_bubble_fixture() -> tuple[pd.DataFrame, dict[str, str]]:
+    rows: list[dict] = []
+    bubble_teams = ["bubble_star", "bubble_b", "bubble_c", "bubble_d"]
+
+    day = 1
+    for _ in range(3):
+        for opp in bubble_teams[1:]:
+            rows += _make_game_pair("bubble_star", opp, 4, 0, f"2026-03-{day:02d}")
+            day += 1
+
+    pair_scores = [(2, 1), (1, 1), (2, 2)]
+    for i, home in enumerate(bubble_teams[1:]):
+        for away in bubble_teams[i + 2 :]:
+            gf, ga = pair_scores[(day - 1) % len(pair_scores)]
+            rows += _make_game_pair(home, away, gf, ga, f"2026-03-{day:02d}")
+            day += 1
+
+    state_map = {team: "ID" for team in bubble_teams}
+    return pd.DataFrame(rows), state_map
+
+
+class TestGlickoSOSAblations:
+    def test_sos_adjustment_only_changes_publication_outputs(self):
+        games = _build_round_robin_cohort()
+        cfg_on = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SOS_ADJ_ENABLED=True)
+        cfg_off = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SOS_ADJ_ENABLED=False)
+
+        teams_on = _run_glicko(games, cfg_on)
+        teams_off = _run_glicko(games, cfg_off)
+
+        _assert_core_fields_unchanged(teams_on, teams_off)
+        np.testing.assert_allclose(_align(teams_on)["sos_raw"], _align(teams_off)["sos_raw"], atol=1e-9)
+        np.testing.assert_allclose(_align(teams_on)["sos_norm"], _align(teams_off)["sos_norm"], atol=1e-9)
+
+        sos_norm = _align(teams_on)["sos_norm"]
+        assert ((sos_norm < cfg_on.SOS_ADJ_WEAK_THRESHOLD) | (sos_norm > cfg_on.SOS_ADJ_STRONG_THRESHOLD)).any()
+        assert _max_abs_diff(teams_on, teams_off, "powerscore_core") > 1e-6
+        assert _max_abs_diff(teams_on, teams_off, "power_score_final") > 1e-6
+
+    def test_repeat_cap_and_trim_change_sos_but_not_glicko_core(self):
+        games = _build_repeat_cap_fixture()
+        baseline = GlickoConfig(MIN_GAMES_PROVISIONAL=1)
+        altered = GlickoConfig(
+            MIN_GAMES_PROVISIONAL=1,
+            SOS_REPEAT_CAP=8,
+            SOS_TRIM_BOTTOM_PCT=0.0,
+            SOS_TRIM_TOP_PCT=0.0,
+        )
+
+        teams_baseline = _run_glicko(games, baseline)
+        teams_altered = _run_glicko(games, altered)
+
+        _assert_core_fields_unchanged(teams_baseline, teams_altered)
+        assert _max_abs_diff(teams_baseline, teams_altered, "sos_raw") > 1e-6
+        assert _max_abs_diff(teams_baseline, teams_altered, "sos_norm") > 1e-6
+        assert _max_abs_diff(teams_baseline, teams_altered, "power_score_final") > 1e-6
+
+    def test_scf_is_post_convergence_mu_and_sos_dampening(self):
+        games, state_map = _build_isolated_bubble_fixture()
+        scf_on = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SCF_ENABLED=True)
+        scf_off = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SCF_ENABLED=False)
+
+        converged_on, _ = run_glicko2_cohort(games, scf_on, pd.Timestamp("2026-03-31"))
+        converged_off, _ = run_glicko2_cohort(games, scf_off, pd.Timestamp("2026-03-31"))
+        _assert_convergence_fields_unchanged(converged_on, converged_off)
+
+        teams_on = _run_glicko(games, scf_on, team_state_map=state_map)
+        teams_off = _run_glicko(games, scf_off, team_state_map=state_map)
+
+        on_row = _align(teams_on).loc["bubble_star"]
+        off_row = _align(teams_off).loc["bubble_star"]
+        neutral = scf_on.INITIAL_MU
+        assert abs(on_row["sos_raw"] - neutral) < abs(off_row["sos_raw"] - neutral)
+        assert abs(on_row["mu"] - neutral) < abs(off_row["mu"] - neutral)
+        assert _max_abs_diff(teams_on, teams_off, "sos_norm") > 1e-6
+
+
+class _DummySupabaseQuery:
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def in_(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=[])
+
+
+class _DummySupabase:
+    def table(self, _name: str):
+        return _DummySupabaseQuery()
+
+
+@pytest.mark.asyncio
+async def test_compute_all_cohorts_builds_glicko_pass2_map_from_mu(monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_compute_rankings_with_ml(
+        supabase_client,
+        games_df,
+        today,
+        v53_cfg=None,
+        layer13_cfg=None,
+        fetch_from_supabase=False,
+        lookback_days=365,
+        provider_filter=None,
+        force_rebuild=False,
+        save_snapshot=False,
+        global_strength_map=None,
+        merge_version=None,
+        team_state_map=None,
+        tier_league_map=None,
+        timing_report=None,
+        pass_label=None,
+        pre_sos_state=None,
+        use_glicko=True,
+        initial_ratings=None,
+    ):
+        assert use_glicko is True
+
+        age = str(games_df["age"].iloc[0])
+        teams_for_age = {
+            "14": {
+                "A": (1610.0, 0.11),
+                "B": (1520.0, 0.22),
+            },
+            "15": {
+                "C": (1580.0, 0.33),
+                "D": (1490.0, 0.44),
+            },
+        }[age]
+
+        rows = []
+        for team_id, (mu, abs_strength) in teams_for_age.items():
+            rows.append(
+                {
+                    "team_id": team_id,
+                    "age": age,
+                    "age_num": int(age),
+                    "gender": "male",
+                    "mu": mu,
+                    "sigma": 80.0,
+                    "volatility": 0.06,
+                    "abs_strength": abs_strength,
+                    "sos_norm": 0.50,
+                    "powerscore_adj": 0.50,
+                    "powerscore_ml": 0.50,
+                    "power_score_true": 0.50,
+                    "power_score_final": 0.50,
+                    "status": "Active",
+                }
+            )
+
+        calls.append(
+            {
+                "pass_label": pass_label,
+                "age": age,
+                "global_strength_map": dict(global_strength_map or {}),
+                "initial_ratings": dict(initial_ratings or {}),
+            }
+        )
+
+        return {
+            "teams": pd.DataFrame(rows),
+            "games_used": games_df.copy(),
+            "pre_sos_state": {"legacy": age},
+        }
+
+    async def fake_save_ranking_snapshot(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(calculator, "compute_rankings_with_ml", fake_compute_rankings_with_ml)
+    monkeypatch.setattr(calculator, "save_ranking_snapshot", fake_save_ranking_snapshot)
+
+    games = pd.DataFrame(
+        _make_game_pair("A", "B", 2, 1, "2026-03-01", age="14")
+        + _make_game_pair("C", "D", 3, 2, "2026-03-02", age="15")
+    )
+
+    result = await calculator.compute_all_cohorts(
+        supabase_client=_DummySupabase(),
+        games_df=games,
+        fetch_from_supabase=False,
+        use_glicko=True,
+    )
+
+    assert not result["teams"].empty
+
+    pass1_calls = [call for call in calls if call["pass_label"] == "Pass1"]
+    pass2_calls = [call for call in calls if call["pass_label"] == "Pass2"]
+    assert len(pass1_calls) == 2
+    assert len(pass2_calls) == 2
+
+    expected_map = {
+        "A": 1610.0,
+        "B": 1520.0,
+        "C": 1580.0,
+        "D": 1490.0,
+    }
+    for call in pass2_calls:
+        assert call["global_strength_map"] == expected_map
+        assert call["initial_ratings"]

--- a/tests/unit/test_sos_adj_baseline.py
+++ b/tests/unit/test_sos_adj_baseline.py
@@ -52,12 +52,12 @@ class TestSOSAdjWeakPenalty:
         sos_norm = pd.Series([0.0, 0.10, 0.20, 0.45])
         scale = _compute_sos_scale(sos_norm, cfg)
 
-        # sos_norm=0.0: weak = 0.45/0.45 = 1.0, scale = 1.0 - 0.10*1.0 = 0.90
-        assert abs(scale.iloc[0] - 0.90) < 1e-12
-        # sos_norm=0.10: weak = 0.35/0.45 ≈ 0.778, scale ≈ 0.922
-        assert abs(scale.iloc[1] - (1.0 - 0.10 * 0.35 / 0.45)) < 1e-12
-        # sos_norm=0.20: weak = 0.25/0.45 ≈ 0.556, scale ≈ 0.944
-        assert abs(scale.iloc[2] - (1.0 - 0.10 * 0.25 / 0.45)) < 1e-12
+        # sos_norm=0.0: weak = 0.45/0.45 = 1.0, scale = 1.0 - 0.16*1.0 = 0.84
+        assert abs(scale.iloc[0] - 0.84) < 1e-12
+        # sos_norm=0.10: weak = 0.35/0.45 ≈ 0.778, scale ≈ 0.876
+        assert abs(scale.iloc[1] - (1.0 - 0.16 * 0.35 / 0.45)) < 1e-12
+        # sos_norm=0.20: weak = 0.25/0.45 ≈ 0.556, scale ≈ 0.911
+        assert abs(scale.iloc[2] - (1.0 - 0.16 * 0.25 / 0.45)) < 1e-12
         # sos_norm=0.45: dead zone edge, scale = 1.0
         assert abs(scale.iloc[3] - 1.0) < 1e-12
 
@@ -69,8 +69,8 @@ class TestSOSAdjWeakPenalty:
         scale = _compute_sos_scale(sos_norm, cfg)
         mu_sos = cfg.INITIAL_MU + (mu - cfg.INITIAL_MU) * scale
 
-        # Weak team: 1500 + 200 * 0.90 = 1680
-        assert abs(mu_sos.iloc[0] - 1680.0) < 1e-9
+        # Weak team: 1500 + 200 * 0.84 = 1668
+        assert abs(mu_sos.iloc[0] - 1668.0) < 1e-9
         # Dead-zone team: 1500 + 200 * 1.0 = 1700
         assert abs(mu_sos.iloc[1] - 1700.0) < 1e-9
 


### PR DESCRIPTION
## Summary
- clarify active Glicko-2 comments and workflow/script logging so SOS is described as post-convergence rather than part of core convergence
- add a focused proof suite covering where SOS does and does not affect the active Glicko path
- tune the weak-side SOS adjustment cap from 10% to 16% while keeping the dead zone and strong-side reward unchanged

## Testing
- python -m pytest C:\PitchRank_cleanpr\tests\unit\test_sos_adj_baseline.py C:\PitchRank_cleanpr\tests\unit\test_glicko_sos_role.py -q