### PR TITLE
Fix SEO fake ranks, extract helpers, align state rank tiebreakers

### DIFF
--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -290,14 +290,17 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
   const paddingTop = virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) : 0;
   const paddingBottom = virtualItems.length > 0 ? totalHeight - (virtualItems[virtualItems.length - 1]?.end ?? 0) : 0;
 
-  // Prepare top teams for schema
-  const topTeamsForSchema = sortedRankings.slice(0, 10).map((team, index) => ({
-    teamName: team.team_name,
-    clubName: team.club_name ?? undefined,
-    rank: getDisplayRank(team) ?? index + 1,
-    powerScore: team.power_score_final ?? undefined,
-    state: team.state ?? undefined,
-  }));
+  // Prepare top teams for schema — only include teams with a published rank
+  const topTeamsForSchema = sortedRankings
+    .filter((team) => getDisplayRank(team) != null)
+    .slice(0, 10)
+    .map((team) => ({
+      teamName: team.team_name,
+      clubName: team.club_name ?? undefined,
+      rank: getDisplayRank(team)!,
+      powerScore: team.power_score_final ?? undefined,
+      state: team.state ?? undefined,
+    }));
 
   return (
     <>

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -323,6 +323,19 @@ def select_games(
     return filtered.head(max_games)
 
 
+def _get_team_games(
+    team_id: str,
+    team_games: Optional[Dict[str, pd.DataFrame]],
+    games_df: pd.DataFrame,
+    cfg: GlickoConfig,
+    today: pd.Timestamp,
+) -> pd.DataFrame:
+    """Return pre-filtered games for a team, falling back to select_games()."""
+    if team_games and team_id in team_games:
+        return team_games[team_id]
+    return select_games(games_df, team_id, cfg.MAX_GAMES, cfg.WINDOW_DAYS, today)
+
+
 def compute_recency_weights(game_dates: pd.Series, today: pd.Timestamp, lambda_: float = 1.0) -> np.ndarray:
     """Compute exponential-decay recency weights.
 
@@ -457,11 +470,7 @@ def derive_offense_defense(
 
     results = []
     for team_id, (team_mu, _, _) in team_ratings.items():
-        tg = (
-            team_games[team_id]
-            if team_games and team_id in team_games
-            else select_games(games_df, team_id, cfg.MAX_GAMES, cfg.WINDOW_DAYS, today)
-        )
+        tg = _get_team_games(team_id, team_games, games_df, cfg, today)
         if len(tg) == 0:
             results.append({"team_id": team_id, "off_raw": 0.0, "def_raw": 0.0})
             continue
@@ -529,11 +538,7 @@ def compute_sos(
 
     results = []
     for team_id in team_ratings:
-        tg = (
-            team_games[team_id]
-            if team_games and team_id in team_games
-            else select_games(games_df, team_id, cfg.MAX_GAMES, cfg.WINDOW_DAYS, today)
-        )
+        tg = _get_team_games(team_id, team_games, games_df, cfg, today)
         if len(tg) == 0:
             results.append({"team_id": team_id, "sos_raw": cfg.INITIAL_MU})
             continue
@@ -765,11 +770,7 @@ def compute_game_explainability(
 
     rows = []
     for team_id, (team_mu, team_sigma, _) in team_ratings.items():
-        tg = (
-            team_games[team_id]
-            if team_games and team_id in team_games
-            else select_games(games_df, team_id, cfg.MAX_GAMES, cfg.WINDOW_DAYS, today)
-        )
+        tg = _get_team_games(team_id, team_games, games_df, cfg, today)
         if len(tg) == 0:
             continue
 
@@ -1245,13 +1246,11 @@ def compute_rankings_v2(
     team_df["def_norm"] = sigmoid_zscore_normalize(team_df["def_raw"].fillna(0))
     team_df["sos_norm"] = sigmoid_zscore_normalize(team_df["sos_raw"].fillna(1500))
     if cfg.SOS_ADJ_ENABLED:
-        weak = ((cfg.SOS_ADJ_WEAK_THRESHOLD - team_df["sos_norm"]).clip(lower=0)
-                / cfg.SOS_ADJ_WEAK_THRESHOLD)
-        strong = ((team_df["sos_norm"] - cfg.SOS_ADJ_STRONG_THRESHOLD).clip(lower=0)
-                  / (1.0 - cfg.SOS_ADJ_STRONG_THRESHOLD))
-        sos_scale = (1.0
-                     + cfg.SOS_ADJ_STRONG_MAX * strong
-                     - cfg.SOS_ADJ_WEAK_MAX * weak)
+        weak = (cfg.SOS_ADJ_WEAK_THRESHOLD - team_df["sos_norm"]).clip(lower=0) / cfg.SOS_ADJ_WEAK_THRESHOLD
+        strong = (team_df["sos_norm"] - cfg.SOS_ADJ_STRONG_THRESHOLD).clip(lower=0) / (
+            1.0 - cfg.SOS_ADJ_STRONG_THRESHOLD
+        )
+        sos_scale = 1.0 + cfg.SOS_ADJ_STRONG_MAX * strong - cfg.SOS_ADJ_WEAK_MAX * weak
         sos_scale = sos_scale.clip(
             1.0 - cfg.SOS_ADJ_WEAK_MAX,
             1.0 + cfg.SOS_ADJ_STRONG_MAX,

--- a/src/rankings/ranking_history.py
+++ b/src/rankings/ranking_history.py
@@ -18,6 +18,12 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
+def _compute_state_ranks(df: pd.DataFrame, active_mask: "pd.Series[bool]", score_col: str) -> "pd.Series[int]":
+    """Compute unique state ranks for active teams using canonical tiebreaker (team_id ASC)."""
+    active_subset = df.loc[active_mask].sort_values([score_col, "team_id"], ascending=[False, True], na_position="last")
+    return active_subset.groupby(["state_code", "age_group", "gender"]).cumcount() + 1
+
+
 async def save_ranking_snapshot(
     supabase_client, rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
 ) -> int:
@@ -72,13 +78,8 @@ async def save_ranking_snapshot(
             logger.warning("⚠️ 'status' column missing in snapshot — all teams treated as Active for state ranking")
             active_mask = pd.Series(True, index=df.index)
         if active_mask.any():
-            active_ranks = (
-                df.loc[active_mask]
-                .groupby(["state_code", "age_group", "gender"])[score_col]
-                .rank(method="min", ascending=False, na_option="bottom")
-                .astype("Int64")
-            )
-            df.loc[active_mask, "rank_in_state"] = active_ranks
+            active_ranks = _compute_state_ranks(df, active_mask, score_col)
+            df.loc[active_ranks.index, "rank_in_state"] = active_ranks.astype("Int64")
 
         state_count = df.loc[active_mask, "state_code"].notna().sum() if active_mask.any() else 0
         logger.info(
@@ -491,13 +492,8 @@ async def calculate_rank_changes(
             logger.warning("⚠️ 'status' column missing — all teams treated as Active for state rank changes")
             active_mask = pd.Series(True, index=df.index)
         if active_mask.any():
-            active_ranks = (
-                df.loc[active_mask]
-                .groupby(["state_code", "age_group", "gender"])[score_col]
-                .rank(method="min", ascending=False, na_option="bottom")
-                .astype("Int64")
-            )
-            current_rankings_df.loc[active_mask, "current_state_rank"] = active_ranks
+            active_ranks = _compute_state_ranks(df, active_mask, score_col)
+            current_rankings_df.loc[active_ranks.index, "current_state_rank"] = active_ranks.astype("Int64")
     else:
         current_rankings_df["current_state_rank"] = None
 

--- a/tests/unit/test_glicko_engine.py
+++ b/tests/unit/test_glicko_engine.py
@@ -29,6 +29,34 @@ from src.etl.glicko_engine import (
 )
 
 
+def make_game(team_a, team_b, gf, ga, date, age="U15", gender="M"):
+    """Create symmetric game rows for a single match."""
+    return [
+        {
+            "team_id": team_a,
+            "opp_id": team_b,
+            "gf": gf,
+            "ga": ga,
+            "date": pd.Timestamp(date),
+            "age": age,
+            "gender": gender,
+            "opp_age": age,
+            "opp_gender": gender,
+        },
+        {
+            "team_id": team_b,
+            "opp_id": team_a,
+            "gf": ga,
+            "ga": gf,
+            "date": pd.Timestamp(date),
+            "age": age,
+            "gender": gender,
+            "opp_age": age,
+            "opp_gender": gender,
+        },
+    ]
+
+
 class TestGlicko2Scale:
     def test_round_trip(self):
         """Converting to glicko2 scale and back gives original values."""
@@ -293,41 +321,14 @@ class TestRecencyWeights:
 
 
 class TestRunGlicko2Cohort:
-    def _make_game(self, team_a, team_b, gf, ga, date, age="U15", gender="M"):
-        """Helper to create symmetric game rows."""
-        return [
-            {
-                "team_id": team_a,
-                "opp_id": team_b,
-                "gf": gf,
-                "ga": ga,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-            {
-                "team_id": team_b,
-                "opp_id": team_a,
-                "gf": ga,
-                "ga": gf,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-        ]
-
     def test_three_team_ordering(self):
         """A beats B, B beats C, A beats C => A > B > C."""
         cfg = GlickoConfig()
         today = pd.Timestamp("2026-03-31")
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-20")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "C", 4, 0, "2026-03-20")
         games = pd.DataFrame(rows)
 
         result, team_games = run_glicko2_cohort(games, cfg, today)
@@ -339,8 +340,8 @@ class TestRunGlicko2Cohort:
         cfg = GlickoConfig()
         today = pd.Timestamp("2026-03-31")
         rows = []
-        rows += self._make_game("A", "B", 2, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 1, "2026-03-10")
+        rows += make_game("A", "B", 2, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 1, "2026-03-10")
         games = pd.DataFrame(rows)
 
         # Should not raise or warn
@@ -353,11 +354,11 @@ class TestRunGlicko2Cohort:
         today = pd.Timestamp("2026-03-31")
         rows = []
         # Team A wins early, loses recently
-        rows += self._make_game("A", "C", 3, 0, "2025-06-01")
-        rows += self._make_game("A", "C", 0, 3, "2026-03-15")
+        rows += make_game("A", "C", 3, 0, "2025-06-01")
+        rows += make_game("A", "C", 0, 3, "2026-03-15")
         # Team B loses early, wins recently
-        rows += self._make_game("B", "C", 0, 3, "2025-06-01")
-        rows += self._make_game("B", "C", 3, 0, "2026-03-15")
+        rows += make_game("B", "C", 0, 3, "2025-06-01")
+        rows += make_game("B", "C", 3, 0, "2026-03-15")
         games = pd.DataFrame(rows)
 
         result, team_games = run_glicko2_cohort(games, cfg, today)
@@ -368,7 +369,7 @@ class TestRunGlicko2Cohort:
         """Output should have all required columns."""
         cfg = GlickoConfig()
         today = pd.Timestamp("2026-03-31")
-        rows = self._make_game("A", "B", 2, 1, "2026-03-01")
+        rows = make_game("A", "B", 2, 1, "2026-03-01")
         games = pd.DataFrame(rows)
 
         result, team_games = run_glicko2_cohort(games, cfg, today)
@@ -393,9 +394,9 @@ class TestRunGlicko2Cohort:
         cfg = GlickoConfig()
         today = pd.Timestamp("2026-03-31")
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")  # A wins
-        rows += self._make_game("A", "B", 1, 1, "2026-03-10")  # draw
-        rows += self._make_game("A", "B", 0, 2, "2026-03-20")  # A loses
+        rows += make_game("A", "B", 3, 1, "2026-03-01")  # A wins
+        rows += make_game("A", "B", 1, 1, "2026-03-10")  # draw
+        rows += make_game("A", "B", 0, 2, "2026-03-20")  # A loses
         games = pd.DataFrame(rows)
 
         result, team_games = run_glicko2_cohort(games, cfg, today)
@@ -822,35 +823,9 @@ class TestSCF:
 
 
 class TestComputeRankingsV2:
-    def _make_game(self, team_a, team_b, gf, ga, date, age="U15", gender="M"):
-        return [
-            {
-                "team_id": team_a,
-                "opp_id": team_b,
-                "gf": gf,
-                "ga": ga,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-            {
-                "team_id": team_b,
-                "opp_id": team_a,
-                "gf": ga,
-                "ga": gf,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-        ]
-
     def test_returns_teams_and_games(self):
         """Should return dict with 'teams' and 'games_used' keys."""
-        rows = self._make_game("A", "B", 2, 1, "2026-03-01")
+        rows = make_game("A", "B", 2, 1, "2026-03-01")
         games = pd.DataFrame(rows)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))
         assert "teams" in result
@@ -859,9 +834,9 @@ class TestComputeRankingsV2:
     def test_all_expected_columns_present(self):
         """Output should have all 57 rankings_full columns."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-20")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "C", 4, 0, "2026-03-20")
         games = pd.DataFrame(rows)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))
         teams = result["teams"]
