### PR TITLE
Add common-opponent signal to compare predictions

### DIFF
--- a/frontend/lib/matchExplainer.test.ts
+++ b/frontend/lib/matchExplainer.test.ts
@@ -156,4 +156,38 @@ describe('explainMatch', () => {
     expect(explanation.factors.some((factor) => factor.factor === 'close_match')).toBe(true);
     expect(explanation.keyInsights.join(' ').toLowerCase()).toContain('coin-flip');
   });
+
+  it('surfaces common-opponent evidence when it meaningfully separates the teams', () => {
+    const teamA = makeTeam({ team_id_master: 'team-a', team_name: 'Alpha FC 14B' });
+    const teamB = makeTeam({ team_id_master: 'team-b', team_name: 'Beta FC 14B' });
+
+    const explanation = explainMatch(
+      teamA,
+      teamB,
+      makePrediction({
+        components: {
+          powerDiff: 0.04,
+          strengthSignal: 0.05,
+          sosDiff: 0.02,
+          formDiffRaw: 0.5,
+          formDiffNorm: 0.02,
+          matchupAdvantage: 0.01,
+          compositeDiff: 0.08,
+          mismatchScore: 0.12,
+          commonOpponentSignal: 0.06,
+        },
+        h2h: undefined,
+        commonOpponents: {
+          sharedOpponents: 4,
+          comparedGames: 8,
+          avgMarginDiff: 1.1,
+          pointsPerGameDiff: 0.9,
+          reliability: 0.7,
+        },
+      })
+    );
+
+    expect(explanation.factors.some((factor) => factor.factor === 'common_opponents')).toBe(true);
+    expect(explanation.keyInsights.join(' ')).toContain('shared opponents');
+  });
 });

--- a/frontend/lib/matchExplainer.ts
+++ b/frontend/lib/matchExplainer.ts
@@ -19,6 +19,7 @@ export type ExplanationFactor =
   | 'offensive_matchup'
   | 'defensive_matchup'
   | 'close_match'
+  | 'common_opponents'
   | 'head_to_head';
 
 export interface Explanation {
@@ -368,6 +369,60 @@ function explainHeadToHead(
   };
 }
 
+function explainCommonOpponents(
+  teamA: TeamWithRanking,
+  teamB: TeamWithRanking,
+  commonOpponents?: {
+    sharedOpponents: number;
+    comparedGames: number;
+    avgMarginDiff: number;
+    pointsPerGameDiff: number;
+    reliability: number;
+  },
+  commonOpponentSignal?: number
+): Explanation | null {
+  if (!commonOpponents || commonOpponents.sharedOpponents < 2) return null;
+
+  const signal = commonOpponentSignal ?? 0;
+  if (Math.abs(signal) < 0.025) return null;
+
+  const advantage: 'team_a' | 'team_b' = signal > 0 ? 'team_a' : 'team_b';
+  const favoredTeam = signal > 0 ? teamA.team_name : teamB.team_name;
+  const absMargin = Math.abs(commonOpponents.avgMarginDiff);
+  const absPoints = Math.abs(commonOpponents.pointsPerGameDiff);
+
+  let magnitude: ExplanationMagnitude;
+  if (
+    commonOpponents.sharedOpponents >= 4 &&
+    commonOpponents.reliability >= 0.45 &&
+    (absMargin >= 1.1 || absPoints >= 0.9)
+  ) {
+    magnitude = 'significant';
+  } else if (absMargin >= 0.6 || absPoints >= 0.55) {
+    magnitude = 'moderate';
+  } else {
+    magnitude = 'minimal';
+  }
+
+  if (magnitude === 'minimal') return null;
+
+  let description = '';
+  if (absPoints >= 0.8) {
+    description = `Shared-opponent edge: against ${commonOpponents.sharedOpponents} common opponents, ${favoredTeam} has taken about ${absPoints.toFixed(1)} more points per game`;
+  } else {
+    description = `Shared-opponent edge: against ${commonOpponents.sharedOpponents} common opponents, ${favoredTeam} has been roughly ${absMargin.toFixed(1)} goals per game better`;
+  }
+
+  return {
+    factor: 'common_opponents',
+    advantage,
+    magnitude,
+    description,
+    icon: 'vs',
+    score: Math.abs(signal) * 12 + commonOpponents.sharedOpponents * 0.18 + commonOpponents.reliability * 0.6,
+  };
+}
+
 /**
  * Generate complete match explanation
  */
