### PR TITLE
Refactor ranking engine: RankingContext dataclass, batch-fetch utility, shared normalize, deduplicate test helpers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,6 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@vitejs/plugin-react": "^6.0.1",
         "cross-env": "^10.1.0",
         "eslint": "^9",
         "eslint-config-next": "^16.2.1",
@@ -3542,13 +3541,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3903,6 +3895,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -4791,32 +4847,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rolldown/plugin-babel": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@vitejs/plugin-react": "^6.0.1",
     "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-next": "^16.2.1",

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -6,20 +6,48 @@ import asyncio
 import hashlib
 import logging
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import pandas as pd
 
 from src.etl.glicko_config import GlickoConfig
 from src.etl.glicko_engine import compute_rankings_v2
 from src.etl.v53e import V53EConfig, compute_rankings
-from src.rankings.data_adapter import fetch_games_for_rankings
+from src.rankings.data_adapter import batch_fetch_rows, fetch_games_for_rankings
 from src.rankings.layer13_predictive_adjustment import Layer13Config, apply_predictive_adjustment
 from src.rankings.ranking_history import calculate_rank_changes, save_ranking_snapshot
 
 if TYPE_CHECKING:
     from src.profiling.timer import TimingReport
+
+
+@dataclass
+class RankingContext:
+    """Shared context for multi-pass ranking computation.
+
+    Groups team metadata, cross-age state, engine control, and instrumentation
+    parameters that were previously passed as individual arguments to
+    ``compute_rankings_with_ml``.
+    """
+
+    # Team metadata
+    team_state_map: Optional[Dict[str, str]] = None
+    tier_league_map: Optional[Dict[str, str]] = None
+    # Cross-age / two-pass state
+    global_strength_map: Optional[Dict] = None
+    pre_sos_state: Optional[Dict] = None
+    merge_version: Optional[str] = None
+    initial_ratings: Optional[Dict] = None
+    # Engine selection & control
+    use_glicko: bool = True
+    force_rebuild: bool = False
+    save_snapshot: bool = True
+    # Instrumentation
+    timing_report: Optional[Any] = None
+    pass_label: Optional[str] = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -150,24 +178,14 @@ async def _persist_game_residuals(supabase_client, game_residuals: pd.DataFrame)
 
 async def compute_rankings_with_ml(
     supabase_client,
-    games_df: Optional[pd.DataFrame] = None,  # Optional: pass games directly
+    games_df: Optional[pd.DataFrame] = None,
     today: Optional[pd.Timestamp] = None,
     v53_cfg: Optional[V53EConfig] = None,
     layer13_cfg: Optional[Layer13Config] = None,
     fetch_from_supabase: bool = True,
     lookback_days: int = 365,
     provider_filter: Optional[str] = None,
-    force_rebuild: bool = False,
-    save_snapshot: bool = True,  # Set to False when called from compute_all_cohorts
-    global_strength_map: Optional[Dict] = None,  # For cross-age opponent-strength lookups in Pass 2
-    merge_version: Optional[str] = None,  # For cache invalidation when merges change
-    team_state_map: Optional[Dict[str, str]] = None,  # For SCF regional bubble detection
-    tier_league_map: Optional[Dict[str, str]] = None,  # For tier-based SOS discounting
-    timing_report: Optional["TimingReport"] = None,
-    pass_label: Optional[str] = None,  # "Pass1" or "Pass2" for log disambiguation
-    pre_sos_state: Optional[Dict] = None,  # Cached state from Pass 1 for two-pass optimization
-    use_glicko: bool = True,  # True = Glicko-2 engine, False = legacy v53e engine
-    initial_ratings: Optional[Dict] = None,  # Warm-start Glicko-2 Pass 2 from Pass 1 converged ratings
+    ctx: Optional[RankingContext] = None,
 ) -> Dict[str, pd.DataFrame]:
     """
     Run the selected rankings engine, then apply the Supabase-aware ML adjustment.
@@ -181,8 +199,7 @@ async def compute_rankings_with_ml(
         fetch_from_supabase: If True and games_df is None, fetch from Supabase
         lookback_days: Days to look back for rankings
         provider_filter: Optional provider code filter
-        merge_version: Version hash from MergeResolver for cache invalidation
-        team_state_map: Optional dict of team_id -> state_code for SCF calculation
+        ctx: Ranking context with team metadata, cross-age state, and engine control
 
     Returns:
         {
@@ -190,6 +207,20 @@ async def compute_rankings_with_ml(
             "games_used": games_used_df
         }
     """
+    ctx = ctx or RankingContext()
+    # Unpack context fields as locals so the body reads naturally
+    force_rebuild = ctx.force_rebuild
+    save_snapshot = ctx.save_snapshot
+    global_strength_map = ctx.global_strength_map
+    merge_version = ctx.merge_version
+    team_state_map = ctx.team_state_map
+    tier_league_map = ctx.tier_league_map
+    timing_report = ctx.timing_report
+    pass_label = ctx.pass_label
+    pre_sos_state = ctx.pre_sos_state
+    use_glicko = ctx.use_glicko
+    initial_ratings = ctx.initial_ratings
+
     v53_cfg = v53_cfg or V53EConfig()
 
     # 1) Get games data
