### PR TITLE
Add 2026 tryout guide blog post and social content

### DIFF
--- a/brand/assets.md
+++ b/brand/assets.md
@@ -30,6 +30,16 @@ Append-only. All skills that produce campaign assets register here.
 | rankings-by-state-ig-carousel | Social (IG carousel) | 2026-03-30 | campaigns/content/social/youth-soccer-rankings-by-state/instagram-carousel.md | draft | 8-slide carousel with design specs |
 | rankings-by-state-tiktok | Social (TikTok scripts) | 2026-03-30 | campaigns/content/social/youth-soccer-rankings-by-state/tiktok-scripts.md | draft | 4 short video scripts with hooks and CTAs |
 | creative-brief | Creative brief | 2026-03-30 | campaigns/creative/creative-brief.md | draft | 7 assets: blog hero, IG carousel, og:image, ad variants, TikTok thumb, email banner |
+| youth-soccer-tryouts-2026 | SEO article (how-to) | 2026-04-07 | campaigns/content/youth-soccer-tryouts-2026.md | draft | Tryout guide for 2026 season, 2750 words, 8 FAQ entries, Article + FAQ JSON-LD schema |
+| tryouts-2026-twitter-thread | Social (X thread) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/twitter/thread.md | draft | 11-tweet thread: 5-step tryout framework |
+| tryouts-2026-twitter-single-01 | Social (X single) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-01.md | draft | "The jersey doesn't develop your kid. Minutes do." |
+| tryouts-2026-twitter-single-02 | Social (X single) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-02.md | draft | Reputation lags reality by 2-3 years |
+| tryouts-2026-twitter-single-03 | Social (X single) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-03.md | draft | Real cost of club soccer breakdown |
+| tryouts-2026-ig-carousel-01 | Social (IG carousel) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel.md | draft | 8-slide: 5 Things Smart Parents Do Before Tryouts |
+| tryouts-2026-ig-carousel-02 | Social (IG carousel) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel-02.md | draft | 7-slide: Real Cost of Club Soccer |
+| tryouts-2026-ig-reel | Social (IG reel) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/instagram/reel-script.md | draft | 35-45s: 3 Things to Watch at Tryouts (Trial Reel) |
+| tryouts-2026-ig-stories | Social (IG story) | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/instagram/story-sequence.md | draft | 6-story tryout quiz sequence with polls |
+| tryouts-2026-schedule | Content calendar | 2026-04-07 | campaigns/content/social/youth-soccer-tryouts-2026/schedule.md | draft | Apr 8-19 posting schedule for X + IG |
 
 ---
 

--- a/campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel-02.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel-02.md
@@ -1,0 +1,120 @@
+---
+platform: instagram
+format: carousel
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Saturday 9:00 AM ET"
+slides: 7
+dimensions: "1080x1350px"
+---
+
+# Instagram Carousel: The Real Cost of Club Soccer (2026)
+
+## Design Notes
+- Brand fonts: Oswald (headers) + DM Sans (body)
+- Use tables/comparisons as visual elements
+- Dollar signs as design motifs
+- Clean, infographic-style layout
+
+---
+
+### Slide 1: Cover (Hook)
+**Headline:** The Real Cost of Club Soccer
+
+**Subtext:** What nobody tells you at tryouts
+
+**Design:** Bold Oswald, piggy bank or dollar sign graphic element, PitchRank brand colors.
+
+---
+
+### Slide 2: The Tier Breakdown
+**Headline:** Annual Cost by Level
+
+| Level | Cost |
+|-------|------|
+| Competitive/Travel | $3K – $5K |
+| ECNL | $8K – $15K |
+| MLS NEXT | $10K – $20K |
+
+**Design:** Clean table layout, each tier in a different shade.
+
+---
+
+### Slide 3: What's Included
+**Headline:** Where the Money Goes
+
+- Club dues: $2K – $5K
+- Travel per tournament: $1,500 – $2,500
+- Gear: $600+
+- Private training: $500 – $2K
+
+**Design:** Pie chart or stacked bar visual.
+
+---
+
+### Slide 4: The Cumulative Number
+**Headline:** By Age 14
+
+**Body:** Most competitive families have spent $20,000 – $80,000 total.
+
+Soccer spending is up 69% since 2019.
+
+**Design:** Large dollar figure centered, trend arrow pointing up.
+
+---
+
+### Slide 5: The Question Nobody Asks
+**Headline:** Is the playing time worth the cost?
+
+**Body:** If your kid sits 40% of games at a $15K club, they're getting less development than starting every game at a $4K club.
+
+Minutes = development. Not the jersey.
+
+---
+
+### Slide 6: What to Ask
+**Headline:** Before You Commit, Ask:
+
+1. What's the TOTAL cost (travel, tournaments, gear)?
+2. How many players on the roster?
+3. What's the playing time philosophy?
+4. What happened to last year's team?
+
+Transparent clubs answer willingly.
+
+---
+
+### Slide 7: CTA
+**Headline:** Compare Clubs with Data
+
+**Body:**
+PitchRank ranks teams across ECNL, MLS NEXT, GA, NPL — same algorithm.
+
+See where your club actually stands.
+
+Link in bio → pitchrank.io
+
+**Design:** PitchRank logo, @PitchRank handle.
+
+---
+
+## Caption
+
+Nobody talks about the real cost of club soccer at tryouts.
+
+Here's what it actually looks like — from competitive travel to ECNL to MLS NEXT.
+
+The number that surprised me most: by age 14, most competitive families have spent $20K-$80K total. And soccer spending is up 69% since 2019.
+
+The question nobody asks: is the playing time worth the price tag?
+
+Save this before tryout season hits. Share with a parent who's about to commit.
+
+Full tryout guide in bio.
+
+.
+.
+.
+
+#clubsoccer #youthsoccer #soccercost #ecnl #mlsnext #soccerparent #tryoutseason #soccermom #soccerdad