@@ -929,9 +904,9 @@ class TestComputeRankingsV2:
     def test_ranking_order_matches_mu(self):
         """National rank should match mu ordering."""
         rows = []
-        rows += self._make_game("A", "B", 5, 0, "2026-03-01")
-        rows += self._make_game("B", "C", 3, 0, "2026-03-10")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-20")
+        rows += make_game("A", "B", 5, 0, "2026-03-01")
+        rows += make_game("B", "C", 3, 0, "2026-03-10")
+        rows += make_game("A", "C", 4, 0, "2026-03-20")
         games = pd.DataFrame(rows)
         # Each team has only 2 games — use low threshold so they qualify as Active
         cfg = GlickoConfig(MIN_GAMES_PROVISIONAL=1)
@@ -943,7 +918,7 @@ class TestComputeRankingsV2:
 
     def test_inactive_team_not_ranked(self):
         """Team with no games in 180 days should be Inactive."""
-        rows = self._make_game("A", "B", 2, 1, "2025-01-01")  # old game
+        rows = make_game("A", "B", 2, 1, "2025-01-01")  # old game
         games = pd.DataFrame(rows)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))
         teams = result["teams"]
@@ -952,7 +927,7 @@ class TestComputeRankingsV2:
 
     def test_low_sample_team_not_ranked(self):
         """Team with < MIN_GAMES_PROVISIONAL games should be 'Not Enough Ranked Games'."""