@@ -562,30 +593,20 @@ async def compute_all_cohorts(
     with _section(timing_report, "team_state_map"):
         if team_ids:
             logger.info(f"🗺️  Fetching state metadata for {len(team_ids):,} teams (for SCF)...")
-            team_ids_list = list(team_ids)
-            batch_size = 100
+            rows = batch_fetch_rows(
+                supabase_client,
+                "teams",
+                "team_id_master, state_code",
+                "team_id_master",
+                list(team_ids),
+            )
+            for row in rows:
+                team_id = str(row.get("team_id_master", ""))
+                state_code = row.get("state_code", "UNKNOWN")
+                if team_id:
+                    team_state_map[team_id] = state_code if state_code else "UNKNOWN"
 
-            for i in range(0, len(team_ids_list), batch_size):
-                batch = team_ids_list[i : i + batch_size]
-                try:
-                    result = (
-                        supabase_client.table("teams")
-                        .select("team_id_master, state_code")
-                        .in_("team_id_master", batch)
-                        .execute()
-                    )
-                    if result.data:
-                        for row in result.data:
-                            team_id = str(row.get("team_id_master", ""))
-                            state_code = row.get("state_code", "UNKNOWN")
-                            if team_id:
-                                team_state_map[team_id] = state_code if state_code else "UNKNOWN"
-                except Exception as e:
-                    logger.warning(f"⚠️ Failed to fetch state metadata batch {i}: {str(e)[:100]}")
-                    continue
-
-            # Count states for logging
-            state_counts = {}
+            state_counts: Dict[str, int] = {}
             for state in team_state_map.values():
                 state_counts[state] = state_counts.get(state, 0) + 1
             top_states = sorted(state_counts.items(), key=lambda x: -x[1])[:5]
@@ -598,26 +619,18 @@ async def compute_all_cohorts(
     with _section(timing_report, "tier_league_map"):
         if team_ids:
             logger.info(f"🏆 Fetching league metadata for {len(team_ids):,} teams (for tier multiplier)...")
-            team_ids_list = list(team_ids)
-            batch_size = 100
-            for i in range(0, len(team_ids_list), batch_size):
-                batch = team_ids_list[i : i + batch_size]
-                try:
-                    result = (
-                        supabase_client.table("teams")
-                        .select("team_id_master, league")
-                        .in_("team_id_master", batch)
-                        .execute()
-                    )
-                    if result.data:
-                        for row in result.data:
-                            team_id = str(row.get("team_id_master", ""))
-                            league = row.get("league")
-                            if team_id and league:
-                                tier_league_map[team_id] = league
-                except Exception as e:
-                    logger.warning(f"⚠️ Failed to fetch league metadata batch {i}: {str(e)[:100]}")
-                    continue
+            rows = batch_fetch_rows(
+                supabase_client,
+                "teams",
+                "team_id_master, league",
+                "team_id_master",
+                list(team_ids),
+            )
+            for row in rows:
+                team_id = str(row.get("team_id_master", ""))
+                league = row.get("league")
+                if team_id and league:
+                    tier_league_map[team_id] = league
             league_counts: Dict[str, int] = {}
             for lg in tier_league_map.values():
                 league_counts[lg] = league_counts.get(lg, 0) + 1
@@ -680,14 +693,16 @@ async def compute_all_cohorts(
             fetch_from_supabase=False,
             lookback_days=lookback_days,
             provider_filter=provider_filter,
-            force_rebuild=force_rebuild,
-            save_snapshot=False,
-            global_strength_map=None,  # No global map yet
-            merge_version=merge_version,  # For cache invalidation
-            team_state_map=team_state_map,  # For SCF regional bubble detection
-            tier_league_map=tier_league_map,  # For tier-based SOS discounting
-            pass_label="Pass1",
-            use_glicko=use_glicko,
+            ctx=RankingContext(
+                force_rebuild=force_rebuild,
+                save_snapshot=False,
+                global_strength_map=None,
+                merge_version=merge_version,
+                team_state_map=team_state_map,
+                tier_league_map=tier_league_map,
+                pass_label="Pass1",
+                use_glicko=use_glicko,
+            ),
         )
         pass1_tasks.append(task)
 
@@ -744,16 +759,18 @@ async def compute_all_cohorts(
             fetch_from_supabase=False,
             lookback_days=lookback_days,
             provider_filter=provider_filter,
-            force_rebuild=True,  # Force rebuild to use new global map
-            save_snapshot=False,
-            global_strength_map=global_strength_map,  # Now with cross-age strengths/ratings
-            merge_version=merge_version,  # For cache invalidation
-            team_state_map=team_state_map,  # For SCF regional bubble detection
-            tier_league_map=tier_league_map,  # For tier-based SOS discounting
-            pass_label="Pass2",
-            pre_sos_state=None if use_glicko else pass1_pre_sos_states.get(i),
-            use_glicko=use_glicko,
-            initial_ratings=pass1_glicko_ratings.get(i) if use_glicko else None,
+            ctx=RankingContext(
+                force_rebuild=True,
+                save_snapshot=False,
+                global_strength_map=global_strength_map,
+                merge_version=merge_version,
+                team_state_map=team_state_map,
+                tier_league_map=tier_league_map,
+                pass_label="Pass2",
+                pre_sos_state=None if use_glicko else pass1_pre_sos_states.get(i),
+                use_glicko=use_glicko,
+                initial_ratings=pass1_glicko_ratings.get(i) if use_glicko else None,
+            ),
         )
         pass2_tasks.append(task)
 
@@ -1243,5 +1260,3 @@ async def compute_all_cohorts(
     logger.info(f"✅ Two-pass rankings flow complete: {len(teams_combined):,} teams ranked")
 
     return {"teams": teams_combined, "games_used": games_used_combined}
-
-

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -83,6 +83,41 @@ def retry_supabase_query(query_func, max_retries=4, initial_delay=2.0, descripti
     raise last_error
 
 
+def batch_fetch_rows(
+    client,
+    table: str,
+    select_cols: str,
+    filter_col: str,
+    filter_values: list,
+    batch_size: int = 100,
+) -> list[dict]:
+    """Batch-fetch rows from a Supabase table with retry logic.
+
+    Splits ``filter_values`` into batches of ``batch_size`` (default 100 to
+    avoid URI length limits with UUIDs) and fetches each batch using
+    :func:`retry_supabase_query` for resilience against transient errors.
+
+    Returns:
+        Flat list of row dicts from all batches.
+    """
+    rows: list[dict] = []
+    for i in range(0, len(filter_values), batch_size):
+        batch = filter_values[i : i + batch_size]
+        try:
+            result = retry_supabase_query(
+                lambda b=batch: client.table(table).select(select_cols).in_(filter_col, b).execute(),
+                max_retries=4,
+                initial_delay=2.0,
+                description=f"Fetching {table} batch {i}-{i + batch_size}",
+            )
+            if getattr(result, "data", None):
+                rows.extend(result.data)
+        except Exception as e:
+            logger.warning(f"⚠️  {table} batch failed ({i}-{i + batch_size}) after retries: {str(e)[:100]}")
+            continue
+    return rows
+
+
 # --------------------------------------------------------------------
 #  Safe numeric conversion
 # --------------------------------------------------------------------
@@ -270,33 +305,14 @@ async def fetch_games_for_rankings(
     logger.info(f"👥 Fetching metadata for {len(team_ids):,} unique teams...")
 
     # Fetch teams in batches (Supabase has URI length limit - UUIDs are long)
-    teams_data = []
-    team_ids_list = list(team_ids)
-    batch_size = 100  # Reduced from 1000 to avoid URI too long errors
-
-    for i in range(0, len(team_ids_list), batch_size):
-        batch = team_ids_list[i : i + batch_size]
-        try:
-            teams_result = retry_supabase_query(
-                lambda b=batch: (
-                    db.table("teams")
-                    .select("team_id_master, age_group, gender, is_deprecated, league")
-                    .in_("team_id_master", b)
-                    .execute()
-                ),
-                max_retries=4,
-                initial_delay=2.0,
-                description=f"Fetching team metadata batch {i}-{i + batch_size}",
-            )
-
-            if getattr(teams_result, "data", None):
-                teams_data.extend(teams_result.data)
-        except Exception as e:
-            logger.warning(f"⚠️  Team metadata batch failed ({i}-{i + batch_size}) after retries: {str(e)[:100]}")
-            continue
-
-        if (i + batch_size) % 1000 == 0 or (i + batch_size) >= len(team_ids_list):
-            logger.info(f"  ✓ Fetched metadata for {len(teams_data):,} teams...")
+    teams_data = batch_fetch_rows(
+        db,
+        "teams",
+        "team_id_master, age_group, gender, is_deprecated, league",
+        "team_id_master",
+        list(team_ids),
+    )
+    logger.info(f"  ✓ Fetched metadata for {len(teams_data):,} teams")
 
     if not teams_data:
         logger.warning("⚠️  No team metadata found")

--- a/src/rankings/layer13_predictive_adjustment.py
+++ b/src/rankings/layer13_predictive_adjustment.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from src.rankings.shared import normalize_by_cohort
+
 logger = logging.getLogger(__name__)
 
 # Prefer XGBoost; fall back to RandomForest; tolerate neither (import-only workflows)
@@ -399,7 +401,7 @@ async def apply_predictive_adjustment(
     out["ml_overperf"] = (
         out["ml_overperf"].fillna(0.0).clip(lower=-cfg.residual_clip_goals, upper=cfg.residual_clip_goals)
     )
-    normalized = _normalize_by_cohort(
+    normalized = normalize_by_cohort(
         out, value_col="ml_overperf", out_col="__tmp__", mode=cfg.norm_mode, cohort_cols=list(cfg.cohort_key_cols)
     )
     # Use .reindex() to align by index, not positional order (groupby may reorder rows)
@@ -523,12 +525,12 @@ def _build_features(
 
     # age gap (vectorized)
     team_age_num = (
-        pd.to_numeric(f[age_col].astype(str).str.extract(r"(\d+)", expand=False), errors="coerce")
-        .fillna(0).astype(int)
+        pd.to_numeric(f[age_col].astype(str).str.extract(r"(\d+)", expand=False), errors="coerce").fillna(0).astype(int)
     )
     opp_age_num = (
         pd.to_numeric(f[opp_age_col].astype(str).str.extract(r"(\d+)", expand=False), errors="coerce")
-        .fillna(0).astype(int)
+        .fillna(0)
+        .astype(int)
     )
     f["age_gap"] = (team_age_num - opp_age_num).abs()
 
@@ -648,33 +650,3 @@ def _aggregate_team_residuals(feats: pd.DataFrame, cfg: Layer13Config) -> pd.Dat
         merged = merged.rename(columns={team_id_col: "team_id"})
 
     return merged[["team_id", "age", "gender", "ml_overperf", "ml_game_count"]]
-
-
-def _normalize_by_cohort(
-    df: pd.DataFrame,
-    *,
-    value_col: str,
-    out_col: str,
-    mode: str,
-    cohort_cols: List[str],
-) -> pd.DataFrame:
-    """Normalize values within cohorts (age, gender)"""
-    parts = []
-    for _, grp in df.groupby(cohort_cols, dropna=False):
-        g = grp.copy()
-        s = g[value_col].astype(float)
-        if mode == "zscore":
-            sd = s.std(ddof=0)
-            if sd == 0 or len(s) < 2:
-                g[out_col] = 0.5
-            else:
-                z = (s - s.mean()) / sd
-                g[out_col] = 1.0 / (1.0 + np.exp(-z))  # sigmoid
-        else:
-            # Singleton cohort: no meaningful percentile rank, use neutral 0.5
-            if len(s) < 2:
-                g[out_col] = 0.5
-            else:
-                g[out_col] = s.rank(method="average", pct=True).astype(float)
-        parts.append(g)
-    return pd.concat(parts, axis=0)

--- a/src/rankings/shared.py
+++ b/src/rankings/shared.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import List, Optional
+
+import numpy as np
 import pandas as pd
 
 from src.rankings.constants import SOS_ML_THRESHOLD_HIGH, SOS_ML_THRESHOLD_LOW
@@ -37,3 +40,84 @@ def normalize_gender(series: pd.Series) -> pd.Series:
             }
         )
     )
+
+
+# --------------------------------------------------------------------
+#  Cohort normalization (shared between v53e and ML layer)
+# --------------------------------------------------------------------
+
+
+def _percentile_norm(x: pd.Series, tiebreaker: Optional[pd.Series] = None) -> pd.Series:
+    """Percentile normalization with optional tie-breaking.
+
+    When ``tiebreaker`` is provided (e.g. pre-clip raw values), ties in ``x``
+    are broken by the tiebreaker so that teams clipped to the same ceiling
+    still receive distinct percentile ranks.
+    """
+    if len(x) == 0:
+        return x
+    if len(x) < 2:
+        return pd.Series([0.5] * len(x), index=x.index)
+    if tiebreaker is not None and len(tiebreaker) == len(x):
+        sorted_unique = np.sort(x.unique())
+        if len(sorted_unique) > 1:
+            diffs = np.diff(sorted_unique)
+            min_gap = diffs[diffs > 0].min() if (diffs > 0).any() else 1e-12
+            eps = min_gap * 0.5
+        else:
+            eps = 1.0
+        composite = x + eps * tiebreaker.rank(method="dense", pct=True)
+        return composite.rank(method="average", pct=True).astype(float)
+    return x.rank(method="average", pct=True).astype(float)
+
+
+def _zscore_norm(x: pd.Series) -> pd.Series:
+    """Sigmoid z-score normalization to [0, 1]."""
+    if len(x) == 0:
+        return x
+    if len(x) < 2:
+        return pd.Series([0.5] * len(x), index=x.index)
+    sd = x.std(ddof=0)
+    if sd == 0:
+        return pd.Series([0.5] * len(x), index=x.index)
+    z = (x - x.mean()) / sd
+    return 1 / (1 + np.exp(-z))
+
+
+def normalize_by_cohort(
+    df: pd.DataFrame,
+    *,
+    value_col: str,
+    out_col: str,
+    mode: str,
+    cohort_cols: Optional[List[str]] = None,
+    tiebreaker_col: Optional[str] = None,
+) -> pd.DataFrame:
+    """Normalize values within demographic cohorts.
+
+    Shared implementation used by the ML layer (``layer13_predictive_adjustment``).
+
+    Args:
+        df: Input DataFrame.
+        value_col: Column containing values to normalize.
+        out_col: Name for the new normalized column.
+        mode: ``"zscore"`` for sigmoid z-score, anything else for percentile rank.
+        cohort_cols: Columns defining cohorts (default ``["age", "gender"]``).
+        tiebreaker_col: Optional column for breaking percentile ties
+            (e.g. pre-clip raw values). Ignored in zscore mode.
+    """
+    if cohort_cols is None:
+        cohort_cols = ["age", "gender"]
+
+    has_tiebreaker = tiebreaker_col is not None and tiebreaker_col in df.columns
+    parts = []
+    for _, grp in df.groupby(cohort_cols, dropna=False):
+        g = grp.copy()
+        s = g[value_col].astype(float)
+        if mode == "zscore":
+            g[out_col] = _zscore_norm(s)
+        else:
+            tb = g[tiebreaker_col] if has_tiebreaker else None
+            g[out_col] = _percentile_norm(s, tiebreaker=tb)
+        parts.append(g)
+    return pd.concat(parts, axis=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Shared test helpers auto-discovered by pytest."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def make_game_pair(
+    gid,
+    date,
+    home,
+    away,
+    hs,
+    as_,
+    age="14",
+    gender="male",
+    opp_age=None,
+    opp_gender=None,
+):
+    """Create home + away perspective rows for a single game.
+
+    Returns a list of two dicts (one per perspective) suitable for building
+    a games DataFrame via ``pd.DataFrame(rows)``.
+    """
+    opp_age = opp_age or age
+    opp_gender = opp_gender or gender
+    return [
+        {
+            "game_id": gid,
+            "date": pd.Timestamp(date),
+            "team_id": home,
+            "opp_id": away,
+            "age": age,
+            "gender": gender,
+            "opp_age": opp_age,
+            "opp_gender": opp_gender,
+            "gf": hs,
+            "ga": as_,
+        },
+        {
+            "game_id": gid,
+            "date": pd.Timestamp(date),
+            "team_id": away,
+            "opp_id": home,
+            "age": opp_age,
+            "gender": opp_gender,
+            "opp_age": age,
+            "opp_gender": gender,
+            "gf": as_,
+            "ga": hs,
+        },
+    ]

--- a/tests/unit/test_active_only_ranking.py
+++ b/tests/unit/test_active_only_ranking.py
@@ -19,41 +19,7 @@ from datetime import datetime, timedelta
 from copy import deepcopy
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    """Create home + away perspective rows for a single game."""
-    return [
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": home,
-            "opp_id": away,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": hs,
-            "ga": as_,
-        },
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": away,
-            "opp_id": home,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": as_,
-            "ga": hs,
-        },
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_mixed_activity_league(today=None):
@@ -86,7 +52,7 @@ def _build_mixed_activity_league(today=None):
         if opp == "team_active_1":
             opp = fillers[i]
         date = today - timedelta(days=10 + i * 7)
-        rows.extend(_make_game_pair(f"g{gid}", date, "team_active_1", opp, 3, 1))
+        rows.extend(make_game_pair(f"g{gid}", date, "team_active_1", opp, 3, 1))
 
     # team_active_2: 10 games
     for i in range(10):
@@ -95,33 +61,33 @@ def _build_mixed_activity_league(today=None):
         if opp == "team_active_2":
             opp = fillers[i + 5]
         date = today - timedelta(days=10 + i * 7)
-        rows.extend(_make_game_pair(f"g{gid}", date, "team_active_2", opp, 2, 1))
+        rows.extend(make_game_pair(f"g{gid}", date, "team_active_2", opp, 2, 1))
 
     # team_active_3: exactly 8 games (edge case)
     for i in range(8):
         gid += 1
         opp = fillers[i + 10]
         date = today - timedelta(days=10 + i * 7)
-        rows.extend(_make_game_pair(f"g{gid}", date, "team_active_3", opp, 2, 0))
+        rows.extend(make_game_pair(f"g{gid}", date, "team_active_3", opp, 2, 0))
 
     # team_low_1: 5 games (Not Enough Ranked Games)
     for i in range(5):
         gid += 1
         opp = fillers[i]
         date = today - timedelta(days=10 + i * 7)
-        rows.extend(_make_game_pair(f"g{gid}", date, "team_low_1", opp, 1, 2))
+        rows.extend(make_game_pair(f"g{gid}", date, "team_low_1", opp, 1, 2))
 
     # team_low_2: 3 games (Not Enough Ranked Games)
     for i in range(3):
         gid += 1
         opp = fillers[i]
         date = today - timedelta(days=10 + i * 7)
-        rows.extend(_make_game_pair(f"g{gid}", date, "team_low_2", opp, 0, 1))
+        rows.extend(make_game_pair(f"g{gid}", date, "team_low_2", opp, 0, 1))
 
     # team_one_game: 1 game (Not Enough Ranked Games)
     gid += 1
     date = today - timedelta(days=10)
-    rows.extend(_make_game_pair(f"g{gid}", date, "team_one_game", fillers[0], 5, 0))
+    rows.extend(make_game_pair(f"g{gid}", date, "team_one_game", fillers[0], 5, 0))
 
     # Give filler teams enough games to be "Active" so they have valid SOS
     for i, filler in enumerate(fillers):
@@ -131,7 +97,7 @@ def _build_mixed_activity_league(today=None):
             if opp == filler:
                 opp = fillers[(i + j + 2) % len(fillers)]
             date = today - timedelta(days=10 + j * 7)
-            rows.extend(_make_game_pair(f"g{gid}", date, filler, opp, 2, 1))
+            rows.extend(make_game_pair(f"g{gid}", date, filler, opp, 2, 1))
 
     return pd.DataFrame(rows)
 
@@ -476,14 +442,14 @@ class TestPowerScoreBounds:
             gid += 1
             date = self.today - timedelta(days=10 + i * 7)
             # 20-0 blowouts (capped at 6 by v53e)
-            rows.extend(_make_game_pair(f"g{gid}", date, "dominant_team", f"weak_{i}", 20, 0))
+            rows.extend(make_game_pair(f"g{gid}", date, "dominant_team", f"weak_{i}", 20, 0))
 
         # Give weak teams enough games
         for i in range(12):
             for j in range(10):
                 gid += 1
                 date = self.today - timedelta(days=10 + j * 7)
-                rows.extend(_make_game_pair(f"g{gid}", date, f"weak_{i}", f"weak_{(i + j + 1) % 12}", 1, 2))
+                rows.extend(make_game_pair(f"g{gid}", date, f"weak_{i}", f"weak_{(i + j + 1) % 12}", 1, 2))
 
         games_df = pd.DataFrame(rows)
         result = compute_rankings(games_df, today=self.today, cfg=self.cfg)

--- a/tests/unit/test_bad_sos_ranking_diagnosis.py
+++ b/tests/unit/test_bad_sos_ranking_diagnosis.py
@@ -27,21 +27,7 @@ from datetime import datetime, timedelta
 from copy import deepcopy
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": home, "opp_id": away, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": hs, "ga": as_},
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": away, "opp_id": home, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": as_, "ga": hs},
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_tiered_league(seed=42):
@@ -69,7 +55,7 @@ def _build_tiered_league(seed=42):
             gc += 1
             hs = rng.choice([1, 2, 3])
             as_ = rng.choice([0, 1, 2])
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"g{gc}", base + timedelta(days=gc), t1, t2, hs, as_))
 
     # Elite vs Mid: elite usually wins