--- a/campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/instagram/carousel.md
@@ -1,0 +1,128 @@
+---
+platform: instagram
+format: carousel
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Wednesday 8:00 PM ET"
+slides: 8
+dimensions: "1080x1350px"
+---
+
+# Instagram Carousel: 5 Things Smart Parents Do Before Tryouts
+
+## Design Notes
+- Brand fonts: Oswald (headers) + DM Sans (body)
+- Color palette: PitchRank brand colors
+- High contrast, minimal text per slide
+- Each slide: one idea, large text, clean layout
+
+---
+
+### Slide 1: Cover (Hook)
+**Headline:** 5 Things Smart Parents Do Before Tryouts
+
+**Subtext:** (That most parents skip)
+
+**Design:** Bold Oswald font, dark background, soccer field texture subtle in background. PitchRank logo bottom corner.
+
+---
+
+### Slide 2: The Problem
+**Headline:** 2026 Tryouts Are Different
+
+**Body:** New age groups. Shuffled rosters. Bigger tryout pools. This is the most fluid tryout season in a decade.
+
+**Design:** Split layout — left side shows old system (Jan-Dec), right shows new (Aug-Jul) with arrow between them.
+
+---
+
+### Slide 3: Point 1
+**Headline:** 1. Confirm Your New Age Group
+
+**Body:**
+Born Jan-Jul → Likely moving UP
+Born Aug-Dec → Likely staying or moving DOWN
+
+Ask the club: "What does the roster look like under the new age groups?"
+
+---
+
+### Slide 4: Point 2
+**Headline:** 2. Define What Matters
+
+**Body:**
+College pathway? → Track record of placements
+High-level competition? → Cross-league rankings
+Development + fun? → Great coaching > elite bench
+
+---
+
+### Slide 5: Point 3
+**Headline:** 3. Use Data, Not Gossip
+
+**Body:**
+Club reputation lags reality by 2-3 years.
+
+Compare teams across leagues — ECNL, MLS NEXT, GA, NPL — using the same data.
+
+Not badges. Not tournament trophies.
+
+---
+
+### Slide 6: Point 4
+**Headline:** 4. Watch the Coaches at Tryouts
+
+**Body:**
+Are they organized?
+Do they give feedback — or just blow whistles?
+How do they handle mistakes?
+
+A well-run tryout tells you how the year will go.
+
+---
+
+### Slide 7: Point 5
+**Headline:** 5. Know When to Switch
+
+**Body:**
+Switch if: declining coaching, no playing time, toxic culture.
+
+Stay if: your kid is happy, developing, and playing.
+
+The jersey doesn't develop your kid. Minutes do.
+
+---
+
+### Slide 8: CTA
+**Headline:** Full Tryout Guide
+
+**Body:**
+Link in bio → pitchrank.io/blog
+
+Save this for later.
+Share with a soccer parent who needs it.
+
+**Design:** PitchRank logo centered, @PitchRank handle, clean CTA layout.
+
+---
+
+## Caption
+
+Tryout season is here. And 2026 is different.
+
+New age groups. Shuffled rosters. The biggest reshuffling in a decade.
+
+Here are 5 things smart soccer parents do before tryouts — that most parents skip.
+
+Swipe through for the breakdown.
+
+Full guide in bio — we break down costs, what to ask clubs, and how to compare teams across leagues using actual data.
+
+Save this. Share it with a parent who's stressing about tryouts right now.
+
+.
+.
+.
+
+#youthsoccer #soccertryouts #clubsoccer #soccerparent #ecnl #mlsnext #soccermom #soccerdad #tryoutseason

