### PR TITLE
Optimize national rankings with RPC backend

### DIFF
--- a/frontend/app/api/rankings/national/route.ts
+++ b/frontend/app/api/rankings/national/route.ts
@@ -1,30 +1,17 @@
-import { createClient } from '@supabase/supabase-js';
+import { createServerSupabase } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 import { normalizeAgeGroup } from '@/lib/utils';
 
-// Module-level singleton — reused across requests within the same serverless
-// function instance. National rankings are public data (no auth needed).
-let _supabase: ReturnType<typeof createClient> | null = null;
-
-function getSupabase() {
-  if (!_supabase) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    if (!url || !key) {
-      throw new Error('Missing Supabase environment variables');
-    }
-    _supabase = createClient(url, key);
-  }
-  return _supabase;
+function isMissingNationalRankingsRpc(error: { code?: string | null } | null): boolean {
+  return error?.code === 'PGRST202';
 }
 
 /**
  * GET /api/rankings/national?age=u12&gender=M&limit=1000&offset=0
  *
  * Returns national rankings for a specific (age, gender) cohort.
- * Queries rankings_view server-side with Vercel edge caching, so parallel
- * browser requests (e.g. Playwright suite) hit the cache instead of each
- * independently querying the complex view.
+ * Uses the get_national_rankings RPC so filters apply on rankings_full before
+ * pagination, avoiding heavy rankings_view scans for large national cohorts.
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -34,18 +21,15 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get('limit') || '1000', 10);
   const offset = parseInt(searchParams.get('offset') || '0', 10);
 
-  // Validate required params
   if (!ageParam || !gender) {
     return NextResponse.json({ error: 'Missing required parameters: age, gender' }, { status: 400 });
   }
 
-  // Normalize age group (e.g., "u12" -> 12)
   const normalizedAge = normalizeAgeGroup(ageParam);
   if (normalizedAge === null) {
     return NextResponse.json({ error: 'Invalid age group format' }, { status: 400 });
   }
 
-  // Validate limit/offset
   if (isNaN(limit) || limit < 1 || limit > 5000) {
     return NextResponse.json({ error: 'limit must be between 1 and 5000' }, { status: 400 });
   }
@@ -54,25 +38,45 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabase = getSupabase();
+    const supabase = await createServerSupabase();
+    const rpcResult = await supabase.rpc('get_national_rankings', {
+      p_age: String(normalizedAge),
+      p_gender: gender,
+      p_limit: limit,
+      p_offset: offset,
+    });
 
-    const { data, error } = await supabase
-      .from('rankings_view')
-      .select('*')
-      .in('status', ['Active', 'Not Enough Ranked Games'])
-      .eq('age', normalizedAge)
-      .eq('gender', gender)
-      // Use the published cohort rank from the engine instead of re-sorting by score.
-      .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
-      .order('team_id_master', { ascending: true })
-      .range(offset, offset + limit - 1);
-
-    if (error) {
-      console.error('[API /rankings/national] Query error:', error.message);
+    if (rpcResult.error && !isMissingNationalRankingsRpc(rpcResult.error)) {
+      console.error('[API /rankings/national] RPC error:', rpcResult.error.message);
       return NextResponse.json({ error: 'Failed to fetch national rankings' }, { status: 500 });
     }
 
-    return NextResponse.json(data || [], {
+    if (rpcResult.error && isMissingNationalRankingsRpc(rpcResult.error)) {
+      console.warn('[API /rankings/national] RPC missing, falling back to rankings_view');
+
+      const { data, error } = await supabase
+        .from('rankings_view')
+        .select('*')
+        .in('status', ['Active', 'Not Enough Ranked Games'])
+        .eq('age', normalizedAge)
+        .eq('gender', gender)
+        .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
+        .order('team_id_master', { ascending: true })
+        .range(offset, offset + limit - 1);
+
+      if (error) {
+        console.error('[API /rankings/national] Fallback query error:', error.message);
+        return NextResponse.json({ error: 'Failed to fetch national rankings' }, { status: 500 });
+      }
+
+      return NextResponse.json(data || [], {
+        headers: {
+          'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+        },
+      });
+    }
+
+    return NextResponse.json(rpcResult.data || [], {
       headers: {
         'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
       },

--- a/frontend/hooks/useRankings.ts
+++ b/frontend/hooks/useRankings.ts
@@ -54,8 +54,8 @@ async function fetchStateRankings(
 }
 
 /**
- * Fetch national rankings via the /api/rankings/national route, which queries
- * rankings_view server-side with edge caching (no browser-side Supabase load).
+ * Fetch national rankings via the /api/rankings/national route, which uses the
+ * get_national_rankings RPC (filters before pagination on rankings_full).
  */
 async function fetchNationalRankings(
   ageGroup: string | undefined,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,10 @@ import type {
 import type { MatchPredictionResponse } from './matchPredictionService';
 import type { TeamPredictive } from '@/types/TeamPredictive';
 
+function isMissingNationalRankingsRpc(error: { code?: string | null } | null): boolean {
+  return error?.code === 'PGRST202';
+}
+
 /**
  * API functions for interacting with Supabase
  * These functions wrap Supabase queries and can be used with React Query
@@ -79,30 +83,47 @@ export const api = {
       return allResults;
     }
 
-    // National rankings: use rankings_view directly (no ROW_NUMBER — fast)
+    // National rankings: use get_national_rankings RPC so large cohorts do not
+    // scan rankings_view in repeated 1000-row batches.
     while (hasMore) {
       const batchSize = fetchLimit ? Math.min(fetchLimit - allResults.length, BATCH_SIZE) : BATCH_SIZE;
 
-      let query = supabase.from('rankings_view').select('*').in('status', ['Active', 'Not Enough Ranked Games']);
+      const rpcResult = await supabase.rpc('get_national_rankings', {
+        p_age: normalizedAge !== null ? String(normalizedAge) : '',
+        p_gender: gender || '',
+        p_limit: batchSize,
+        p_offset: offset,
+      });
 
-      if (normalizedAge !== null) {
-        query = query.eq('age', normalizedAge);
+      if (rpcResult.error && !isMissingNationalRankingsRpc(rpcResult.error)) {
+        console.error('Error fetching national rankings via RPC:', rpcResult.error);
+        throw rpcResult.error;
       }
 
-      if (gender) {
-        query = query.eq('gender', gender);
-      }
+      let data = rpcResult.data as RankingWithTeam[] | null;
 
-      query = query
-        .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
-        .order('team_id_master', { ascending: true })
-        .range(offset, offset + batchSize - 1);
+      if (rpcResult.error && isMissingNationalRankingsRpc(rpcResult.error)) {
+        let fallbackQuery = supabase.from('rankings_view').select('*').in('status', ['Active', 'Not Enough Ranked Games']);
 
-      const { data, error } = await query;
+        if (normalizedAge !== null) {
+          fallbackQuery = fallbackQuery.eq('age', normalizedAge);
+        }
 
-      if (error) {
-        console.error('Error fetching rankings from rankings_view:', error);
-        throw error;
+        if (gender) {
+          fallbackQuery = fallbackQuery.eq('gender', gender);
+        }
+
+        const fallbackResult = await fallbackQuery
+          .order('rank_in_cohort_final', { ascending: true, nullsFirst: false })
+          .order('team_id_master', { ascending: true })
+          .range(offset, offset + batchSize - 1);
+
+        if (fallbackResult.error) {
+          console.error('Error fetching national rankings fallback from rankings_view:', fallbackResult.error);
+          throw fallbackResult.error;
+        }
+
+        data = fallbackResult.data as RankingWithTeam[] | null;
       }
 
       if (!data || data.length === 0) {
@@ -150,26 +171,41 @@ export const api = {
       return (data as number) ?? 0;
     }
 
-    // National rankings: use rankings_view directly
-    let query = supabase
-      .from('rankings_view')
-      .select('*', { count: 'exact', head: true })
-      .in('status', ['Active', 'Not Enough Ranked Games']);
+    // National rankings: use get_national_rankings_count RPC for a direct count.
+    const rpcResult = await supabase.rpc('get_national_rankings_count', {
+      p_age: normalizedAge !== null ? String(normalizedAge) : '',
+      p_gender: gender || '',
+    });
 
-    if (normalizedAge !== null) {
-      query = query.eq('age', normalizedAge);
-    }
-    if (gender) {
-      query = query.eq('gender', gender);
-    }
-
-    const { count, error } = await query;
-
-    if (error) {
-      console.error('Error fetching rankings count from rankings_view:', error);
+    if (rpcResult.error && !isMissingNationalRankingsRpc(rpcResult.error)) {
+      console.error('Error fetching national rankings count via RPC:', rpcResult.error);
       return 0;
     }
-    return count ?? 0;
+
+    if (rpcResult.error && isMissingNationalRankingsRpc(rpcResult.error)) {
+      let fallbackQuery = supabase
+        .from('rankings_view')
+        .select('*', { count: 'exact', head: true })
+        .in('status', ['Active', 'Not Enough Ranked Games']);
+
+      if (normalizedAge !== null) {
+        fallbackQuery = fallbackQuery.eq('age', normalizedAge);
+      }
+      if (gender) {
+        fallbackQuery = fallbackQuery.eq('gender', gender);
+      }
+
+      const fallbackResult = await fallbackQuery;
+
+      if (fallbackResult.error) {
+        console.error('Error fetching national rankings count fallback from rankings_view:', fallbackResult.error);
+        return 0;
+      }
+
+      return fallbackResult.count ?? 0;
+    }
+
+    return (rpcResult.data as number) ?? 0;
   },
 
   /**

--- a/supabase/migrations/20260406000000_add_get_national_rankings_rpc.sql
+++ b/supabase/migrations/20260406000000_add_get_national_rankings_rpc.sql
@@ -1,0 +1,273 @@
+-- Migration: Add optimized national rankings RPCs
+-- Date: 2026-04-06
+-- Purpose: Replace direct rankings_view scans for national rankings with RPCs
+--          that filter on rankings_full first, then paginate the filtered cohort.
+
+-- =====================================================
+-- Function 1: get_national_rankings - paginated national rankings list
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_national_rankings(
+    p_age TEXT DEFAULT '',
+    p_gender TEXT DEFAULT '',
+    p_limit INT DEFAULT 1000,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    team_id_master UUID,
+    team_name TEXT,
+    club_name TEXT,
+    state TEXT,
+    age INT,
+    gender TEXT,
+    games_played INT,
+    wins INT,
+    losses INT,
+    draws INT,
+    total_games_played INT,
+    total_wins INT,
+    total_losses INT,
+    total_draws INT,
+    win_percentage NUMERIC,
+    power_score_final FLOAT8,
+    sos_norm FLOAT8,
+    sos_norm_state FLOAT8,
+    offense_norm FLOAT8,
+    defense_norm FLOAT8,
+    perf_centered FLOAT8,
+    rank_in_cohort_final INT,
+    sos_rank_national INT,
+    sos_rank_state INT,
+    rank_change_7d INT,
+    rank_change_30d INT,
+    rank_change_state_7d INT,
+    rank_change_state_30d INT,
+    status TEXT,
+    last_game TIMESTAMPTZ,
+    last_calculated TIMESTAMPTZ
+) LANGUAGE sql STABLE AS $$
+    WITH
+    age_norm AS (
+        SELECT CASE
+            WHEN NULLIF(p_age, '') IS NULL THEN NULL
+            WHEN p_age::INTEGER = 18 THEN 19
+            ELSE p_age::INTEGER
+        END AS age_val
+    ),
+    gender_norm AS (
+        SELECT CASE
+            WHEN p_gender IN ('M', 'B') THEN 'Male'
+            WHEN p_gender IN ('F', 'G') THEN 'Female'
+            ELSE p_gender
+        END AS gender_val
+    ),
+    base AS (
+        SELECT
+            t.team_id_master,
+            t.team_name,
+            t.club_name,
+            rf.state_code,
+            CASE
+                WHEN (
+                    CASE
+                        WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                        WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                        WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                        ELSE NULL
+                    END
+                ) = 18 THEN 19
+                ELSE
+                    CASE
+                        WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                        WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                        WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                        ELSE NULL
+                    END
+            END AS normalized_age,
+            rf.gender AS raw_gender,
+            COALESCE(rf.games_played, cr.games_played) AS games_played,
+            COALESCE(rf.wins, cr.wins) AS wins,
+            COALESCE(rf.losses, cr.losses) AS losses,
+            COALESCE(rf.draws, cr.draws) AS draws,
+            COALESCE(rf.total_games_played, 0) AS total_games_played,
+            COALESCE(rf.total_wins, 0) AS total_wins,
+            COALESCE(rf.total_losses, 0) AS total_losses,
+            COALESCE(rf.total_draws, 0) AS total_draws,
+            rf.power_score_final,
+            rf.sos_norm,
+            rf.sos_norm_state,
+            rf.off_norm,
+            rf.def_norm,
+            rf.perf_centered,
+            CASE
+                WHEN rf.status = 'Active'
+                THEN COALESCE(rf.rank_in_cohort_final, rf.rank_in_cohort_ml, rf.rank_in_cohort)
+                ELSE NULL
+            END AS rank_in_cohort_final,
+            rf.sos_rank_national,
+            rf.sos_rank_state,
+            rf.rank_change_7d,
+            rf.rank_change_30d,
+            rf.rank_change_state_7d,
+            rf.rank_change_state_30d,
+            rf.status,
+            rf.last_game,
+            rf.last_calculated
+        FROM teams t
+        JOIN rankings_full rf ON t.team_id_master = rf.team_id
+        LEFT JOIN current_rankings cr ON t.team_id_master = cr.team_id
+        CROSS JOIN age_norm an
+        CROSS JOIN gender_norm gn
+        WHERE rf.status IN ('Active', 'Not Enough Ranked Games')
+          AND t.is_deprecated IS NOT TRUE
+          AND rf.power_score_final IS NOT NULL
+          AND (
+              an.age_val IS NULL
+              OR
+              CASE
+                  WHEN (
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
+                  ) = 18 THEN 19
+                  ELSE
+                      CASE
+                          WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                          WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                          WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                          ELSE NULL
+                      END
+              END = an.age_val
+          )
+          AND (
+              NULLIF(p_gender, '') IS NULL
+              OR rf.gender = gn.gender_val
+          )
+    )
+    SELECT
+        b.team_id_master,
+        b.team_name,
+        b.club_name,
+        b.state_code AS state,
+        b.normalized_age AS age,
+        CASE
+            WHEN b.raw_gender = 'Male' THEN 'M'
+            WHEN b.raw_gender = 'Female' THEN 'F'
+            WHEN b.raw_gender = 'Boys' THEN 'M'
+            WHEN b.raw_gender = 'Girls' THEN 'F'
+            WHEN b.raw_gender = 'M' THEN 'M'
+            WHEN b.raw_gender = 'F' THEN 'F'
+            ELSE b.raw_gender
+        END AS gender,
+        b.games_played,
+        b.wins,
+        b.losses,
+        b.draws,
+        b.total_games_played,
+        b.total_wins,
+        b.total_losses,
+        b.total_draws,
+        CASE
+            WHEN b.total_games_played > 0
+            THEN ((b.total_wins::NUMERIC + b.total_draws::NUMERIC * 0.5)
+                  / b.total_games_played::NUMERIC) * 100
+            ELSE NULL
+        END AS win_percentage,
+        b.power_score_final,
+        b.sos_norm,
+        b.sos_norm_state,
+        b.off_norm AS offense_norm,
+        b.def_norm AS defense_norm,
+        b.perf_centered,
+        b.rank_in_cohort_final,
+        b.sos_rank_national,
+        b.sos_rank_state,
+        b.rank_change_7d,
+        b.rank_change_30d,
+        b.rank_change_state_7d,
+        b.rank_change_state_30d,
+        b.status,
+        b.last_game,
+        b.last_calculated
+    FROM base b
+    ORDER BY
+        b.rank_in_cohort_final ASC NULLS LAST,
+        b.team_id_master ASC
+    LIMIT p_limit
+    OFFSET p_offset;
+$$;
+
+COMMENT ON FUNCTION get_national_rankings IS
+  'Paginated national rankings RPC. Filters on rankings_full first, then returns '
+  'RankingRow-compatible rows ordered by stored rank_in_cohort_final. Intended '
+  'for national age/gender cohort pages to avoid heavy rankings_view scans.';
+
+-- =====================================================
+-- Function 2: get_national_rankings_count - fast count
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION get_national_rankings_count(
+    p_age TEXT DEFAULT '',
+    p_gender TEXT DEFAULT ''
+)
+RETURNS BIGINT LANGUAGE sql STABLE AS $$
+    WITH age_norm AS (
+        SELECT CASE
+            WHEN NULLIF(p_age, '') IS NULL THEN NULL
+            WHEN p_age::INTEGER = 18 THEN 19
+            ELSE p_age::INTEGER
+        END AS age_val
+    )
+    SELECT COUNT(*)
+    FROM rankings_full rf
+    JOIN teams t ON t.team_id_master = rf.team_id
+    CROSS JOIN age_norm an
+    WHERE rf.status IN ('Active', 'Not Enough Ranked Games')
+      AND t.is_deprecated IS NOT TRUE
+      AND rf.power_score_final IS NOT NULL
+      AND (
+          an.age_val IS NULL
+          OR
+          CASE
+              WHEN (
+                  CASE
+                      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                      ELSE NULL
+                  END
+              ) = 18 THEN 19
+              ELSE
+                  CASE
+                      WHEN rf.age_group ~ '^[0-9]+$' THEN rf.age_group::INTEGER
+                      WHEN rf.age_group ~ '^[uU][0-9]+$' THEN (regexp_replace(rf.age_group, '^[uU]', ''))::INTEGER
+                      WHEN rf.age_group ~ '[0-9]+' THEN (regexp_replace(rf.age_group, '[^0-9]', '', 'g'))::INTEGER
+                      ELSE NULL
+                  END
+          END = an.age_val
+      )
+      AND (
+          NULLIF(p_gender, '') IS NULL
+          OR rf.gender = CASE
+              WHEN p_gender IN ('M', 'B') THEN 'Male'
+              WHEN p_gender IN ('F', 'G') THEN 'Female'
+              ELSE p_gender
+          END
+      );
+$$;
+
+COMMENT ON FUNCTION get_national_rankings_count IS
+  'Fast count of national rankings rows for an age/gender cohort. Uses rankings_full '
+  'filters directly instead of querying rankings_view with exact count.';
+
+-- =====================================================
+-- Grant permissions
+-- =====================================================
+
+GRANT EXECUTE ON FUNCTION get_national_rankings(TEXT, TEXT, INT, INT) TO anon;
+GRANT EXECUTE ON FUNCTION get_national_rankings(TEXT, TEXT, INT, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_national_rankings_count(TEXT, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION get_national_rankings_count(TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary
- switch the national rankings API route to the new get_national_rankings RPC
- add client/helper fallbacks to ankings_view when the RPC is unavailable
- add the national rankings/count RPC migration for parity with the state rankings path

## Verification
- applied supabase/migrations/20260406000000_add_get_national_rankings_rpc.sql to the live database
- 
pm run lint -- app/api/rankings/national/route.ts hooks/useRankings.ts lib/api.ts
- 
pm run typecheck
- verified the live RPC returns rows for p_age=12, p_gender=M, including deep offsets