@@ -79,7 +65,7 @@ def _build_tiered_league(seed=42):
             gc += 1
             hs = rng.randint(2, 5)  # elite scores 2-4
             as_ = rng.randint(0, 2)  # mid scores 0-1
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"g{gc}", base + timedelta(days=gc), e, m, hs, as_))
 
     # Mid vs Mid: fairly competitive
@@ -89,7 +75,7 @@ def _build_tiered_league(seed=42):
             gc += 1
             hs = rng.randint(1, 4)
             as_ = rng.randint(0, 3)
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"g{gc}", base + timedelta(days=gc), t1, t2, hs, as_))
 
     # Mid vs Weak (bridge games — only 2 mid teams play weak teams)
@@ -100,7 +86,7 @@ def _build_tiered_league(seed=42):
             gc += 1
             hs = rng.randint(3, 6)
             as_ = rng.randint(0, 1)
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"g{gc}", base + timedelta(days=gc), m, w, hs, as_))
 
     # Weak vs Weak: the bubble league — lots of games, easy opponents
@@ -111,7 +97,7 @@ def _build_tiered_league(seed=42):
             # Some weak teams dominate: scores like 4-0, 5-1
             hs = rng.randint(0, 5)
             as_ = rng.randint(0, 4)
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"g{gc}", base + timedelta(days=gc), t1, t2, hs, as_))
 
     return pd.DataFrame(rows), elite, mid, weak

