### PR TITLE
Fix remaining P0/P1 audit findings: CVE, Supabase client migration, quality

### DIFF
--- a/frontend/app/api/agent-activity/route.ts
+++ b/frontend/app/api/agent-activity/route.ts
@@ -64,6 +64,7 @@ export async function POST(request: NextRequest) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const body = await request.json();
     const { session_key, agent_name, agent_emoji, message_preview, full_message, message_type } = body;

--- a/frontend/app/api/agent-activity/route.ts
+++ b/frontend/app/api/agent-activity/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 // GET - fetch recent agent activity from Supabase
@@ -7,6 +6,7 @@ export async function GET() {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     console.log('[AgentActivity] Fetching from Supabase');
 

--- a/frontend/app/api/agent-status/route.ts
+++ b/frontend/app/api/agent-status/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 interface AgentStatusResponse {
@@ -77,6 +76,7 @@ export async function GET() {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const agentIds = Object.keys(AGENT_SCHEDULES);
 

--- a/frontend/app/api/agent-webhook/route.ts
+++ b/frontend/app/api/agent-webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createServerSupabase } from '@/lib/supabase/server';
 
 /**
  * Agent Webhook API
@@ -24,7 +25,7 @@ interface WebhookPayload {
 }
 
 /** Find the task_id associated with a session key via task_comments */
-async function findTaskBySession(sessionKey: string): Promise<string | null> {
+async function findTaskBySession(supabase: SupabaseClient, sessionKey: string): Promise<string | null> {
   const { data: comments } = await supabase
     .from('task_comments')
     .select('task_id')
@@ -72,6 +73,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const supabase = await createServerSupabase();
     const body: WebhookPayload = await request.json();
     const { action, sessionKey, agentName, task, result, error: errorMsg } = body;
 
@@ -163,7 +165,7 @@ export async function POST(request: NextRequest) {
           })
           .eq('session_key', sessionKey);
 
-        const taskId = await findTaskBySession(sessionKey);
+        const taskId = await findTaskBySession(supabase, sessionKey);
         if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }
@@ -191,7 +193,7 @@ export async function POST(request: NextRequest) {
           })
           .eq('session_key', sessionKey);
 
-        const taskId = await findTaskBySession(sessionKey);
+        const taskId = await findTaskBySession(supabase, sessionKey);
         if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }
@@ -238,7 +240,7 @@ export async function POST(request: NextRequest) {
           })
           .eq('session_key', sessionKey);
 
-        const taskId = await findTaskBySession(sessionKey);
+        const taskId = await findTaskBySession(supabase, sessionKey);
         if (!taskId) {
           return NextResponse.json({ error: 'Task not found for session' }, { status: 404 });
         }