--- a/campaigns/content/social/youth-soccer-tryouts-2026/instagram/reel-script.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/instagram/reel-script.md
@@ -1,0 +1,72 @@
+---
+platform: instagram
+format: reel
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Thursday 7:00 PM ET"
+duration: "35-45 seconds"
+dimensions: "1080x1920px (9:16)"
+trial_reel: true
+---
+
+# Reel Script: 3 Things to Watch at Tryouts (That Aren't Your Kid)
+
+## Format
+- Talking head with text overlays
+- Quick cuts between points
+- Brand colors in text overlays (Oswald font)
+
+---
+
+## Script
+
+**[0-3 sec] HOOK:**
+(On screen text: "3 things to watch at tryouts")
+
+"Soccer parents — stop watching your kid at tryouts. Watch these three things instead."
+
+---
+
+**[3-12 sec] POINT 1:**
+(On screen text: "1. Watch the coaches")
+
+"First — watch the coaches. Are they organized? Do they give feedback during drills, or just blow whistles? How they run a tryout is exactly how they'll run every practice for the next year."
+
+---
+
+**[12-22 sec] POINT 2:**
+(On screen text: "2. Watch the other parents")
+
+"Second — watch the other parents. You're about to spend 40 weekends with these people. Are they supportive or toxic? Sideline culture is contagious."
+
+---
+
+**[22-32 sec] POINT 3:**
+(On screen text: "3. Ask the hard questions")
+
+"Third — ask the club what they won't volunteer. Total cost including travel. Playing time philosophy. What happened to last year's team. Transparent clubs answer these willingly."
+
+---
+
+**[32-38 sec] PAYOFF:**
+(On screen text: "The jersey doesn't develop your kid. Minutes do.")
+
+"Remember: the jersey doesn't develop your kid. Minutes do."
+
+---
+
+**[38-42 sec] CTA:**
+(On screen text: "@PitchRank — link in bio")
+
+"Full tryout guide in our bio. Save this for someone who needs it."
+
+---
+
+## Caption
+
+Tryout season tip: stop watching your kid. Watch everything else.
+
+Full 2026 tryout guide — link in bio.
+
+#soccertryouts #youthsoccer #clubsoccer #soccerparent #tryoutseason

--- a/campaigns/content/social/youth-soccer-tryouts-2026/instagram/story-sequence.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/instagram/story-sequence.md
@@ -1,0 +1,76 @@
+---
+platform: instagram
+format: story-sequence
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Wednesday 12:00 PM ET"
+stories: 6
+dimensions: "1080x1920px"
+---
+
+# Story Sequence: Tryout Season Quick Quiz
+
+## Story 1: Poll Hook
+**Visual:** Text on brand-color background
+
+**Text:** "Quick question for soccer parents..."
+
+**Sticker:** Poll
+- "Tryouts stress me out" → YES / NO
+
+---
+
+## Story 2: Context
+**Visual:** Text on dark background
+
+**Text:** "2026 tryouts are different. Age groups are reshuffling for the first time in nearly a decade. Every team is reforming."
+
+**Sticker:** None (let them read)
+
+---
+
+## Story 3: Tip 1
+**Visual:** Bold text card
+
+**Text:** "Tip 1: Confirm your kid's new age group FIRST."
+
+"Born Jan-Jul → likely moving UP"
+"Born Aug-Dec → likely staying or moving DOWN"
+
+**Sticker:** Quiz — "The new age cutoff date is:" Aug 1 / Jan 1 / Sep 1 (Answer: Aug 1)
+
+---
+
+## Story 4: Tip 2
+**Visual:** Bold text card
+
+**Text:** "Tip 2: Compare clubs with data, not reputation."
+
+"Club reputation lags reality by 2-3 years. The dominant U12 club might be mid-pack at U14 now."
+
+**Sticker:** None
+
+---
+
+## Story 5: Tip 3
+**Visual:** Bold text card
+
+**Text:** "Tip 3: Watch the coaches at tryouts — not just your kid."
+
+"How they run a tryout = how they'll run the year."
+
+**Sticker:** Emoji slider — "How stressed are you about tryouts?" (soccer ball emoji)
+
+---
+
+## Story 6: CTA
+**Visual:** Brand background with PitchRank logo
+
+**Text:** "Full 2026 Tryout Guide"
+
+"Everything you need — costs, what to ask, how to compare clubs."
+
+**Sticker:** Link sticker → pitchrank.io/blog/youth-soccer-tryouts-2026
+
+**Additional:** "DM us 'TRYOUTS' for a direct link"