--- a/tests/unit/test_component_sos_normalization.py
+++ b/tests/unit/test_component_sos_normalization.py
@@ -36,41 +36,12 @@ from src.etl.v53e import (
     V53EConfig,
     compute_rankings,
 )
+from tests.conftest import make_game_pair
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_game_pair(game_id, date, home, away, home_score, away_score, age="14", gender="male"):
-    """Create both perspective rows for a single game."""
-    return [
-        {
-            "game_id": game_id,
-            "date": pd.Timestamp(date),
-            "team_id": home,
-            "opp_id": away,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": home_score,
-            "ga": away_score,
-        },
-        {
-            "game_id": game_id,
-            "date": pd.Timestamp(date),
-            "team_id": away,
-            "opp_id": home,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": away_score,
-            "ga": home_score,
-        },
-    ]
 
 
 def _build_ecosystem(
@@ -99,7 +70,7 @@ def _build_ecosystem(
         game_id = f"{team_prefix}_g{game_counter:04d}"
         game_counter += 1
 
-        rows.extend(_make_game_pair(game_id, game_date, home, away, home_score, away_score, age=age, gender=gender))
+        rows.extend(make_game_pair(game_id, game_date, home, away, home_score, away_score, age=age, gender=gender))
 
     return rows, team_ids
 
@@ -366,7 +337,7 @@ class TestBridgeGameConnects:
         rows_b, ids_b = _build_ecosystem("eco_b", 18, 12, base_date, seed=99)
 
         # Add ONE bridge game between the ecosystems
-        bridge_rows = _make_game_pair(
+        bridge_rows = make_game_pair(
             "bridge_001",
             base_date - timedelta(days=50),
             ids_a[0],

--- a/tests/unit/test_cross_age_opponent_adjustment.py
+++ b/tests/unit/test_cross_age_opponent_adjustment.py
@@ -5,39 +5,7 @@ import pandas as pd
 import numpy as np
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="12", gender="male",
-                    opp_age=None, opp_gender=None):
-    """Create home + away perspective rows for a single game."""
-    opp_age = opp_age or age
-    opp_gender = opp_gender or gender
-    return [
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": home,
-            "opp_id": away,
-            "age": age,
-            "gender": gender,
-            "opp_age": opp_age,
-            "opp_gender": opp_gender,
-            "gf": hs,
-            "ga": as_,
-        },
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": away,
-            "opp_id": home,
-            "age": opp_age,
-            "gender": opp_gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": as_,
-            "ga": hs,
-        },
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_same_age_league(today=None):
@@ -66,7 +34,8 @@ def _build_same_age_league(today=None):
                 hs, as_ = 0, 5
             else:
                 hs, as_ = 2, 1
-            rows.extend(_make_game_pair(str(gid), date, home, away, hs, as_))
+            rows.extend(make_game_pair(str(gid), date, home, away, hs, as_,
+                                      age="12"))
 
     return pd.DataFrame(rows)
 
@@ -116,14 +85,14 @@ def _build_cross_age_league(today=None):
     for i, opp in enumerate(u12_fillers):
         gid += 1
         date = today - pd.Timedelta(days=gid)
-        rows.extend(_make_game_pair(str(gid), date, "team_same", opp, 4, 1,
+        rows.extend(make_game_pair(str(gid), date, "team_same", opp, 4, 1,
                                     age="12", gender="male"))
 
     # team_cross: 8 games vs U13 (2-1 wins) — 100% cross-age schedule
     for i in range(8):
         gid += 1
         date = today - pd.Timedelta(days=gid)
-        rows.extend(_make_game_pair(str(gid), date, "team_cross", u13_fillers[i], 2, 1,
+        rows.extend(make_game_pair(str(gid), date, "team_cross", u13_fillers[i], 2, 1,
                                     age="12", gender="male",
                                     opp_age="13", opp_gender="male"))
 
@@ -132,14 +101,15 @@ def _build_cross_age_league(today=None):
         for away in u12_fillers[i + 1:]:
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game_pair(str(gid), date, home, away, 2, 1))
+            rows.extend(make_game_pair(str(gid), date, home, away, 2, 1,
+                                      age="12"))
 
     # U13 fillers play each other (so they have strength in global_strength_map)
     for i, home in enumerate(u13_fillers):
         for away in u13_fillers[i + 1:]:
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game_pair(str(gid), date, home, away, 2, 1,
+            rows.extend(make_game_pair(str(gid), date, home, away, 2, 1,
                                         age="13", gender="male"))
 
     return pd.DataFrame(rows)
@@ -290,20 +260,20 @@ class TestCrossAgeEdgeCases:
         for i in range(6):
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game_pair(str(gid), date, "team_down", u12_fillers[i], 4, 0,
+            rows.extend(make_game_pair(str(gid), date, "team_down", u12_fillers[i], 4, 0,
                                         age="13", gender="male",
                                         opp_age="12", opp_gender="male"))
         for i in range(2):
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game_pair(str(gid), date, "team_down", u13_fillers[i], 2, 1,
+            rows.extend(make_game_pair(str(gid), date, "team_down", u13_fillers[i], 2, 1,
                                         age="13", gender="male"))
 
         # team_honest: U13 team that plays 8 games vs U13 (2-1 wins)
         for i in range(8):
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game_pair(str(gid), date, "team_honest", u13_fillers[i % 8], 2, 1,
+            rows.extend(make_game_pair(str(gid), date, "team_honest", u13_fillers[i % 8], 2, 1,
                                         age="13", gender="male"))
 
         # U13 fillers play each other
@@ -311,7 +281,7 @@ class TestCrossAgeEdgeCases:
             for away in u13_fillers[i + 1:]:
                 gid += 1
                 date = today - pd.Timedelta(days=gid)
-                rows.extend(_make_game_pair(str(gid), date, home, away, 2, 1,
+                rows.extend(make_game_pair(str(gid), date, home, away, 2, 1,
                                             age="13", gender="male"))
 
         # U12 fillers play each other (for global_strength_map)
@@ -319,7 +289,7 @@ class TestCrossAgeEdgeCases:
             for away in u12_fillers[i + 1:]:
                 gid += 1
                 date = today - pd.Timedelta(days=gid)
-                rows.extend(_make_game_pair(str(gid), date, home, away, 2, 1,
+                rows.extend(make_game_pair(str(gid), date, home, away, 2, 1,
                                             age="12", gender="male"))
 
         games = pd.DataFrame(rows)

--- a/tests/unit/test_glicko_sos_role.py
+++ b/tests/unit/test_glicko_sos_role.py
@@ -240,18 +240,15 @@ async def test_compute_all_cohorts_builds_glicko_pass2_map_from_mu(monkeypatch):
         fetch_from_supabase=False,
         lookback_days=365,
         provider_filter=None,
-        force_rebuild=False,
-        save_snapshot=False,
-        global_strength_map=None,
-        merge_version=None,
-        team_state_map=None,
-        tier_league_map=None,
-        timing_report=None,
-        pass_label=None,
-        pre_sos_state=None,
-        use_glicko=True,
-        initial_ratings=None,
+        ctx=None,
     ):
+        from src.rankings.calculator import RankingContext
+
+        ctx = ctx or RankingContext()
+        pass_label = ctx.pass_label
+        global_strength_map = ctx.global_strength_map
+        initial_ratings = ctx.initial_ratings
+        use_glicko = ctx.use_glicko
         assert use_glicko is True
 
         age = str(games_df["age"].iloc[0])

--- a/tests/unit/test_linear_shrinkage_regression.py
+++ b/tests/unit/test_linear_shrinkage_regression.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 
 from src.etl.v53e import V53EConfig
+from tests.conftest import make_game_pair
 
 
 # ===========================================================================
@@ -204,16 +205,6 @@ class TestComponentSizeShrinkage:
 class TestShrinkageInPipeline:
     """Verify shrinkage behavior in actual compute_rankings output."""
 
-    def _make_game_pair(self, gid, date, home, away, hs, as_, age="14", gender="male"):
-        return [
-            {"game_id": gid, "date": pd.Timestamp(date),
-             "team_id": home, "opp_id": away, "age": age, "gender": gender,
-             "opp_age": age, "opp_gender": gender, "gf": hs, "ga": as_},
-            {"game_id": gid, "date": pd.Timestamp(date),
-             "team_id": away, "opp_id": home, "age": age, "gender": gender,
-             "opp_age": age, "opp_gender": gender, "gf": as_, "ga": hs},
-        ]
-
     def test_low_gp_teams_shrunk_toward_half(self):
         """Teams with low game count should have sos_norm closer to 0.5
         than teams with high game count (all else equal-ish)."""
@@ -231,13 +222,13 @@ class TestShrinkageInPipeline:
                     continue
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(self._make_game_pair(f"g_{gc:04d}", d, h, a, 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, h, a, 2, 1))
                     gc += 1
 
         # 1 "low" team: only 2 games (well below MIN_GAMES_FOR_TOP_SOS=6)
         for i in range(2):
             d = base - timedelta(days=i * 10)
-            rows.extend(self._make_game_pair(f"g_{gc:04d}", d, "low_gp", full_ids[i], 3, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, "low_gp", full_ids[i], 3, 0))
             gc += 1
 
         games = pd.DataFrame(rows)

--- a/tests/unit/test_minmax_vs_percentile_sos.py
+++ b/tests/unit/test_minmax_vs_percentile_sos.py
@@ -24,21 +24,7 @@ from datetime import datetime, timedelta
 from copy import deepcopy
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": home, "opp_id": away, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": hs, "ga": as_},
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": away, "opp_id": home, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": as_, "ga": hs},
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_cohort(num_teams=30, games_per_team=14, seed=42, age="14"):
@@ -52,7 +38,7 @@ def _build_cohort(num_teams=30, games_per_team=14, seed=42, age="14"):
         h, a = rng.choice(num_teams, size=2, replace=False)
         hs, as_ = int(rng.poisson(1.5)), int(rng.poisson(1.5))
         d = base - timedelta(days=int(rng.randint(1, 300)))
-        rows.extend(_make_game_pair(f"g_{gc:04d}", d, ids[h], ids[a], hs, as_, age=age))
+        rows.extend(make_game_pair(f"g_{gc:04d}", d, ids[h], ids[a], hs, as_, age=age))
         gc += 1
     return pd.DataFrame(rows), ids
 
@@ -304,13 +290,13 @@ class TestOutlierSensitivity:
             for j in range(i + 1, min(i + 6, 19)):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
                     gc += 1
 
         # t19 plays only against unranked/unknown teams (very low SOS)
         for i in range(12):
             d = base - timedelta(days=gc)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[19], f"unknown_{i}", 5, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[19], f"unknown_{i}", 5, 0))
             gc += 1
 
         games = pd.DataFrame(rows)
@@ -338,12 +324,12 @@ class TestOutlierSensitivity:
             for j in range(i + 1, min(i + 6, 19)):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
                     gc += 1
 
         for i in range(12):
             d = base - timedelta(days=gc)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[19], f"unknown_{i}", 5, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[19], f"unknown_{i}", 5, 0))
             gc += 1
 
         games = pd.DataFrame(rows)
@@ -479,7 +465,7 @@ class TestIdenticalResults:
                     if i >= j:
                         continue
                     d = base - timedelta(days=gc * 3 + rnd)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, h, a, 1, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, h, a, 1, 1))
                     gc += 1
 
         games = pd.DataFrame(rows)
@@ -521,13 +507,13 @@ class TestBubbleEffects:
             for j in range(i + 1, min(i + 5, 15)):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, normals[i], normals[j], 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, normals[i], normals[j], 2, 1))
                     gc += 1
 
         # 1 team playing ONLY unknowns
         for i in range(12):
             d = base - timedelta(days=gc)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, "loner", f"ghost_{i}", 5, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, "loner", f"ghost_{i}", 5, 0))
             gc += 1
 
         games = pd.DataFrame(rows)

