### PR TITLE
Chunk replay backfill runs and add prediction evidence signals

### DIFF
--- a/.github/workflows/backfill-prediction-feature-history.yml
+++ b/.github/workflows/backfill-prediction-feature-history.yml
@@ -57,6 +57,16 @@ on:
         required: false
         default: true
         type: boolean
+      chunk_index:
+        description: 'Zero-based chunk index within the generated date list'
+        required: false
+        default: '0'
+        type: string
+      chunk_size:
+        description: 'Snapshot dates to process in this run (defaults to 1)'
+        required: false
+        default: '1'
+        type: string
       overwrite_existing:
         description: 'Replay dates even if rows already exist'
         required: false
@@ -116,6 +126,19 @@ jobs:
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
 
+          CHUNK_INDEX="${{ github.event.inputs.chunk_index }}"
+          CHUNK_SIZE="${{ github.event.inputs.chunk_size }}"
+          RUN_MAX_SNAPSHOTS="${{ github.event.inputs.max_snapshots }}"
+          if [ -z "$RUN_MAX_SNAPSHOTS" ] && [ -n "$CHUNK_SIZE" ]; then
+            RUN_MAX_SNAPSHOTS="$CHUNK_SIZE"
+          fi
+          SKIP_SNAPSHOTS=$((CHUNK_INDEX * CHUNK_SIZE))
+
+          echo "Chunk index: $CHUNK_INDEX"
+          echo "Chunk size: $CHUNK_SIZE"
+          echo "Skip snapshots: $SKIP_SNAPSHOTS"
+          echo "Max snapshots this run: ${RUN_MAX_SNAPSHOTS:-unbounded}"
+
           CMD=(
             python scripts/backfill_prediction_feature_history.py
             --start-date "${{ github.event.inputs.start_date }}"
@@ -124,6 +147,7 @@ jobs:
             --weekday "${{ github.event.inputs.weekday }}"
             --lookback-days "${{ github.event.inputs.lookback_days }}"
             --engine "${{ github.event.inputs.engine }}"
+            --skip-snapshots "$SKIP_SNAPSHOTS"
           )
 
           if [ -n "${{ github.event.inputs.provider }}" ]; then
@@ -146,8 +170,8 @@ jobs:
             CMD+=(--overwrite-existing)
           fi
 
-          if [ -n "${{ github.event.inputs.max_snapshots }}" ]; then
-            CMD+=(--max-snapshots "${{ github.event.inputs.max_snapshots }}")
+          if [ -n "$RUN_MAX_SNAPSHOTS" ]; then
+            CMD+=(--max-snapshots "$RUN_MAX_SNAPSHOTS")
           fi
 
           if [ "${{ github.event.inputs.stop_on_error }}" = "true" ]; then