-        rows = self._make_game("A", "B", 2, 1, "2026-03-01")  # recent, but only 1 game
+        rows = make_game("A", "B", 2, 1, "2026-03-01")  # recent, but only 1 game
         games = pd.DataFrame(rows)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))
         teams = result["teams"]
@@ -961,7 +936,7 @@ class TestComputeRankingsV2:
 
     def test_provisional_mult_from_sigma(self):
         """High sigma (new team) should give low provisional_mult."""
-        rows = self._make_game("A", "B", 2, 1, "2026-03-01")
+        rows = make_game("A", "B", 2, 1, "2026-03-01")
         games = pd.DataFrame(rows)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))
         teams = result["teams"]
@@ -971,7 +946,7 @@ class TestComputeRankingsV2:
 
     def test_powerscore_adj_uses_provisional_multiplier(self):
         """Glicko published baseline should apply the provisional multiplier."""
-        rows = self._make_game("A", "B", 2, 1, "2026-03-01")
+        rows = make_game("A", "B", 2, 1, "2026-03-01")
         games = pd.DataFrame(rows)
         cfg = GlickoConfig(MIN_GAMES_PROVISIONAL=1)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"), cfg=cfg)
@@ -985,33 +960,6 @@ class TestComputeRankingsV2:
 
 class TestGameExplainability:
     """Tests for compute_game_explainability post-hoc breakdown."""