--- a/tests/unit/test_offnorm_tie_compression_fix.py
+++ b/tests/unit/test_offnorm_tie_compression_fix.py
@@ -23,24 +23,12 @@ from src.etl.v53e import (
     compute_rankings,
     _percentile_norm,
 )
+from tests.conftest import make_game_pair
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _make_game_pair(game_id, date, home, away, home_score, away_score,
-                    age="16", gender="female"):
-    """Create both perspective rows for a single game."""
-    return [
-        {"game_id": game_id, "date": pd.Timestamp(date),
-         "team_id": home, "opp_id": away, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": home_score, "ga": away_score},
-        {"game_id": game_id, "date": pd.Timestamp(date),
-         "team_id": away, "opp_id": home, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": away_score, "ga": home_score},
-    ]
-
 
 def _build_regional_bubble(bubble_teams, num_games_per_team=12, seed=42,
                             age="16", gender="female", base_date=None,
@@ -71,7 +59,7 @@ def _build_regional_bubble(bubble_teams, num_games_per_team=12, seed=42,
             aws = int(rng.poisson(1.5))
 
         game_date = base_date - timedelta(days=int(rng.randint(1, 200)))
-        rows.extend(_make_game_pair(
+        rows.extend(make_game_pair(
             f"g_{game_counter:04d}", game_date, home, away, hs, aws,
             age=age, gender=gender
         ))
@@ -109,7 +97,7 @@ def _build_national_league(national_teams, num_games_per_team=15, seed=99,
         aws = int(rng.poisson(away_lambda))
 
         game_date = base_date - timedelta(days=int(rng.randint(1, 200)))
-        rows.extend(_make_game_pair(
+        rows.extend(make_game_pair(
             f"g_{game_counter:04d}", game_date, home, away, hs, aws,
             age=age, gender=gender
         ))
@@ -144,7 +132,7 @@ def _build_arkansas_rising_scenario():
     def add_game(home, away, hs, aws):
         nonlocal gc
         game_date = base_date - timedelta(days=int(rng.randint(1, 300)))
-        all_rows.extend(_make_game_pair(f"g_{gc:05d}", game_date, home, away, hs, aws))
+        all_rows.extend(make_game_pair(f"g_{gc:05d}", game_date, home, away, hs, aws, age="16", gender="female"))
         gc += 1
 
     # --- 1) RL bubble: only play each other, rl_team_0 dominates ---

--- a/tests/unit/test_power_sos_iteration.py
+++ b/tests/unit/test_power_sos_iteration.py
@@ -22,17 +22,7 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": home, "opp_id": away, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": hs, "ga": as_},
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": away, "opp_id": home, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": as_, "ga": hs},
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_league(num_teams=20, games_per_team=12, seed=42):
@@ -46,7 +36,7 @@ def _build_league(num_teams=20, games_per_team=12, seed=42):
         h, a = rng.choice(num_teams, size=2, replace=False)
         hs, as_ = int(rng.poisson(1.5)), int(rng.poisson(1.5))
         d = base - timedelta(days=int(rng.randint(1, 300)))
-        rows.extend(_make_game_pair(f"g_{gc:04d}", d, ids[h], ids[a], hs, as_))
+        rows.extend(make_game_pair(f"g_{gc:04d}", d, ids[h], ids[a], hs, as_))
         gc += 1
     return pd.DataFrame(rows), ids
 
@@ -167,7 +157,7 @@ class TestFloorPreventsCollapse:
                     if i >= j:
                         continue
                     d = base - timedelta(days=gc * 2 + rnd)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, h, a, 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, h, a, 2, 1))
                     gc += 1
 
         games = pd.DataFrame(rows)

--- a/tests/unit/test_powerscore_accuracy.py
+++ b/tests/unit/test_powerscore_accuracy.py
@@ -18,6 +18,7 @@ from src.etl.v53e import (
     V53EConfig,
     compute_rankings,
 )
+from tests.conftest import make_game_pair
 
 
 # ---------------------------------------------------------------------------
@@ -39,17 +40,6 @@ def _make_game_row(game_id, date, team_id, opp_id, gf, ga,
         "gf": gf,
         "ga": ga,
     }
-
-
-def _make_game_pair(game_id, date, home, away, home_score, away_score,
-                    age="14", gender="male"):
-    """Create both perspective rows for a single game."""
-    return [
-        _make_game_row(game_id, date, home, away, home_score, away_score,
-                       age, gender),
-        _make_game_row(game_id, date, away, home, away_score, home_score,
-                       age, gender),
-    ]
 
 
 def _build_realistic_cohort(num_teams=10, games_per_team=12, age="14",
@@ -82,7 +72,7 @@ def _build_realistic_cohort(num_teams=10, games_per_team=12, age="14",
         game_id = f"g_{game_counter:04d}"
         game_counter += 1
 
-        rows.extend(_make_game_pair(
+        rows.extend(make_game_pair(
             game_id, game_date, home, away, home_score, away_score,
             age=age, gender=gender
         ))
@@ -260,9 +250,9 @@ class TestSelfPlayFiltering:
             gid = f"normal_{i}"
             opp = f"opp_{i}"
             game_date = base_date - timedelta(days=i * 10)
-            rows.extend(_make_game_pair(gid, game_date, "team_a", opp, 2, 1))
+            rows.extend(make_game_pair(gid, game_date, "team_a", opp, 2, 1))
             # Give opponents some games too
-            rows.extend(_make_game_pair(
+            rows.extend(make_game_pair(
                 f"opp_game_{i}", game_date - timedelta(days=1),
                 opp, f"opp_other_{i}", 1, 1
             ))
@@ -371,7 +361,7 @@ class TestSOS365DayWindow:
                 partner = all_opps[(i + j + 1) % len(all_opps)]
                 d = base - timedelta(days=30 + i * 7 + j * 3)
                 gid = f"op_{gc:04d}"; gc += 1
-                rows.extend(_make_game_pair(
+                rows.extend(make_game_pair(
                     gid, d, opp, partner, 2, 1,
                     age=age, gender=gender,
                 ))
@@ -381,7 +371,7 @@ class TestSOS365DayWindow:
             for rep in range(2):
                 d = base - timedelta(days=5 + k * 2 + rep)  # days 5-24
                 gid = f"dr_{gc:04d}"; gc += 1
-                rows.extend(_make_game_pair(
+                rows.extend(make_game_pair(
                     gid, d, "deep_team", opp, 3, 1,
                     age=age, gender=gender,
                 ))
@@ -392,7 +382,7 @@ class TestSOS365DayWindow:
             for rep in range(2):
                 d = base - timedelta(days=100 + k * 8 + rep)  # days 100-180
                 gid = f"do_{gc:04d}"; gc += 1
-                rows.extend(_make_game_pair(
+                rows.extend(make_game_pair(
                     gid, d, "deep_team", opp, 2, 1,
                     age=age, gender=gender,
                 ))

--- a/tests/unit/test_powerscore_edge_cases.py
+++ b/tests/unit/test_powerscore_edge_cases.py
@@ -16,35 +16,7 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from src.etl.v53e import V53EConfig, compute_rankings, _provisional_multiplier
-
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": home,
-            "opp_id": away,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": hs,
-            "ga": as_,
-        },
-        {
-            "game_id": gid,
-            "date": pd.Timestamp(date),
-            "team_id": away,
-            "opp_id": home,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": as_,
-            "ga": hs,
-        },
-    ]
+from tests.conftest import make_game_pair
 
 
 def _round_robin(team_ids, base_date, score_fn=None, n_rounds=2):
@@ -60,7 +32,7 @@ def _round_robin(team_ids, base_date, score_fn=None, n_rounds=2):
                     continue
                 hs, as_ = score_fn(i, j)
                 d = base_date - timedelta(days=gc * 3 + rnd)
-                rows.extend(_make_game_pair(f"g_{gc:04d}", d, h, a, hs, as_))
+                rows.extend(make_game_pair(f"g_{gc:04d}", d, h, a, hs, as_))
                 gc += 1
     return pd.DataFrame(rows)
 
@@ -83,14 +55,14 @@ class TestPowerScoreBounds:
         for i in range(1, len(team_ids)):
             for rep in range(3):
                 d = base - timedelta(days=gc)
-                rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[0], team_ids[i], 6, 0))
+                rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[0], team_ids[i], 6, 0))
                 gc += 1
         # Others play each other
         for i in range(1, len(team_ids)):
             for j in range(i + 1, min(i + 4, len(team_ids))):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 1, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 1, 1))
                     gc += 1
 
         games = pd.DataFrame(rows)
@@ -113,14 +85,14 @@ class TestPowerScoreBounds:
         for i in range(1, len(team_ids)):
             for rep in range(3):
                 d = base - timedelta(days=gc)
-                rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[0], team_ids[i], 0, 6))
+                rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[0], team_ids[i], 0, 6))
                 gc += 1
         # Others play each other
         for i in range(1, len(team_ids)):
             for j in range(i + 1, min(i + 4, len(team_ids))):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
                     gc += 1
 
         games = pd.DataFrame(rows)
@@ -150,13 +122,13 @@ class TestGoalDiffCap:
         # t0 vs t1: 10-0 blowout
         for rep in range(5):
             d = base - timedelta(days=rep * 5)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, "t0", "t1", 10, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, "t0", "t1", 10, 0))
             gc += 1
 
         # t0 vs t2: 6-0 (exact cap)
         for rep in range(5):
             d = base - timedelta(days=rep * 5 + 1)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, "t0", "t2", 6, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, "t0", "t2", 6, 0))
             gc += 1
 
         # Fill out remaining games
@@ -164,7 +136,7 @@ class TestGoalDiffCap:
             for j in range(i + 1, min(i + 4, len(team_ids))):
                 for rep in range(2):
                     d = base - timedelta(days=gc)
-                    rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
+                    rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[i], team_ids[j], 2, 1))
                     gc += 1
 
         games = pd.DataFrame(rows)
