### PR TITLE
Upgrade compare predictor and add point-in-time backtests

### DIFF
--- a/frontend/components/ComparePanel.tsx
+++ b/frontend/components/ComparePanel.tsx
@@ -141,7 +141,7 @@ export function ComparePanel() {
         team_b_name: team2Details.team_name,
         win_probability_a: prediction.winProbabilityA,
         win_probability_b: prediction.winProbabilityB,
-        draw_probability: prediction.predictedWinner === 'draw' ? 1 : 0,
+        draw_probability: prediction.drawProbability ?? (prediction.predictedWinner === 'draw' ? 1 : 0),
         predicted_winner: predictedWinnerName,
       });
     }

--- a/frontend/components/EnhancedPredictionCard.tsx
+++ b/frontend/components/EnhancedPredictionCard.tsx
@@ -65,7 +65,7 @@ function ExplanationFactor({
  * - Key insights
  */
 export function EnhancedPredictionCard({ teamAName, teamBName, prediction, explanation }: EnhancedPredictionCardProps) {
-  const { predictedWinner, winProbabilityA, winProbabilityB, expectedScore, confidence } = prediction;
+  const { predictedWinner, winProbabilityA, winProbabilityB, drawProbability, expectedScore, confidence } = prediction;
   const { summary, factors, keyInsights, predictionQuality } = explanation;
 
   // Determine favored team for styling
@@ -133,6 +133,18 @@ export function EnhancedPredictionCard({ teamAName, teamBName, prediction, expla
               </div>
               <span className="text-sm font-semibold w-14 text-right">{(winProbabilityB * 100).toFixed(0)}%</span>
             </div>
+            {drawProbability != null && drawProbability > 0.03 && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm w-20 sm:w-32 truncate">Draw</span>
+                <div className="flex-1 h-6 bg-gray-200 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-gray-500 transition-all duration-300"
+                    style={{ width: `${drawProbability * 100}%` }}
+                  />
+                </div>
+                <span className="text-sm font-semibold w-14 text-right">{(drawProbability * 100).toFixed(0)}%</span>
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/lib/confidenceEngine.ts
+++ b/frontend/lib/confidenceEngine.ts
@@ -65,6 +65,10 @@ loadConfidenceParametersV2().catch(() => {
   // Silently fail - will use defaults
 });
 
+export async function warmConfidenceCalibration(): Promise<void> {
+  await loadConfidenceParametersV2();
+}
+
 /**
  * Calculate variance of goals for a team from game history
  */

--- a/frontend/lib/matchExplainer.ts
+++ b/frontend/lib/matchExplainer.ts
@@ -292,8 +292,20 @@ function explainCloseMatch(
   teamA: TeamWithRanking,
   teamB: TeamWithRanking,
   compositeDiff: number,
-  winProbabilityA: number
+  winProbabilityA: number,
+  drawProbability?: number
 ): Explanation | null {
+  if ((drawProbability ?? 0) >= 0.2) {
+    return {
+      factor: 'close_match',
+      advantage: 'neutral',
+      magnitude: 'minimal',
+      description: `This projects as a genuine stalemate candidate - both teams profile similarly and the draw probability is elevated`,
+      icon: 'âš–ï¸',
+      score: 1.6,
+    };
+  }
+
   // Use calibrated probability - if within 3% of 50%, it's a close match
   const probDiffFrom50 = Math.abs(winProbabilityA - 0.5);
   if (probDiffFrom50 > 0.08) return null; // Not that close
@@ -378,6 +390,8 @@ export function explainMatch(
     formA,
     formB,
     winProbabilityA,
+    winProbabilityB,
+    drawProbability,
     confidence,
     confidence_score,
     expectedMargin,
@@ -392,7 +406,7 @@ export function explainMatch(
     explainSOS(teamA, teamB, components.sosDiff),
     explainRecentForm(teamA, teamB, formA, formB, components.formDiffRaw),
     explainOffensiveMatchup(teamA, teamB),
-    explainCloseMatch(teamA, teamB, components.compositeDiff, winProbabilityA),
+    explainCloseMatch(teamA, teamB, components.compositeDiff, winProbabilityA, drawProbability),
   ];
 
   // Filter out nulls
@@ -423,11 +437,14 @@ export function explainMatch(
 
   let summary = '';
   if (prediction.predictedWinner === 'draw') {
-    // Draw prediction - explain why based on calibrated probability
-    const probPercent = Math.round(winProbabilityA * 100);
-    summary = `Genuine toss-up (${probPercent}%-${100 - probPercent}%) - our calibrated model sees no clear favorite`;
+    const drawPercent = Math.round((drawProbability ?? 0.33) * 100);
+    const teamAPercent = Math.round(winProbabilityA * 100);
+    const teamBPercent = Math.round(winProbabilityB * 100);
+    summary = `Genuine toss-up (${teamAPercent}% / ${drawPercent}% draw / ${teamBPercent}%) - our model sees no clear favorite`;
   } else {
-    const probPercent = Math.round(Math.max(winProbabilityA, 1 - winProbabilityA) * 100);
+    const probPercent = Math.round(
+      prediction.predictedWinner === 'team_a' ? winProbabilityA * 100 : winProbabilityB * 100
+    );
     if (probPercent >= 75) {
       summary = `${favoredTeam} is the clear favorite at ${probPercent}% win probability`;
     } else if (probPercent >= 60) {

--- a/frontend/lib/matchPredictionService.test.ts
+++ b/frontend/lib/matchPredictionService.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockPredictMatch, mockExplainMatch } = vi.hoisted(() => ({
+const { mockPredictMatch, mockExplainMatch, mockWarmMatchPredictorCalibration } = vi.hoisted(() => ({
   mockPredictMatch: vi.fn(),
   mockExplainMatch: vi.fn(),
+  mockWarmMatchPredictorCalibration: vi.fn(),
 }));
 
 vi.mock('server-only', () => ({}));
 
 vi.mock('./matchPredictor', () => ({
   predictMatch: mockPredictMatch,
+  warmMatchPredictorCalibration: mockWarmMatchPredictorCalibration,
 }));
 
 vi.mock('./matchExplainer', () => ({
@@ -116,6 +118,7 @@ function createMockSupabase() {
         return { data: null, error: null };
       case 'state_rankings_view':
       case 'rankings_full':
+      case 'team_predictive_view':
         return { data: null, error: null };
       case 'games':
         return {
@@ -178,10 +181,12 @@ function createMockSupabase() {
 describe('buildMatchPrediction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWarmMatchPredictorCalibration.mockResolvedValue(undefined);
     mockPredictMatch.mockReturnValue({
       predictedWinner: 'team_a',
       winProbabilityA: 0.77,
       winProbabilityB: 0.23,
+      drawProbability: 0,
       expectedScore: { teamA: 3, teamB: 1 },
       expectedMargin: 2,
       confidence: 'high',

--- a/frontend/lib/matchPredictionService.ts
+++ b/frontend/lib/matchPredictionService.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { AppError } from './errors';
 import { explainMatch, type MatchExplanation } from './matchExplainer';
-import { predictMatch, type MatchPrediction } from './matchPredictor';
+import { predictMatch, type MatchPrediction, warmMatchPredictorCalibration } from './matchPredictor';
 import type { Game, TeamWithRanking } from './types';
 import { normalizeAgeGroup } from './utils';
 
@@ -69,6 +69,13 @@ type RankingsFullRow = {
   games_played?: number | null;
 };
 
+type PredictiveRow = {
+  exp_margin?: number | null;
+  exp_win_rate?: number | null;
+  exp_goals_for?: number | null;
+  exp_goals_against?: number | null;
+};
+
 type MergeRow = {
   deprecated_team_id: string;
 };
@@ -121,7 +128,7 @@ async function resolvePredictionTeamIds(
 }
 
 async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Promise<TeamWithRanking> {
-  const [teamResult, rankingResult, stateRankingResult, rankingsFullResult] = await Promise.all([
+  const [teamResult, rankingResult, stateRankingResult, rankingsFullResult, predictiveResult] = await Promise.all([
     supabase
       .from('teams')
       .select('team_id_master, team_name, club_name, state, state_code, age_group, gender, last_scraped_at')
@@ -148,6 +155,11 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
       )
       .eq('team_id', teamId)
       .maybeSingle(),
+    supabase
+      .from('team_predictive_view')
+      .select('exp_margin, exp_win_rate, exp_goals_for, exp_goals_against')
+      .eq('team_id_master', teamId)
+      .maybeSingle(),
   ]);
 
   if (teamResult.error) {
@@ -158,6 +170,7 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
   const rankingData = rankingResult.data as RankingRow | null;
   const stateRankingData = stateRankingResult.data as RankingRow | null;
   const rankingsFullData = rankingsFullResult.data as RankingsFullRow | null;
+  const predictiveData = predictiveResult.data as PredictiveRow | null;
 
   if (!teamData) {
     throw new AppError('Team not found', 'team_not_found', 404);
@@ -168,6 +181,13 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
     normalizeAgeGroup(stateRankingData?.age) ??
     normalizeAgeGroup(rankingsFullData?.age_group) ??
     normalizeAgeGroup(teamData.age_group);
+
+  const wins = rankingData?.wins ?? stateRankingData?.wins ?? rankingsFullData?.wins ?? 0;
+  const losses = rankingData?.losses ?? stateRankingData?.losses ?? rankingsFullData?.losses ?? 0;
+  const draws = rankingData?.draws ?? stateRankingData?.draws ?? rankingsFullData?.draws ?? 0;
+  const gamesPlayed =
+    rankingData?.games_played ?? stateRankingData?.games_played ?? rankingsFullData?.games_played ?? 0;
+  const computedWinPercentage = gamesPlayed > 0 ? ((wins + draws * 0.5) / gamesPlayed) * 100 : null;
 
   const team: TeamWithRanking = {
     team_id_master: teamData.team_id_master,
@@ -201,12 +221,16 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
     sos_norm_state: stateRankingData?.sos_norm_state ?? rankingsFullData?.sos_norm ?? null,
     offense_norm: rankingData?.offense_norm ?? stateRankingData?.offense_norm ?? rankingsFullData?.off_norm ?? null,
     defense_norm: rankingData?.defense_norm ?? stateRankingData?.defense_norm ?? rankingsFullData?.def_norm ?? null,
-    wins: rankingData?.wins ?? stateRankingData?.wins ?? rankingsFullData?.wins ?? 0,
-    losses: rankingData?.losses ?? stateRankingData?.losses ?? rankingsFullData?.losses ?? 0,
-    draws: rankingData?.draws ?? stateRankingData?.draws ?? rankingsFullData?.draws ?? 0,
-    games_played: rankingData?.games_played ?? stateRankingData?.games_played ?? rankingsFullData?.games_played ?? 0,
+    wins,
+    losses,
+    draws,
+    games_played: gamesPlayed,
     last_scraped_at: teamData.last_scraped_at,
-    win_percentage: null,
+    win_percentage: computedWinPercentage,
+    exp_margin: predictiveData?.exp_margin ?? null,
+    exp_win_rate: predictiveData?.exp_win_rate ?? null,
+    exp_goals_for: predictiveData?.exp_goals_for ?? null,
+    exp_goals_against: predictiveData?.exp_goals_against ?? null,
   };
 
   if (team.power_score_final == null || team.games_played <= 0) {
@@ -226,7 +250,9 @@ async function fetchPredictionGames(supabase: SupabaseClient, teamIds: string[])
 
   const { data, error } = await supabase
     .from('games')
-    .select('id, game_date, home_team_master_id, away_team_master_id, home_score, away_score')
+    .select(
+      'id, game_date, home_team_master_id, away_team_master_id, home_score, away_score, competition, division_name, event_name, ml_overperformance'
+    )
     .gte('game_date', cutoffDate.toISOString().split('T')[0])
     .not('home_score', 'is', null)
     .not('away_score', 'is', null)
@@ -261,6 +287,8 @@ export async function buildMatchPrediction(
   teamAId: string,
   teamBId: string
 ): Promise<MatchPredictionResponse> {
+  await warmMatchPredictorCalibration();
+
   const [resolvedTeamA, resolvedTeamB] = await Promise.all([
     resolvePredictionTeamIds(supabase, teamAId),
     resolvePredictionTeamIds(supabase, teamBId),

--- a/frontend/lib/matchPredictor.test.ts
+++ b/frontend/lib/matchPredictor.test.ts
@@ -105,7 +105,11 @@ describe('predictMatch', () => {
     const prediction = predictMatch(teamA, teamB, games);
 
     expect(prediction.predictedWinner).toBe('team_a');
-    expect(prediction.winProbabilityA).toBeGreaterThan(0.7);
+    expect(prediction.winProbabilityA).toBeGreaterThan(0.6);
+    expect(prediction.drawProbability ?? 0).toBeLessThan(0.2);
+    expect(
+      (prediction.winProbabilityA + prediction.winProbabilityB + (prediction.drawProbability ?? 0)).toFixed(6)
+    ).toBe('1.000000');
     expect(prediction.expectedMargin).toBeGreaterThan(0);
     expect(prediction.expectedScore.teamA).toBeGreaterThanOrEqual(prediction.expectedScore.teamB);
   });
@@ -144,6 +148,7 @@ describe('predictMatch', () => {
 
     expect(prediction.predictedWinner).toBe('draw');
     expect(prediction.confidence).toBe('low');
+    expect(prediction.drawProbability ?? 0).toBeGreaterThan(0.2);
     expect(prediction.winProbabilityA).toBeGreaterThan(0);
     expect(prediction.winProbabilityA).toBeLessThan(1);
     expect(prediction.expectedScore.teamA).toBeGreaterThanOrEqual(0);

--- a/frontend/lib/matchPredictor.ts
+++ b/frontend/lib/matchPredictor.ts
@@ -45,7 +45,7 @@
 import type { TeamWithRanking } from './types';
 import type { Game } from './types';
 import { loadCalibrationJson } from './calibrationLoader';
-import { computeConfidence } from './confidenceEngine';
+import { computeConfidence, warmConfidenceCalibration } from './confidenceEngine';
 import { extractAgeFromTeamName } from './utils';
 
 // Age group parameters (loaded from JSON, fallback to defaults)
@@ -75,6 +75,17 @@ let probabilityParams: ProbabilityParameters | null = null;
 let probabilityParamsLoading: Promise<void> | null = null;
 let marginParamsV2: MarginParametersV2 | null = null;
 let marginParamsV2Loading: Promise<void> | null = null;
+
+interface RecentProfile {
+  goalDiff: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  drawRate: number;
+  totalGoals: number;
+  mlTrend: number;
+  volatility: number;
+  sampleWeight: number;
+}
 
 /**
  * Load age group parameters from JSON file
@@ -153,6 +164,15 @@ loadMarginParametersV2().catch(() => {
   // Silently fail - will use defaults
 });
 
+export async function warmMatchPredictorCalibration(): Promise<void> {
+  await Promise.all([
+    loadAgeGroupParameters(),
+    loadProbabilityParameters(),
+    loadMarginParametersV2(),
+    warmConfidenceCalibration(),
+  ]);
+}
+
 // Base feature weights (optimized for close matchups - 74.7% accuracy)
 const BASE_WEIGHTS = {
   POWER_SCORE: 0.5, // Base strength
@@ -178,9 +198,10 @@ const SKILL_GAP_THRESHOLDS = {
 
 // Prediction parameters (with calibration overrides)
 const DEFAULT_SENSITIVITY = 4.5;
-const MARGIN_COEFFICIENT = 8.0;
 const RECENT_GAMES_COUNT = 5;
 const GLICKO_ELO_DIVISOR = 400;
+const POISSON_MAX_GOALS = 10;
+const DEFAULT_DRAW_RATE = 0.13;
 
 /**
  * Get calibrated SENSITIVITY value
@@ -231,39 +252,87 @@ const _CONFIDENCE_THRESHOLDS = {
  * - 5+ games out of 5 needed = 100% weight
  */
 export function calculateRecentForm(teamId: string, allGames: Game[], n: number = RECENT_GAMES_COUNT): number {
-  // Get team's recent games
+  return buildRecentProfile(teamId, allGames, n).goalDiff;
+}
+
+function buildRecentProfile(teamId: string, allGames: Game[], n: number = 8): RecentProfile {
   const teamGames = allGames
     .filter((g) => g.home_team_master_id === teamId || g.away_team_master_id === teamId)
     .sort((a, b) => new Date(b.game_date).getTime() - new Date(a.game_date).getTime())
     .slice(0, n);
 
-  if (teamGames.length === 0) return 0;
+  if (teamGames.length === 0) {
+    return {
+      goalDiff: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+      drawRate: DEFAULT_DRAW_RATE,
+      totalGoals: 0,
+      mlTrend: 0,
+      volatility: 1,
+      sampleWeight: 0,
+    };
+  }
 
-  // Calculate average goal differential
-  let totalGoalDiff = 0;
-  let gamesWithScores = 0;
+  let weightedGoalsFor = 0;
+  let weightedGoalsAgainst = 0;
+  let weightedGoalDiff = 0;
+  let weightedDraws = 0;
+  let weightedMlTrend = 0;
+  let weightedSquaredGoalDiff = 0;
+  let totalWeight = 0;
 
-  for (const game of teamGames) {
+  for (let index = 0; index < teamGames.length; index++) {
+    const game = teamGames[index];
     const isHome = game.home_team_master_id === teamId;
     const teamScore = isHome ? game.home_score : game.away_score;
     const oppScore = isHome ? game.away_score : game.home_score;
 
-    if (teamScore !== null && oppScore !== null) {
-      totalGoalDiff += teamScore - oppScore;
-      gamesWithScores++;
-    }
+    if (teamScore == null || oppScore == null) continue;
+
+    const recencyWeight = Math.exp(-0.28 * index);
+    const goalDiff = teamScore - oppScore;
+    const drawIndicator = teamScore === oppScore ? 1 : 0;
+    const mlOverperformance = (game.ml_overperformance ?? 0) * (isHome ? 1 : -1);
+
+    weightedGoalsFor += teamScore * recencyWeight;
+    weightedGoalsAgainst += oppScore * recencyWeight;
+    weightedGoalDiff += goalDiff * recencyWeight;
+    weightedDraws += drawIndicator * recencyWeight;
+    weightedMlTrend += mlOverperformance * recencyWeight;
+    weightedSquaredGoalDiff += goalDiff * goalDiff * recencyWeight;
+    totalWeight += recencyWeight;
   }
 
-  if (gamesWithScores === 0) return 0;
+  if (totalWeight <= 0) {
+    return {
+      goalDiff: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+      drawRate: DEFAULT_DRAW_RATE,
+      totalGoals: 0,
+      mlTrend: 0,
+      volatility: 1,
+      sampleWeight: 0,
+    };
+  }
 
-  // Calculate average goal differential
-  const avgGoalDiff = totalGoalDiff / gamesWithScores;
+  const goalsFor = weightedGoalsFor / totalWeight;
+  const goalsAgainst = weightedGoalsAgainst / totalWeight;
+  const goalDiff = weightedGoalDiff / totalWeight;
+  const variance = Math.max(0, weightedSquaredGoalDiff / totalWeight - goalDiff * goalDiff);
+  const sampleWeight = Math.min(1, teamGames.length / n);
 
-  // Weight by sample size to reduce noise from small samples
-  // This prevents a team with 1 game from being treated as reliably as a team with 5 games
-  const sampleSizeWeight = gamesWithScores / n;
-
-  return avgGoalDiff * sampleSizeWeight;
+  return {
+    goalDiff: goalDiff * sampleWeight,
+    goalsFor,
+    goalsAgainst,
+    drawRate: Math.max(0, Math.min(0.5, weightedDraws / totalWeight)),
+    totalGoals: goalsFor + goalsAgainst,
+    mlTrend: weightedMlTrend / totalWeight,
+    volatility: Math.sqrt(variance + 1),
+    sampleWeight,
+  };
 }
 
 /**
@@ -573,6 +642,90 @@ function getAgeSpecificMarginMultiplier(age: number | null, absPowerDiff: number
   return baseMultiplier * powerGapScaling * marginScale;
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function deriveWinRate(team: TeamWithRanking): number {
+  if (team.win_percentage != null) {
+    return clamp(team.win_percentage / 100, 0, 1);
+  }
+
+  const gamesPlayed = Math.max(0, team.games_played || 0);
+  if (gamesPlayed === 0) return 0.5;
+
+  return clamp(((team.wins || 0) + (team.draws || 0) * 0.5) / gamesPlayed, 0, 1);
+}
+
+function blendOptional(left: number | null | undefined, right: number | null | undefined): number | null {
+  if (left == null && right == null) return null;
+  if (left == null) return right ?? null;
+  if (right == null) return left;
+
+  return Math.sqrt(Math.max(0.15, left) * Math.max(0.15, right));
+}
+
+function poissonMass(lambda: number, maxGoals: number = POISSON_MAX_GOALS): number[] {
+  const safeLambda = Math.max(0.05, lambda);
+  const probabilities = new Array(maxGoals + 1).fill(0);
+  probabilities[0] = Math.exp(-safeLambda);
+
+  for (let goals = 1; goals <= maxGoals; goals++) {
+    probabilities[goals] = (probabilities[goals - 1] * safeLambda) / goals;
+  }
+
+  const probabilitySum = probabilities.reduce((sum, value) => sum + value, 0);
+  probabilities[maxGoals] += Math.max(0, 1 - probabilitySum);
+  return probabilities;
+}
+
+function buildOutcomeDistribution(lambdaA: number, lambdaB: number) {
+  const probsA = poissonMass(lambdaA);
+  const probsB = poissonMass(lambdaB);
+
+  let winA = 0;
+  let draw = 0;
+  let winB = 0;
+  let bestWinA = { teamA: 1, teamB: 0, probability: 0 };
+  let bestDraw = { teamA: 1, teamB: 1, probability: 0 };
+  let bestWinB = { teamA: 0, teamB: 1, probability: 0 };
+
+  for (let scoreA = 0; scoreA <= POISSON_MAX_GOALS; scoreA++) {
+    for (let scoreB = 0; scoreB <= POISSON_MAX_GOALS; scoreB++) {
+      const probability = probsA[scoreA] * probsB[scoreB];
+
+      if (scoreA > scoreB) {
+        winA += probability;
+        if (probability > bestWinA.probability) bestWinA = { teamA: scoreA, teamB: scoreB, probability };
+      } else if (scoreA < scoreB) {
+        winB += probability;
+        if (probability > bestWinB.probability) bestWinB = { teamA: scoreA, teamB: scoreB, probability };
+      } else {
+        draw += probability;
+        if (probability > bestDraw.probability) bestDraw = { teamA: scoreA, teamB: scoreB, probability };
+      }
+    }
+  }
+
+  const total = winA + draw + winB;
+  return {
+    winA: total > 0 ? winA / total : 0.5,
+    draw: total > 0 ? draw / total : DEFAULT_DRAW_RATE,
+    winB: total > 0 ? winB / total : 0.5,
+    bestWinA,
+    bestDraw,
+    bestWinB,
+  };
+}
+
+function normalizedEntropy(probabilities: number[]): number {
+  const safe = probabilities.filter((value) => value > 0);
+  if (safe.length === 0) return 1;
+
+  const entropy = -safe.reduce((sum, probability) => sum + probability * Math.log(probability), 0);
+  return entropy / Math.log(probabilities.length);
+}
+
 /**
  * Match prediction result
  */
@@ -581,6 +734,7 @@ export interface MatchPrediction {
   predictedWinner: 'team_a' | 'team_b' | 'draw';
   winProbabilityA: number;
   winProbabilityB: number;
+  drawProbability?: number;
   expectedScore: {
     teamA: number;
     teamB: number;
@@ -620,167 +774,185 @@ export interface MatchPrediction {
  * v2.3: Multi-metric mismatch detection for better blowout prediction
  */
 export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, allGames: Game[]): MatchPrediction {
-  // 1. Base power score differential
   const powerDiff = (teamA.power_score_final || 0.5) - (teamB.power_score_final || 0.5);
   const glickoStrength = calculateGlickoStrength(teamA, teamB);
-  const strengthSignal = glickoStrength ? glickoStrength.signal * 0.75 + powerDiff * 0.25 : powerDiff;
-
-  // 2. Offense vs Defense values (needed for mismatch detection)
   const offenseA = teamA.offense_norm || 0.5;
   const defenseA = teamA.defense_norm || 0.5;
   const offenseB = teamB.offense_norm || 0.5;
   const defenseB = teamB.defense_norm || 0.5;
-
-  // 3. Calculate adaptive weights based on multi-metric mismatch detection
   const { weights, mismatchScore } = getAdaptiveWeights(powerDiff, offenseA, offenseB, defenseA, defenseB);
-
-  // 4. SOS differential
   const sosDiff = (teamA.sos_norm || 0.5) - (teamB.sos_norm || 0.5);
-
-  // 5. Recent form
-  const formA = calculateRecentForm(teamA.team_id_master, allGames);
-  const formB = calculateRecentForm(teamB.team_id_master, allGames);
+  const recentA = buildRecentProfile(teamA.team_id_master, allGames);
+  const recentB = buildRecentProfile(teamB.team_id_master, allGames);
+  const formA = recentA.goalDiff;
+  const formB = recentB.goalDiff;
   const formDiffRaw = formA - formB;
   const formDiffNorm = normalizeRecentForm(formDiffRaw) - 0.5;
-
-  // 6. Matchup asymmetry (how much A's offense exploits B's defense)
   const matchupAdvantage = offenseA - defenseB - (offenseB - defenseA);
-
-  // 7. Head-to-head history (HIGHLY predictive if available)
   const h2h = calculateHeadToHead(teamA.team_id_master, teamB.team_id_master, allGames);
-  // H2H weight: increases with more historical meetings (max 0.15 for 3+ games)
   const h2hWeight = h2h.gamesPlayed > 0 ? Math.min(0.05 * h2h.gamesPlayed, 0.15) : 0;
 
-  // 8. Composite differential (weighted combination with adaptive weights)
-  // Reduce other weights proportionally when H2H data is available
-  const h2hAdjustment = 1 - h2hWeight;
-  let compositeDiff =
-    weights.POWER_SCORE * strengthSignal * h2hAdjustment +
-    weights.SOS * sosDiff * h2hAdjustment +
-    weights.RECENT_FORM * formDiffNorm * h2hAdjustment +
-    weights.MATCHUP * matchupAdvantage * h2hAdjustment +
-    h2hWeight * h2h.advantage * 3; // Scale H2H advantage (reduced from 10 to prevent over-weighting small sample H2H)
+  const predictiveWinSignal = ((teamA.exp_win_rate ?? 0.5) - (teamB.exp_win_rate ?? 0.5)) * 0.9;
+  const predictiveMarginSignal = clamp(((teamA.exp_margin ?? 0) - (teamB.exp_margin ?? 0)) / 6, -0.35, 0.35);
+  const predictiveSignal = predictiveWinSignal + predictiveMarginSignal;
+  const minGamesPlayed = Math.min(teamA.games_played || 0, teamB.games_played || 0);
+  const recordDiff = (deriveWinRate(teamA) - deriveWinRate(teamB)) * Math.min(1, minGamesPlayed / 18);
+  const residualSignal = clamp((recentA.mlTrend - recentB.mlTrend) / 3.5, -0.2, 0.2);
+  const h2hSignal = h2hWeight > 0 ? h2h.advantage * (1 + h2hWeight) : 0;
+  const strengthSignal = glickoStrength
+    ? glickoStrength.signal * 0.55 + powerDiff * 0.25 + predictiveSignal * 0.2
+    : powerDiff * 0.5 + predictiveSignal * 0.25 + recordDiff * 0.25;
 
-  // 8. Mismatch amplification: boost composite diff for clear mismatches
-  // This ensures large offense/defense gaps translate to higher probabilities
-  // v2.5: Lowered threshold from 0.5 to 0.4 to catch more moderate mismatches
+  let compositeDiff =
+    weights.POWER_SCORE * strengthSignal +
+    weights.SOS * sosDiff +
+    weights.RECENT_FORM * formDiffNorm +
+    weights.MATCHUP * matchupAdvantage +
+    recordDiff * 0.08 +
+    residualSignal * 0.06 +
+    h2hSignal * 0.08;
+
   if (mismatchScore > 0.4) {
-    // Amplify by up to 1.8x for extreme mismatches (was 1.5x)
-    const amplification = 1.0 + (mismatchScore - 0.4) * 1.33;
+    const amplification = 1.0 + (mismatchScore - 0.4) * 0.9;
     compositeDiff *= amplification;
   }
 
-  // 9. Win probability (using calibrated sensitivity + per-bucket calibration)
-  const sensitivity = getSensitivity();
-  const rawWinProbA = sigmoid(sensitivity * compositeDiff);
-  const winProbA = calibrateProbability(rawWinProbA);
-  const winProbB = 1 - winProbA;
-
-  // 10. Expected goal margin with age-specific and mismatch-based amplification
-  // Get age: prefer extracting from team name (handles "14B" = U12 format), fallback to database age
   const effectiveAge =
     extractAgeFromTeamName(teamA.team_name) || extractAgeFromTeamName(teamB.team_name) || teamA.age || teamB.age;
-  // Use raw powerDiff for margin scaling - ensures large skill gaps produce larger margins
-  const absPowerDiff = Math.abs(powerDiff);
-  // v2.5: Pass mismatchScore to allow full dampening removal for blowouts
-  const marginMultiplier = getAgeSpecificMarginMultiplier(effectiveAge, absPowerDiff, mismatchScore);
-  // Mismatch amplification is already applied in two places:
-  // 1. compositeDiff amplification (line 690-693, up to 1.8x)
-  // 2. getAgeSpecificMarginMultiplier dampening reduction (removes dampening for mismatches)
-  // A third mismatchMarginBoost was stacking to ~4.1x total, causing unrealistic predictions.
-  const expectedMargin = compositeDiff * MARGIN_COEFFICIENT * marginMultiplier;
-
-  // 11. Expected scores using age-adjusted league average
   const leagueAvgGoals = getLeagueAverageGoals(effectiveAge);
-  const absExpectedMargin = Math.abs(expectedMargin);
+  const baseTotalGoals = leagueAvgGoals * 2;
+  const predictiveGoalsA = blendOptional(teamA.exp_goals_for, teamB.exp_goals_against);
+  const predictiveGoalsB = blendOptional(teamB.exp_goals_for, teamA.exp_goals_against);
+  const predictiveTotalGoals =
+    predictiveGoalsA != null || predictiveGoalsB != null
+      ? (predictiveGoalsA ?? leagueAvgGoals) + (predictiveGoalsB ?? leagueAvgGoals)
+      : null;
+  const combinedRecentWeight = recentA.sampleWeight + recentB.sampleWeight;
+  const recentTotalGoals =
+    combinedRecentWeight > 0
+      ? (recentA.totalGoals * recentA.sampleWeight + recentB.totalGoals * recentB.sampleWeight) / combinedRecentWeight
+      : null;
+  const styleTotalFactor = clamp(
+    0.95 +
+      (offenseA + offenseB - 1) * 0.2 +
+      (1 - defenseA + (1 - defenseB) - 1) * 0.16 +
+      (Math.abs(recentA.mlTrend) + Math.abs(recentB.mlTrend)) * 0.03,
+    0.72,
+    1.35
+  );
 
-  // For mismatches, use a different scoring model:
-  // - Underdog scores 0-1 goals in blowouts
-  // - Favorite scores underdog + margin
-  let rawScoreA: number;
-  let rawScoreB: number;
+  let totalGoals = baseTotalGoals * styleTotalFactor;
+  if (predictiveTotalGoals != null) {
+    totalGoals = totalGoals * 0.68 + predictiveTotalGoals * 0.32;
+  }
+  if (recentTotalGoals != null && recentTotalGoals > 0) {
+    totalGoals = totalGoals * 0.82 + recentTotalGoals * 0.18;
+  }
+  totalGoals = clamp(totalGoals, 1.4, 8.8);
 
-  if (mismatchScore > 0.5) {
-    // Clear mismatch: underdog gets reduced score (0-1.5 range)
-    // v2.5: Lowered threshold from 0.6 to 0.5 for consistency
-    // At mismatch=0.5: underdog=1.5, at mismatch=0.8: underdog=0.75, at mismatch=1.0: underdog=0.25
-    const underdogScore = Math.max(0, 1.5 - (mismatchScore - 0.5) * 2.5);
-    if (expectedMargin >= 0) {
-      rawScoreB = underdogScore;
-      rawScoreA = underdogScore + absExpectedMargin;
-    } else {
-      rawScoreA = underdogScore;
-      rawScoreB = underdogScore + absExpectedMargin;
-    }
-  } else {
-    // Competitive match: both teams score around league average
-    if (expectedMargin >= 0) {
-      rawScoreB = leagueAvgGoals - absExpectedMargin / 2;
-      rawScoreA = leagueAvgGoals + absExpectedMargin / 2;
-    } else {
-      rawScoreA = leagueAvgGoals - absExpectedMargin / 2;
-      rawScoreB = leagueAvgGoals + absExpectedMargin / 2;
+  const predictiveShareBias =
+    predictiveGoalsA != null && predictiveGoalsB != null
+      ? clamp((predictiveGoalsA - predictiveGoalsB) / Math.max(1, predictiveGoalsA + predictiveGoalsB), -0.2, 0.2)
+      : 0;
+  const shareSignal = clamp(compositeDiff + predictiveShareBias * 0.45 + residualSignal * 0.15, -0.9, 0.9);
+  const shareA = sigmoid(getSensitivity() * shareSignal);
+  let lambdaA = totalGoals * shareA;
+  let lambdaB = totalGoals * (1 - shareA);
+
+  if (predictiveGoalsA != null) {
+    lambdaA = lambdaA * 0.75 + predictiveGoalsA * 0.25;
+  }
+  if (predictiveGoalsB != null) {
+    lambdaB = lambdaB * 0.75 + predictiveGoalsB * 0.25;
+  }
+
+  const absPowerDiff = Math.abs(powerDiff);
+  const marginMultiplier = getAgeSpecificMarginMultiplier(effectiveAge, absPowerDiff, mismatchScore);
+  const desiredMargin = (lambdaA - lambdaB) * clamp(marginMultiplier / 1.25, 0.85, 1.25);
+  lambdaA = clamp((totalGoals + desiredMargin) / 2, 0.15, 7.5);
+  lambdaB = clamp(totalGoals - lambdaA, 0.15, 7.5);
+
+  const distribution = buildOutcomeDistribution(lambdaA, lambdaB);
+  const decisiveMass = distribution.winA + distribution.winB;
+  let winProbA = distribution.winA;
+  let winProbB = distribution.winB;
+  const drawProbability = distribution.draw;
+
+  if (decisiveMass > 0) {
+    const calibratedDecisiveWinA = calibrateProbability(distribution.winA / decisiveMass);
+    winProbA = calibratedDecisiveWinA * decisiveMass;
+    winProbB = (1 - calibratedDecisiveWinA) * decisiveMass;
+  }
+
+  let normalizedDrawProbability = drawProbability;
+  const probabilityTotal = winProbA + normalizedDrawProbability + winProbB;
+  if (probabilityTotal > 0) {
+    winProbA /= probabilityTotal;
+    normalizedDrawProbability /= probabilityTotal;
+    winProbB /= probabilityTotal;
+  }
+
+  const closeDecisiveEdge = Math.abs(winProbA - winProbB) < 0.06;
+  const sparseMatchup = Math.min(recentA.sampleWeight, recentB.sampleWeight) < 0.4 || minGamesPlayed < 4;
+  if (closeDecisiveEdge && sparseMatchup) {
+    const drawBoost = Math.min(0.05, 0.24 - normalizedDrawProbability);
+    if (drawBoost > 0) {
+      const decisiveScale = (1 - (normalizedDrawProbability + drawBoost)) / Math.max(0.0001, winProbA + winProbB);
+      normalizedDrawProbability += drawBoost;
+      winProbA *= decisiveScale;
+      winProbB *= decisiveScale;
     }
   }
 
-  const roundedMargin = Math.round(absExpectedMargin);
+  const predictedWinner: 'team_a' | 'team_b' | 'draw' =
+    (normalizedDrawProbability + DRAW_THRESHOLD >= Math.max(winProbA, winProbB) &&
+      Math.abs(winProbA - winProbB) < 0.12) ||
+    (closeDecisiveEdge && sparseMatchup && normalizedDrawProbability >= DEFAULT_DRAW_RATE * 0.9)
+      ? 'draw'
+      : winProbA >= winProbB
+        ? 'team_a'
+        : 'team_b';
 
-  // Round the underdog's score, then add the rounded margin for the favorite
-  // This ensures the displayed margin matches the rounded expected margin
-  let expectedScoreA: number;
-  let expectedScoreB: number;
+  const expectedScore =
+    predictedWinner === 'draw'
+      ? distribution.bestDraw
+      : predictedWinner === 'team_a'
+        ? distribution.bestWinA
+        : distribution.bestWinB;
 
-  // v2.5: Cap individual scores to realistic range
-  // No youth team realistically scores 10+ goals regularly
-  const MAX_TEAM_SCORE = 10;
+  const expectedMargin = lambdaA - lambdaB;
 
-  if (roundedMargin === 0) {
-    // Close match - show same score
-    const avgScore = Math.round(leagueAvgGoals);
-    expectedScoreA = avgScore;
-    expectedScoreB = avgScore;
-  } else if (expectedMargin >= 0) {
-    // Team A is favored
-    expectedScoreB = Math.max(0, Math.round(rawScoreB));
-    expectedScoreA = Math.min(MAX_TEAM_SCORE, Math.max(0, expectedScoreB + roundedMargin));
-    // Ensure margin is maintained even with cap
-    if (expectedScoreA === MAX_TEAM_SCORE && expectedScoreB > MAX_TEAM_SCORE - roundedMargin) {
-      expectedScoreB = Math.max(0, MAX_TEAM_SCORE - roundedMargin);
-    }
-  } else {
-    // Team B is favored
-    expectedScoreA = Math.max(0, Math.round(rawScoreA));
-    expectedScoreB = Math.min(MAX_TEAM_SCORE, Math.max(0, expectedScoreA + roundedMargin));
-    // Ensure margin is maintained even with cap
-    if (expectedScoreB === MAX_TEAM_SCORE && expectedScoreA > MAX_TEAM_SCORE - roundedMargin) {
-      expectedScoreA = Math.max(0, MAX_TEAM_SCORE - roundedMargin);
-    }
+  const baseConfidence = computeConfidence(teamA, teamB, compositeDiff, allGames);
+  const outcomeEntropy = normalizedEntropy([winProbA, normalizedDrawProbability, winProbB]);
+  const maxOutcomeProbability = Math.max(winProbA, normalizedDrawProbability, winProbB);
+  let confidenceScore = clamp(
+    (baseConfidence.confidence_score ?? 0.5) * 0.6 + maxOutcomeProbability * 0.25 + (1 - outcomeEntropy) * 0.15,
+    0.05,
+    0.98
+  );
+
+  if (normalizedDrawProbability > 0.22) {
+    confidenceScore = clamp(confidenceScore - 0.05, 0.05, 0.98);
+  }
+  if (Math.min(recentA.sampleWeight, recentB.sampleWeight) < 0.4) {
+    confidenceScore = clamp(confidenceScore - 0.04, 0.05, 0.98);
   }
 
-  // 10. Predicted winner (with draw threshold for close matchups)
-  // ~16% of games end in draws - predict draw when probability is very close to 50%
-  let predictedWinner: 'team_a' | 'team_b' | 'draw';
-  if (Math.abs(winProbA - 0.5) < DRAW_THRESHOLD) {
-    predictedWinner = 'draw';
-  } else {
-    predictedWinner = winProbA >= 0.5 ? 'team_a' : 'team_b';
-  }
-
-  // 11. Confidence level (using variance-based confidence engine)
-  const confidenceResult = computeConfidence(teamA, teamB, compositeDiff, allGames);
-  const confidence = confidenceResult.confidence;
+  const confidence: 'high' | 'medium' | 'low' =
+    confidenceScore >= 0.66 ? 'high' : confidenceScore >= 0.53 ? 'medium' : 'low';
 
   return {
     predictedWinner,
     winProbabilityA: winProbA,
     winProbabilityB: winProbB,
+    drawProbability: normalizedDrawProbability,
     expectedScore: {
-      teamA: expectedScoreA,
-      teamB: expectedScoreB,
+      teamA: expectedScore.teamA,
+      teamB: expectedScore.teamB,
     },
     expectedMargin,
     confidence,
-    confidence_score: confidenceResult.confidence_score,
+    confidence_score: confidenceScore,
     components: {
       powerDiff,
       strengthSignal,

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -132,6 +132,11 @@ export interface TeamWithRanking {
   total_losses?: number; // Total losses from all games
   total_draws?: number; // Total draws from all games
   win_percentage: number | null; // backend should calculate
+  // Optional predictive fields from team_predictive_view
+  exp_margin?: number | null;
+  exp_win_rate?: number | null;
+  exp_goals_for?: number | null;
+  exp_goals_against?: number | null;
   // Deprecated fields (do not use)
   /** @deprecated Use state instead */
   state_code?: never;

--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -1,8 +1,9 @@
 """
-Historical Backtesting Engine for Match Predictor
+Historical Backtesting Engine for Match Predictor.
 
-Fetches historical games, runs predictions using Python port of matchPredictor.ts,
-and generates calibration outputs for analysis.
+Prefers point-in-time predictor feature snapshots from prediction_feature_history
+when available. Falls back to current rankings only when those snapshots are not
+present, which should be treated as a lower-fidelity benchmark mode.
 
 Usage:
     python scripts/backtest_predictor.py [--lookback-days 365] [--limit 10000] [--test-slice]
@@ -189,6 +190,161 @@ async def fetch_rankings(supabase: Client) -> pd.DataFrame:
         return pd.DataFrame()
 
 
+async def fetch_prediction_feature_snapshots(
+    supabase: Client,
+    team_ids: List[str],
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    """
+    Fetch point-in-time predictor snapshots for the requested teams and date range.
+    """
+    if not team_ids:
+        return pd.DataFrame()
+
+    logger.info(
+        "Fetching prediction feature snapshots for %s teams between %s and %s...",
+        f"{len(team_ids):,}",
+        start_date,
+        end_date,
+    )
+
+    fields = (
+        "snapshot_date, team_id, age_group, gender, status, rank_in_cohort_final, "
+        "power_score_final, sos_norm, offense_norm, defense_norm, glicko_rating, glicko_rd, "
+        "glicko_volatility, wins, losses, draws, games_played, win_percentage, exp_margin, "
+        "exp_win_rate, exp_goals_for, exp_goals_against"
+    )
+
+    rows = []
+    batch_size = 100
+
+    for index in range(0, len(team_ids), batch_size):
+        batch = team_ids[index : index + batch_size]
+        try:
+            response = (
+                supabase.table("prediction_feature_history")
+                .select(fields)
+                .in_("team_id", batch)
+                .gte("snapshot_date", start_date)
+                .lte("snapshot_date", end_date)
+                .order("snapshot_date", desc=False)
+                .execute()
+            )
+        except Exception as error:
+            error_message = str(error).lower()
+            if "prediction_feature_history" in error_message and (
+                "does not exist" in error_message or "relation" in error_message or "schema cache" in error_message
+            ):
+                logger.warning(
+                    "prediction_feature_history is unavailable. Backtest will fall back to current rankings."
+                )
+                return pd.DataFrame()
+
+            logger.warning(
+                "Error fetching prediction snapshots for batch %s-%s: %s",
+                index,
+                index + batch_size,
+                error,
+            )
+            continue
+
+        if response.data:
+            rows.extend(response.data)
+
+    snapshots_df = pd.DataFrame(rows)
+    logger.info("Fetched %s prediction snapshots", f"{len(snapshots_df):,}")
+    return snapshots_df
+
+
+def build_snapshot_index(snapshots_df: pd.DataFrame) -> Dict[str, List[dict]]:
+    """
+    Build a per-team ordered snapshot lookup for as-of queries.
+    """
+    if snapshots_df.empty:
+        return {}
+
+    indexed_df = snapshots_df.copy()
+    indexed_df["snapshot_ts"] = pd.to_datetime(indexed_df["snapshot_date"], errors="coerce")
+    indexed_df = indexed_df.dropna(subset=["snapshot_ts"]).sort_values(["team_id", "snapshot_ts"])
+
+    snapshot_index: Dict[str, List[dict]] = {}
+    for team_id, group in indexed_df.groupby("team_id", sort=False):
+        snapshot_index[str(team_id)] = group.to_dict("records")
+    return snapshot_index
+
+
+def get_snapshot_as_of(snapshot_index: Dict[str, List[dict]], team_id: str, target_date: str) -> Optional[dict]:
+    """
+    Return the latest snapshot on or before the target match date.
+    """
+    entries = snapshot_index.get(team_id)
+    if not entries:
+        return None
+
+    target_ts = pd.Timestamp(target_date).normalize()
+    candidate = None
+
+    for entry in entries:
+        snapshot_ts = entry.get("snapshot_ts")
+        if snapshot_ts is None or pd.isna(snapshot_ts):
+            continue
+        if snapshot_ts <= target_ts:
+            candidate = entry
+            continue
+        break
+
+    return candidate
+
+
+def get_team_age(source_row: dict) -> Optional[int]:
+    """
+    Normalize team age from either an integer age field or an age_group string.
+    """
+    age_value = source_row.get("age")
+    if age_value is not None and not pd.isna(age_value):
+        try:
+            return int(age_value)
+        except (TypeError, ValueError):
+            pass
+
+    age_group = source_row.get("age_group")
+    if age_group is None or pd.isna(age_group):
+        return None
+
+    import re
+
+    match = re.search(r"\d+", str(age_group).lower())
+    if match:
+        return int(match.group())
+    return None
+
+
+def build_team_ranking(team_id: str, source_row: dict, team_name: Optional[str]) -> TeamRanking:
+    """
+    Build a predictor TeamRanking from either a current ranking row or a snapshot row.
+    """
+    games_played = source_row.get("games_played", 0)
+    try:
+        games_played = int(games_played) if games_played is not None and not pd.isna(games_played) else 0
+    except (TypeError, ValueError):
+        games_played = 0
+
+    return TeamRanking(
+        team_id_master=team_id,
+        power_score_final=source_row.get("power_score_final"),
+        sos_norm=source_row.get("sos_norm"),
+        offense_norm=source_row.get("offense_norm", source_row.get("off_norm")),
+        defense_norm=source_row.get("defense_norm", source_row.get("def_norm")),
+        age=get_team_age(source_row),
+        games_played=games_played,
+        team_name=team_name,
+        glicko_rating=source_row.get("glicko_rating"),
+        glicko_rd=source_row.get("glicko_rd"),
+        glicko_volatility=source_row.get("glicko_volatility"),
+    )
+
+
 async def fetch_team_game_histories(
     supabase: Client, team_ids: List[str], lookback_days: int = 365
 ) -> Dict[str, List[PredictorGame]]:
@@ -318,6 +474,7 @@ async def run_backtest(
     team_histories: Dict[str, List[PredictorGame]],
     team_names: Dict[str, str],
     output_dir: Path,
+    snapshot_index: Optional[Dict[str, List[dict]]] = None,
 ) -> pd.DataFrame:
     """
     Run backtest predictions on historical games
@@ -326,11 +483,13 @@ async def run_backtest(
     """
     logger.info(f"Running backtest on {len(games_df):,} games...")
 
-    # Convert rankings to dict for fast lookup
+    # Convert fallback current rankings to dict for fast lookup
     rankings_dict = {}
     for _, row in rankings_df.iterrows():
         team_id = str(row["team_id"])
         rankings_dict[team_id] = {
+            "team_id": team_id,
+            "age_group": row.get("age_group"),
             "power_score_final": row.get("power_score_final"),
             "sos_norm": row.get("sos_norm"),
             "offense_norm": row.get("offense_norm"),
@@ -344,6 +503,9 @@ async def run_backtest(
         }
 
     results = []
+    skipped_missing_snapshot = 0
+    skipped_prediction_errors = 0
+    using_point_in_time = bool(snapshot_index)
 
     for idx, game_row in tqdm(games_df.iterrows(), total=len(games_df), desc="Predicting"):
         game_id = str(game_row["id"])
@@ -353,38 +515,18 @@ async def run_backtest(
         away_score = game_row["away_score"]
         game_date = game_row["game_date"]
 
-        # Get team rankings
-        home_rank = rankings_dict.get(home_id, {})
-        away_rank = rankings_dict.get(away_id, {})
+        home_snapshot = get_snapshot_as_of(snapshot_index, home_id, game_date) if snapshot_index else None
+        away_snapshot = get_snapshot_as_of(snapshot_index, away_id, game_date) if snapshot_index else None
 
-        # Create TeamRanking objects
-        team_a = TeamRanking(
-            team_id_master=home_id,
-            power_score_final=home_rank.get("power_score_final"),
-            sos_norm=home_rank.get("sos_norm"),
-            offense_norm=home_rank.get("offense_norm"),
-            defense_norm=home_rank.get("defense_norm"),
-            age=home_rank.get("age"),
-            games_played=home_rank.get("games_played", 0),
-            team_name=home_rank.get("team_name"),
-            glicko_rating=home_rank.get("glicko_rating"),
-            glicko_rd=home_rank.get("glicko_rd"),
-            glicko_volatility=home_rank.get("glicko_volatility"),
-        )
+        if using_point_in_time and (home_snapshot is None or away_snapshot is None):
+            skipped_missing_snapshot += 1
+            continue
 
-        team_b = TeamRanking(
-            team_id_master=away_id,
-            power_score_final=away_rank.get("power_score_final"),
-            sos_norm=away_rank.get("sos_norm"),
-            offense_norm=away_rank.get("offense_norm"),
-            defense_norm=away_rank.get("defense_norm"),
-            age=away_rank.get("age"),
-            games_played=away_rank.get("games_played", 0),
-            team_name=away_rank.get("team_name"),
-            glicko_rating=away_rank.get("glicko_rating"),
-            glicko_rd=away_rank.get("glicko_rd"),
-            glicko_volatility=away_rank.get("glicko_volatility"),
-        )
+        home_rank = home_snapshot if home_snapshot is not None else rankings_dict.get(home_id, {})
+        away_rank = away_snapshot if away_snapshot is not None else rankings_dict.get(away_id, {})
+
+        team_a = build_team_ranking(home_id, home_rank, team_names.get(home_id))
+        team_b = build_team_ranking(away_id, away_rank, team_names.get(away_id))
 
         # Get game histories for recent form
         all_games_list = []
@@ -419,8 +561,8 @@ async def run_backtest(
 
             actual_margin = home_score - away_score
 
-            # Get age_group from rankings
-            age_group = home_rank.get("age") or away_rank.get("age")
+            # Get age_group from whichever point-in-time source powered the prediction.
+            age_group = get_team_age(home_rank) or get_team_age(away_rank)
             age_group_str = f"u{age_group}" if age_group else "unknown"
 
             # Store result
@@ -431,6 +573,9 @@ async def run_backtest(
                     "team_a_id": home_id,
                     "team_b_id": away_id,
                     "age_group": age_group_str,
+                    "feature_source": "point_in_time_snapshot" if using_point_in_time else "current_rankings_fallback",
+                    "snapshot_date_a": home_rank.get("snapshot_date"),
+                    "snapshot_date_b": away_rank.get("snapshot_date"),
                     "predicted_winner": prediction.predicted_winner,
                     "actual_winner": actual_winner,
                     "predicted_win_prob_a": prediction.win_probability_a,
@@ -459,10 +604,18 @@ async def run_backtest(
 
         except Exception as e:
             logger.warning(f"Error predicting game {game_id}: {e}")
+            skipped_prediction_errors += 1
             continue
 
     results_df = pd.DataFrame(results)
     logger.info(f"Completed {len(results_df):,} predictions")
+    if using_point_in_time and skipped_missing_snapshot > 0:
+        logger.info(
+            "Skipped %s games because one or both teams lacked a pre-match predictor snapshot",
+            f"{skipped_missing_snapshot:,}",
+        )
+    if skipped_prediction_errors > 0:
+        logger.info("Skipped %s games due to prediction errors", f"{skipped_prediction_errors:,}")
 
     # Save raw backtest CSV
     raw_csv_path = output_dir / "raw_backtest.csv"
@@ -683,6 +836,11 @@ async def main():
         default=0.8,
         help="Fraction of games (oldest first) used for training/calibration (default: 0.8)",
     )
+    parser.add_argument(
+        "--require-point-in-time",
+        action="store_true",
+        help="Fail instead of falling back to current rankings when prediction_feature_history is unavailable.",
+    )
 
     args = parser.parse_args()
 
@@ -715,8 +873,6 @@ async def main():
         logger.error("No games found")
         sys.exit(1)
 
-    rankings_df = await fetch_rankings(supabase)
-
     # Get unique team IDs
     team_ids = list(
         set(
@@ -724,9 +880,6 @@ async def main():
             + list(games_df["away_team_master_id"].dropna().astype(str))
         )
     )
-
-    team_histories = await fetch_team_game_histories(supabase, team_ids, lookback_days=args.lookback_days)
-    team_names = await fetch_team_names(supabase, team_ids)
 
     # Temporal train/test split: sort by date, use oldest games for training
     # This prevents the worst form of data leakage where the same games used
@@ -742,8 +895,46 @@ async def main():
         f"(split at {split_date}, {args.train_split:.0%}/{1 - args.train_split:.0%})"
     )
 
+    team_histories = await fetch_team_game_histories(supabase, team_ids, lookback_days=args.lookback_days)
+    team_names = await fetch_team_names(supabase, team_ids)
+
+    snapshot_start = (pd.Timestamp(games_df["game_date"].min()) - pd.Timedelta(days=30)).strftime("%Y-%m-%d")
+    snapshot_end = pd.Timestamp(games_df["game_date"].max()).strftime("%Y-%m-%d")
+    snapshots_df = await fetch_prediction_feature_snapshots(supabase, team_ids, snapshot_start, snapshot_end)
+    snapshot_index = build_snapshot_index(snapshots_df)
+
+    rankings_df = pd.DataFrame()
+    if snapshot_index:
+        logger.info(
+            "Using %s point-in-time predictor snapshots across %s teams",
+            f"{len(snapshots_df):,}",
+            f"{len(snapshot_index):,}",
+        )
+    else:
+        if args.require_point_in_time:
+            logger.error("prediction_feature_history snapshots are unavailable; aborting because --require-point-in-time was set")
+            sys.exit(1)
+
+        logger.warning("Falling back to current rankings. This benchmark mode is not leakage-safe.")
+        rankings_df = await fetch_rankings(supabase)
+        if rankings_df.empty:
+            logger.error("Current rankings fallback is unavailable")
+            sys.exit(1)
+
     # Run backtest on test set only (future games the model hasn't seen)
-    raw_df = await run_backtest(supabase, test_df, rankings_df, team_histories, team_names, output_dir)
+    raw_df = await run_backtest(
+        supabase,
+        test_df,
+        rankings_df,
+        team_histories,
+        team_names,
+        output_dir,
+        snapshot_index=snapshot_index,
+    )
+
+    if raw_df.empty:
+        logger.error("Backtest produced no predictions")
+        sys.exit(1)
 
     # Generate derived outputs (metrics computed on held-out test set)
     generate_derived_outputs(raw_df, output_dir)

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -18,6 +18,7 @@ from src.etl.glicko_engine import compute_rankings_v2
 from src.etl.v53e import V53EConfig, compute_rankings
 from src.rankings.data_adapter import batch_fetch_rows, fetch_games_for_rankings
 from src.rankings.layer13_predictive_adjustment import Layer13Config, apply_predictive_adjustment
+from src.rankings.prediction_feature_history import save_prediction_feature_snapshot
 from src.rankings.ranking_history import calculate_rank_changes, save_ranking_snapshot
 
 if TYPE_CHECKING:
@@ -58,6 +59,16 @@ def _section(timing_report: Optional["TimingReport"], name: str, **metadata):
     if timing_report is not None:
         return timing_report.section(name, **metadata)
     return nullcontext()
+
+
+async def _save_prediction_feature_snapshot_safe(supabase_client, rankings_df: pd.DataFrame) -> None:
+    """
+    Persist benchmark-only predictor snapshots without blocking rankings publication.
+    """
+    try:
+        await save_prediction_feature_snapshot(supabase_client=supabase_client, rankings_df=rankings_df)
+    except Exception as error:
+        logger.warning("Skipping prediction feature snapshot save after write failure: %s", error)
 
 
 def _safe_int(value: Any) -> int:
@@ -725,6 +736,8 @@ async def compute_rankings_with_ml(
         logger.info("💾 Saving ranking snapshot for future comparisons...")
         with _section(timing_report, "save_ranking_snapshot"):
             await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_with_ml)
+        with _section(timing_report, "save_prediction_feature_snapshot"):
+            await _save_prediction_feature_snapshot_safe(supabase_client=supabase_client, rankings_df=teams_with_ml)
 
     return {
         "teams": teams_with_ml,
@@ -1577,6 +1590,7 @@ async def compute_all_cohorts(
     if not teams_combined.empty:
         logger.info("💾 Saving combined ranking snapshot for all cohorts...")
         await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_combined)
+        await _save_prediction_feature_snapshot_safe(supabase_client=supabase_client, rankings_df=teams_combined)
 
     logger.info(f"✅ Two-pass rankings flow complete: {len(teams_combined):,} teams ranked")
 

--- a/src/rankings/prediction_feature_history.py
+++ b/src/rankings/prediction_feature_history.py
@@ -1,0 +1,240 @@
+"""
+Point-in-time predictor feature snapshots.
+
+This module persists the feature subset consumed by match prediction so
+offline backtests and future model training can evaluate matches using the
+same pre-match information that was available at ranking time.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from datetime import date
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+LEAGUE_AVG_TOTAL_GOALS = 3.1
+
+
+def _safe_int(value) -> Optional[int]:
+    try:
+        if pd.isna(value) or value == "":
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value) -> Optional[float]:
+    try:
+        if pd.isna(value) or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_gender(raw_gender) -> Optional[str]:
+    if pd.isna(raw_gender):
+        return None
+
+    value = str(raw_gender).strip().lower()
+    if value in {"male", "m", "b", "boys", "boy"}:
+        return "Male"
+    if value in {"female", "f", "g", "girls", "girl"}:
+        return "Female"
+    if value in {"", "none", "null", "nan"}:
+        return None
+    return str(raw_gender).strip()
+
+
+def _derive_age_group(age_value, age_group_value) -> Optional[str]:
+    if pd.notna(age_group_value) and str(age_group_value).strip():
+        return str(age_group_value).strip().lower()
+
+    if pd.isna(age_value) or str(age_value).strip() == "":
+        return None
+
+    try:
+        return f"u{int(float(age_value))}"
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_expected_goals(
+    offense_norm: Optional[float], defense_norm: Optional[float], exp_margin: Optional[float]
+) -> tuple[Optional[float], Optional[float]]:
+    if offense_norm is None or defense_norm is None or exp_margin is None:
+        return None, None
+
+    expected_total_goals = LEAGUE_AVG_TOTAL_GOALS * ((offense_norm + defense_norm) / 2.0)
+    exp_goals_for = expected_total_goals / (1.0 + math.exp(-exp_margin))
+    exp_goals_against = expected_total_goals - exp_goals_for
+    return exp_goals_for, exp_goals_against
+
+
+def build_prediction_feature_snapshot_records(
+    rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
+) -> list[dict]:
+    """
+    Build serializable records for prediction_feature_history.
+
+    The input DataFrame is expected to be the post-ranking calculator output
+    (e.g. teams_with_ml / teams_combined), not raw rankings_full rows.
+    """
+    if snapshot_date is None:
+        snapshot_date = date.today()
+
+    if rankings_df.empty:
+        return []
+
+    df = rankings_df.copy()
+
+    if "games_played" not in df.columns and "gp" in df.columns:
+        df["games_played"] = df["gp"]
+
+    if "offense_norm" not in df.columns and "off_norm" in df.columns:
+        df["offense_norm"] = df["off_norm"]
+    if "defense_norm" not in df.columns and "def_norm" in df.columns:
+        df["defense_norm"] = df["def_norm"]
+
+    if "glicko_rating" not in df.columns and "mu" in df.columns:
+        df["glicko_rating"] = df["mu"]
+    if "glicko_rd" not in df.columns and "sigma" in df.columns:
+        df["glicko_rd"] = df["sigma"]
+    if "glicko_volatility" not in df.columns and "volatility" in df.columns:
+        df["glicko_volatility"] = df["volatility"]
+
+    records: list[dict] = []
+    snapshot_date_str = snapshot_date.isoformat()
+
+    for _, row in df.iterrows():
+        team_id = row.get("team_id")
+        if pd.isna(team_id) or not str(team_id).strip():
+            continue
+
+        wins = _safe_int(row.get("wins")) or 0
+        losses = _safe_int(row.get("losses")) or 0
+        draws = _safe_int(row.get("draws")) or 0
+        games_played = _safe_int(row.get("games_played")) or 0
+
+        win_percentage = (
+            ((wins + (0.5 * draws)) / games_played) * 100.0 if games_played > 0 else _safe_float(row.get("win_percentage"))
+        )
+
+        offense_norm = _safe_float(row.get("offense_norm"))
+        defense_norm = _safe_float(row.get("defense_norm"))
+        exp_margin = _safe_float(row.get("exp_margin"))
+        exp_goals_for = _safe_float(row.get("exp_goals_for"))
+        exp_goals_against = _safe_float(row.get("exp_goals_against"))
+
+        if exp_goals_for is None or exp_goals_against is None:
+            derived_gf, derived_ga = _compute_expected_goals(offense_norm, defense_norm, exp_margin)
+            exp_goals_for = exp_goals_for if exp_goals_for is not None else derived_gf
+            exp_goals_against = exp_goals_against if exp_goals_against is not None else derived_ga
+
+        record = {
+            "snapshot_date": snapshot_date_str,
+            "team_id": str(team_id),
+            "age_group": _derive_age_group(row.get("age"), row.get("age_group")),
+            "gender": _normalize_gender(row.get("gender")),
+            "state_code": str(row.get("state_code")).strip() if pd.notna(row.get("state_code")) else None,
+            "status": str(row.get("status")).strip() if pd.notna(row.get("status")) else None,
+            "rank_in_cohort_final": _safe_int(row.get("rank_in_cohort_final")),
+            "power_score_final": _safe_float(row.get("power_score_final")),
+            "sos_norm": _safe_float(row.get("sos_norm")),
+            "offense_norm": offense_norm,
+            "defense_norm": defense_norm,
+            "glicko_rating": _safe_float(row.get("glicko_rating")),
+            "glicko_rd": _safe_float(row.get("glicko_rd")),
+            "glicko_volatility": _safe_float(row.get("glicko_volatility")),
+            "wins": wins,
+            "losses": losses,
+            "draws": draws,
+            "games_played": games_played,
+            "win_percentage": win_percentage,
+            "exp_margin": exp_margin,
+            "exp_win_rate": _safe_float(row.get("exp_win_rate")),
+            "exp_goals_for": exp_goals_for,
+            "exp_goals_against": exp_goals_against,
+            "last_calculated": row.get("last_calculated").isoformat()
+            if isinstance(row.get("last_calculated"), pd.Timestamp) and pd.notna(row.get("last_calculated"))
+            else None,
+        }
+        records.append(record)
+
+    return records
+
+
+async def save_prediction_feature_snapshot(
+    supabase_client, rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
+) -> int:
+    """
+    Persist point-in-time predictor inputs for future backtests.
+    """
+    records = build_prediction_feature_snapshot_records(rankings_df, snapshot_date=snapshot_date)
+    if not records:
+        logger.warning("No prediction feature snapshot records to save")
+        return 0
+
+    total_records = len(records)
+    batch_size = 1000
+    max_retries = 4
+    saved_count = 0
+
+    logger.info("Saving %s prediction feature snapshots...", f"{total_records:,}")
+
+    for index in range(0, total_records, batch_size):
+        batch = records[index : index + batch_size]
+        batch_num = (index // batch_size) + 1
+        total_batches = (total_records + batch_size - 1) // batch_size
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = (
+                    supabase_client.table("prediction_feature_history")
+                    .upsert(batch, on_conflict="team_id,snapshot_date")
+                    .execute()
+                )
+                batch_saved = len(response.data) if response.data else len(batch)
+                saved_count += batch_saved
+                if total_batches > 1:
+                    label = f" (retry {attempt})" if attempt > 0 else ""
+                    logger.info(
+                        "  Batch %s/%s%s: saved %s predictor snapshots",
+                        batch_num,
+                        total_batches,
+                        label,
+                        f"{batch_saved:,}",
+                    )
+                break
+            except Exception as error:
+                if attempt < max_retries:
+                    wait_seconds = 2 ** (attempt + 1)
+                    logger.warning(
+                        "Prediction feature snapshot batch %s/%s failed on attempt %s. Retrying in %ss: %s",
+                        batch_num,
+                        total_batches,
+                        attempt + 1,
+                        wait_seconds,
+                        error,
+                    )
+                    time.sleep(wait_seconds)
+                    continue
+
+                logger.error(
+                    "Prediction feature snapshot batch %s/%s failed after %s attempts: %s",
+                    batch_num,
+                    total_batches,
+                    max_retries + 1,
+                    error,
+                )
+                raise
+
+    logger.info("Saved %s/%s prediction feature snapshots", f"{saved_count:,}", f"{total_records:,}")
+    return saved_count

--- a/supabase/migrations/20260408000000_create_prediction_feature_history.sql
+++ b/supabase/migrations/20260408000000_create_prediction_feature_history.sql
@@ -1,0 +1,63 @@
+-- Point-in-time predictor feature snapshots for offline backtests and model training.
+-- This stores the subset of team-level features consumed by match prediction as they
+-- existed at ranking snapshot time, so evaluation can avoid current-snapshot leakage.
+
+CREATE TABLE IF NOT EXISTS prediction_feature_history (
+    snapshot_date DATE NOT NULL,
+    team_id UUID NOT NULL REFERENCES teams(team_id_master) ON DELETE CASCADE,
+    age_group TEXT,
+    gender TEXT,
+    state_code TEXT,
+    status TEXT,
+    rank_in_cohort_final INTEGER,
+    power_score_final FLOAT,
+    sos_norm FLOAT,
+    offense_norm FLOAT,
+    defense_norm FLOAT,
+    glicko_rating FLOAT,
+    glicko_rd FLOAT,
+    glicko_volatility FLOAT,
+    wins INTEGER,
+    losses INTEGER,
+    draws INTEGER,
+    games_played INTEGER,
+    win_percentage FLOAT,
+    exp_margin FLOAT,
+    exp_win_rate FLOAT,
+    exp_goals_for FLOAT,
+    exp_goals_against FLOAT,
+    last_calculated TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, snapshot_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prediction_feature_history_snapshot
+ON prediction_feature_history(snapshot_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_prediction_feature_history_team_date
+ON prediction_feature_history(team_id, snapshot_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_prediction_feature_history_cohort
+ON prediction_feature_history(age_group, gender, snapshot_date DESC);
+
+ALTER TABLE prediction_feature_history ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE prediction_feature_history IS
+'Point-in-time predictor feature snapshots captured during ranking runs. Used for leakage-safe backtests and future model training.';
+
+COMMENT ON COLUMN prediction_feature_history.snapshot_date IS
+'UTC date for the ranking snapshot that produced this predictor feature row.';
+
+COMMENT ON COLUMN prediction_feature_history.rank_in_cohort_final IS
+'Published final rank at the time of the snapshot. Useful for stratified evaluation.';
+
+COMMENT ON COLUMN prediction_feature_history.win_percentage IS
+'Draw-aware win percentage used by compare feature assembly: (wins + 0.5 * draws) / games_played * 100.';
+
+COMMENT ON COLUMN prediction_feature_history.exp_margin IS
+'Optional predictive expected margin. Populated when the ranking pipeline emits it.';
+
+COMMENT ON COLUMN prediction_feature_history.exp_win_rate IS
+'Optional predictive expected win probability. Populated when the ranking pipeline emits it.';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON prediction_feature_history TO service_role;

--- a/tests/unit/test_prediction_feature_history.py
+++ b/tests/unit/test_prediction_feature_history.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from src.rankings.prediction_feature_history import (
+    LEAGUE_AVG_TOTAL_GOALS,
+    build_prediction_feature_snapshot_records,
+)
+
+
+def test_build_prediction_feature_snapshot_records_normalizes_live_predictor_fields():
+    snapshot_date = pd.Timestamp("2026-04-07").date()
+    rankings_df = pd.DataFrame(
+        [
+            {
+                "team_id": "team-1",
+                "age": 14,
+                "gender": "Boys",
+                "state_code": "AZ",
+                "status": "Active",
+                "rank_in_cohort_final": 8,
+                "power_score_final": 0.81,
+                "sos_norm": 0.63,
+                "off_norm": 0.71,
+                "def_norm": 0.66,
+                "mu": 1580.0,
+                "sigma": 54.0,
+                "volatility": 0.06,
+                "wins": 12,
+                "losses": 3,
+                "draws": 5,
+                "gp": 20,
+                "exp_margin": 0.45,
+                "last_calculated": pd.Timestamp("2026-04-07T16:45:00Z"),
+            }
+        ]
+    )
+
+    records = build_prediction_feature_snapshot_records(rankings_df, snapshot_date=snapshot_date)
+
+    assert len(records) == 1
+    record = records[0]
+
+    assert record["snapshot_date"] == "2026-04-07"
+    assert record["team_id"] == "team-1"
+    assert record["age_group"] == "u14"
+    assert record["gender"] == "Male"
+    assert record["state_code"] == "AZ"
+    assert record["rank_in_cohort_final"] == 8
+    assert record["offense_norm"] == 0.71
+    assert record["defense_norm"] == 0.66
+    assert record["glicko_rating"] == 1580.0
+    assert record["glicko_rd"] == 54.0
+    assert record["glicko_volatility"] == 0.06
+    assert record["games_played"] == 20
+    assert record["wins"] == 12
+    assert record["losses"] == 3
+    assert record["draws"] == 5
+    assert math.isclose(record["win_percentage"], 72.5, rel_tol=1e-9)
+    assert record["last_calculated"] == "2026-04-07T16:45:00+00:00"
+
+    expected_total = LEAGUE_AVG_TOTAL_GOALS * ((0.71 + 0.66) / 2.0)
+    expected_goals_for = expected_total / (1.0 + math.exp(-0.45))
+    expected_goals_against = expected_total - expected_goals_for
+    assert math.isclose(record["exp_goals_for"], expected_goals_for, rel_tol=1e-9)
+    assert math.isclose(record["exp_goals_against"], expected_goals_against, rel_tol=1e-9)
+
+
+def test_build_prediction_feature_snapshot_records_skips_blank_team_ids_and_preserves_explicit_age_group():
+    rankings_df = pd.DataFrame(
+        [
+            {
+                "team_id": None,
+                "age": 13,
+                "gender": "Girls",
+            },
+            {
+                "team_id": "team-2",
+                "age_group": "U19",
+                "gender": "Female",
+                "games_played": 0,
+                "wins": 0,
+                "losses": 0,
+                "draws": 0,
+                "exp_goals_for": 1.4,
+                "exp_goals_against": 0.9,
+            },
+        ]
+    )
+
+    records = build_prediction_feature_snapshot_records(rankings_df, snapshot_date=pd.Timestamp("2026-04-08").date())
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["team_id"] == "team-2"
+    assert record["age_group"] == "u19"
+    assert record["gender"] == "Female"
+    assert record["win_percentage"] is None
+    assert record["exp_goals_for"] == 1.4
+    assert record["exp_goals_against"] == 0.9


### PR DESCRIPTION
## Summary
- upgrade the live /compare prediction flow with a richer hybrid predictor and explicit draw probability support
- warm calibration before inference and expand compare feature inputs with predictive fields and recent ml_overperformance
- add prediction_feature_history snapshots plus leakage-safer backtest support that prefers point-in-time team features

## Verification
- npm run test -- matchPredictor.test.ts matchPredictionService.test.ts matchExplainer.test.ts ComparePanel.test.tsx
- npm run typecheck
- python -m pytest tests/unit/test_prediction_feature_history.py tests/unit/test_glicko_sos_role.py -q
- py_compile on modified Python files