--- a/campaigns/content/social/youth-soccer-tryouts-2026/schedule.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/schedule.md
@@ -1,0 +1,61 @@
+---
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+---
+
+# Content Calendar: Tryout Guide Social Distribution
+
+## April 2026
+
+### Week 1 (Apr 7-13)
+
+| Day | Platform | Content | Time (ET) | File |
+|-----|----------|---------|-----------|------|
+| Tue Apr 8 | X/Twitter | Thread: 5-Step Tryout Framework | 7:30 AM | twitter/thread.md |
+| Wed Apr 9 | Instagram | Carousel: 5 Things Smart Parents Do | 8:00 PM | instagram/carousel.md |
+| Wed Apr 9 | Instagram | Story Sequence: Tryout Quiz | 12:00 PM | instagram/story-sequence.md |
+| Thu Apr 10 | X/Twitter | Single: "The jersey doesn't develop your kid" | 8:00 AM | twitter/single-01.md |
+| Thu Apr 10 | Instagram | Reel: 3 Things to Watch at Tryouts | 7:00 PM | instagram/reel-script.md |
+
+### Week 2 (Apr 14-20)
+
+| Day | Platform | Content | Time (ET) | File |
+|-----|----------|---------|-----------|------|
+| Tue Apr 15 | X/Twitter | Single: Reputation Lag | 9:00 PM | twitter/single-02.md |
+| Sat Apr 19 | Instagram | Carousel: Real Cost of Club Soccer | 9:00 AM | instagram/carousel-02.md |
+| Sat Apr 19 | X/Twitter | Single: Cost Reality | 8:00 AM | twitter/single-03.md |
+
+---
+
+## Posting Strategy Notes
+
+### X/Twitter
+- **No external links in tweets** (Grok suppresses link posts for non-Premium accounts as of Mar 2026). Put the link only in the final tweet of the thread and your bio.
+- **Replies matter most.** Craft tweets that invite discussion — ask questions, state opinions.
+- **First 30-60 min is critical.** Post when your audience is active (7-9 AM or 8-10 PM ET for soccer parents — before work or after practice/dinner).
+- **Positive/constructive tone.** Grok's sentiment analysis gives wider distribution to constructive content, reduces reach for combative posts even if engagement is high.
+
+### Instagram
+- **Watch time is the #1 signal in 2026.** Carousels drive dwell time (swipe = time on post). Reels need strong first 3 seconds.
+- **DM shares ("sends per reach") are critical.** Create content people want to DM to a friend — the cost carousel and tryout checklist are designed for this.
+- **Use Trial Reels** for the Reel script — it reaches non-followers first without publishing to your main grid. If it performs, promote it.
+- **Post carousels at peak times** (Wed/Sat evenings for soccer parents — after practice/games).
+- **Relationship signals > vanity metrics.** Story replies, DMs, and saves matter more than likes.
+
+### Timing Rationale
+- **Tue-Thu AM:** Parents checking phones before work/school drop-off
+- **Wed/Thu PM:** After practice, kids in bed, parents scrolling
+- **Sat AM:** Tournament mornings, parents at fields, checking phones between games
+- Avoid Monday (weekly reset chaos) and Friday (practice nights)
+
+---
+
+## Content Recycling
+
+After the initial posting window (Apr 8-19), these pieces can be re-used:
+
+1. **Thread → Carousel adaptation:** Reformat the X thread as a LinkedIn carousel in May
+2. **Cost carousel → Reel:** Turn the cost data into a 15-second Reel with dramatic reveals
+3. **Singles → Quote tweets:** Use singles as responses when tryout discussions trend
+4. **Story sequence → Repeat monthly:** Re-run the story quiz sequence in May during peak tryout season

--- a/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-01.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-01.md
@@ -1,0 +1,16 @@
+---
+platform: twitter
+format: single-tweet
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Thursday 8:00 AM ET"
+---
+
+# Single Tweet: The Jersey Line
+
+The jersey doesn't develop your kid. Minutes do.
+
+If your child sits 40% of games at an elite club, they're getting less development than starting every game one tier down.
+
+Tryout season reality check.

--- a/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-02.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-02.md
@@ -1,0 +1,18 @@
+---
+platform: twitter
+format: single-tweet
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Tuesday 9:00 PM ET"
+---
+
+# Single Tweet: Reputation Lag
+
+Club reputation lags reality by 2-3 years.
+
+The club that was dominant at U12 might have lost its best coach and is now mid-pack at U14.
+
+Don't pick a club based on what they were. Look at what they are.
+
+Data > sideline gossip.

--- a/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-03.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/twitter/single-03.md
@@ -1,0 +1,20 @@
+---
+platform: twitter
+format: single-tweet
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Saturday 8:00 AM ET"
+---
+
+# Single Tweet: Cost Reality
+
+Youth soccer costs parents don't talk about:
+
+Competitive: $3K-$5K/yr
+ECNL: $8K-$15K/yr
+MLS NEXT: $10K-$20K/yr
+
+By age 14, most families have spent $20K-$80K total.
+
+Before tryouts this spring, ask clubs for a FULL cost breakdown. Transparent clubs give it willingly.