@@ -228,7 +200,7 @@ class TestDegenerateCohorts:
         for i in range(len(opp15)):
             for j in range(i + 1, min(i + 3, len(opp15))):
                 d = base - timedelta(days=gc)
-                rows.extend(_make_game_pair(f"g_{gc:04d}", d, opp15[i], opp15[j], 1, 1, age="15"))
+                rows.extend(make_game_pair(f"g_{gc:04d}", d, opp15[i], opp15[j], 1, 1, age="15"))
                 gc += 1
 
         games = pd.DataFrame(rows)
@@ -357,7 +329,7 @@ class TestNaNHandling:
         # One ranked team plays 10 games against unknown opponents
         for i in range(10):
             d = base - timedelta(days=i * 5)
-            rows.extend(_make_game_pair(f"g_{gc:04d}", d, "ranked_team", f"unknown_{i}", 3, 0))
+            rows.extend(make_game_pair(f"g_{gc:04d}", d, "ranked_team", f"unknown_{i}", 3, 0))
             gc += 1
 
         games = pd.DataFrame(rows)

--- a/tests/unit/test_provisional_sos_shrinkage.py
+++ b/tests/unit/test_provisional_sos_shrinkage.py
@@ -15,40 +15,12 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from src.etl.v53e import V53EConfig, compute_rankings, _provisional_multiplier
+from tests.conftest import make_game_pair
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_game_pair(game_id, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {
-            "game_id": game_id,
-            "date": pd.Timestamp(date),
-            "team_id": home,
-            "opp_id": away,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": hs,
-            "ga": as_,
-        },
-        {
-            "game_id": game_id,
-            "date": pd.Timestamp(date),
-            "team_id": away,
-            "opp_id": home,
-            "age": age,
-            "gender": gender,
-            "opp_age": age,
-            "opp_gender": gender,
-            "gf": as_,
-            "ga": hs,
-        },
-    ]
 
 
 def _build_team_with_n_games(team_id, n_games, opponents, base_date, gc_start=0):