--- a/frontend/app/api/announcements/route.ts
+++ b/frontend/app/api/announcements/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServerSupabase } from '@/lib/supabase/server';
 
 export interface Announcement {
   id: string;
@@ -12,6 +12,7 @@ export interface Announcement {
 /** GET is intentionally public — announcements are user-facing content */
 export async function GET(request: NextRequest) {
   try {
+    const supabase = await createServerSupabase();
     const { searchParams } = new URL(request.url);
     const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '10'), 1), 50);
 
@@ -38,6 +39,7 @@ export async function POST(request: NextRequest) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const body = await request.json();
     const { message, author } = body;

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
+import { createServerSupabase } from '@/lib/supabase/server';
 
 /**
  * GET /api/chat
@@ -7,6 +7,7 @@ import { supabase } from '@/lib/supabaseClient';
  */
 export async function GET() {
   try {
+    const supabase = await createServerSupabase();
     const { data, error } = await supabase
       .from('mission_chat')
       .select('*')
@@ -35,6 +36,7 @@ export async function GET() {
  */
 export async function POST(request: NextRequest) {
   try {
+    const supabase = await createServerSupabase();
     const body = await request.json();
     const { author, author_type = 'human', content } = body;
 

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -55,7 +55,7 @@ export async function GET(request: Request) {
   const platform = searchParams.get('platform') || 'instagram'; // instagram, twitter, story
   const ageGroup = searchParams.get('age_group') || undefined;
   const gender = searchParams.get('gender') || undefined;
-  const limit = parseInt(searchParams.get('limit') || '5');
+  const limit = Math.min(parseInt(searchParams.get('limit') || '5') || 5, 10);
 
   // Platform dimensions
   const dimensions = {

--- a/frontend/app/api/tasks/[id]/comments/route.ts
+++ b/frontend/app/api/tasks/[id]/comments/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 export interface TaskComment {
@@ -19,6 +18,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { id: taskId } = await params;
 
@@ -45,6 +45,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { id: taskId } = await params;
     const body = await request.json();

--- a/frontend/app/api/tasks/[id]/route.ts
+++ b/frontend/app/api/tasks/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 interface RouteParams {
@@ -11,6 +10,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { id } = await params;
 
@@ -32,6 +32,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { id } = await params;
     const body = await request.json();
@@ -98,6 +99,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { id } = await params;
 

--- a/frontend/app/api/tasks/route.ts
+++ b/frontend/app/api/tasks/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 export interface AgentTask {
@@ -19,6 +18,7 @@ export async function GET() {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const { data, error } = await supabase.from('agent_tasks').select('*').order('created_at', { ascending: false });
 
@@ -39,6 +39,7 @@ export async function POST(request: NextRequest) {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const body = await request.json();
 

--- a/frontend/app/api/tasks/seed/route.ts
+++ b/frontend/app/api/tasks/seed/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
 import { requireAdmin } from '@/lib/supabase/admin';
 
 const seedTasks = [
@@ -46,6 +45,7 @@ export async function POST() {
   try {
     const auth = await requireAdmin();
     if (auth.error) return auth.error;
+    const { supabase } = auth;
 
     const results = {
       created: 0,

--- a/frontend/components/HomeStats.tsx
+++ b/frontend/components/HomeStats.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { createClientSupabase } from '@/lib/supabase/client';
 
 interface HomeStatsProps {
   fallbackGames?: number;
@@ -17,6 +17,7 @@ export function HomeStats({ fallbackGames = 16000, fallbackTeams = 2800 }: HomeS
   useEffect(() => {
     async function fetchStats() {
       try {
+        const supabase = createClientSupabase();
         // Try RPC function first
         const { data, error } = await supabase.rpc('get_db_stats');
 

--- a/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
+++ b/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
@@ -57,15 +57,15 @@ In late 2024, U.S. Soccer removed the January 1 mandate. In June 2025, the three
 
 This is where it gets messy. Not everyone is on the same page.
 
-| Organization | New Aug 1 Cutoff? | Notes |
-|---|---|---|
-| US Club Soccer | Yes | |
-| US Youth Soccer | Yes | |
-| AYSO | Yes | |
-| ECNL (boys and girls) | Yes | |
-| Girls Academy | Yes | |
-| MLS NEXT — Academy Division | Yes | |
-| **MLS NEXT — Homegrown Division** | **No** | **Stays on Jan 1 birth year** |
+| Organization                      | New Aug 1 Cutoff? | Notes                         |
+| --------------------------------- | ----------------- | ----------------------------- |
+| US Club Soccer                    | Yes               |                               |
+| US Youth Soccer                   | Yes               |                               |
+| AYSO                              | Yes               |                               |
+| ECNL (boys and girls)             | Yes               |                               |
+| Girls Academy                     | Yes               |                               |
+| MLS NEXT — Academy Division       | Yes               |                               |
+| **MLS NEXT — Homegrown Division** | **No**            | **Stays on Jan 1 birth year** |
 
 That last row is the one causing headaches. MLS NEXT's Homegrown Division — the pathway that feeds directly into MLS professional academies — is keeping the January 1 cutoff to stay aligned with international standards.
 
@@ -77,18 +77,18 @@ If this sounds confusing, that's because it is. Ask your club directly which sys
 
 Here's where every birth date falls under the new August 1 – July 31 system for the 2026-2027 season:
 
-| Age Group | Birth Date Range |
-|---|---|
-| U19 | Aug 1, 2007 – Jul 31, 2009 |
-| U17 | Aug 1, 2009 – Jul 31, 2010 |
-| U16 | Aug 1, 2010 – Jul 31, 2011 |
-| U15 | Aug 1, 2011 – Jul 31, 2012 |
-| U14 | Aug 1, 2012 – Jul 31, 2013 |
-| U13 | Aug 1, 2013 – Jul 31, 2014 |
-| U12 | Aug 1, 2014 – Jul 31, 2015 |
-| U11 | Aug 1, 2015 – Jul 31, 2016 |
-| U10 | Aug 1, 2016 – Jul 31, 2017 |
-| U9 | Aug 1, 2017 – Jul 31, 2018 |
+| Age Group | Birth Date Range           |
+| --------- | -------------------------- |
+| U19       | Aug 1, 2007 – Jul 31, 2009 |
+| U17       | Aug 1, 2009 – Jul 31, 2010 |
+| U16       | Aug 1, 2010 – Jul 31, 2011 |
+| U15       | Aug 1, 2011 – Jul 31, 2012 |
+| U14       | Aug 1, 2012 – Jul 31, 2013 |
+| U13       | Aug 1, 2013 – Jul 31, 2014 |
+| U12       | Aug 1, 2014 – Jul 31, 2015 |
+| U11       | Aug 1, 2015 – Jul 31, 2016 |
+| U10       | Aug 1, 2016 – Jul 31, 2017 |
+| U9        | Aug 1, 2017 – Jul 31, 2018 |
 
 **Quick rule of thumb:**
 
@@ -204,4 +204,4 @@ In 2017, U.S. Soccer mandated a January 1 – December 31 cutoff to align with F
 
 ---
 
-*Sources: [US Club Soccer](https://usclubsoccer.org/age-group-cut-off-update-for-2026-27-season/), [US Youth Soccer](https://www.usyouthsoccer.org/news/2025/06/10/updated-decision-on-age-group-formation/), [U.S. Soccer](https://www.ussoccer.com/ecosystem-review/player-registration), [MLS NEXT](https://www.mlssoccer.com/mlsnext/news/mls-next-announces-age-group-update), [Girls Academy](https://girlsacademyleague.com/2025/09/girls-academy-to-adopt-seasonal-year-age-group-formation-beginning-in-2026-2027/)*
+_Sources: [US Club Soccer](https://usclubsoccer.org/age-group-cut-off-update-for-2026-27-season/), [US Youth Soccer](https://www.usyouthsoccer.org/news/2025/06/10/updated-decision-on-age-group-formation/), [U.S. Soccer](https://www.ussoccer.com/ecosystem-review/player-registration), [MLS NEXT](https://www.mlssoccer.com/mlsnext/news/mls-next-announces-age-group-update), [Girls Academy](https://girlsacademyleague.com/2025/09/girls-academy-to-adopt-seasonal-year-age-group-formation-beginning-in-2026-2027/)_

--- a/frontend/content/blog/youth-soccer-tryouts-2026.mdx
+++ b/frontend/content/blog/youth-soccer-tryouts-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents'
 slug: 'youth-soccer-tryouts-2026'
-excerpt: "Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch."
+excerpt: 'Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch.'
 author: 'PitchRank Team'
 date: '2026-04-07'
 readingTime: '10 min read'
@@ -45,16 +45,16 @@ Before you do anything else, confirm which age group your child falls into under
 
 **The rule is simple:** Age groups now run August 1 through July 31 instead of January 1 through December 31.
 
-| Birth Month | What Happens |
-|-------------|-------------|
-| January – July | You likely move *up* one age group |
-| August – December | You likely stay or move *down* one age group |
+| Birth Month       | What Happens                                 |
+| ----------------- | -------------------------------------------- |
+| January – July    | You likely move _up_ one age group           |
+| August – December | You likely stay or move _down_ one age group |
 
 **Example:** A player born March 15, 2013 was in the 2013 birth-year group (U13). Under the new system, they'll be grouped with players born August 1, 2012 through July 31, 2013 — effectively moving up to compete with some kids a year older.
 
 A player born October 2013 would now be grouped with August 2013 – July 2014, potentially moving down to play with younger kids.
 
-This matters for tryouts because the team your child is trying out for might have a completely different roster composition than what you're expecting. Ask the club directly: *"What does the roster look like under the new age groups?"*
+This matters for tryouts because the team your child is trying out for might have a completely different roster composition than what you're expecting. Ask the club directly: _"What does the roster look like under the new age groups?"_
 
 We wrote a [full breakdown of the age-group change](/blog/youth-soccer-age-group-change-2026-2027) if you want the details.
 
@@ -72,11 +72,11 @@ Before you attend a single tryout, answer these three questions honestly:
 
 **2. What can you actually commit to?**
 
-| Level | Annual Cost | Travel | Practice Days |
-|-------|------------|--------|--------------|
-| Competitive/Travel | $3,000 – $5,000 | Regional | 2-3x/week |
-| ECNL | $8,000 – $15,000 | Regional + National | 3-4x/week |
-| MLS NEXT | $10,000 – $20,000 | Regional + National | 4-5x/week |
+| Level              | Annual Cost       | Travel              | Practice Days |
+| ------------------ | ----------------- | ------------------- | ------------- |
+| Competitive/Travel | $3,000 – $5,000   | Regional            | 2-3x/week     |
+| ECNL               | $8,000 – $15,000  | Regional + National | 3-4x/week     |
+| MLS NEXT           | $10,000 – $20,000 | Regional + National | 4-5x/week     |
 
 Be honest about this. A family spending $15K/year on ECNL when they can't make Thursday practices isn't getting $15K of value. A $4K competitive club where your kid plays every minute and has a coach who knows their name might be the smarter investment.
 

--- a/frontend/hooks/useInstagramHandles.ts
+++ b/frontend/hooks/useInstagramHandles.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabaseClient';
+import { createClientSupabase } from '@/lib/supabase/client';
 
 export interface InstagramHandle {
   team_id: string;
@@ -17,6 +17,7 @@ export function useInstagramHandles(teamIds: string[]) {
     queryKey: ['instagram-handles', teamIds.join(',')],
     enabled: teamIds.length > 0,
     queryFn: async () => {
+      const supabase = createClientSupabase();
       // Batch to 100 IDs max per query (Supabase URI limit)
       const batchSize = 100;
       const allRows: InstagramHandle[] = [];

--- a/frontend/hooks/useScrapeRequestNotifications.ts
+++ b/frontend/hooks/useScrapeRequestNotifications.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { createClientSupabase } from '@/lib/supabase/client';
 import { toast } from '@/components/ui/Toaster';
 
 /**
@@ -9,6 +9,7 @@ import { toast } from '@/components/ui/Toaster';
  * Tracks request IDs from localStorage (submitted from this browser session)
  */
 export function useScrapeRequestNotifications() {
+  const supabase = createClientSupabase();
   const subscriptionRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
   const processedRequestsRef = useRef<Set<string>>(new Set());
 

--- a/frontend/hooks/useTeamSearch.ts
+++ b/frontend/hooks/useTeamSearch.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabaseClient';
+import { createClientSupabase } from '@/lib/supabase/client';
 import { normalizeAgeGroup } from '@/lib/utils';
 import type { RankingRow } from '@/types/RankingRow';
 
@@ -15,6 +15,7 @@ export function useTeamSearch() {
   return useQuery<RankingRow[]>({
     queryKey: ['team-search'],
     queryFn: async () => {
+      const supabase = createClientSupabase();
       const BATCH_SIZE = 1000; // Supabase default limit
       const allTeams: RankingRow[] = [];
       let offset = 0;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,8 @@
-import { supabase } from './supabaseClient';
+import { createClientSupabase } from './supabase/client';
 import { AppError } from './errors';
+
+// Singleton — createClientSupabase() caches the instance internally
+const supabase = createClientSupabase();
 import { normalizeAgeGroup } from './utils';
 import type {
   Team,

--- a/frontend/lib/supabase/admin.ts
+++ b/frontend/lib/supabase/admin.ts
@@ -1,17 +1,23 @@
 import { NextResponse } from 'next/server';
+import { SupabaseClient } from '@supabase/supabase-js';
 import { createServerSupabase } from './server';
 
 /**
  * Verify the request is from an authenticated admin user.
- * Returns the user object if authorized, or a NextResponse error.
+ * Returns the user and supabase client if authorized, or a NextResponse error.
  *
  * Usage in route handlers:
  *   const auth = await requireAdmin();
  *   if (auth.error) return auth.error;
- *   const { user } = auth;
+ *   const { user, supabase } = auth;
  */
 export async function requireAdmin(): Promise<
-  { user: { id: string; email?: string }; error: null } | { user: null; error: NextResponse }
+  | {
+      user: { id: string; email?: string };
+      supabase: SupabaseClient;
+      error: null;
+    }
+  | { user: null; supabase: null; error: NextResponse }
 > {
   try {
     const supabase = await createServerSupabase();
@@ -24,6 +30,7 @@ export async function requireAdmin(): Promise<
     if (authError || !user) {
       return {
         user: null,
+        supabase: null,
         error: NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
       };
     }
@@ -33,14 +40,16 @@ export async function requireAdmin(): Promise<
     if (!profile || profile.plan !== 'admin') {
       return {
         user: null,
+        supabase: null,
         error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
       };
     }
 
-    return { user, error: null };
+    return { user, supabase, error: null };
   } catch {
     return {
       user: null,
+      supabase: null,
       error: NextResponse.json({ error: 'Authentication failed' }, { status: 500 }),
     };
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3268,9 +3268,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -3285,9 +3285,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -3319,9 +3319,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -3353,9 +3353,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
@@ -3387,9 +3387,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3404,9 +3404,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
@@ -3421,9 +3421,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
@@ -3438,9 +3438,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
@@ -3455,9 +3455,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -3472,9 +3472,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -3482,16 +3482,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3508,9 +3510,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -3525,9 +3527,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -3540,6 +3542,13 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -11299,14 +11308,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -11315,29 +11324,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -12786,16 +12788,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.13",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -12813,7 +12815,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,5 +80,8 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "vite": ">=8.0.5"
   }
 }

--- a/src/rankings/constants.py
+++ b/src/rankings/constants.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-# Static age → anchor mapping for U10–U19
-# Younger teams have lower max PowerScore, older teams can reach 1.0
+from src.etl.glicko_config import GlickoConfig
+
+# Compute age → anchor mapping from gendered anchors (avg M/F).
+# This ensures AGE_TO_ANCHOR stays in sync with GlickoConfig.MALE_ANCHORS
+# and FEMALE_ANCHORS automatically — no manual updates needed.
+_cfg = GlickoConfig()
 AGE_TO_ANCHOR: dict[int, float] = {
-    10: 0.788,  # Calibrated from empirical cross-age competition data (avg M/F)
-    11: 0.811,  # Old values (U10=0.40, U14=0.70) over-penalized younger ages by ~2x
-    12: 0.855,
-    13: 0.896,
-    14: 0.943,
-    15: 0.949,
-    16: 0.973,
-    17: 0.981,
-    18: 0.992,
-    19: 1.000,  # U19 encompasses birth years 2007+2008 (formerly U18+U19)
+    age: round((_cfg.MALE_ANCHORS[age] + _cfg.FEMALE_ANCHORS[age]) / 2, 3)
+    for age in _cfg.MALE_ANCHORS
+    if age in _cfg.FEMALE_ANCHORS
 }
+del _cfg
 
 # SOS-conditioned ML scaling thresholds
 # Below LOW, ML has no authority; above HIGH, ML has full authority


### PR DESCRIPTION
## Summary
- **D-1**: Fix vite 8.0.3 CVEs (3 advisories: GHSA-4w7w, GHSA-v2wj, GHSA-p9ff) via npm override `>=8.0.5`
- **S-4**: Cap infographic `limit` param to max 10 to prevent unbounded server-side rendering
- **Q-2**: `requireAdmin()` now returns `{ user, supabase, error }` matching `requireAuth`/`requirePremium` pattern
- **Q-1**: Migrate all 14 files from legacy `supabaseClient.ts` singleton to proper `@supabase/ssr` browser/server clients
- **Q-4**: `AGE_TO_ANCHOR` computed from `MALE_ANCHORS + FEMALE_ANCHORS` at import time (auto-sync with `glicko_config.py`)

Builds on the 44-finding fix in 4ed0ed6. Together these two commits resolve all P0 and most P1 findings from the April 7 audit.

### Evaluated & skipped (noted in improvements backlog)
- **Q-5**: Matcher dedup (4 providers, ~300 lines) — too high blast radius for this PR
- **C-11**: ML temporal data leakage — requires ranking snapshot infrastructure
- **T-5→T-13**: Test coverage gaps — tracked separately
- **A-3, S-8**: Disputed by Devil's Advocate review — code is correct as-is

## Test plan
- [ ] `npm run typecheck` passes in frontend
- [ ] `npm run test` passes (vitest)
- [ ] `npm run build` succeeds (verifies no broken imports after Supabase client migration)
- [ ] Verify `AGE_TO_ANCHOR` values match expected averages: `cd C:/PitchRank && python -c "from src.rankings.constants import AGE_TO_ANCHOR; print(AGE_TO_ANCHOR)"`
- [ ] Spot-check admin routes still work (Mission Control tasks, agent status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)