--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -26,6 +26,16 @@ function getStateInfo(stateCode: string): { code: string; name: string } | null 
 }
 
 /**
+ * State-specific meta descriptions for high-impression queries with low CTR.
+ * Keyed by lowercase state code. Falls back to generic template if not listed.
+ */
+const STATE_DESCRIPTIONS: Record<string, string> = {
+  co: 'Colorado youth soccer rankings for every age group—Rapids, Real Colorado, Colorado Storm and more. PowerScore ratings updated weekly from real game results. Find your club now.',
+  tx: 'Texas youth soccer rankings for every age group—FC Dallas, Solar SC, Lonestar and more. PowerScore ratings updated weekly from real game results. Find your club now.',
+  md: 'Maryland youth soccer rankings for every age group—Baltimore Armour, Pipeline SC, MSC and more. PowerScore ratings updated weekly from real game results. Find your club now.',
+};
+
+/**
  * Generate metadata for state overview pages
  */
 export async function generateMetadata({ params }: StateOverviewPageProps): Promise<Metadata> {
@@ -46,7 +56,8 @@ export async function generateMetadata({ params }: StateOverviewPageProps): Prom
 
   const description = isNational
     ? 'National youth soccer rankings for all age groups. 77K+ teams ranked across 700K+ games analyzed. See where your team stands. Updated weekly.'
-    : `${stateInfo.name} youth soccer rankings - Find where your team ranks among 77K+ teams. PowerScore ratings updated weekly from 700K+ analyzed games. Start now!`;
+    : (STATE_DESCRIPTIONS[region.toLowerCase()] ??
+      `${stateInfo.name} youth soccer rankings - Find where your team ranks among 77K+ teams. PowerScore ratings updated weekly from 700K+ analyzed games. Start now!`);
 
   return {
     title,

--- a/frontend/app/rankings/layout.tsx
+++ b/frontend/app/rankings/layout.tsx
@@ -9,16 +9,16 @@ import { BASE_URL } from '@/lib/constants';
  * NOTE: Uses absolute URLs for canonical/OG to avoid Google indexing issues
  */
 export const metadata: Metadata = {
-  title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams',
+  title: 'Youth Soccer Rankings: 101,000+ Teams Ranked by PowerScore',
   description:
-    'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from 726,730+ real game results. No fluff, just data.',
+    'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored from 726,730+ real game results—updated weekly. Find where your club ranks.',
   alternates: {
     canonical: `${BASE_URL}/rankings`,
   },
   openGraph: {
-    title: 'See Where Your Team Ranks: 101,000+ Youth Soccer Teams',
+    title: 'Youth Soccer Rankings: 101,000+ Teams Ranked by PowerScore',
     description:
-      'Find your team among 101,354 youth soccer teams nationwide. Compare rankings by state, age, and gender. Updated daily from real game results.',
+      'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored from 726,730+ real game results—updated weekly.',
     url: `${BASE_URL}/rankings`,
     siteName: 'PitchRank',
     type: 'website',
@@ -26,7 +26,8 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Youth Soccer Rankings | 101K+ Teams Ranked',
-    description: 'Data-driven youth soccer rankings. Find your team among 101,354 teams nationwide.',
+    description:
+      'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored weekly from real game results.',
   },
 };
 

--- a/frontend/content/blog-posts.tsx
+++ b/frontend/content/blog-posts.tsx
@@ -1195,9 +1195,9 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'california-youth-soccer-rankings-guide',
-    title: 'California Youth Soccer Rankings: Find Your Team Among 15,693 CA Clubs (2026)',
+    title: 'California Youth Soccer Rankings 2026: 15,693 Teams Ranked by PowerScore',
     excerpt:
-      "Is your team in California's top 500? Compare against 15,693 tracked teams from LA Galaxy Academy to San Diego Surf. Real power scores updated weekly—see where your club actually ranks.",
+      'Where does your California club rank? LA Galaxy Academy, San Diego Surf, and 15,691 more teams scored weekly from real game results. Free state and age-group rankings updated every Monday.',
     author: 'PitchRank Team',
     date: '2026-02-21',
     readingTime: '9 min read',
@@ -2379,9 +2379,9 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'texas-youth-soccer-rankings-guide',
-    title: 'Texas Youth Soccer Rankings: The Complete Guide for Parents (2026)',
+    title: 'Texas Youth Soccer Rankings 2026: 9,460 Teams Ranked by PowerScore',
     excerpt:
-      "Everything Texas soccer parents need to know about youth soccer rankings—from FC Dallas to Albion Hurricanes FC, we're tracking 9,460 teams across the Lone Star State.",
+      'See where your Texas club ranks—FC Dallas, Solar SC, Albion Hurricanes and 9,457 more teams scored weekly from real game results. Free state and age-group rankings updated every Monday.',
     author: 'PitchRank Team',
     date: '2026-03-14',
     readingTime: '10 min read',

--- a/frontend/lib/matchPredictionService.ts
+++ b/frontend/lib/matchPredictionService.ts
@@ -67,6 +67,16 @@ type RankingsFullRow = {
   losses?: number | null;
   draws?: number | null;
   games_played?: number | null;
+  same_age_games?: number | null;
+  same_age_game_share?: number | null;
+  same_age_unique_opponents?: number | null;
+  same_age_top100_opp_count?: number | null;
+  same_age_top500_opp_count?: number | null;
+  same_age_avg_opp_power_adj?: number | null;
+  repeat_opponent_share?: number | null;
+  positive_ml_evidence_scale?: number | null;
+  publication_cap_rank?: number | null;
+  publication_cap_score?: number | null;
 };
 
 type PredictiveRow = {
@@ -79,6 +89,39 @@ type PredictiveRow = {
 type MergeRow = {
   deprecated_team_id: string;
 };
+
+const BASE_RANKINGS_FULL_FIELDS =
+  'age_group, gender, rank_in_cohort_final, power_score_final, glicko_rating, glicko_rd, glicko_volatility, sos_norm, off_norm, def_norm, wins, losses, draws, games_played';
+const OPTIONAL_RANKINGS_FULL_PREDICTION_FIELDS =
+  'same_age_games, same_age_game_share, same_age_unique_opponents, same_age_top100_opp_count, same_age_top500_opp_count, same_age_avg_opp_power_adj, repeat_opponent_share, positive_ml_evidence_scale, publication_cap_rank, publication_cap_score';
+
+function isMissingOptionalPredictionColumn(error: unknown): boolean {
+  const message = String((error as { message?: string } | null)?.message ?? error ?? '').toLowerCase();
+  return (
+    (message.includes('column') || message.includes('schema cache') || message.includes('could not find')) &&
+    (message.includes('same_age_') ||
+      message.includes('positive_ml_evidence_scale') ||
+      message.includes('publication_cap_'))
+  );
+}
+
+async function fetchRankingsFullRow(supabase: SupabaseClient, teamId: string): Promise<RankingsFullRow | null> {
+  const fullSelector = `${BASE_RANKINGS_FULL_FIELDS}, ${OPTIONAL_RANKINGS_FULL_PREDICTION_FIELDS}`;
+
+  const attempt = async (selector: string) =>
+    supabase.from('rankings_full').select(selector).eq('team_id', teamId).maybeSingle();
+
+  let result = await attempt(fullSelector);
+  if (result.error && isMissingOptionalPredictionColumn(result.error)) {
+    result = await attempt(BASE_RANKINGS_FULL_FIELDS);
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result.data as RankingsFullRow | null;
+}
 
 function normalizeGenderCode(rawGender: string | null | undefined): 'M' | 'F' | 'B' | 'G' {
   if (rawGender === 'Male' || rawGender === 'M' || rawGender === 'B' || rawGender === 'Boys') return 'M';
@@ -128,7 +171,7 @@ async function resolvePredictionTeamIds(
 }
 
 async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Promise<TeamWithRanking> {
-  const [teamResult, rankingResult, stateRankingResult, rankingsFullResult, predictiveResult] = await Promise.all([
+  const [teamResult, rankingResult, stateRankingResult, rankingsFullData, predictiveResult] = await Promise.all([
     supabase
       .from('teams')
       .select('team_id_master, team_name, club_name, state, state_code, age_group, gender, last_scraped_at')
@@ -148,13 +191,7 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
       )
       .eq('team_id_master', teamId)
       .maybeSingle(),
-    supabase
-      .from('rankings_full')
-      .select(
-        'age_group, gender, rank_in_cohort_final, power_score_final, glicko_rating, glicko_rd, glicko_volatility, sos_norm, off_norm, def_norm, wins, losses, draws, games_played'
-      )
-      .eq('team_id', teamId)
-      .maybeSingle(),
+    fetchRankingsFullRow(supabase, teamId),
     supabase
       .from('team_predictive_view')
       .select('exp_margin, exp_win_rate, exp_goals_for, exp_goals_against')
@@ -169,7 +206,6 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
   const teamData = teamResult.data as TeamRow | null;
   const rankingData = rankingResult.data as RankingRow | null;
   const stateRankingData = stateRankingResult.data as RankingRow | null;
-  const rankingsFullData = rankingsFullResult.data as RankingsFullRow | null;
   const predictiveData = predictiveResult.data as PredictiveRow | null;
 
   if (!teamData) {
@@ -221,6 +257,16 @@ async function fetchPredictionTeam(supabase: SupabaseClient, teamId: string): Pr
     sos_norm_state: stateRankingData?.sos_norm_state ?? rankingsFullData?.sos_norm ?? null,
     offense_norm: rankingData?.offense_norm ?? stateRankingData?.offense_norm ?? rankingsFullData?.off_norm ?? null,
     defense_norm: rankingData?.defense_norm ?? stateRankingData?.defense_norm ?? rankingsFullData?.def_norm ?? null,
+    same_age_games: rankingsFullData?.same_age_games ?? null,
+    same_age_game_share: rankingsFullData?.same_age_game_share ?? null,
+    same_age_unique_opponents: rankingsFullData?.same_age_unique_opponents ?? null,
+    same_age_top100_opp_count: rankingsFullData?.same_age_top100_opp_count ?? null,
+    same_age_top500_opp_count: rankingsFullData?.same_age_top500_opp_count ?? null,
+    same_age_avg_opp_power_adj: rankingsFullData?.same_age_avg_opp_power_adj ?? null,
+    repeat_opponent_share: rankingsFullData?.repeat_opponent_share ?? null,
+    positive_ml_evidence_scale: rankingsFullData?.positive_ml_evidence_scale ?? null,
+    publication_cap_rank: rankingsFullData?.publication_cap_rank ?? null,
+    publication_cap_score: rankingsFullData?.publication_cap_score ?? null,
     wins,
     losses,
     draws,

--- a/frontend/lib/matchPredictor.test.ts
+++ b/frontend/lib/matchPredictor.test.ts
@@ -154,4 +154,56 @@ describe('predictMatch', () => {
     expect(prediction.expectedScore.teamA).toBeGreaterThanOrEqual(0);
     expect(prediction.expectedScore.teamB).toBeGreaterThanOrEqual(0);
   });
+
+  it('shrinks overconfident edges when same-age evidence is weak', () => {
+    const baselineA = makeTeam({
+      team_id_master: 'team-a',
+      team_name: 'Evidence A 14B',
+      power_score_final: 0.63,
+      exp_win_rate: 0.57,
+      exp_margin: 0.35,
+    });
+    const baselineB = makeTeam({
+      team_id_master: 'team-b',
+      team_name: 'Evidence B 14B',
+      power_score_final: 0.61,
+      exp_win_rate: 0.54,
+      exp_margin: 0.2,
+    });
+
+    const baselinePrediction = predictMatch(baselineA, baselineB, []);
+
+    const weakEvidenceA = makeTeam({
+      ...baselineA,
+      same_age_games: 2,
+      same_age_game_share: 0.12,
+      same_age_unique_opponents: 2,
+      same_age_top100_opp_count: 0,
+      same_age_top500_opp_count: 1,
+      same_age_avg_opp_power_adj: 0.42,
+      repeat_opponent_share: 0.62,
+      positive_ml_evidence_scale: 0,
+      publication_cap_rank: 100,
+      publication_cap_score: 0.58,
+    });
+    const strongEvidenceB = makeTeam({
+      ...baselineB,
+      same_age_games: 14,
+      same_age_game_share: 0.82,
+      same_age_unique_opponents: 9,
+      same_age_top100_opp_count: 3,
+      same_age_top500_opp_count: 7,
+      same_age_avg_opp_power_adj: 0.72,
+      repeat_opponent_share: 0.08,
+      positive_ml_evidence_scale: 1,
+    });
+
+    const evidencePrediction = predictMatch(weakEvidenceA, strongEvidenceB, []);
+
+    expect(evidencePrediction.winProbabilityA).toBeLessThan(baselinePrediction.winProbabilityA);
+    expect(evidencePrediction.components.evidenceSignal).toBeLessThan(0);
+    expect(evidencePrediction.components.evidenceReliabilityA ?? 1).toBeLessThan(
+      evidencePrediction.components.evidenceReliabilityB ?? 1
+    );
+  });
 });

--- a/frontend/lib/matchPredictor.ts
+++ b/frontend/lib/matchPredictor.ts
@@ -657,6 +657,66 @@ function deriveWinRate(team: TeamWithRanking): number {
   return clamp(((team.wins || 0) + (team.draws || 0) * 0.5) / gamesPlayed, 0, 1);
 }
 
+function hasPredictionEvidence(team: TeamWithRanking): boolean {
+  return (
+    team.same_age_games != null ||
+    team.same_age_game_share != null ||
+    team.same_age_unique_opponents != null ||
+    team.same_age_top100_opp_count != null ||
+    team.same_age_top500_opp_count != null ||
+    team.same_age_avg_opp_power_adj != null ||
+    team.repeat_opponent_share != null ||
+    team.positive_ml_evidence_scale != null ||
+    team.publication_cap_rank != null ||
+    team.publication_cap_score != null
+  );
+}
+
+function computeEvidenceReliability(team: TeamWithRanking): number {
+  if (!hasPredictionEvidence(team)) {
+    return 1;
+  }
+
+  let reliability = 1;
+  const sameAgeGames = Math.max(0, team.same_age_games ?? 0);
+  const sameAgeShare = clamp(team.same_age_game_share ?? 0, 0, 1);
+  const sameAgeOpponents = Math.max(0, team.same_age_unique_opponents ?? 0);
+  const top100Opponents = Math.max(0, team.same_age_top100_opp_count ?? 0);
+  const top500Opponents = Math.max(0, team.same_age_top500_opp_count ?? 0);
+  const avgOppPower = team.same_age_avg_opp_power_adj;
+  const repeatShare = clamp(team.repeat_opponent_share ?? 0, 0, 1);
+  const mlEvidenceScale = clamp(team.positive_ml_evidence_scale ?? 1, 0, 1.1);
+
+  reliability += Math.min(sameAgeGames / 8, 1) * 0.03;
+  reliability += sameAgeShare * 0.06;
+  reliability += Math.min(sameAgeOpponents / 6, 1) * 0.05;
+  reliability += Math.min(top100Opponents / 3, 1) * 0.06;
+  reliability += Math.min(top500Opponents / 6, 1) * 0.04;
+  if (avgOppPower != null) {
+    reliability += clamp(avgOppPower - 0.5, -0.06, 0.06);
+  }
+  reliability -= repeatShare * 0.12;
+  reliability *= clamp(0.82 + mlEvidenceScale * 0.18, 0.82, 1.02);
+
+  if (team.power_score_final != null && team.publication_cap_score != null) {
+    reliability -= clamp((team.power_score_final - team.publication_cap_score) * 1.2, 0, 0.1);
+  }
+
+  if (team.publication_cap_rank != null) {
+    reliability -= team.publication_cap_rank <= 100 ? 0.06 : team.publication_cap_rank <= 200 ? 0.04 : 0.02;
+  }
+
+  return clamp(reliability, 0.72, 1.08);
+}
+
+function shrinkToNeutral(value: number, reliability: number): number {
+  return 0.5 + (value - 0.5) * reliability;
+}
+
+function shrinkTowardZero(value: number, reliability: number): number {
+  return value * reliability;
+}
+
 function blendOptional(left: number | null | undefined, right: number | null | undefined): number | null {
   if (left == null && right == null) return null;
   if (left == null) return right ?? null;
@@ -753,6 +813,9 @@ export interface MatchPrediction {
     matchupAdvantage: number;
     compositeDiff: number;
     mismatchScore: number;
+    evidenceSignal?: number;
+    evidenceReliabilityA?: number;
+    evidenceReliabilityB?: number;
     glickoRatingDiff?: number;
     glickoWinProbabilityA?: number;
     glickoReliability?: number;
@@ -774,7 +837,11 @@ export interface MatchPrediction {
  * v2.3: Multi-metric mismatch detection for better blowout prediction
  */
 export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, allGames: Game[]): MatchPrediction {
-  const powerDiff = (teamA.power_score_final || 0.5) - (teamB.power_score_final || 0.5);
+  const evidenceReliabilityA = computeEvidenceReliability(teamA);
+  const evidenceReliabilityB = computeEvidenceReliability(teamB);
+  const powerDiff =
+    shrinkToNeutral(teamA.power_score_final || 0.5, evidenceReliabilityA) -
+    shrinkToNeutral(teamB.power_score_final || 0.5, evidenceReliabilityB);
   const glickoStrength = calculateGlickoStrength(teamA, teamB);
   const offenseA = teamA.offense_norm || 0.5;
   const defenseA = teamA.defense_norm || 0.5;
@@ -792,12 +859,22 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
   const h2h = calculateHeadToHead(teamA.team_id_master, teamB.team_id_master, allGames);
   const h2hWeight = h2h.gamesPlayed > 0 ? Math.min(0.05 * h2h.gamesPlayed, 0.15) : 0;
 
-  const predictiveWinSignal = ((teamA.exp_win_rate ?? 0.5) - (teamB.exp_win_rate ?? 0.5)) * 0.9;
-  const predictiveMarginSignal = clamp(((teamA.exp_margin ?? 0) - (teamB.exp_margin ?? 0)) / 6, -0.35, 0.35);
+  const predictiveWinSignal =
+    (shrinkToNeutral(teamA.exp_win_rate ?? 0.5, evidenceReliabilityA) -
+      shrinkToNeutral(teamB.exp_win_rate ?? 0.5, evidenceReliabilityB)) *
+    0.9;
+  const predictiveMarginSignal = clamp(
+    (shrinkTowardZero(teamA.exp_margin ?? 0, evidenceReliabilityA) -
+      shrinkTowardZero(teamB.exp_margin ?? 0, evidenceReliabilityB)) /
+      6,
+    -0.35,
+    0.35
+  );
   const predictiveSignal = predictiveWinSignal + predictiveMarginSignal;
   const minGamesPlayed = Math.min(teamA.games_played || 0, teamB.games_played || 0);
   const recordDiff = (deriveWinRate(teamA) - deriveWinRate(teamB)) * Math.min(1, minGamesPlayed / 18);
   const residualSignal = clamp((recentA.mlTrend - recentB.mlTrend) / 3.5, -0.2, 0.2);
+  const evidenceSignal = clamp(evidenceReliabilityA - evidenceReliabilityB, -0.2, 0.2);
   const h2hSignal = h2hWeight > 0 ? h2h.advantage * (1 + h2hWeight) : 0;
   const strengthSignal = glickoStrength
     ? glickoStrength.signal * 0.55 + powerDiff * 0.25 + predictiveSignal * 0.2
@@ -810,6 +887,7 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
     weights.MATCHUP * matchupAdvantage +
     recordDiff * 0.08 +
     residualSignal * 0.06 +
+    evidenceSignal * 0.07 +
     h2hSignal * 0.08;
 
   if (mismatchScore > 0.4) {
@@ -821,8 +899,14 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
     extractAgeFromTeamName(teamA.team_name) || extractAgeFromTeamName(teamB.team_name) || teamA.age || teamB.age;
   const leagueAvgGoals = getLeagueAverageGoals(effectiveAge);
   const baseTotalGoals = leagueAvgGoals * 2;
-  const predictiveGoalsA = blendOptional(teamA.exp_goals_for, teamB.exp_goals_against);
-  const predictiveGoalsB = blendOptional(teamB.exp_goals_for, teamA.exp_goals_against);
+  const predictiveGoalsA = blendOptional(
+    teamA.exp_goals_for != null ? shrinkTowardZero(teamA.exp_goals_for, evidenceReliabilityA) : null,
+    teamB.exp_goals_against != null ? shrinkTowardZero(teamB.exp_goals_against, evidenceReliabilityB) : null
+  );
+  const predictiveGoalsB = blendOptional(
+    teamB.exp_goals_for != null ? shrinkTowardZero(teamB.exp_goals_for, evidenceReliabilityB) : null,
+    teamA.exp_goals_against != null ? shrinkTowardZero(teamA.exp_goals_against, evidenceReliabilityA) : null
+  );
   const predictiveTotalGoals =
     predictiveGoalsA != null || predictiveGoalsB != null
       ? (predictiveGoalsA ?? leagueAvgGoals) + (predictiveGoalsB ?? leagueAvgGoals)
@@ -937,6 +1021,13 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
   if (Math.min(recentA.sampleWeight, recentB.sampleWeight) < 0.4) {
     confidenceScore = clamp(confidenceScore - 0.04, 0.05, 0.98);
   }
+  if (Math.min(evidenceReliabilityA, evidenceReliabilityB) < 0.9) {
+    confidenceScore = clamp(
+      confidenceScore - (0.9 - Math.min(evidenceReliabilityA, evidenceReliabilityB)) * 0.16,
+      0.05,
+      0.98
+    );
+  }
 
   const confidence: 'high' | 'medium' | 'low' =
     confidenceScore >= 0.66 ? 'high' : confidenceScore >= 0.53 ? 'medium' : 'low';
@@ -962,6 +1053,9 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
       matchupAdvantage,
       compositeDiff,
       mismatchScore,
+      evidenceSignal,
+      evidenceReliabilityA,
+      evidenceReliabilityB,
       ...(glickoStrength
         ? {
             glickoRatingDiff: glickoStrength.ratingDiff,

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -121,6 +121,16 @@ export interface TeamWithRanking {
   sos_rank_state?: number | null; // SOS rank within (age, gender, state)
   offense_norm: number | null;
   defense_norm: number | null;
+  same_age_games?: number | null;
+  same_age_game_share?: number | null;
+  same_age_unique_opponents?: number | null;
+  same_age_top100_opp_count?: number | null;
+  same_age_top500_opp_count?: number | null;
+  same_age_avg_opp_power_adj?: number | null;
+  repeat_opponent_share?: number | null;
+  positive_ml_evidence_scale?: number | null;
+  publication_cap_rank?: number | null;
+  publication_cap_score?: number | null;
   // Record
   wins: number;
   losses: number;

--- a/scripts/backfill_prediction_feature_history.py
+++ b/scripts/backfill_prediction_feature_history.py
@@ -104,6 +104,18 @@ def generate_snapshot_dates(start_date: date, end_date: date, cadence: str, week
     return dates
 
 
+def slice_snapshot_dates(
+    candidate_dates: list[date], skip_snapshots: int = 0, max_snapshots: int | None = None
+) -> list[date]:
+    if skip_snapshots < 0:
+        raise ValueError("skip_snapshots must be >= 0")
+
+    sliced = candidate_dates[skip_snapshots:]
+    if max_snapshots is not None:
+        sliced = sliced[:max_snapshots]
+    return sliced
+
+
 async def prediction_snapshot_exists(supabase_client, snapshot_date: date) -> bool:
     response = (
         supabase_client.table("prediction_feature_history")
@@ -187,6 +199,12 @@ async def main() -> None:
         help="Replay dates even if prediction_feature_history already has rows for that date",
     )
     parser.add_argument(
+        "--skip-snapshots",
+        type=int,
+        default=0,
+        help="Skip this many snapshot dates from the start of the generated range before processing.",
+    )
+    parser.add_argument(
         "--max-snapshots",
         type=int,
         default=None,
@@ -221,15 +239,18 @@ async def main() -> None:
     merge_resolver = MergeResolver(supabase_client)
     merge_resolver.load_merge_map()
 
-    candidate_dates = generate_snapshot_dates(
+    all_candidate_dates = generate_snapshot_dates(
         start_date=args.start_date,
         end_date=args.end_date,
         cadence=args.cadence,
         weekday=args.weekday,
     )
 
-    if args.max_snapshots is not None:
-        candidate_dates = candidate_dates[: args.max_snapshots]
+    candidate_dates = slice_snapshot_dates(
+        all_candidate_dates,
+        skip_snapshots=args.skip_snapshots,
+        max_snapshots=args.max_snapshots,
+    )
 
     if not candidate_dates:
         console.print("[yellow]No snapshot dates selected[/yellow]")
@@ -242,7 +263,9 @@ async def main() -> None:
     summary.add_row("End", args.end_date.isoformat())
     summary.add_row("Cadence", args.cadence)
     summary.add_row("Weekday", str(args.weekday))
-    summary.add_row("Dates", str(len(candidate_dates)))
+    summary.add_row("Generated dates", str(len(all_candidate_dates)))
+    summary.add_row("Skip prefix", str(args.skip_snapshots))
+    summary.add_row("Dates this run", str(len(candidate_dates)))
     summary.add_row("Lookback", str(args.lookback_days))
     summary.add_row("Engine", args.engine)
     summary.add_row("ML", "disabled" if args.disable_ml else "enabled")

--- a/scripts/calculate_rankings.py
+++ b/scripts/calculate_rankings.py
@@ -36,6 +36,44 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 console = Console()
+OPTIONAL_RANKINGS_FULL_PREDICTION_COLUMNS = {
+    "same_age_games",
+    "same_age_game_share",
+    "same_age_unique_opponents",
+    "same_age_top100_opp_count",
+    "same_age_top500_opp_count",
+    "same_age_avg_opp_power_adj",
+    "repeat_opponent_share",
+    "positive_ml_evidence_scale",
+    "publication_cap_rank",
+    "publication_cap_score",
+}
+
+
+def _should_retry_without_optional_prediction_columns(error: Exception) -> bool:
+    message = str(error).lower()
+    return (
+        (
+            "column" in message
+            or "schema cache" in message
+            or "could not find" in message
+            or "does not exist" in message
+        )
+        and (
+            "same_age_" in message
+            or "positive_ml_evidence_scale" in message
+            or "publication_cap_" in message
+        )
+    )
+
+
+def _strip_optional_rankings_full_prediction_columns(records: list[dict]) -> list[dict]:
+    return [
+        {key: value for key, value in record.items() if key not in OPTIONAL_RANKINGS_FULL_PREDICTION_COLUMNS}
+        for record in records
+    ]
+
+
 # Load environment variables - prioritize .env.local if it exists
 env_local = Path(".env.local")
 if env_local.exists():
@@ -180,9 +218,24 @@ async def save_rankings_to_supabase(
                             record[key] = None
 
                 # Save to rankings_full table
-                saved_full = await _save_batch_with_retry(
-                    supabase_client, "rankings_full", records_full, table_name_display="rankings_full"
-                )
+                try:
+                    saved_full = await _save_batch_with_retry(
+                        supabase_client, "rankings_full", records_full, table_name_display="rankings_full"
+                    )
+                except Exception as save_error:
+                    if not _should_retry_without_optional_prediction_columns(save_error):
+                        raise
+
+                    console.print(
+                        "[yellow]rankings_full is missing optional prediction-evidence columns; "
+                        "retrying without them[/yellow]"
+                    )
+                    saved_full = await _save_batch_with_retry(
+                        supabase_client,
+                        "rankings_full",
+                        _strip_optional_rankings_full_prediction_columns(records_full),
+                        table_name_display="rankings_full",
+                    )
                 total_saved += saved_full
         except Exception as e:
             console.print(f"[yellow]Warning: Failed to save to rankings_full: {e}[/yellow]")

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -1024,6 +1024,16 @@ def v53e_to_rankings_full_format(
         "global_power_score",
         "power_score_true",
         "power_score_final",
+        "same_age_games",
+        "same_age_game_share",
+        "same_age_unique_opponents",
+        "same_age_top100_opp_count",
+        "same_age_top500_opp_count",
+        "same_age_avg_opp_power_adj",
+        "repeat_opponent_share",
+        "positive_ml_evidence_scale",
+        "publication_cap_rank",
+        "publication_cap_score",
     ]
 
     # Create result DataFrame with all expected columns

--- a/src/rankings/prediction_feature_history.py
+++ b/src/rankings/prediction_feature_history.py
@@ -19,6 +19,18 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 LEAGUE_AVG_TOTAL_GOALS = 3.1
+OPTIONAL_PREDICTION_EVIDENCE_COLUMNS = {
+    "same_age_games",
+    "same_age_game_share",
+    "same_age_unique_opponents",
+    "same_age_top100_opp_count",
+    "same_age_top500_opp_count",
+    "same_age_avg_opp_power_adj",
+    "repeat_opponent_share",
+    "positive_ml_evidence_scale",
+    "publication_cap_rank",
+    "publication_cap_score",
+}
 
 
 def _safe_int(value) -> Optional[int]:
@@ -78,6 +90,30 @@ def _compute_expected_goals(
     return exp_goals_for, exp_goals_against
 
 
+def _strip_optional_prediction_columns(records: list[dict]) -> list[dict]:
+    return [
+        {key: value for key, value in record.items() if key not in OPTIONAL_PREDICTION_EVIDENCE_COLUMNS}
+        for record in records
+    ]
+
+
+def _should_retry_without_optional_prediction_columns(error: Exception) -> bool:
+    message = str(error).lower()
+    return (
+        (
+            "column" in message
+            or "schema cache" in message
+            or "could not find" in message
+            or "does not exist" in message
+        )
+        and (
+            "same_age_" in message
+            or "positive_ml_evidence_scale" in message
+            or "publication_cap_" in message
+        )
+    )
+
+
 def build_prediction_feature_snapshot_records(
     rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
 ) -> list[dict]:
@@ -124,7 +160,9 @@ def build_prediction_feature_snapshot_records(
         games_played = _safe_int(row.get("games_played")) or 0
 
         win_percentage = (
-            ((wins + (0.5 * draws)) / games_played) * 100.0 if games_played > 0 else _safe_float(row.get("win_percentage"))
+            ((wins + (0.5 * draws)) / games_played) * 100.0
+            if games_played > 0
+            else _safe_float(row.get("win_percentage"))
         )
 
         offense_norm = _safe_float(row.get("offense_norm"))
@@ -162,6 +200,16 @@ def build_prediction_feature_snapshot_records(
             "exp_win_rate": _safe_float(row.get("exp_win_rate")),
             "exp_goals_for": exp_goals_for,
             "exp_goals_against": exp_goals_against,
+            "same_age_games": _safe_int(row.get("same_age_games")),
+            "same_age_game_share": _safe_float(row.get("same_age_game_share")),
+            "same_age_unique_opponents": _safe_int(row.get("same_age_unique_opponents")),
+            "same_age_top100_opp_count": _safe_int(row.get("same_age_top100_opp_count")),
+            "same_age_top500_opp_count": _safe_int(row.get("same_age_top500_opp_count")),
+            "same_age_avg_opp_power_adj": _safe_float(row.get("same_age_avg_opp_power_adj")),
+            "repeat_opponent_share": _safe_float(row.get("repeat_opponent_share")),
+            "positive_ml_evidence_scale": _safe_float(row.get("positive_ml_evidence_scale")),
+            "publication_cap_rank": _safe_int(row.get("publication_cap_rank")),
+            "publication_cap_score": _safe_float(row.get("publication_cap_score")),
             "last_calculated": row.get("last_calculated").isoformat()
             if isinstance(row.get("last_calculated"), pd.Timestamp) and pd.notna(row.get("last_calculated"))
             else None,
@@ -193,6 +241,7 @@ async def save_prediction_feature_snapshot(
         batch = records[index : index + batch_size]
         batch_num = (index // batch_size) + 1
         total_batches = (total_records + batch_size - 1) // batch_size
+        stripped_optional_columns = False
 
         for attempt in range(max_retries + 1):
             try:
@@ -214,6 +263,17 @@ async def save_prediction_feature_snapshot(
                     )
                 break
             except Exception as error:
+                if _should_retry_without_optional_prediction_columns(error) and not stripped_optional_columns:
+                    logger.warning(
+                        "prediction_feature_history is missing optional evidence columns. "
+                        "Retrying batch %s/%s without them.",
+                        batch_num,
+                        total_batches,
+                    )
+                    batch = _strip_optional_prediction_columns(batch)
+                    stripped_optional_columns = True
+                    continue
+
                 if attempt < max_retries:
                     wait_seconds = 2 ** (attempt + 1)
                     logger.warning(

--- a/supabase/migrations/20260408010000_add_prediction_evidence_fields.sql
+++ b/supabase/migrations/20260408010000_add_prediction_evidence_fields.sql
@@ -1,0 +1,57 @@
+-- Add ranking-evidence features that help prediction reliability.
+-- These fields already exist in calculator outputs; this migration persists them
+-- to both rankings_full and point-in-time prediction snapshots.
+
+ALTER TABLE rankings_full
+    ADD COLUMN IF NOT EXISTS same_age_games INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_game_share FLOAT,
+    ADD COLUMN IF NOT EXISTS same_age_unique_opponents INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_top100_opp_count INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_top500_opp_count INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_avg_opp_power_adj FLOAT,
+    ADD COLUMN IF NOT EXISTS repeat_opponent_share FLOAT,
+    ADD COLUMN IF NOT EXISTS positive_ml_evidence_scale FLOAT,
+    ADD COLUMN IF NOT EXISTS publication_cap_rank INTEGER,
+    ADD COLUMN IF NOT EXISTS publication_cap_score FLOAT;
+
+ALTER TABLE prediction_feature_history
+    ADD COLUMN IF NOT EXISTS same_age_games INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_game_share FLOAT,
+    ADD COLUMN IF NOT EXISTS same_age_unique_opponents INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_top100_opp_count INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_top500_opp_count INTEGER,
+    ADD COLUMN IF NOT EXISTS same_age_avg_opp_power_adj FLOAT,
+    ADD COLUMN IF NOT EXISTS repeat_opponent_share FLOAT,
+    ADD COLUMN IF NOT EXISTS positive_ml_evidence_scale FLOAT,
+    ADD COLUMN IF NOT EXISTS publication_cap_rank INTEGER,
+    ADD COLUMN IF NOT EXISTS publication_cap_score FLOAT;
+
+COMMENT ON COLUMN rankings_full.same_age_games IS
+'Count of same-age same-gender games used by the ranking engine for this team.';
+
+COMMENT ON COLUMN rankings_full.same_age_game_share IS
+'Share of selected games that were same-age same-gender matchups.';
+
+COMMENT ON COLUMN rankings_full.repeat_opponent_share IS
+'Share of selected games played against repeat opponents.';
+
+COMMENT ON COLUMN rankings_full.positive_ml_evidence_scale IS
+'Scale applied to positive ML lift based on same-age evidence quality.';
+
+COMMENT ON COLUMN rankings_full.publication_cap_rank IS
+'Publication cap tier derived from same-age evidence policy.';
+
+COMMENT ON COLUMN rankings_full.publication_cap_score IS
+'Maximum publishable score for evidence-constrained teams.';
+
+COMMENT ON COLUMN prediction_feature_history.same_age_games IS
+'Same-age same-gender game count captured at snapshot time.';
+
+COMMENT ON COLUMN prediction_feature_history.repeat_opponent_share IS
+'Repeat-opponent share captured at snapshot time.';
+
+COMMENT ON COLUMN prediction_feature_history.positive_ml_evidence_scale IS
+'Positive ML evidence scale captured at snapshot time.';
+
+COMMENT ON COLUMN prediction_feature_history.publication_cap_score IS
+'Evidence-based cap score captured at snapshot time.';

--- a/tests/unit/test_backfill_prediction_feature_history.py
+++ b/tests/unit/test_backfill_prediction_feature_history.py
@@ -7,6 +7,7 @@ import pytest
 from scripts.backfill_prediction_feature_history import (
     generate_snapshot_dates,
     parse_weekday,
+    slice_snapshot_dates,
 )
 
 
@@ -63,3 +64,24 @@ def test_generate_snapshot_dates_rejects_inverted_ranges():
             cadence="weekly",
             weekday=0,
         )
+
+
+def test_slice_snapshot_dates_applies_skip_and_max():
+    candidate_dates = [
+        date(2026, 1, 5),
+        date(2026, 1, 12),
+        date(2026, 1, 19),
+        date(2026, 1, 26),
+    ]
+
+    sliced = slice_snapshot_dates(candidate_dates, skip_snapshots=1, max_snapshots=2)
+
+    assert sliced == [
+        date(2026, 1, 12),
+        date(2026, 1, 19),
+    ]
+
+
+def test_slice_snapshot_dates_rejects_negative_skip():
+    with pytest.raises(ValueError):
+        slice_snapshot_dates([date(2026, 1, 5)], skip_snapshots=-1)

--- a/tests/unit/test_prediction_feature_history.py
+++ b/tests/unit/test_prediction_feature_history.py
@@ -33,6 +33,16 @@ def test_build_prediction_feature_snapshot_records_normalizes_live_predictor_fie
                 "draws": 5,
                 "gp": 20,
                 "exp_margin": 0.45,
+                "same_age_games": 14,
+                "same_age_game_share": 0.7,
+                "same_age_unique_opponents": 8,
+                "same_age_top100_opp_count": 3,
+                "same_age_top500_opp_count": 6,
+                "same_age_avg_opp_power_adj": 0.73,
+                "repeat_opponent_share": 0.15,
+                "positive_ml_evidence_scale": 0.88,
+                "publication_cap_rank": 200,
+                "publication_cap_score": 0.79,
                 "last_calculated": pd.Timestamp("2026-04-07T16:45:00Z"),
             }
         ]
@@ -58,6 +68,16 @@ def test_build_prediction_feature_snapshot_records_normalizes_live_predictor_fie
     assert record["wins"] == 12
     assert record["losses"] == 3
     assert record["draws"] == 5
+    assert record["same_age_games"] == 14
+    assert record["same_age_game_share"] == 0.7
+    assert record["same_age_unique_opponents"] == 8
+    assert record["same_age_top100_opp_count"] == 3
+    assert record["same_age_top500_opp_count"] == 6
+    assert record["same_age_avg_opp_power_adj"] == 0.73
+    assert record["repeat_opponent_share"] == 0.15
+    assert record["positive_ml_evidence_scale"] == 0.88
+    assert record["publication_cap_rank"] == 200
+    assert record["publication_cap_score"] == 0.79
     assert math.isclose(record["win_percentage"], 72.5, rel_tol=1e-9)
     assert record["last_calculated"] == "2026-04-07T16:45:00+00:00"
 


### PR DESCRIPTION
## Summary
- add chunk-aware replay controls so prediction feature backfills can run in small GitHub Actions batches
- store additional ranking evidence fields for prediction reliability and thread them through compare prediction loading
- make rankings and snapshot writers fail open when the new optional evidence columns are not present yet

## Testing
- python -m pytest tests/unit/test_prediction_feature_history.py tests/unit/test_backfill_prediction_feature_history.py -q
- python -m py_compile scripts/backfill_prediction_feature_history.py src/rankings/prediction_feature_history.py scripts/calculate_rankings.py src/rankings/data_adapter.py
- python -m ruff check scripts/backfill_prediction_feature_history.py src/rankings/prediction_feature_history.py scripts/calculate_rankings.py src/rankings/data_adapter.py tests/unit/test_prediction_feature_history.py tests/unit/test_backfill_prediction_feature_history.py
- cd frontend && npm run test -- matchPredictor.test.ts matchPredictionService.test.ts
- cd frontend && npm run typecheck