-
-    def _make_game(self, team_a, team_b, gf, ga, date, age="U15", gender="M"):
-        """Helper to create symmetric game rows (mirrors TestRunGlicko2Cohort)."""
-        return [
-            {
-                "team_id": team_a,
-                "opp_id": team_b,
-                "gf": gf,
-                "ga": ga,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-            {
-                "team_id": team_b,
-                "opp_id": team_a,
-                "gf": ga,
-                "ga": gf,
-                "date": pd.Timestamp(date),
-                "age": age,
-                "gender": gender,
-                "opp_age": age,
-                "opp_gender": gender,
-            },
-        ]
 
     def _run_cohort_and_explain(self, games_df, cfg=None, today=None, global_rating_map=None):
         """Run convergence then explainability in one shot."""
@@ -1037,9 +985,9 @@ class TestGameExplainability:
     def test_returns_expected_columns(self):
         """Output should have all required columns."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-20")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "C", 4, 0, "2026-03-20")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1068,9 +1016,9 @@ class TestGameExplainability:
     def test_row_count_matches_perspectives(self):
         """3 teams each with 2 games = 6 rows (one per team-game perspective)."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-20")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "C", 4, 0, "2026-03-20")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1080,8 +1028,8 @@ class TestGameExplainability:
     def test_expected_outcome_bounds(self):
         """All expected_outcome values should be in [0, 1]."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1091,8 +1039,8 @@ class TestGameExplainability:
     def test_actual_outcome_bounds(self):
         """All actual_outcome values should be in [0, 1]."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("A", "B", 0, 5, "2026-03-10")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("A", "B", 0, 5, "2026-03-10")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1102,8 +1050,8 @@ class TestGameExplainability:
     def test_surprise_equals_actual_minus_expected(self):
         """outcome_surprise should equal actual_outcome - expected_outcome."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-10")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("B", "C", 2, 0, "2026-03-10")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1117,8 +1065,8 @@ class TestGameExplainability:
     def test_recency_weights_positive(self):
         """All recency weights should be > 0."""
         rows = []
-        rows += self._make_game("A", "B", 2, 1, "2026-01-01")
-        rows += self._make_game("A", "B", 1, 2, "2026-03-15")
+        rows += make_game("A", "B", 2, 1, "2026-01-01")
+        rows += make_game("A", "B", 1, 2, "2026-03-15")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1127,7 +1075,7 @@ class TestGameExplainability:
     def test_rating_contribution_sign(self):
         """Upset win should have positive contribution; expected loss negative."""
         rows = []
-        rows += self._make_game("Weak", "Strong", 3, 0, "2026-03-01")
+        rows += make_game("Weak", "Strong", 3, 0, "2026-03-01")
         games = pd.DataFrame(rows)
 
         cfg = GlickoConfig()
@@ -1150,9 +1098,9 @@ class TestGameExplainability:
     def test_contribution_sum_correlates_with_mu_delta(self):
         """Sum of rating_contribution should have same sign as mu change."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