--- a/campaigns/content/social/youth-soccer-tryouts-2026/twitter/thread.md
+++ b/campaigns/content/social/youth-soccer-tryouts-2026/twitter/thread.md
@@ -1,0 +1,128 @@
+---
+platform: twitter
+format: thread
+source: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+created: 2026-04-07
+status: draft
+recommended_post_time: "Tuesday 7:30 AM ET"
+---
+
+# Twitter Thread: 2026 Tryout Season Guide
+
+**Tweet 1 (Hook):**
+2026 tryout season is here — and it's unlike any other year.
+
+New age groups. Shuffled rosters. Bigger tryout pools.
+
+Here's a 5-step framework for making the right club decision this spring:
+
+🧵
+
+---
+
+**Tweet 2:**
+First, the context:
+
+Youth soccer is switching from birth-year to school-year age groups starting fall 2026.
+
+That means 2-5 players on every team are shifting age groups. Some teams are losing half their roster.
+
+Tryout pools are bigger and less predictable than any year in recent memory.
+
+---
+
+**Tweet 3:**
+Step 1: Confirm your child's new age group.
+
+The rule: age groups now run Aug 1 – Jul 31 instead of Jan 1 – Dec 31.
+
+Born Jan-Jul → likely moving UP one age group
+Born Aug-Dec → likely staying or moving DOWN
+
+Ask the club directly what their roster looks like under the new system.
+
+---
+
+**Tweet 4:**
+Step 2: Define what actually matters.
+
+Every parent says they want the "best club." But best at what?
+
+- College pathway? Look at placement track records.
+- High-level competition? Check where teams actually rank — across leagues.
+- Development + fun? A mid-tier club with great coaching > an elite club bench.
+
+---
+
+**Tweet 5:**
+The cost reality most parents don't calculate:
+
+Competitive/Travel: $3K-$5K/yr
+ECNL: $8K-$15K/yr
+MLS NEXT: $10K-$20K/yr
+
+If your kid sits 40% of games at a $15K ECNL club, they're getting less development than starting every game at a $4K club one tier down.
+
+---
+
+**Tweet 6:**
+Step 3: Evaluate clubs with data, not sideline gossip.
+
+Reputation lags reality by 2-3 years.
+
+The club that was dominant at U12 might have lost its best coach and is now mid-pack at U14.
+
+Compare teams across leagues using the same data. Not badges. Not tournament trophies.
+
+---
+
+**Tweet 7:**
+Step 4: At tryouts, watch the coaches — not just your kid.
+
+- Are they organized?
+- Do they give individual feedback?
+- How do they handle mistakes?
+
+Then watch the other parents. Sideline culture is contagious. You're about to spend 40+ weekends with these people.
+
+---
+
+**Tweet 8:**
+Step 5: The stay-or-switch decision.
+
+Switch if: playing time dropped, coaching quality declined, team culture is toxic, or another club's team is objectively stronger at the same age group.
+
+Stay if: your kid is happy, developing, and getting meaningful minutes.
+
+---
+
+**Tweet 9:**
+The biggest mistake I see parents make:
+
+Chasing the league name instead of evaluating the team.
+
+"ECNL" and "MLS NEXT" are affiliations, not quality guarantees. The 8th-best ECNL team in your state might be worse than the 2nd-best NPL team.
+
+Compare teams, not badges.
+
+---
+
+**Tweet 10:**
+One line that should guide every tryout decision:
+
+The jersey doesn't develop your kid. Minutes do.
+
+---
+
+**Tweet 11 (CTA):**
+TL;DR:
+
+1. Confirm your new age group
+2. Define what matters (not just "best club")
+3. Evaluate with data, not reputation
+4. Watch coaches and parents at tryouts
+5. Switch for real reasons, not league names
+
+Full guide: pitchrank.io/blog/youth-soccer-tryouts-2026
+
+Follow @PitchRank for rankings you can trust.