@@ -58,7 +30,7 @@ def _build_team_with_n_games(team_id, n_games, opponents, base_date, gc_start=0)
     for i in range(n_games):
         opp = opponents[i % len(opponents)]
         d = base_date - timedelta(days=i * 5)
-        rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_id, opp, 2, 1))
+        rows.extend(make_game_pair(f"g_{gc:04d}", d, team_id, opp, 2, 1))
         gc += 1
     return rows, gc
 
@@ -117,7 +89,7 @@ class TestProvisionalMultInPipeline:
                 f2 = fillers[j]
                 for rep in range(3):
                     d = base - timedelta(days=10 + i * 3 + j + rep)
-                    rows.extend(_make_game_pair(f"fg_{gc:04d}", d, f1, f2, 2, 1))
+                    rows.extend(make_game_pair(f"fg_{gc:04d}", d, f1, f2, 2, 1))
                     gc += 1
 
         # Test teams play against fillers

--- a/tests/unit/test_sos_effective_weight.py
+++ b/tests/unit/test_sos_effective_weight.py
@@ -12,31 +12,12 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from src.etl.v53e import V53EConfig, compute_rankings
+from tests.conftest import make_game_pair
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _make_game_pair(game_id, date, home, away, home_score, away_score,
-                    age="14", gender="male"):
-    return [
-        {
-            "game_id": game_id, "date": pd.Timestamp(date),
-            "team_id": home, "opp_id": away,
-            "age": age, "gender": gender,
-            "opp_age": age, "opp_gender": gender,
-            "gf": home_score, "ga": away_score,
-        },
-        {
-            "game_id": game_id, "date": pd.Timestamp(date),
-            "team_id": away, "opp_id": home,
-            "age": age, "gender": gender,
-            "opp_age": age, "opp_gender": gender,
-            "gf": away_score, "ga": home_score,
-        },
-    ]
-
 
 def _build_cohort(num_teams=20, games_per_team=12, seed=42):
     """Build a cohort with enough teams and games for meaningful SOS variance."""
@@ -51,7 +32,7 @@ def _build_cohort(num_teams=20, games_per_team=12, seed=42):
         h, a = rng.choice(num_teams, size=2, replace=False)
         hs, as_ = int(rng.poisson(1.5)), int(rng.poisson(1.5))
         d = base - timedelta(days=int(rng.randint(1, 300)))