-        rows += self._make_game("A", "C", 4, 0, "2026-03-10")
-        rows += self._make_game("B", "C", 2, 0, "2026-03-20")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("A", "C", 4, 0, "2026-03-10")
+        rows += make_game("B", "C", 2, 0, "2026-03-20")
         games = pd.DataFrame(rows)
 
         cfg = GlickoConfig()
@@ -1176,7 +1124,7 @@ class TestGameExplainability:
     def test_off_def_residuals_computed(self):
         """Off/def residuals should not be NaN for teams with games."""
         rows = []
-        rows += self._make_game("A", "B", 3, 1, "2026-03-01")
+        rows += make_game("A", "B", 3, 1, "2026-03-01")
         games = pd.DataFrame(rows)
 
         _, _, explain_df = self._run_cohort_and_explain(games)
@@ -1264,8 +1212,8 @@ class TestGameExplainability:
     def test_compute_rankings_v2_includes_explainability(self):
         """compute_rankings_v2 should return game_explainability key."""
         rows = []
-        rows += self._make_game("A", "B", 2, 1, "2026-03-01")
-        rows += self._make_game("B", "C", 3, 0, "2026-03-10")
+        rows += make_game("A", "B", 2, 1, "2026-03-01")
+        rows += make_game("B", "C", 3, 0, "2026-03-10")
         games = pd.DataFrame(rows)
 
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"))


### PR DESCRIPTION
Four quick wins from the improvement backlog.

- Filter unranked teams from SEO structured data. Previously `topTeamsForSchema` fell back to `index + 1` for teams without a published rank, emitting bogus numbers in Google search results.
- Extract `_get_team_games()` helper in `glicko_engine.py` to replace 3 duplicated cache-or-fallback ternaries across `derive_offense_defense`, `compute_sos`, and `compute_game_explainability`.
- Promote `_make_game` test helper from 3 identical class methods to a single module-level `make_game()` in `test_glicko_engine.py`.
- Align state rank computation in `ranking_history.py` with the canonical `power_score_final DESC, team_id ASC` tiebreaker. Replaces `.rank(method="min")` (which produced tied/gapped ranks) with sort + cumcount via a shared `_compute_state_ranks()` helper.

Also removes the stale "duplicate subscriptions" improvement entry (already implemented in checkout route).