### PR TITLE
Add prediction snapshot replay backfill

### DIFF
--- a/.github/workflows/backfill-prediction-feature-history.yml
+++ b/.github/workflows/backfill-prediction-feature-history.yml
@@ -1,0 +1,161 @@
+name: Backfill Prediction Feature History
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: 'Inclusive start date (YYYY-MM-DD)'
+        required: true
+        type: string
+      end_date:
+        description: 'Inclusive end date (YYYY-MM-DD)'
+        required: true
+        type: string
+      cadence:
+        description: 'Replay cadence'
+        required: true
+        default: weekly
+        type: choice
+        options:
+          - weekly
+          - daily
+      weekday:
+        description: 'Weekday for weekly cadence (Mon..Sun or 0..6)'
+        required: false
+        default: Mon
+        type: string
+      lookback_days:
+        description: 'Ranking lookback window'
+        required: false
+        default: '365'
+        type: string
+      provider:
+        description: 'Optional provider filter'
+        required: false
+        default: ''
+        type: string
+      engine:
+        description: 'Ranking engine to use during replay'
+        required: true
+        default: glicko
+        type: choice
+        options:
+          - glicko
+          - v53e
+      disable_ml:
+        description: 'Disable Layer 13 during replay'
+        required: false
+        default: false
+        type: boolean
+      force_rebuild:
+        description: 'Ignore cached cohort results'
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: 'Compute dates without writing snapshots'
+        required: false
+        default: true
+        type: boolean
+      overwrite_existing:
+        description: 'Replay dates even if rows already exist'
+        required: false
+        default: false
+        type: boolean
+      max_snapshots:
+        description: 'Optional cap on processed snapshot dates'
+        required: false
+        default: ''
+        type: string
+      stop_on_error:
+        description: 'Abort immediately on first failed date'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: prediction-feature-history-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill-prediction-feature-history:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Show commit hash
+        run: |
+          echo "Current commit:"
+          git rev-parse HEAD
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          python -c "import supabase, pandas, numpy, rich; print('All critical imports successful')"
+
+      - name: Run prediction feature backfill
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+
+          CMD=(
+            python scripts/backfill_prediction_feature_history.py
+            --start-date "${{ github.event.inputs.start_date }}"
+            --end-date "${{ github.event.inputs.end_date }}"
+            --cadence "${{ github.event.inputs.cadence }}"
+            --weekday "${{ github.event.inputs.weekday }}"
+            --lookback-days "${{ github.event.inputs.lookback_days }}"
+            --engine "${{ github.event.inputs.engine }}"
+          )
+
+          if [ -n "${{ github.event.inputs.provider }}" ]; then
+            CMD+=(--provider "${{ github.event.inputs.provider }}")
+          fi
+
+          if [ "${{ github.event.inputs.disable_ml }}" = "true" ]; then
+            CMD+=(--disable-ml)
+          fi
+
+          if [ "${{ github.event.inputs.force_rebuild }}" = "true" ]; then
+            CMD+=(--force-rebuild)
+          fi
+
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            CMD+=(--dry-run)
+          fi
+
+          if [ "${{ github.event.inputs.overwrite_existing }}" = "true" ]; then
+            CMD+=(--overwrite-existing)
+          fi
+
+          if [ -n "${{ github.event.inputs.max_snapshots }}" ]; then
+            CMD+=(--max-snapshots "${{ github.event.inputs.max_snapshots }}")
+          fi
+
+          if [ "${{ github.event.inputs.stop_on_error }}" = "true" ]; then
+            CMD+=(--stop-on-error)
+          fi
+
+          printf 'Running command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"