-        rows.extend(_make_game_pair(f"g_{gc:04d}", d, team_ids[h], team_ids[a], hs, as_))
+        rows.extend(make_game_pair(f"g_{gc:04d}", d, team_ids[h], team_ids[a], hs, as_))
         gc += 1
 
     return pd.DataFrame(rows), team_ids

--- a/tests/unit/test_sos_monotonicity.py
+++ b/tests/unit/test_sos_monotonicity.py
@@ -9,29 +9,7 @@ import pandas as pd
 import numpy as np
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-def _make_game(gid, date, home, away, hs, as_, age="15", gender="male",
-               opp_age=None, opp_gender=None):
-    """Create home + away perspective rows for a single game."""
-    opp_age = opp_age or age
-    opp_gender = opp_gender or gender
-    return [
-        {
-            "game_id": str(gid), "date": pd.Timestamp(date),
-            "team_id": home, "opp_id": away,
-            "age": age, "gender": gender,
-            "opp_age": opp_age, "opp_gender": opp_gender,
-            "gf": hs, "ga": as_,
-        },
-        {
-            "game_id": str(gid), "date": pd.Timestamp(date),
-            "team_id": away, "opp_id": home,
-            "age": opp_age, "gender": opp_gender,
-            "opp_age": age, "opp_gender": gender,
-            "gf": as_, "ga": hs,
-        },
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_multi_component_league():
@@ -70,7 +48,8 @@ def _build_multi_component_league():
                 hs, as_ = 1, 3
             else:
                 hs, as_ = 2, 1
-            rows.extend(_make_game(gid, date, home, away, hs, as_))
+            rows.extend(make_game_pair(gid, date, home, away, hs, as_,
+                                      age="15"))
 
     # Component B: 4 teams, round-robin (completely disconnected from A)
     comp_b = [f"team_B{i}" for i in range(4)]
@@ -84,7 +63,8 @@ def _build_multi_component_league():
                 hs, as_ = 0, 4
             else:
                 hs, as_ = 1, 1
-            rows.extend(_make_game(gid, date, home, away, hs, as_))
+            rows.extend(make_game_pair(gid, date, home, away, hs, as_,
+                                      age="15"))
 
     return pd.DataFrame(rows)
 
@@ -212,7 +192,8 @@ def _build_varied_gp_league():
         for away in all_pool[i + 1:]:
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game(gid, date, home, away, 2, 1))
+            rows.extend(make_game_pair(gid, date, home, away, 2, 1,
+                                      age="15"))
 
     # Teams with varied GP, all beating anchor 3-1.
     # Same single opponent => identical raw SOS; only shrinkage differs.
@@ -221,7 +202,8 @@ def _build_varied_gp_league():
         for _ in range(gp_count):
             gid += 1
             date = today - pd.Timedelta(days=gid)
-            rows.extend(_make_game(gid, date, team_name, anchor, 3, 1))
+            rows.extend(make_game_pair(gid, date, team_name, anchor, 3, 1,
+                                      age="15"))
 
     return pd.DataFrame(rows)
 

--- a/tests/unit/test_tier_multiplier.py
+++ b/tests/unit/test_tier_multiplier.py
@@ -104,26 +104,7 @@ import pandas as pd
 from src.etl.v53e import V53EConfig, compute_rankings
 
 
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male",
-                    opp_age=None, opp_gender=None):
-    opp_age = opp_age or age
-    opp_gender = opp_gender or gender
-    return [
-        {
-            "game_id": gid, "date": pd.Timestamp(date),
-            "team_id": home, "opp_id": away,
-            "age": age, "gender": gender,
-            "opp_age": opp_age, "opp_gender": opp_gender,
-            "gf": hs, "ga": as_,
-        },
-        {
-            "game_id": gid, "date": pd.Timestamp(date),
-            "team_id": away, "opp_id": home,
-            "age": opp_age, "gender": opp_gender,
-            "opp_age": age, "opp_gender": gender,
-            "gf": as_, "ga": hs,
-        },
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_tier_test_league():
@@ -146,7 +127,7 @@ def _build_tier_test_league():
                     hs, as_ = 0, 4
                 else:
                     hs, as_ = 2, 1
-                rows.extend(_make_game_pair(str(gid), date, home, away, hs, as_))
+                rows.extend(make_game_pair(str(gid), date, home, away, hs, as_))
     return pd.DataFrame(rows)
 
 

--- a/tests/unit/test_weight_rebalance_analysis.py
+++ b/tests/unit/test_weight_rebalance_analysis.py
@@ -25,21 +25,7 @@ from datetime import datetime, timedelta
 from itertools import product
 
 from src.etl.v53e import V53EConfig, compute_rankings
-
-
-# ---------------------------------------------------------------------------
-# League Builders
-# ---------------------------------------------------------------------------
-
-def _make_game_pair(gid, date, home, away, hs, as_, age="14", gender="male"):
-    return [
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": home, "opp_id": away, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": hs, "ga": as_},
-        {"game_id": gid, "date": pd.Timestamp(date),
-         "team_id": away, "opp_id": home, "age": age, "gender": gender,
-         "opp_age": age, "opp_gender": gender, "gf": as_, "ga": hs},
-    ]
+from tests.conftest import make_game_pair
 
 
 def _build_large_tiered_league(seed=42):
@@ -90,7 +76,7 @@ def _build_large_tiered_league(seed=42):
                 gc += 1
                 hs, as_ = _score(true_skill[t1], true_skill[t2], rng)
                 d = base + timedelta(days=gc % 300)
-                rows.extend(_make_game_pair(f"g{gc}", d, t1, t2, hs, as_))
+                rows.extend(make_game_pair(f"g{gc}", d, t1, t2, hs, as_))
 
     # Elite vs Elite: round-robin (every pair plays twice)
     for i, t1 in enumerate(elite):
@@ -99,7 +85,7 @@ def _build_large_tiered_league(seed=42):
                 gc += 1
                 hs, as_ = _score(true_skill[t1], true_skill[t2], rng)
                 d = base + timedelta(days=gc % 300)
-                rows.extend(_make_game_pair(f"g{gc}", d, t1, t2, hs, as_))
+                rows.extend(make_game_pair(f"g{gc}", d, t1, t2, hs, as_))
 
     # Elite vs Strong: 5 games each
     _add_games(elite, strong, 5, rng)
@@ -120,7 +106,7 @@ def _build_large_tiered_league(seed=42):
             gc += 1
             hs, as_ = _score(true_skill[m], true_skill[w], rng)
             d = base + timedelta(days=gc % 300)
-            rows.extend(_make_game_pair(f"g{gc}", d, m, w, hs, as_))
+            rows.extend(make_game_pair(f"g{gc}", d, m, w, hs, as_))
 
     # Weak vs Weak: lots of games (bubble league)
     _add_games(weak, weak, 8, rng)


### PR DESCRIPTION
## Summary

Tackles 5 items from the improvements backlog focused on reducing complexity and duplication in the ranking engine.

- **RankingContext dataclass**: Groups 11 of 19 parameters on `compute_rankings_with_ml` into a single context object. Callers are cleaner, function signature drops from 19 to 9 params.
- **batch_fetch_rows utility**: Consolidates 3 separate batch-fetch-from-Supabase loops into one shared function in `data_adapter.py`. The two calculator.py loops that were missing retry logic now get it for free.
- **Shared normalize_by_cohort**: Moves cohort normalization into `shared.py` for the ML layer (layer13). Adds tiebreaker support and explicit singleton handling.
- **Remove @vitejs/plugin-react**: Unused devDependency in a Next.js project. `lint-staged` confirmed active and kept.
- **Extract make_game_pair to conftest.py**: 15 test files had near-identical `_make_game_pair` helpers. Now one shared function with cross-age support. 3 files with genuinely different signatures keep their local helpers.

## Test plan

- [x] All 483 unit tests pass
- [x] TypeScript compilation clean after devDep removal
- [x] All imports verified (`RankingContext`, `batch_fetch_rows`, `normalize_by_cohort`)