--- a/campaigns/content/youth-soccer-tryouts-2026.md
+++ b/campaigns/content/youth-soccer-tryouts-2026.md
@@ -1,0 +1,312 @@
+---
+title: "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents"
+meta_description: "Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch — from parents who've been through it."
+primary_keyword: "youth soccer tryouts 2026"
+secondary_keywords:
+  - "how to choose a youth soccer club"
+  - "preparing for soccer tryouts"
+  - "should I switch soccer clubs"
+  - "club soccer tryouts near me"
+  - "youth soccer tryout tips"
+  - "ECNL vs MLS NEXT tryouts"
+content_type: "how-to"
+search_intent: "informational"
+target_word_count: 2800
+actual_word_count: 2750
+author: "PitchRank Team"
+date_created: "2026-04-07"
+last_updated: "2026-04-07"
+status: "draft"
+serp_snapshot_date: "2026-04-07"
+paa_questions_answered: 8
+schema_article: |
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents",
+    "description": "Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch.",
+    "author": {
+      "@type": "Organization",
+      "name": "PitchRank"
+    },
+    "datePublished": "2026-04-07",
+    "dateModified": "2026-04-07",
+    "publisher": {
+      "@type": "Organization",
+      "name": "PitchRank"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://pitchrank.io/blog/youth-soccer-tryouts-2026"
+    },
+    "keywords": ["youth soccer tryouts 2026", "how to choose a youth soccer club", "preparing for soccer tryouts", "ECNL vs MLS NEXT", "club soccer tryouts"]
+  }
+schema_faq: |
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "When are youth soccer tryouts in 2026?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Most club soccer tryouts happen between April and June 2026. ECNL and MLS NEXT clubs typically hold tryouts in May-June. Local competitive clubs may start as early as March. Check your state association website for specific dates — many publish a tryout calendar by region."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do youth soccer tryouts work?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Most tryouts run 60-90 minutes and include small-sided games (5v5 or 7v7), technical skill stations, and full-sided scrimmages. Coaches evaluate technical ability, game sense, positioning, coachability, and effort. Some clubs hold two sessions to give players a fair evaluation."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do the 2026-2027 age group changes affect tryouts?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Starting fall 2026, most youth soccer organizations are switching from birth-year (Jan 1 – Dec 31) to school-year (Aug 1 – Jul 31) age groups. Players born January through July may move up an age group. Players born August through December may move down. This means spring 2026 tryouts will form teams under the new system, making roster composition less predictable than usual."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Should I switch my child's soccer club?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Consider switching if your child isn't getting meaningful playing time, if the coaching quality has declined, if the club's competitive level no longer matches your child's ability, or if the team culture is toxic. Don't switch just because another club won a tournament — one result doesn't tell you much. Use cross-league ranking data to compare clubs objectively before making a $5K-$15K decision."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What should parents look for at soccer tryouts?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Watch the coaches, not just your kid. Are they organized? Do they give individual feedback? How do they handle mistakes — with coaching or criticism? Also observe the other parents. Sideline culture tells you a lot about what the next year will look like. Ask about the club's player development philosophy, coaching credentials, and total cost including travel and tournament fees."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How much does club soccer cost per year?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Competitive travel soccer costs $3,000-$5,000 per year. ECNL clubs run $8,000-$15,000. MLS NEXT independent clubs can reach $10,000-$20,000. These figures include club dues, travel, tournaments, gear, and private training. Always ask for a full cost breakdown before committing."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is ECNL or MLS NEXT better for my child?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "It depends on your child's age group, location, and goals. In some states and age groups, the top ECNL teams outrank MLS NEXT teams — and in others, it's the opposite. There's no universal answer. Use cross-league ranking data to compare the specific clubs available to your child rather than relying on league reputation alone."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I prepare my child for soccer tryouts?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Start 4-6 weeks before tryouts. Focus on fitness (endurance and agility), first touch, and passing accuracy — those are the basics coaches notice first. But the biggest factor most parents overlook: game sense. Playing pickup games and small-sided scrimmages builds decision-making under pressure, which is what separates players at tryouts more than any technical drill."
+        }
+      }
+    ]
+  }
+---
+
+# Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents
+
+Tryout season is here. And this year, it's different.
+
+The 2026-2027 season brings a major age-group restructuring — the first in nearly a decade. Teams are reforming. Rosters are shuffling. Parents who've been at the same club for four years are suddenly shopping around, and clubs that usually have locked rosters are genuinely open.
+
+If you're trying to figure out which club is right for your kid, whether to stay or switch, or what any of this actually means for the fall — this guide is for you. Not the generic "bring shin guards and a positive attitude" version. The version that uses actual data.
+
+## Why 2026 Tryouts Are Unlike Any Other Year
+
+Two things are colliding at once.
+
+**First, the age-group change.** Starting fall 2026, youth soccer is moving from birth-year age groups (January 1 – December 31) to school-year age groups (August 1 – July 31). US Club Soccer, US Youth Soccer, and AYSO have all adopted it. MLS NEXT Academy Division too.
+
+This means 2-5 players on every team are shifting age groups. Some kids who were the oldest on their team are now the youngest on a new one. Some teams are losing half their roster. Others are gaining players they've never trained with.
+
+The result: tryout pools are bigger, more competitive, and less predictable than any year in recent memory.
+
+**Second, the ECNL/MLS NEXT/GA landscape keeps shifting.** Clubs are switching affiliations. New programs are launching. The league your kid played in last year might not exist at the same club next year.
+
+This is the most fluid tryout season in a decade. That's stressful. But it's also an opportunity — if you know what to look for.
+
+## Step 1: Figure Out Your Child's New Age Group
+
+Before you do anything else, confirm which age group your child falls into under the new system.
+
+**The rule is simple:** Age groups now run August 1 through July 31 instead of January 1 through December 31.
+
+| Birth Month | What Happens |
+|-------------|-------------|
+| January – July | You likely move *up* one age group |
+| August – December | You likely stay or move *down* one age group |
+
+**Example:** A player born March 15, 2013 was in the 2013 birth-year group (U13). Under the new system, they'll be grouped with players born August 1, 2012 through July 31, 2013 — effectively moving up to compete with some kids a year older.
+
+A player born October 2013 would now be grouped with August 2013 – July 2014, potentially moving down to play with younger kids.
+
+This matters for tryouts because the team your child is trying out for might have a completely different roster composition than what you're expecting. Ask the club directly: *"What does the roster look like under the new age groups?"*
+
+We wrote a [full breakdown of the age-group change](https://pitchrank.io/blog/youth-soccer-age-group-change-2026-2027) if you want the details.
+
+## Step 2: Define What Actually Matters to Your Family
+
+Every parent says they want the "best club." But best at what?
+
+Before you attend a single tryout, answer these three questions honestly:
+
+**1. What's the goal?**
+
+- College pathway? You need a club with a track record of placing players — not just one that claims to.
+- High-level competition? Look at where teams rank, not just which league crest is on the jersey.
+- Development and fun? A mid-tier club with great coaching might be better than an elite club where your kid rides the bench.
+
+**2. What can you actually commit to?**
+
+| Level | Annual Cost | Travel | Practice Days |
+|-------|------------|--------|--------------|
+| Competitive/Travel | $3,000 – $5,000 | Regional | 2-3x/week |
+| ECNL | $8,000 – $15,000 | Regional + National | 3-4x/week |
+| MLS NEXT | $10,000 – $20,000 | Regional + National | 4-5x/week |
+
+Be honest about this. A family spending $15K/year on ECNL when they can't make Thursday practices isn't getting $15K of value. A $4K competitive club where your kid plays every minute and has a coach who knows their name might be the smarter investment.
+
+**3. Does the playing time justify the cost?**
+
+If your kid sits 40% of games at an ECNL club, they're getting less actual development than they would starting every game at a competitive club one tier down. Playing time is development time. The jersey doesn't develop your kid. Minutes do.
+
+## Step 3: Evaluate Clubs with Data, Not Sideline Gossip
+
+Here's where most parents go wrong: they pick clubs based on reputation, league name, or what another parent told them at a tournament.
+
+Reputation lags reality by 2-3 years. The club that was dominant at U12 might have lost its best coach and is now middle-of-the-pack at U14. The MLS NEXT affiliate everyone talks about might actually rank below an ECNL-RL team in your area at your child's age group.
+
+**What to look at instead:**
+
+**Cross-league rankings.** Don't just compare teams within the same league. Compare across leagues. An ECNL team ranked #45 nationally might be weaker than an NPL team ranked #12 in your state. The league name on the jersey tells you less than you think.
+
+This is exactly what [PitchRank](https://pitchrank.io) was built for — ranking teams across ECNL, MLS NEXT, GA, NPL, and state leagues using the same algorithm. Same data. Same method. Apples to apples.
+
+**Strength of schedule.** A team with a 10-2 record against weak opponents isn't the same as a team that went 7-5 against top-25 competition. Look at who they played, not just whether they won.
+
+**Trend over time.** Is the club's program getting better or worse? A team that's climbed 30 spots in the rankings over two seasons has momentum. A team that's dropped 50 spots has a problem — and it's probably not the players.
+
+**Coach tenure.** How long has the coach been with this team? High coach turnover is a red flag. If the coach who built the program left six months ago, the team you're trying out for might not resemble the one you researched.
+
+## Step 4: What to Watch at Tryouts (Besides Your Kid)
+
+Your kid is going to be nervous. You're going to be nervous. But tryouts aren't just an audition for your child — they're an audition for the club.
+
+**Watch the coaches.**
+
+- Are they organized? A well-run tryout tells you how practices will run all year.
+- Do they give individual feedback during drills, or just blow whistles?
+- How do they handle mistakes? Coaching and encouragement, or yelling and bench threats?
+- Do they know the players' names? Even returning players?
+
+**Watch the other parents.**
+
+This part gets overlooked. You're about to spend 40+ weekends with these people. Are they supportive or toxic? Do they scream instructions from the sideline? Do they trash-talk other clubs or referees?
+
+Sideline culture is contagious. A team full of talent with a toxic parent group will drain your family's energy faster than a long tournament weekend.
+
+**Ask the right questions.**
+
+Don't just ask "what league are you in?" Ask:
+
+- What's the total cost for the year, including travel and tournaments?
+- How many players will be on the roster?
+- What's the playing time philosophy? (Minutes-based? Merit-based? Rotation?)
+- What's the coach-to-player ratio at practice?
+- How are teams formed under the new age groups?
+- What happened to last year's team? Did players leave? Why?
+
+A club that's transparent about these answers is one worth considering. A club that dodges them is telling you something.
+
+## Step 5: The Stay-or-Switch Decision
+
+This is the hardest part. Your kid has friends on the current team. You've invested years. Switching feels disloyal.
+
+But loyalty to a club that isn't serving your child isn't loyalty — it's inertia.
+
+**Consider switching if:**
+
+- Your child's playing time has dropped significantly without explanation
+- The coaching staff turned over and the replacement is weaker
+- The team's competitive level no longer matches your child's ability (too high or too low)
+- The club's culture has shifted — more politics, less development
+- Another club's team at the same age group is objectively stronger (check the data, not the sideline talk)
+
+**Stay if:**
+
+- Your child is happy, developing, and getting meaningful minutes
+- The coaching is strong and consistent
+- The team's trajectory is positive — improving season over season
+- The club is transparent and communicates well with families
+
+**Don't switch just because:**
+
+- Another club won a single tournament (one weekend doesn't tell you much)
+- A parent from another club recruited you at a showcase (that's sales, not scouting)
+- You're chasing a league name without comparing the actual teams
+
+The age-group restructuring makes 2026 a natural transition point. If you've been thinking about switching, this is the year to do it — everyone is reshuffling.
+
+## Common Mistakes Parents Make During Tryout Season
+
+**Chasing the league name instead of the team.** "ECNL" and "MLS NEXT" are league affiliations, not quality guarantees. The 8th-best ECNL team in your state might be worse than the 2nd-best NPL team. Compare teams, not badges.
+
+**Ignoring total cost.** Registration is just the start. Travel, tournaments, gear, private training — the real number is 2-3x what the club quotes on their website. Get the full picture before you commit.
+
+**Making decisions based on one tryout.** A 90-minute tryout is a terrible sample size. Your kid might have an off day. The coach might be distracted. Attend open practices, watch games, talk to current families. Build a fuller picture.
+
+**Letting your ego choose the club.** "My kid plays ECNL" sounds great at the office. But if your kid is miserable, riding the bench, and dreading practice, the social status isn't worth it. Development happens where your child is challenged, coached, and actually playing.
+
+**Not factoring in the age-group change.** This year isn't like other years. The team your kid is trying out for might look completely different by August. Ask clubs specifically how the new age groups affect their roster plans.
+
+## Frequently Asked Questions
+
+### When are youth soccer tryouts in 2026?
+
+Most club soccer tryouts happen between April and June 2026. ECNL and MLS NEXT clubs typically hold tryouts in May-June. Local competitive clubs may start as early as March. Check your state association website or [US Club Soccer's tryout page](https://usclubsoccer.org) for specific dates in your area.
+
+### How do youth soccer tryouts work?
+
+Most tryouts run 60-90 minutes. Coaches use small-sided games (5v5 or 7v7) to see how players handle real game pressure, then move to full-sided scrimmages. They're evaluating technical ability, game sense, positioning, coachability, and effort. Some clubs hold two sessions to give players a fair look — ask if that's an option.
+
+### How do the 2026-2027 age group changes affect tryouts?
+
+The switch from birth-year (Jan 1 – Dec 31) to school-year (Aug 1 – Jul 31) age groups means rosters are reshuffling across the board. Players born January through July may move up an age group. Players born August through December may move down. Spring 2026 tryouts will form teams under the new system, so expect bigger tryout pools and less roster continuity than usual.
+
+### Should I switch my child's soccer club?
+
+Only if there's a real reason — declining coaching quality, lack of playing time, a mismatch in competitive level, or toxic team culture. Don't switch because another club won a tournament or because a parent recruited you. Use ranking data to compare clubs objectively. And if you're on the fence, the age-group restructuring makes 2026 a natural transition point.
+
+### What should I look for when choosing a club?
+
+Look at the coach first, the club second, and the league third. A great coach at a mid-tier club will develop your kid faster than a mediocre coach at an elite club. Then compare the team's actual performance using cross-league data — not reputation, not league name, not tournament results from two years ago.
+
+### Is ECNL or MLS NEXT better for my child?
+
+There's no universal answer. In some states and age groups, ECNL teams dominate. In others, MLS NEXT clubs are stronger. The only way to know is to compare the specific teams available to your child at their age group in your area. [PitchRank](https://pitchrank.io) ranks teams across all leagues using the same algorithm — check where the clubs you're considering actually stand.
+
+### How much does club soccer really cost?
+
+Competitive travel soccer runs $3,000-$5,000/year. ECNL: $8,000-$15,000. MLS NEXT: $10,000-$20,000. These are all-in estimates including dues, travel, tournaments, gear, and training. By age 14, most competitive families have spent $20,000-$80,000 total. Always ask for a full cost breakdown — transparent clubs provide it willingly.
+
+### How do I prepare my child for tryouts?
+
+Start 4-6 weeks out. Focus on fitness, first touch, and passing accuracy — coaches notice those immediately. But the biggest differentiator is game sense: reading the play, making decisions under pressure, playing without the ball. Small-sided pickup games build this better than cone drills. And the night before? Rest. A well-rested player who plays relaxed beats a tired one trying too hard.
+
+---
+
+**Internal links included:**
+- [Youth Soccer Age Group Changes for 2026-2027](https://pitchrank.io/blog/youth-soccer-age-group-change-2026-2027)
+- [PitchRank Rankings](https://pitchrank.io)
+- [What Predicts Winning Beyond Goals](https://pitchrank.io/blog/what-predicts-winning-beyond-goals)


### PR DESCRIPTION
SEO blog post covering 2026 tryout season (age group restructuring, club evaluation framework, cost breakdowns, stay-or-switch decision guide). Includes Article + FAQ JSON-LD schema with 8 PAA questions.

Atomized into X/Twitter (11-tweet thread + 3 singles) and Instagram (2 carousels, 1 Reel script, 1 story sequence) with an April 8-19 posting schedule. Algorithm-adjusted for Grok link suppression on X and Trial Reels on Instagram.

All content in `campaigns/content/` and `campaigns/content/social/youth-soccer-tryouts-2026/`. Asset registry updated.