--- a/scripts/backfill_prediction_feature_history.py
+++ b/scripts/backfill_prediction_feature_history.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Backfill point-in-time prediction_feature_history snapshots.
+
+This replays historical ranking dates using the current ranking pipeline with
+an as-of date, then persists only predictor feature snapshots. It does not
+rewrite rankings_full/current_rankings, and it deliberately skips persisting
+historical game residuals back onto the live games table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.table import Table
+from supabase.lib.client_options import SyncClientOptions
+
+from supabase import create_client
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.rankings.calculator import compute_all_cohorts
+from src.rankings.layer13_predictive_adjustment import Layer13Config
+from src.rankings.prediction_feature_history import save_prediction_feature_snapshot
+from src.utils.merge_resolver import MergeResolver
+
+logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=[logging.StreamHandler()])
+logger = logging.getLogger(__name__)
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+console = Console()
+
+WEEKDAY_LOOKUP = {
+    "mon": 0,
+    "monday": 0,
+    "tue": 1,
+    "tues": 1,
+    "tuesday": 1,
+    "wed": 2,
+    "wednesday": 2,
+    "thu": 3,
+    "thur": 3,
+    "thurs": 3,
+    "thursday": 3,
+    "fri": 4,
+    "friday": 4,
+    "sat": 5,
+    "saturday": 5,
+    "sun": 6,
+    "sunday": 6,
+}
+
+
+def parse_iso_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"Invalid date '{value}'. Expected YYYY-MM-DD.") from error
+
+
+def parse_weekday(value: str) -> int:
+    normalized = value.strip().lower()
+    if normalized.isdigit():
+        weekday = int(normalized)
+        if 0 <= weekday <= 6:
+            return weekday
+        raise argparse.ArgumentTypeError("Weekday integer must be between 0 (Mon) and 6 (Sun).")
+
+    if normalized in WEEKDAY_LOOKUP:
+        return WEEKDAY_LOOKUP[normalized]
+
+    raise argparse.ArgumentTypeError(f"Unsupported weekday '{value}'. Use Mon..Sun or 0..6.")
+
+
+def generate_snapshot_dates(start_date: date, end_date: date, cadence: str, weekday: int) -> list[date]:
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+
+    if cadence == "daily":
+        dates: list[date] = []
+        current = start_date
+        while current <= end_date:
+            dates.append(current)
+            current += timedelta(days=1)
+        return dates
+
+    days_until_weekday = (weekday - start_date.weekday()) % 7
+    current = start_date + timedelta(days=days_until_weekday)
+    dates = []
+    while current <= end_date:
+        dates.append(current)
+        current += timedelta(days=7)
+    return dates
+
+
+async def prediction_snapshot_exists(supabase_client, snapshot_date: date) -> bool:
+    response = (
+        supabase_client.table("prediction_feature_history")
+        .select("snapshot_date")
+        .eq("snapshot_date", snapshot_date.isoformat())
+        .limit(1)
+        .execute()
+    )
+    return bool(response.data)
+
+
+async def replay_prediction_snapshot(
+    supabase_client,
+    merge_resolver: MergeResolver,
+    snapshot_date: date,
+    lookback_days: int,
+    provider_filter: str | None,
+    use_glicko: bool,
+    ml_enabled: bool,
+    force_rebuild: bool,
+    dry_run: bool,
+) -> tuple[int, int]:
+    snapshot_ts = pd.Timestamp(snapshot_date)
+    layer13_cfg = None if ml_enabled else Layer13Config(enabled=False)
+
+    result = await compute_all_cohorts(
+        supabase_client=supabase_client,
+        today=snapshot_ts,
+        layer13_cfg=layer13_cfg,
+        fetch_from_supabase=True,
+        lookback_days=lookback_days,
+        provider_filter=provider_filter,
+        force_rebuild=force_rebuild,
+        merge_resolver=merge_resolver,
+        use_glicko=use_glicko,
+        persist_game_residuals=False,
+        calculate_rank_changes=False,
+        save_snapshot=False,
+    )
+
+    teams_df = result["teams"]
+    if teams_df.empty:
+        return 0, 0
+
+    if dry_run:
+        return len(teams_df), len(teams_df)
+
+    saved = await save_prediction_feature_snapshot(
+        supabase_client=supabase_client,
+        rankings_df=teams_df,
+        snapshot_date=snapshot_date,
+    )
+    return len(teams_df), saved
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay historical prediction feature snapshots")
+    parser.add_argument("--start-date", type=parse_iso_date, required=True, help="Inclusive start date (YYYY-MM-DD)")
+    parser.add_argument("--end-date", type=parse_iso_date, required=True, help="Inclusive end date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--cadence",
+        choices=["weekly", "daily"],
+        default="weekly",
+        help="Replay cadence. Weekly is the practical default.",
+    )
+    parser.add_argument(
+        "--weekday",
+        type=parse_weekday,
+        default=0,
+        help="Weekday for weekly cadence. Accepts Mon..Sun or 0..6 where 0=Mon.",
+    )
+    parser.add_argument("--lookback-days", type=int, default=365, help="Ranking lookback window (default: 365)")
+    parser.add_argument("--provider", type=str, default=None, help="Optional provider filter")
+    parser.add_argument("--engine", choices=["glicko", "v53e"], default="glicko", help="Ranking engine")
+    parser.add_argument("--disable-ml", action="store_true", help="Disable Layer 13 during replay")
+    parser.add_argument("--force-rebuild", action="store_true", help="Ignore cached cohort results")
+    parser.add_argument("--dry-run", action="store_true", help="Compute replay dates without writing snapshots")
+    parser.add_argument(
+        "--overwrite-existing",
+        action="store_true",
+        help="Replay dates even if prediction_feature_history already has rows for that date",
+    )
+    parser.add_argument(
+        "--max-snapshots",
+        type=int,
+        default=None,
+        help="Optional cap on how many snapshot dates to process after filtering/skipping",
+    )
+    parser.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help="Abort the backfill immediately on the first failed snapshot date",
+    )
+
+    args = parser.parse_args()
+
+    env_local = Path(".env.local")
+    if env_local.exists():
+        load_dotenv(env_local, override=True)
+    else:
+        load_dotenv()
+
+    supabase_url = os.getenv("SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not supabase_url or not supabase_key:
+        console.print("[red]Error: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set[/red]")
+        sys.exit(1)
+
+    supabase_client = create_client(
+        supabase_url,
+        supabase_key,
+        options=SyncClientOptions(postgrest_client_timeout=360),
+    )
+
+    merge_resolver = MergeResolver(supabase_client)
+    merge_resolver.load_merge_map()
+
+    candidate_dates = generate_snapshot_dates(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        cadence=args.cadence,
+        weekday=args.weekday,
+    )
+
+    if args.max_snapshots is not None:
+        candidate_dates = candidate_dates[: args.max_snapshots]
+
+    if not candidate_dates:
+        console.print("[yellow]No snapshot dates selected[/yellow]")
+        return
+
+    summary = Table(title="Replay Plan")
+    summary.add_column("Setting")
+    summary.add_column("Value")
+    summary.add_row("Start", args.start_date.isoformat())
+    summary.add_row("End", args.end_date.isoformat())
+    summary.add_row("Cadence", args.cadence)
+    summary.add_row("Weekday", str(args.weekday))
+    summary.add_row("Dates", str(len(candidate_dates)))
+    summary.add_row("Lookback", str(args.lookback_days))
+    summary.add_row("Engine", args.engine)
+    summary.add_row("ML", "disabled" if args.disable_ml else "enabled")
+    summary.add_row("Dry run", "yes" if args.dry_run else "no")
+    console.print(summary)
+
+    processed = 0
+    skipped_existing = 0
+    failed_dates: list[str] = []
+    total_saved_rows = 0
+
+    for snapshot_date in candidate_dates:
+        if not args.overwrite_existing:
+            if await prediction_snapshot_exists(supabase_client, snapshot_date):
+                skipped_existing += 1
+                console.print(f"[dim]Skipping {snapshot_date.isoformat()} (already backfilled)[/dim]")
+                continue
+
+        console.print(f"\n[bold]Replaying {snapshot_date.isoformat()}[/bold]")
+        try:
+            team_count, saved_rows = await replay_prediction_snapshot(
+                supabase_client=supabase_client,
+                merge_resolver=merge_resolver,
+                snapshot_date=snapshot_date,
+                lookback_days=args.lookback_days,
+                provider_filter=args.provider,
+                use_glicko=(args.engine == "glicko"),
+                ml_enabled=not args.disable_ml,
+                force_rebuild=args.force_rebuild,
+                dry_run=args.dry_run,
+            )
+
+            if team_count == 0:
+                console.print(f"[yellow]No teams produced for {snapshot_date.isoformat()}[/yellow]")
+            else:
+                mode_label = "would save" if args.dry_run else "saved"
+                console.print(
+                    f"[green]{snapshot_date.isoformat()} complete:[/green] "
+                    f"{team_count:,} teams processed, {mode_label} {saved_rows:,} snapshot rows"
+                )
+                total_saved_rows += saved_rows
+            processed += 1
+        except Exception as error:
+            failed_dates.append(snapshot_date.isoformat())
+            console.print(f"[red]{snapshot_date.isoformat()} failed:[/red] {error}")
+            if args.stop_on_error:
+                break
+
+    console.print("\n[bold]Replay Summary[/bold]")
+    console.print(f"Processed dates: {processed}")
+    console.print(f"Skipped existing: {skipped_existing}")
+    console.print(f"Failed dates: {len(failed_dates)}")
+    console.print(f"Snapshot rows {'planned' if args.dry_run else 'saved'}: {total_saved_rows:,}")
+    if failed_dates:
+        console.print(f"[yellow]Failed date list:[/yellow] {', '.join(failed_dates)}")
+
+    if failed_dates:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 from contextlib import nullcontext
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
@@ -46,6 +47,8 @@ class RankingContext:
     use_glicko: bool = True
     force_rebuild: bool = False
     save_snapshot: bool = True
+    persist_game_residuals: bool = True
+    calculate_rank_changes: bool = True
     # Instrumentation
     timing_report: Optional[Any] = None
     pass_label: Optional[str] = None
@@ -61,12 +64,26 @@ def _section(timing_report: Optional["TimingReport"], name: str, **metadata):
     return nullcontext()
 
 
-async def _save_prediction_feature_snapshot_safe(supabase_client, rankings_df: pd.DataFrame) -> None:
+def _normalize_snapshot_date(today: Optional[pd.Timestamp]) -> Optional[date]:
+    if today is None:
+        return None
+
+    timestamp = pd.Timestamp(today)
+    return timestamp.date()
+
+
+async def _save_prediction_feature_snapshot_safe(
+    supabase_client, rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
+) -> None:
     """
     Persist benchmark-only predictor snapshots without blocking rankings publication.
     """
     try:
-        await save_prediction_feature_snapshot(supabase_client=supabase_client, rankings_df=rankings_df)
+        await save_prediction_feature_snapshot(
+            supabase_client=supabase_client,
+            rankings_df=rankings_df,
+            snapshot_date=snapshot_date,
+        )
     except Exception as error:
         logger.warning("Skipping prediction feature snapshot save after write failure: %s", error)
 
@@ -481,6 +498,8 @@ async def compute_rankings_with_ml(
     # Unpack context fields as locals so the body reads naturally
     force_rebuild = ctx.force_rebuild
     save_snapshot = ctx.save_snapshot
+    persist_game_residuals = ctx.persist_game_residuals
+    calculate_rank_changes_enabled = ctx.calculate_rank_changes
     global_strength_map = ctx.global_strength_map
     merge_version = ctx.merge_version
     team_state_map = ctx.team_state_map
@@ -490,6 +509,7 @@ async def compute_rankings_with_ml(
     pre_sos_state = ctx.pre_sos_state
     use_glicko = ctx.use_glicko
     initial_ratings = ctx.initial_ratings
+    snapshot_date = _normalize_snapshot_date(today)
 
     v53_cfg = v53_cfg or V53EConfig()
 
@@ -696,7 +716,9 @@ async def compute_rankings_with_ml(
     # Persist game residuals to database (skip during Pass 1 — Pass 2 values overwrite)
     skip_persist = pass_label == "Pass1"
     with _section(timing_report, "persist_game_residuals"):
-        if skip_persist:
+        if not persist_game_residuals:
+            logger.info("Skipping residual persistence (disabled for this run)")
+        elif skip_persist:
             logger.info("⏭️  Skipping residual persistence (Pass 1 — will persist in Pass 2)")
         elif not game_residuals.empty:
             logger.info(f"💾 Persisting {len(game_residuals):,} game residuals to database...")
@@ -726,18 +748,40 @@ async def compute_rankings_with_ml(
                 logger.debug(f"  {age} {gender}: pre-ML={before:.3f}, post-ML={after:.3f}, diff={after - before:+.3f}")
 
     # Calculate rank changes using historical snapshots (7d and 30d)
-    logger.info("📊 Calculating rank changes from historical data...")
-    with _section(timing_report, "rank_changes"):
-        teams_with_ml = await calculate_rank_changes(supabase_client=supabase_client, current_rankings_df=teams_with_ml)
+    if calculate_rank_changes_enabled:
+        logger.info("📊 Calculating rank changes from historical data...")
+        with _section(timing_report, "rank_changes"):
+            teams_with_ml = await calculate_rank_changes(
+                supabase_client=supabase_client,
+                current_rankings_df=teams_with_ml,
+                reference_date=snapshot_date,
+            )
+    else:
+        for column in [
+            "rank_change_7d",
+            "rank_change_30d",
+            "rank_change_state_7d",
+            "rank_change_state_30d",
+        ]:
+            if column not in teams_with_ml.columns:
+                teams_with_ml[column] = None
 
     # Save current rankings as a snapshot for future rank change calculations
     # (Skip if save_snapshot=False, e.g., when called from compute_all_cohorts)
     if save_snapshot and not teams_with_ml.empty:
         logger.info("💾 Saving ranking snapshot for future comparisons...")
         with _section(timing_report, "save_ranking_snapshot"):
-            await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_with_ml)
+            await save_ranking_snapshot(
+                supabase_client=supabase_client,
+                rankings_df=teams_with_ml,
+                snapshot_date=snapshot_date,
+            )
         with _section(timing_report, "save_prediction_feature_snapshot"):
-            await _save_prediction_feature_snapshot_safe(supabase_client=supabase_client, rankings_df=teams_with_ml)
+            await _save_prediction_feature_snapshot_safe(
+                supabase_client=supabase_client,
+                rankings_df=teams_with_ml,
+                snapshot_date=snapshot_date,
+            )
 
     return {
         "teams": teams_with_ml,
@@ -817,6 +861,9 @@ async def compute_all_cohorts(
     merge_resolver=None,  # Optional MergeResolver for team merge resolution
     timing_report: Optional["TimingReport"] = None,
     use_glicko: bool = True,  # True = Glicko-2 engine, False = legacy v53e engine
+    persist_game_residuals: bool = True,
+    calculate_rank_changes: bool = True,
+    save_snapshot: bool = True,
 ) -> Dict[str, pd.DataFrame]:
     """
     Compute rankings for all cohorts using two-pass architecture.
@@ -974,6 +1021,8 @@ async def compute_all_cohorts(
                 tier_league_map=tier_league_map,
                 pass_label="Pass1",
                 use_glicko=use_glicko,
+                persist_game_residuals=persist_game_residuals,
+                calculate_rank_changes=calculate_rank_changes,
             ),
         )
         pass1_tasks.append(task)
@@ -1042,6 +1091,8 @@ async def compute_all_cohorts(
                 pre_sos_state=None if use_glicko else pass1_pre_sos_states.get(i),
                 use_glicko=use_glicko,
                 initial_ratings=pass1_glicko_ratings.get(i) if use_glicko else None,
+                persist_game_residuals=persist_game_residuals,
+                calculate_rank_changes=calculate_rank_changes,
             ),
         )
         pass2_tasks.append(task)
@@ -1304,7 +1355,7 @@ async def compute_all_cohorts(
     """
 
     # Diagnostic: Log distribution stats for sos_norm and powerscore_adj per cohort
-    if not teams_combined.empty:
+    if save_snapshot and not teams_combined.empty:
         logger.info("📊 Distribution diagnostics per age/gender cohort:")
         for (age, gender), cohort_df in teams_combined.groupby(["age", "gender"]):
             if "sos_norm" in cohort_df.columns:
@@ -1587,10 +1638,18 @@ async def compute_all_cohorts(
                     )
 
     # Save one combined snapshot for all cohorts
-    if not teams_combined.empty:
+    if save_snapshot and not teams_combined.empty:
         logger.info("💾 Saving combined ranking snapshot for all cohorts...")
-        await save_ranking_snapshot(supabase_client=supabase_client, rankings_df=teams_combined)
-        await _save_prediction_feature_snapshot_safe(supabase_client=supabase_client, rankings_df=teams_combined)
+        await save_ranking_snapshot(
+            supabase_client=supabase_client,
+            rankings_df=teams_combined,
+            snapshot_date=_normalize_snapshot_date(today),
+        )
+        await _save_prediction_feature_snapshot_safe(
+            supabase_client=supabase_client,
+            rankings_df=teams_combined,
+            snapshot_date=_normalize_snapshot_date(today),
+        )
 
     logger.info(f"✅ Two-pass rankings flow complete: {len(teams_combined):,} teams ranked")
 

--- a/tests/unit/test_backfill_prediction_feature_history.py
+++ b/tests/unit/test_backfill_prediction_feature_history.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from scripts.backfill_prediction_feature_history import (
+    generate_snapshot_dates,
+    parse_weekday,
+)
+
+
+def test_parse_weekday_accepts_names_and_numbers():
+    assert parse_weekday("Mon") == 0
+    assert parse_weekday("thursday") == 3
+    assert parse_weekday("6") == 6
+
+
+def test_parse_weekday_rejects_invalid_values():
+    with pytest.raises(Exception):
+        parse_weekday("8")
+
+    with pytest.raises(Exception):
+        parse_weekday("noday")
+
+
+def test_generate_snapshot_dates_weekly_aligns_to_requested_weekday():
+    dates = generate_snapshot_dates(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 31),
+        cadence="weekly",
+        weekday=0,
+    )
+
+    assert dates == [
+        date(2026, 1, 5),
+        date(2026, 1, 12),
+        date(2026, 1, 19),
+        date(2026, 1, 26),
+    ]
+
+
+def test_generate_snapshot_dates_daily_includes_range_endpoints():
+    dates = generate_snapshot_dates(
+        start_date=date(2026, 4, 6),
+        end_date=date(2026, 4, 8),
+        cadence="daily",
+        weekday=0,
+    )
+
+    assert dates == [
+        date(2026, 4, 6),
+        date(2026, 4, 7),
+        date(2026, 4, 8),
+    ]
+
+
+def test_generate_snapshot_dates_rejects_inverted_ranges():
+    with pytest.raises(ValueError):
+        generate_snapshot_dates(
+            start_date=date(2026, 4, 8),
+            end_date=date(2026, 4, 6),
+            cadence="weekly",
+            weekday=0,
+        )

--- a/tests/unit/test_glicko_sos_role.py
+++ b/tests/unit/test_glicko_sos_role.py
@@ -7,8 +7,7 @@ import pandas as pd
 import pytest
 
 from src.etl.glicko_config import GlickoConfig
-from src.etl.glicko_engine import compute_rankings_v2
-from src.etl.glicko_engine import run_glicko2_cohort
+from src.etl.glicko_engine import compute_rankings_v2, run_glicko2_cohort
 from src.rankings import calculator
 
 
@@ -333,3 +332,103 @@ async def test_compute_all_cohorts_builds_glicko_pass2_map_from_mu(monkeypatch):
     for call in pass2_calls:
         assert call["global_strength_map"] == expected_map
         assert call["initial_ratings"]
+
+
+@pytest.mark.asyncio
+async def test_compute_all_cohorts_can_skip_snapshot_and_rank_change_side_effects(monkeypatch):
+    calls: list[dict] = []
+    save_calls = {"ranking": 0, "prediction": 0}
+
+    async def fake_compute_rankings_with_ml(
+        supabase_client,
+        games_df,
+        today,
+        v53_cfg=None,
+        layer13_cfg=None,
+        fetch_from_supabase=True,
+        lookback_days=365,
+        provider_filter=None,
+        ctx=None,
+    ):
+        pass_label = ctx.pass_label if ctx else None
+        age = str(games_df.iloc[0]["age"])
+        rows = []
+        ratings = {
+            "14": {"A": 1610.0, "B": 1520.0},
+            "15": {"C": 1580.0, "D": 1490.0},
+        }[age]
+        gender = "male"
+
+        for team_id, mu in ratings.items():
+            rows.append(
+                {
+                    "team_id": team_id,
+                    "age": int(age),
+                    "age_num": int(age),
+                    "gender": gender,
+                    "mu": mu,
+                    "sigma": 80.0,
+                    "volatility": 0.06,
+                    "sos": 0.5,
+                    "sos_norm": 0.5,
+                    "power_score_true": 0.5,
+                    "power_score_final": 0.5,
+                    "powerscore_adj": 0.5,
+                    "powerscore_ml": 0.5,
+                    "positive_ml_evidence_scale": 1.0,
+                    "publication_cap_score": pd.NA,
+                    "status": "Active",
+                    "rank_in_cohort_final": 1,
+                }
+            )
+
+        calls.append(
+            {
+                "pass_label": pass_label,
+                "persist_game_residuals": ctx.persist_game_residuals if ctx else None,
+                "calculate_rank_changes": ctx.calculate_rank_changes if ctx else None,
+                "save_snapshot": ctx.save_snapshot if ctx else None,
+            }
+        )
+
+        return {
+            "teams": pd.DataFrame(rows),
+            "games_used": games_df.copy(),
+            "pre_sos_state": {"legacy": age},
+        }
+
+    async def fake_save_ranking_snapshot(*_args, **_kwargs):
+        save_calls["ranking"] += 1
+        return None
+
+    async def fake_save_prediction_feature_snapshot(*_args, **_kwargs):
+        save_calls["prediction"] += 1
+        return None
+
+    monkeypatch.setattr(calculator, "compute_rankings_with_ml", fake_compute_rankings_with_ml)
+    monkeypatch.setattr(calculator, "save_ranking_snapshot", fake_save_ranking_snapshot)
+    monkeypatch.setattr(calculator, "_save_prediction_feature_snapshot_safe", fake_save_prediction_feature_snapshot)
+
+    games = pd.DataFrame(
+        _make_game_pair("A", "B", 2, 1, "2026-03-01", age="14")
+        + _make_game_pair("C", "D", 3, 2, "2026-03-02", age="15")
+    )
+
+    result = await calculator.compute_all_cohorts(
+        supabase_client=_DummySupabase(),
+        games_df=games,
+        fetch_from_supabase=False,
+        use_glicko=True,
+        persist_game_residuals=False,
+        calculate_rank_changes=False,
+        save_snapshot=False,
+    )
+
+    assert not result["teams"].empty
+    assert save_calls == {"ranking": 0, "prediction": 0}
+    assert len(calls) == 4
+    assert all(call["persist_game_residuals"] is False for call in calls)
+    assert all(call["calculate_rank_changes"] is False for call in calls)
+    assert all(call["save_snapshot"] is False for call in calls)
+    assert "same_age_games" in result["teams"].columns
+    assert "publication_cap_rank" in result["teams"].columns


### PR DESCRIPTION
## Summary
- add a replay/backfill CLI for `prediction_feature_history` using historical as-of ranking dates
- let the ranking calculator skip residual persistence, rank-change calculation, and snapshot writes during replay runs
- keep replay output aligned with live feature assembly and cover the new flow with unit tests

## Verification
- `python -m pytest C:\PitchRank\tests\unit\test_prediction_feature_history.py C:\PitchRank\tests\unit\test_backfill_prediction_feature_history.py C:\PitchRank\tests\unit\test_glicko_sos_role.py -q`
- `python -m py_compile C:\PitchRank\src\rankings\calculator.py C:\PitchRank\scripts\backfill_prediction_feature_history.py C:\PitchRank\src\rankings\prediction_feature_history.py`
- `python -m ruff check C:\PitchRank\scripts\backfill_prediction_feature_history.py C:\PitchRank\tests\unit\test_backfill_prediction_feature_history.py C:\PitchRank\tests\unit\test_glicko_sos_role.py`