@@ -388,11 +443,13 @@ export function explainMatch(
     expectedMargin,
     expectedScore,
     h2h,
+    commonOpponents,
   } = prediction;
 
   // Generate all possible explanations
   const allExplanations: (Explanation | null)[] = [
     explainHeadToHead(teamA, teamB, h2h), // H2H first - highly predictive
+    explainCommonOpponents(teamA, teamB, commonOpponents, components.commonOpponentSignal),
     explainPowerScore(teamA, teamB, components.powerDiff),
     explainSOS(teamA, teamB, components.sosDiff),
     explainRecentForm(teamA, teamB, formA, formB, components.formDiffRaw),
@@ -495,6 +552,26 @@ export function explainMatch(
     keyInsights.push(
       `Both teams have deep recent samples (${minGamesPlayed}+ matches), which makes the read more trustworthy.`
     );
+  }
+
+  if (
+    commonOpponents &&
+    commonOpponents.sharedOpponents >= 2 &&
+    Math.abs(components.commonOpponentSignal ?? 0) >= 0.025
+  ) {
+    const commonOpponentTeam = (components.commonOpponentSignal ?? 0) > 0 ? teamA.team_name : teamB.team_name;
+    const absCommonMargin = Math.abs(commonOpponents.avgMarginDiff);
+    const absCommonPoints = Math.abs(commonOpponents.pointsPerGameDiff);
+
+    if (absCommonPoints >= 0.8) {
+      keyInsights.push(
+        `${commonOpponentTeam} has done better against ${commonOpponents.sharedOpponents} shared opponents, taking about ${absCommonPoints.toFixed(1)} more points per game in those matchups.`
+      );
+    } else {
+      keyInsights.push(
+        `${commonOpponentTeam} has been stronger against ${commonOpponents.sharedOpponents} shared opponents, running about ${absCommonMargin.toFixed(1)} goals per game better in that shared sample.`
+      );
+    }
   }
 
   // 3. Margin interpretation

--- a/frontend/lib/matchPredictor.test.ts
+++ b/frontend/lib/matchPredictor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { predictMatch } from './matchPredictor';
+import { calculateCommonOpponentSignal, predictMatch } from './matchPredictor';
 import type { Game, TeamWithRanking } from './types';
 
 function makeTeam(overrides: Partial<TeamWithRanking> = {}): TeamWithRanking {
@@ -205,5 +205,78 @@ describe('predictMatch', () => {
     expect(evidencePrediction.components.evidenceReliabilityA ?? 1).toBeLessThan(
       evidencePrediction.components.evidenceReliabilityB ?? 1
     );
+  });
+
+  it('uses common-opponent performance as a matchup signal', () => {
+    const commonOpponentGames: Game[] = [
+      makeGame({
+        game_date: '2026-03-20',
+        home_team_master_id: 'team-a',
+        away_team_master_id: 'opp-1',
+        home_score: 3,
+        away_score: 0,
+      }),
+      makeGame({
+        game_date: '2026-03-13',
+        home_team_master_id: 'team-a',
+        away_team_master_id: 'opp-2',
+        home_score: 2,
+        away_score: 0,
+      }),
+      makeGame({
+        game_date: '2026-03-06',
+        home_team_master_id: 'opp-1',
+        away_team_master_id: 'team-b',
+        home_score: 2,
+        away_score: 1,
+      }),
+      makeGame({
+        game_date: '2026-02-27',
+        home_team_master_id: 'opp-2',
+        away_team_master_id: 'team-b',
+        home_score: 1,
+        away_score: 1,
+      }),
+    ];
+
+    const summary = calculateCommonOpponentSignal('team-a', 'team-b', commonOpponentGames);
+    expect(summary.sharedOpponents).toBe(2);
+    expect(summary.advantage).toBeGreaterThan(0);
+
+    const balancedTeamA = makeTeam({
+      team_id_master: 'team-a',
+      team_name: 'Alpha FC 14B',
+      power_score_final: 0.6,
+      glicko_rating: 1535,
+      glicko_rd: 90,
+      sos_norm: 0.56,
+      offense_norm: 0.58,
+      defense_norm: 0.56,
+      wins: 10,
+      losses: 5,
+      draws: 2,
+      games_played: 17,
+    });
+    const balancedTeamB = makeTeam({
+      team_id_master: 'team-b',
+      team_name: 'Beta FC 14B',
+      power_score_final: 0.6,
+      glicko_rating: 1535,
+      glicko_rd: 90,
+      sos_norm: 0.56,
+      offense_norm: 0.58,
+      defense_norm: 0.56,
+      wins: 10,
+      losses: 5,
+      draws: 2,
+      games_played: 17,
+    });
+
+    const prediction = predictMatch(balancedTeamA, balancedTeamB, commonOpponentGames);
+
+    expect(prediction.predictedWinner).toBe('team_a');
+    expect(prediction.components.commonOpponentSignal ?? 0).toBeGreaterThan(0);
+    expect(prediction.components.commonOpponentCount).toBe(2);
+    expect(prediction.commonOpponents?.sharedOpponents).toBe(2);
   });
 });

--- a/frontend/lib/matchPredictor.ts
+++ b/frontend/lib/matchPredictor.ts
@@ -87,6 +87,22 @@ interface RecentProfile {
   sampleWeight: number;
 }
 
+interface OpponentAggregate {
+  weightedPoints: number;
+  weightedMargin: number;
+  totalWeight: number;
+  games: number;
+}
+
+interface CommonOpponentSummary {
+  advantage: number;
+  sharedOpponents: number;
+  comparedGames: number;
+  avgMarginDiff: number;
+  pointsPerGameDiff: number;
+  reliability: number;
+}
+
 /**
  * Load age group parameters from JSON file
  * Caches result after first load
@@ -202,6 +218,7 @@ const RECENT_GAMES_COUNT = 5;
 const GLICKO_ELO_DIVISOR = 400;
 const POISSON_MAX_GOALS = 10;
 const DEFAULT_DRAW_RATE = 0.13;
+const COMMON_OPPONENT_RECENCY_DAYS = 150;
 
 /**
  * Get calibrated SENSITIVITY value
@@ -399,6 +416,156 @@ export function calculateHeadToHead(
     advantage,
     gamesPlayed: gamesWithScores,
     avgMargin,
+  };
+}
+
+function getLatestGameTimestamp(allGames: Game[]): number | null {
+  const timestamps = allGames
+    .map((game) => Date.parse(game.game_date))
+    .filter((timestamp) => Number.isFinite(timestamp));
+
+  if (timestamps.length === 0) {
+    return null;
+  }
+
+  return Math.max(...timestamps);
+}
+
+function updateOpponentAggregate(
+  aggregates: Map<string, OpponentAggregate>,
+  opponentId: string,
+  points: number,
+  goalDiff: number,
+  weight: number
+): void {
+  const current = aggregates.get(opponentId) ?? {
+    weightedPoints: 0,
+    weightedMargin: 0,
+    totalWeight: 0,
+    games: 0,
+  };
+
+  current.weightedPoints += points * weight;
+  current.weightedMargin += goalDiff * weight;
+  current.totalWeight += weight;
+  current.games += 1;
+  aggregates.set(opponentId, current);
+}
+
+export function calculateCommonOpponentSignal(
+  teamAId: string,
+  teamBId: string,
+  allGames: Game[]
+): CommonOpponentSummary {
+  const referenceTimestamp = getLatestGameTimestamp(allGames);
+  const teamAOpponents = new Map<string, OpponentAggregate>();
+  const teamBOpponents = new Map<string, OpponentAggregate>();
+
+  for (const game of allGames) {
+    if (game.home_score == null || game.away_score == null) continue;
+
+    const involvesTeamA = game.home_team_master_id === teamAId || game.away_team_master_id === teamAId;
+    const involvesTeamB = game.home_team_master_id === teamBId || game.away_team_master_id === teamBId;
+
+    if ((!involvesTeamA && !involvesTeamB) || (involvesTeamA && involvesTeamB)) {
+      continue;
+    }
+
+    const isTeamARecord = involvesTeamA;
+    const teamId = isTeamARecord ? teamAId : teamBId;
+    const isHome = game.home_team_master_id === teamId;
+    const opponentId = isHome ? game.away_team_master_id : game.home_team_master_id;
+
+    if (!opponentId || opponentId === teamAId || opponentId === teamBId) {
+      continue;
+    }
+
+    const teamScore = isHome ? game.home_score : game.away_score;
+    const oppScore = isHome ? game.away_score : game.home_score;
+    if (teamScore == null || oppScore == null) continue;
+
+    const gameTimestamp = Date.parse(game.game_date);
+    const daysSince =
+      referenceTimestamp != null && Number.isFinite(gameTimestamp)
+        ? Math.max(0, (referenceTimestamp - gameTimestamp) / (1000 * 60 * 60 * 24))
+        : 0;
+    const recencyWeight = Math.exp(-daysSince / COMMON_OPPONENT_RECENCY_DAYS);
+    const points = teamScore > oppScore ? 3 : teamScore === oppScore ? 1 : 0;
+    const goalDiff = teamScore - oppScore;
+
+    updateOpponentAggregate(
+      isTeamARecord ? teamAOpponents : teamBOpponents,
+      opponentId,
+      points,
+      goalDiff,
+      recencyWeight
+    );
+  }
+
+  const sharedOpponentIds = Array.from(teamAOpponents.keys()).filter((opponentId) => teamBOpponents.has(opponentId));
+  if (sharedOpponentIds.length === 0) {
+    return {
+      advantage: 0,
+      sharedOpponents: 0,
+      comparedGames: 0,
+      avgMarginDiff: 0,
+      pointsPerGameDiff: 0,
+      reliability: 0,
+    };
+  }
+
+  let signalSum = 0;
+  let weightSum = 0;
+  let totalComparedGames = 0;
+  let weightedMarginDiff = 0;
+  let weightedPointsDiff = 0;
+
+  for (const opponentId of sharedOpponentIds) {
+    const teamAStats = teamAOpponents.get(opponentId);
+    const teamBStats = teamBOpponents.get(opponentId);
+    if (!teamAStats || !teamBStats || teamAStats.totalWeight <= 0 || teamBStats.totalWeight <= 0) {
+      continue;
+    }
+
+    const teamAPointsPerGame = teamAStats.weightedPoints / teamAStats.totalWeight;
+    const teamBPointsPerGame = teamBStats.weightedPoints / teamBStats.totalWeight;
+    const teamAAvgMargin = teamAStats.weightedMargin / teamAStats.totalWeight;
+    const teamBAvgMargin = teamBStats.weightedMargin / teamBStats.totalWeight;
+
+    const pointsPerGameDiff = teamAPointsPerGame - teamBPointsPerGame;
+    const avgMarginDiff = teamAAvgMargin - teamBAvgMargin;
+    const opponentSignal = clamp(pointsPerGameDiff / 3, -1, 1) * 0.65 + clamp(avgMarginDiff / 4, -1, 1) * 0.35;
+    const opponentWeight = clamp((teamAStats.games + teamBStats.games) / 4, 0.35, 1);
+
+    signalSum += opponentSignal * opponentWeight;
+    weightSum += opponentWeight;
+    totalComparedGames += teamAStats.games + teamBStats.games;
+    weightedMarginDiff += avgMarginDiff * opponentWeight;
+    weightedPointsDiff += pointsPerGameDiff * opponentWeight;
+  }
+
+  if (weightSum <= 0) {
+    return {
+      advantage: 0,
+      sharedOpponents: 0,
+      comparedGames: 0,
+      avgMarginDiff: 0,
+      pointsPerGameDiff: 0,
+      reliability: 0,
+    };
+  }
+
+  const sharedOpponents = sharedOpponentIds.length;
+  const reliability = Math.sqrt(clamp(sharedOpponents / 5, 0, 1) * clamp(totalComparedGames / 10, 0, 1));
+  const rawSignal = signalSum / weightSum;
+
+  return {
+    advantage: clamp(rawSignal * (0.02 + reliability * 0.1), -0.12, 0.12),
+    sharedOpponents,
+    comparedGames: totalComparedGames,
+    avgMarginDiff: weightedMarginDiff / weightSum,
+    pointsPerGameDiff: weightedPointsDiff / weightSum,
+    reliability,
   };
 }
 
@@ -816,6 +983,12 @@ export interface MatchPrediction {
     evidenceSignal?: number;
     evidenceReliabilityA?: number;
     evidenceReliabilityB?: number;
+    commonOpponentSignal?: number;
+    commonOpponentCount?: number;
+    commonOpponentGameCount?: number;
+    commonOpponentReliability?: number;
+    commonOpponentAvgMarginDiff?: number;
+    commonOpponentPointsPerGameDiff?: number;
     glickoRatingDiff?: number;
     glickoWinProbabilityA?: number;
     glickoReliability?: number;
@@ -829,6 +1002,14 @@ export interface MatchPrediction {
   h2h?: {
     gamesPlayed: number;
     avgMargin: number; // Team A's average goal margin in H2H meetings
+  };
+
+  commonOpponents?: {
+    sharedOpponents: number;
+    comparedGames: number;
+    avgMarginDiff: number;
+    pointsPerGameDiff: number;
+    reliability: number;
   };
 }
 
@@ -857,6 +1038,7 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
   const formDiffNorm = normalizeRecentForm(formDiffRaw) - 0.5;
   const matchupAdvantage = offenseA - defenseB - (offenseB - defenseA);
   const h2h = calculateHeadToHead(teamA.team_id_master, teamB.team_id_master, allGames);
+  const commonOpponent = calculateCommonOpponentSignal(teamA.team_id_master, teamB.team_id_master, allGames);
   const h2hWeight = h2h.gamesPlayed > 0 ? Math.min(0.05 * h2h.gamesPlayed, 0.15) : 0;
 
   const predictiveWinSignal =
@@ -888,7 +1070,8 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
     recordDiff * 0.08 +
     residualSignal * 0.06 +
     evidenceSignal * 0.07 +
-    h2hSignal * 0.08;
+    h2hSignal * 0.08 +
+    commonOpponent.advantage;
 
   if (mismatchScore > 0.4) {
     const amplification = 1.0 + (mismatchScore - 0.4) * 0.9;
@@ -1056,6 +1239,12 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
       evidenceSignal,
       evidenceReliabilityA,
       evidenceReliabilityB,
+      commonOpponentSignal: commonOpponent.advantage,
+      commonOpponentCount: commonOpponent.sharedOpponents,
+      commonOpponentGameCount: commonOpponent.comparedGames,
+      commonOpponentReliability: commonOpponent.reliability,
+      commonOpponentAvgMarginDiff: commonOpponent.avgMarginDiff,
+      commonOpponentPointsPerGameDiff: commonOpponent.pointsPerGameDiff,
       ...(glickoStrength
         ? {
             glickoRatingDiff: glickoStrength.ratingDiff,
@@ -1071,6 +1260,15 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
       h2h: {
         gamesPlayed: h2h.gamesPlayed,
         avgMargin: h2h.avgMargin,
+      },
+    }),
+    ...(commonOpponent.sharedOpponents > 0 && {
+      commonOpponents: {
+        sharedOpponents: commonOpponent.sharedOpponents,
+        comparedGames: commonOpponent.comparedGames,
+        avgMarginDiff: commonOpponent.avgMarginDiff,
+        pointsPerGameDiff: commonOpponent.pointsPerGameDiff,
+        reliability: commonOpponent.reliability,
       },
     }),
   };

--- a/scripts/predictor_python.py
+++ b/scripts/predictor_python.py
@@ -7,6 +7,7 @@ scripts use the same prediction logic as the live compare UI:
 - Glicko rating edge when available, with published score as fallback context
 - SOS, recent form, and offense/defense matchup asymmetry
 - Head-to-head history
+- Common-opponent performance
 - Probability calibration and age-specific margin calibration
 - Glicko-aware confidence scoring
 """
@@ -19,6 +20,8 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Optional
+
+import pandas as pd
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CALIBRATION_DIR = REPO_ROOT / "frontend" / "public" / "data" / "calibration"
@@ -49,6 +52,7 @@ RECENT_GAMES_COUNT = 5
 GLICKO_ELO_DIVISOR = 400.0
 DRAW_THRESHOLD = 0.03
 MAX_TEAM_SCORE = 10
+COMMON_OPPONENT_RECENCY_DAYS = 150.0
 
 DEFAULT_CONFIDENCE_THRESHOLDS = {
     "high": 0.65,
@@ -100,6 +104,7 @@ class MatchPrediction:
     form_a: float = 0.0
     form_b: float = 0.0
     h2h: Optional[Dict[str, float]] = None
+    common_opponents: Optional[Dict[str, float]] = None
 
 
 @lru_cache(maxsize=1)
@@ -237,6 +242,133 @@ def calculate_head_to_head(team_a_id: str, team_b_id: str, all_games: List[Game]
     avg_margin = total_goal_diff / games_with_scores
     advantage = avg_margin * 0.04
     return {"advantage": advantage, "gamesPlayed": float(games_with_scores), "avgMargin": avg_margin}
+
+
+def _latest_game_timestamp(all_games: List[Game]) -> Optional[float]:
+    timestamps: List[float] = []
+    for game in all_games:
+        try:
+            timestamps.append(float(pd.Timestamp(game.game_date).timestamp()))
+        except Exception:
+            continue
+    return max(timestamps) if timestamps else None
+
+
+def calculate_common_opponent_signal(team_a_id: str, team_b_id: str, all_games: List[Game]) -> Dict[str, float]:
+    latest_timestamp = _latest_game_timestamp(all_games)
+    team_a_opponents: Dict[str, Dict[str, float]] = {}
+    team_b_opponents: Dict[str, Dict[str, float]] = {}
+
+    for game in all_games:
+        if game.home_score is None or game.away_score is None:
+            continue
+
+        involves_team_a = game.home_team_master_id == team_a_id or game.away_team_master_id == team_a_id
+        involves_team_b = game.home_team_master_id == team_b_id or game.away_team_master_id == team_b_id
+
+        if (not involves_team_a and not involves_team_b) or (involves_team_a and involves_team_b):
+            continue
+
+        is_team_a_record = involves_team_a
+        team_id = team_a_id if is_team_a_record else team_b_id
+        is_home = game.home_team_master_id == team_id
+        opponent_id = game.away_team_master_id if is_home else game.home_team_master_id
+
+        if opponent_id is None or opponent_id in {team_a_id, team_b_id}:
+            continue
+
+        team_score = game.home_score if is_home else game.away_score
+        opp_score = game.away_score if is_home else game.home_score
+        if team_score is None or opp_score is None:
+            continue
+
+        try:
+            game_timestamp = float(pd.Timestamp(game.game_date).timestamp())
+            days_since = (
+                max(0.0, (latest_timestamp - game_timestamp) / 86400.0) if latest_timestamp is not None else 0.0
+            )
+        except Exception:
+            days_since = 0.0
+
+        recency_weight = math.exp(-days_since / COMMON_OPPONENT_RECENCY_DAYS)
+        points = 3.0 if team_score > opp_score else 1.0 if team_score == opp_score else 0.0
+        goal_diff = float(team_score - opp_score)
+
+        bucket = team_a_opponents if is_team_a_record else team_b_opponents
+        current = bucket.setdefault(
+            str(opponent_id),
+            {"weightedPoints": 0.0, "weightedMargin": 0.0, "totalWeight": 0.0, "games": 0.0},
+        )
+        current["weightedPoints"] += points * recency_weight
+        current["weightedMargin"] += goal_diff * recency_weight
+        current["totalWeight"] += recency_weight
+        current["games"] += 1.0
+
+    shared_opponents = [opponent_id for opponent_id in team_a_opponents if opponent_id in team_b_opponents]
+    if not shared_opponents:
+        return {
+            "advantage": 0.0,
+            "sharedOpponents": 0.0,
+            "comparedGames": 0.0,
+            "avgMarginDiff": 0.0,
+            "pointsPerGameDiff": 0.0,
+            "reliability": 0.0,
+        }
+
+    signal_sum = 0.0
+    weight_sum = 0.0
+    total_compared_games = 0.0
+    weighted_margin_diff = 0.0
+    weighted_points_diff = 0.0
+
+    for opponent_id in shared_opponents:
+        team_a_stats = team_a_opponents[opponent_id]
+        team_b_stats = team_b_opponents[opponent_id]
+        if team_a_stats["totalWeight"] <= 0 or team_b_stats["totalWeight"] <= 0:
+            continue
+
+        team_a_points_per_game = team_a_stats["weightedPoints"] / team_a_stats["totalWeight"]
+        team_b_points_per_game = team_b_stats["weightedPoints"] / team_b_stats["totalWeight"]
+        team_a_avg_margin = team_a_stats["weightedMargin"] / team_a_stats["totalWeight"]
+        team_b_avg_margin = team_b_stats["weightedMargin"] / team_b_stats["totalWeight"]
+
+        points_per_game_diff = team_a_points_per_game - team_b_points_per_game
+        avg_margin_diff = team_a_avg_margin - team_b_avg_margin
+        opponent_signal = max(-1.0, min(1.0, points_per_game_diff / 3.0)) * 0.65 + max(
+            -1.0, min(1.0, avg_margin_diff / 4.0)
+        ) * 0.35
+        opponent_weight = max(0.35, min(1.0, (team_a_stats["games"] + team_b_stats["games"]) / 4.0))
+
+        signal_sum += opponent_signal * opponent_weight
+        weight_sum += opponent_weight
+        total_compared_games += team_a_stats["games"] + team_b_stats["games"]
+        weighted_margin_diff += avg_margin_diff * opponent_weight
+        weighted_points_diff += points_per_game_diff * opponent_weight
+
+    if weight_sum <= 0:
+        return {
+            "advantage": 0.0,
+            "sharedOpponents": 0.0,
+            "comparedGames": 0.0,
+            "avgMarginDiff": 0.0,
+            "pointsPerGameDiff": 0.0,
+            "reliability": 0.0,
+        }
+
+    shared_opponent_count = float(len(shared_opponents))
+    reliability = math.sqrt(
+        max(0.0, min(1.0, shared_opponent_count / 5.0)) * max(0.0, min(1.0, total_compared_games / 10.0))
+    )
+    raw_signal = signal_sum / weight_sum
+
+    return {
+        "advantage": max(-0.12, min(0.12, raw_signal * (0.02 + reliability * 0.1))),
+        "sharedOpponents": shared_opponent_count,
+        "comparedGames": total_compared_games,
+        "avgMarginDiff": weighted_margin_diff / weight_sum,
+        "pointsPerGameDiff": weighted_points_diff / weight_sum,
+        "reliability": reliability,
+    }
 
 
 def detect_mismatch(
@@ -532,6 +664,7 @@ def predict_match(team_a: TeamRanking, team_b: TeamRanking, all_games: List[Game
     matchup_advantage = offense_a - defense_b - (offense_b - defense_a)
 
     h2h = calculate_head_to_head(team_a.team_id_master, team_b.team_id_master, all_games)
+    common_opponents = calculate_common_opponent_signal(team_a.team_id_master, team_b.team_id_master, all_games)
     h2h_games_played = int(h2h["gamesPlayed"])
     h2h_weight = min(0.05 * h2h_games_played, 0.15) if h2h_games_played > 0 else 0.0
     h2h_adjustment = 1.0 - h2h_weight
@@ -542,6 +675,7 @@ def predict_match(team_a: TeamRanking, team_b: TeamRanking, all_games: List[Game
         + float(weights["RECENT_FORM"]) * form_diff_norm * h2h_adjustment
         + float(weights["MATCHUP"]) * matchup_advantage * h2h_adjustment
         + h2h_weight * float(h2h["advantage"]) * 3.0
+        + float(common_opponents["advantage"])
     )
 
     if mismatch_score > 0.4:
@@ -615,6 +749,12 @@ def predict_match(team_a: TeamRanking, team_b: TeamRanking, all_games: List[Game
         "matchupAdvantage": matchup_advantage,
         "compositeDiff": composite_diff,
         "mismatchScore": mismatch_score,
+        "commonOpponentSignal": float(common_opponents["advantage"]),
+        "commonOpponentCount": float(common_opponents["sharedOpponents"]),
+        "commonOpponentGameCount": float(common_opponents["comparedGames"]),
+        "commonOpponentReliability": float(common_opponents["reliability"]),
+        "commonOpponentAvgMarginDiff": float(common_opponents["avgMarginDiff"]),
+        "commonOpponentPointsPerGameDiff": float(common_opponents["pointsPerGameDiff"]),
     }
     if glicko_strength:
         components.update(
@@ -639,4 +779,5 @@ def predict_match(team_a: TeamRanking, team_b: TeamRanking, all_games: List[Game
         h2h={"gamesPlayed": float(h2h_games_played), "avgMargin": float(h2h["avgMargin"])}
         if h2h_games_played > 0
         else None,
+        common_opponents=common_opponents if common_opponents["sharedOpponents"] > 0 else None,
     )

--- a/tests/unit/test_predictor_python.py
+++ b/tests/unit/test_predictor_python.py
@@ -1,4 +1,4 @@
-from scripts.predictor_python import Game, TeamRanking, predict_match
+from scripts.predictor_python import Game, TeamRanking, calculate_common_opponent_signal, predict_match
 
 
 def test_predict_match_prefers_team_with_higher_glicko_rating():
@@ -101,3 +101,45 @@ def test_predict_match_confidence_drops_with_high_glicko_rd():
     assert low_rd_prediction.confidence_score is not None
     assert high_rd_prediction.confidence_score is not None
     assert low_rd_prediction.confidence_score > high_rd_prediction.confidence_score
+
+
+def test_predict_match_uses_common_opponent_signal():
+    team_a = TeamRanking(
+        team_id_master="a",
+        power_score_final=0.58,
+        sos_norm=0.54,
+        offense_norm=0.57,
+        defense_norm=0.56,
+        age=14,
+        games_played=18,
+        glicko_rating=1520,
+        glicko_rd=85,
+    )
+    team_b = TeamRanking(
+        team_id_master="b",
+        power_score_final=0.58,
+        sos_norm=0.54,
+        offense_norm=0.57,
+        defense_norm=0.56,
+        age=14,
+        games_played=18,
+        glicko_rating=1520,
+        glicko_rd=85,
+    )
+
+    history = [
+        Game("g1", "a", "opp-1", 3, 0, "2026-03-20"),
+        Game("g2", "a", "opp-2", 2, 0, "2026-03-13"),
+        Game("g3", "opp-1", "b", 2, 1, "2026-03-06"),
+        Game("g4", "opp-2", "b", 1, 1, "2026-02-27"),
+    ]
+
+    common_opponents = calculate_common_opponent_signal("a", "b", history)
+    prediction = predict_match(team_a, team_b, history)
+
+    assert common_opponents["sharedOpponents"] == 2.0
+    assert common_opponents["advantage"] > 0.0
+    assert prediction.predicted_winner == "team_a"
+    assert prediction.components["commonOpponentSignal"] > 0.0
+    assert prediction.common_opponents is not None
+    assert prediction.common_opponents["sharedOpponents"] == 2.0


### PR DESCRIPTION
## Summary
- add a recency-weighted common-opponent signal to the live compare predictor
- expose shared-opponent evidence in compare explanations and key insights
- mirror the same logic in the Python predictor used by backtests

## Verification
- npm run test -- matchPredictor.test.ts matchExplainer.test.ts
- npm run typecheck
- python -m pytest tests/unit/test_predictor_python.py -q
- python -m ruff check scripts/predictor_python.py tests/unit/test_predictor_python.py