### PR TITLE
Build point-in-time model evaluation and shadow plumbing

### DIFF
--- a/frontend/app/api/match-prediction/route.ts
+++ b/frontend/app/api/match-prediction/route.ts
@@ -2,7 +2,8 @@ import { parseJsonBody } from '@/lib/api/parseJsonBody';
 import { checkRateLimit } from '@/lib/api/rateLimit';
 import { requirePremium } from '@/lib/api/requirePremium';
 import { AppError } from '@/lib/errors';
-import { buildMatchPrediction } from '@/lib/matchPredictionService';
+import { buildMatchPredictionWithShadowContext } from '@/lib/matchPredictionService';
+import { maybeLogMatchPredictionShadow } from '@/lib/matchPredictionShadow';
 import { NextRequest, NextResponse } from 'next/server';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -43,8 +44,16 @@ export async function POST(request: NextRequest) {
       return auth.error;
     }
 
-    const result = await buildMatchPrediction(auth.supabase, teamAId, teamBId);
-    return NextResponse.json(result);
+    const result = await buildMatchPredictionWithShadowContext(auth.supabase, teamAId, teamBId);
+    void maybeLogMatchPredictionShadow({
+      userId: auth.user.id,
+      requestIp: ip,
+      teamAId,
+      teamBId,
+      response: result.response,
+      shadowContext: result.shadowContext,
+    });
+    return NextResponse.json(result.response);
   } catch (error) {
     if (error instanceof AppError && error.statusCode) {
       return NextResponse.json({ error: error.message }, { status: error.statusCode });

--- a/frontend/lib/matchPredictionService.ts
+++ b/frontend/lib/matchPredictionService.ts
@@ -22,6 +22,23 @@ export interface MatchPredictionResponse {
   explanation: MatchExplanation;
 }
 
+export interface MatchPredictionShadowContext {
+  predictorVersion: string;
+  resolvedTeamAIds: string[];
+  resolvedTeamBIds: string[];
+  relevantGameIds: string[];
+  relevantGameCount: number;
+  teamAInput: TeamWithRanking;
+  teamBInput: TeamWithRanking;
+}
+
+export interface MatchPredictionBuildResult {
+  response: MatchPredictionResponse;
+  shadowContext: MatchPredictionShadowContext;
+}
+
+export const MATCH_PREDICTION_VERSION = 'heuristic_v3_shadow_ready';
+
 type TeamRow = {
   team_id_master: string;
   team_name: string;
@@ -333,6 +350,15 @@ export async function buildMatchPrediction(
   teamAId: string,
   teamBId: string
 ): Promise<MatchPredictionResponse> {
+  const result = await buildMatchPredictionWithShadowContext(supabase, teamAId, teamBId);
+  return result.response;
+}
+
+export async function buildMatchPredictionWithShadowContext(
+  supabase: SupabaseClient,
+  teamAId: string,
+  teamBId: string
+): Promise<MatchPredictionBuildResult> {
   await warmMatchPredictorCalibration();
 
   const [resolvedTeamA, resolvedTeamB] = await Promise.all([
@@ -357,17 +383,28 @@ export async function buildMatchPrediction(
   const explanation = explainMatch(teamA, teamB, prediction);
 
   return {
-    teamA: {
-      team_id_master: teamA.team_id_master,
-      team_name: teamA.team_name,
-      club_name: teamA.club_name,
+    response: {
+      teamA: {
+        team_id_master: teamA.team_id_master,
+        team_name: teamA.team_name,
+        club_name: teamA.club_name,
+      },
+      teamB: {
+        team_id_master: teamB.team_id_master,
+        team_name: teamB.team_name,
+        club_name: teamB.club_name,
+      },
+      prediction,
+      explanation,
     },
-    teamB: {
-      team_id_master: teamB.team_id_master,
-      team_name: teamB.team_name,
-      club_name: teamB.club_name,
+    shadowContext: {
+      predictorVersion: MATCH_PREDICTION_VERSION,
+      resolvedTeamAIds: resolvedTeamA.allTeamIds,
+      resolvedTeamBIds: resolvedTeamB.allTeamIds,
+      relevantGameIds: games.map((game) => game.id),
+      relevantGameCount: games.length,
+      teamAInput: teamA,
+      teamBInput: teamB,
     },
-    prediction,
-    explanation,
   };
 }

--- a/frontend/lib/matchPredictionShadow.test.ts
+++ b/frontend/lib/matchPredictionShadow.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insertMock, fromMock, createServiceSupabaseMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  fromMock: vi.fn(),
+  createServiceSupabaseMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceSupabase: createServiceSupabaseMock,
+}));
+
+import { maybeLogMatchPredictionShadow } from './matchPredictionShadow';
+
+describe('maybeLogMatchPredictionShadow', () => {
+  const originalEnv = process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertMock.mockResolvedValue({ error: null });
+    fromMock.mockReturnValue({ insert: insertMock });
+    createServiceSupabaseMock.mockReturnValue({ from: fromMock });
+  });
+
+  afterEach(() => {
+    if (originalEnv == null) {
+      delete process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING;
+    } else {
+      process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING = originalEnv;
+    }
+  });
+
+  it('skips writes when shadow logging is disabled', async () => {
+    process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING = 'false';
+
+    await maybeLogMatchPredictionShadow({
+      userId: 'user-1',
+      teamAId: '11111111-1111-1111-1111-111111111111',
+      teamBId: '22222222-2222-2222-2222-222222222222',
+      requestIp: '127.0.0.1',
+      response: {
+        teamA: { team_id_master: 'a', team_name: 'Alpha', club_name: 'Alpha Club' },
+        teamB: { team_id_master: 'b', team_name: 'Beta', club_name: 'Beta Club' },
+        prediction: {} as never,
+        explanation: {} as never,
+      },
+      shadowContext: {
+        predictorVersion: 'heuristic_v3_shadow_ready',
+        resolvedTeamAIds: ['a'],
+        resolvedTeamBIds: ['b'],
+        relevantGameIds: ['g1'],
+        relevantGameCount: 1,
+        teamAInput: {} as never,
+        teamBInput: {} as never,
+      },
+    });
+
+    expect(createServiceSupabaseMock).not.toHaveBeenCalled();
+  });
+
+  it('writes a shadow payload when enabled', async () => {
+    process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING = 'true';
+
+    await maybeLogMatchPredictionShadow({
+      userId: 'user-1',
+      teamAId: '11111111-1111-1111-1111-111111111111',
+      teamBId: '22222222-2222-2222-2222-222222222222',
+      requestIp: '127.0.0.1',
+      response: {
+        teamA: { team_id_master: 'a', team_name: 'Alpha', club_name: 'Alpha Club' },
+        teamB: { team_id_master: 'b', team_name: 'Beta', club_name: 'Beta Club' },
+        prediction: {} as never,
+        explanation: {} as never,
+      },
+      shadowContext: {
+        predictorVersion: 'heuristic_v3_shadow_ready',
+        resolvedTeamAIds: ['a'],
+        resolvedTeamBIds: ['b'],
+        relevantGameIds: ['g1'],
+        relevantGameCount: 1,
+        teamAInput: {} as never,
+        teamBInput: {} as never,
+      },
+    });
+
+    expect(createServiceSupabaseMock).toHaveBeenCalledTimes(1);
+    expect(fromMock).toHaveBeenCalledWith('match_prediction_shadow_log');
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/matchPredictionShadow.ts
+++ b/frontend/lib/matchPredictionShadow.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+
+import { createServiceSupabase } from '@/lib/supabase/service';
+import type { MatchPredictionResponse, MatchPredictionShadowContext } from './matchPredictionService';
+
+export interface MatchPredictionShadowLogInput {
+  userId?: string | null;
+  requestIp?: string | null;
+  teamAId: string;
+  teamBId: string;
+  response: MatchPredictionResponse;
+  shadowContext: MatchPredictionShadowContext;
+}
+
+function shadowLoggingEnabled(): boolean {
+  return process.env.ENABLE_MATCH_PREDICTION_SHADOW_LOGGING === 'true';
+}
+
+export async function maybeLogMatchPredictionShadow(input: MatchPredictionShadowLogInput): Promise<void> {
+  if (!shadowLoggingEnabled()) {
+    return;
+  }
+
+  try {
+    const supabase = createServiceSupabase();
+    const payload = {
+      user_id: input.userId ?? null,
+      request_ip: input.requestIp ?? null,
+      team_a_id: input.teamAId,
+      team_b_id: input.teamBId,
+      predictor_version: input.shadowContext.predictorVersion,
+      shadow_status: 'pending',
+      live_response: input.response,
+      team_a_input: input.shadowContext.teamAInput,
+      team_b_input: input.shadowContext.teamBInput,
+      request_context: {
+        resolvedTeamAIds: input.shadowContext.resolvedTeamAIds,
+        resolvedTeamBIds: input.shadowContext.resolvedTeamBIds,
+        relevantGameIds: input.shadowContext.relevantGameIds,
+        relevantGameCount: input.shadowContext.relevantGameCount,
+      },
+    };
+
+    const { error } = await supabase.from('match_prediction_shadow_log').insert(payload);
+    if (error) {
+      throw error;
+    }
+  } catch (error) {
+    console.error('[matchPredictionShadow] Failed to log shadow prediction payload:', error);
+  }
+}

--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from scripts.predictor_python import Game as PredictorGame  # noqa: E402
 from scripts.predictor_python import TeamRanking, predict_match  # noqa: E402
+from src.predictions.evaluation_reporting import write_evaluation_bundle  # noqa: E402
 from supabase import Client, create_client  # noqa: E402
 
 # Configure logging
@@ -579,6 +580,7 @@ async def run_backtest(
                     "predicted_winner": prediction.predicted_winner,
                     "actual_winner": actual_winner,
                     "predicted_win_prob_a": prediction.win_probability_a,
+                    "predicted_draw_prob": getattr(prediction, "draw_probability", 0.0),
                     "predicted_win_prob_b": prediction.win_probability_b,
                     "predicted_margin": prediction.expected_margin,
                     "actual_margin": actual_margin,
@@ -628,6 +630,24 @@ async def run_backtest(
 def generate_derived_outputs(raw_df: pd.DataFrame, output_dir: Path):
     """Generate derived CSV outputs from raw_backtest.csv"""
     logger.info("Generating derived outputs...")
+
+    benchmark_frame = pd.DataFrame(
+        {
+            "game_id": raw_df["game_id"],
+            "game_date": raw_df["game_date"],
+            "age_group": raw_df.get("age_group"),
+            "feature_source": raw_df.get("feature_source"),
+            "actual_outcome": raw_df["actual_winner"],
+            "predicted_outcome": raw_df["predicted_winner"],
+            "prob_team_a_win": pd.to_numeric(raw_df.get("predicted_win_prob_a"), errors="coerce").fillna(0.0),
+            "prob_draw": pd.to_numeric(raw_df.get("predicted_draw_prob"), errors="coerce").fillna(0.0),
+            "prob_team_b_win": pd.to_numeric(raw_df.get("predicted_win_prob_b"), errors="coerce").fillna(0.0),
+            "predicted_margin": pd.to_numeric(raw_df.get("predicted_margin"), errors="coerce").fillna(0.0),
+            "actual_margin": pd.to_numeric(raw_df.get("actual_margin"), errors="coerce").fillna(0.0),
+        }
+    )
+    summary = write_evaluation_bundle(benchmark_frame, output_dir, prefix="backtest")
+    logger.info("Saved backtest evaluation bundle: %s", summary)
 
     # 1. Bucket accuracy
     buckets = [
@@ -912,7 +932,10 @@ async def main():
         )
     else:
         if args.require_point_in_time:
-            logger.error("prediction_feature_history snapshots are unavailable; aborting because --require-point-in-time was set")
+            logger.error(
+                "prediction_feature_history snapshots are unavailable; "
+                "aborting because --require-point-in-time was set"
+            )
             sys.exit(1)
 
         logger.warning("Falling back to current rankings. This benchmark mode is not leakage-safe.")

--- a/scripts/calibrate_point_in_time_match_model.py
+++ b/scripts/calibrate_point_in_time_match_model.py
@@ -1,0 +1,75 @@
+"""Calibrate point-in-time match model probabilities from an evaluation CSV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from src.predictions.evaluation_reporting import write_evaluation_bundle
+from src.predictions.point_in_time_calibration import calibrate_evaluation_frame
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calibrate point-in-time model probabilities")
+    parser.add_argument(
+        "--evaluation-csv",
+        required=True,
+        help="CSV produced by train_point_in_time_match_model.py (point_in_time_model_evaluation.csv)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="models/point_in_time_match_predictor",
+        help="Directory to write calibration artifacts and reports",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["temperature", "isotonic"],
+        default="temperature",
+        help="Calibration method to use",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="point_in_time_model_calibration",
+        help="Artifact/report filename prefix",
+    )
+    args = parser.parse_args()
+
+    evaluation_frame = pd.read_csv(args.evaluation_csv)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    result = calibrate_evaluation_frame(
+        evaluation_frame=evaluation_frame,
+        output_dir=str(output_dir),
+        method=args.method,
+        prefix=args.prefix,
+    )
+
+    calibrated_frame_path = output_dir / f"{args.prefix}_evaluation.csv"
+    if calibrated_frame_path.exists():
+        calibrated_frame = pd.read_csv(calibrated_frame_path)
+        write_evaluation_bundle(calibrated_frame, output_dir, prefix=f"{args.prefix}_report")
+
+    summary_path = output_dir / f"{args.prefix}_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "method": result.method,
+                "before_metrics": result.before_metrics,
+                "after_metrics": result.after_metrics,
+                "artifact_path": result.artifact_path,
+                "metadata_path": result.metadata_path,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"Calibration complete. Summary written to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_point_in_time_match_model.py
+++ b/scripts/train_point_in_time_match_model.py
@@ -1,0 +1,172 @@
+"""
+Train the offline point-in-time match model from prediction_feature_history.
+
+This harness is the first step toward replacing the live heuristic predictor.
+It only reads historical games plus point-in-time feature snapshots and writes
+model artifacts; it does not change production compare behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.backtest_predictor import (  # noqa: E402
+    build_snapshot_index,
+    fetch_historical_games,
+    fetch_prediction_feature_snapshots,
+    fetch_team_names,
+)
+from src.predictions.point_in_time_match_model import (  # noqa: E402
+    DatasetBuildResult,
+    PointInTimeMatchModel,
+    build_point_in_time_dataset,
+)
+from supabase import create_client  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _write_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Train point-in-time match model from predictor snapshots")
+    parser.add_argument("--lookback-days", type=int, default=365, help="Historical game window to fetch")
+    parser.add_argument(
+        "--limit",
+        type=lambda value: None if str(value).lower() == "none" else int(value),
+        default=None,
+        help='Maximum number of games to fetch (default: all, use "None" for no limit)',
+    )
+    parser.add_argument(
+        "--test-slice",
+        nargs=2,
+        metavar=("STATE", "AGE_GROUP"),
+        help="Optional slice for smoke tests, e.g. --test-slice AZ u12",
+    )
+    parser.add_argument("--test-ratio", type=float, default=0.2, help="Chronological holdout ratio")
+    parser.add_argument("--min-examples", type=int, default=100, help="Minimum dataset size required to train")
+    parser.add_argument(
+        "--model-dir",
+        default="models/point_in_time_match_predictor",
+        help="Directory to write model artifacts and reports",
+    )
+    parser.add_argument(
+        "--save-dataset",
+        action="store_true",
+        help="Persist the built training frame to CSV for inspection",
+    )
+    args = parser.parse_args()
+
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        logger.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables")
+        sys.exit(1)
+
+    supabase = create_client(supabase_url, supabase_key)
+    logger.info("Connected to Supabase")
+
+    test_slice = tuple(args.test_slice) if args.test_slice else None
+    games_df = await fetch_historical_games(
+        supabase,
+        lookback_days=args.lookback_days,
+        limit=args.limit,
+        test_slice=test_slice,
+    )
+    if games_df.empty:
+        logger.error("No historical games found")
+        sys.exit(1)
+
+    team_ids = sorted(
+        set(games_df["home_team_master_id"].dropna().astype(str)).union(
+            set(games_df["away_team_master_id"].dropna().astype(str))
+        )
+    )
+    snapshot_start = (pd.Timestamp(games_df["game_date"].min()) - pd.Timedelta(days=30)).strftime("%Y-%m-%d")
+    snapshot_end = pd.Timestamp(games_df["game_date"].max()).strftime("%Y-%m-%d")
+    snapshots_df = await fetch_prediction_feature_snapshots(supabase, team_ids, snapshot_start, snapshot_end)
+    if snapshots_df.empty:
+        logger.error("No point-in-time snapshots found in prediction_feature_history")
+        sys.exit(1)
+
+    snapshot_index = build_snapshot_index(snapshots_df)
+    team_names = await fetch_team_names(supabase, team_ids)
+
+    logger.info(
+        "Building point-in-time dataset from %s games, %s snapshots, and %s teams",
+        f"{len(games_df):,}",
+        f"{len(snapshots_df):,}",
+        f"{len(team_ids):,}",
+    )
+    dataset_result: DatasetBuildResult = build_point_in_time_dataset(
+        games_df,
+        snapshot_index=snapshot_index,
+        team_names=team_names,
+        include_mirrored_examples=True,
+    )
+
+    model_dir = Path(args.model_dir)
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_path = model_dir / "dataset_summary.json"
+    _write_json(summary_path, dataset_result.summary)
+    logger.info("Dataset summary saved to %s", summary_path)
+    logger.info("Dataset summary: %s", dataset_result.summary)
+
+    if args.save_dataset and not dataset_result.dataset.empty:
+        dataset_path = model_dir / "training_dataset.csv"
+        dataset_result.dataset.to_csv(dataset_path, index=False)
+        logger.info("Training dataset saved to %s", dataset_path)
+
+    if dataset_result.dataset.empty:
+        logger.warning("Dataset builder produced zero examples. Nothing to train yet.")
+        return
+
+    if len(dataset_result.dataset) < args.min_examples:
+        logger.warning(
+            "Built only %s examples, below the training threshold of %s. "
+            "Harness is ready, but the backfill needs more coverage before this model is meaningful.",
+            f"{len(dataset_result.dataset):,}",
+            f"{args.min_examples:,}",
+        )
+        return
+
+    model = PointInTimeMatchModel(model_dir=str(model_dir))
+    metrics = model.train(
+        dataset_result.dataset,
+        test_ratio=args.test_ratio,
+        min_examples=args.min_examples,
+    )
+    artifact_paths = model.save()
+    evaluation_report = model.write_evaluation_report(str(model_dir), prefix="point_in_time_model")
+
+    metrics_path = model_dir / "training_metrics.json"
+    _write_json(metrics_path, metrics)
+    logger.info("Training metrics saved to %s", metrics_path)
+    logger.info("Saved model artifacts: %s", artifact_paths)
+    logger.info("Saved evaluation report: %s", evaluation_report)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/predictions/evaluation_reporting.py
+++ b/src/predictions/evaluation_reporting.py
@@ -1,0 +1,248 @@
+"""Shared evaluation and reporting utilities for match prediction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import log_loss
+
+OUTCOME_ORDER = ["team_a", "draw", "team_b"]
+PROBABILITY_COLUMNS = {
+    "team_a": "prob_team_a_win",
+    "draw": "prob_draw",
+    "team_b": "prob_team_b_win",
+}
+
+
+def _normalize_probabilities(frame: pd.DataFrame) -> pd.DataFrame:
+    normalized = frame.copy()
+    for column_name in PROBABILITY_COLUMNS.values():
+        if column_name not in normalized.columns:
+            normalized[column_name] = 0.0
+        normalized[column_name] = pd.to_numeric(normalized[column_name], errors="coerce").fillna(0.0).clip(0.0, 1.0)
+
+    row_sums = normalized[list(PROBABILITY_COLUMNS.values())].sum(axis=1)
+    valid_rows = row_sums > 0
+    normalized.loc[valid_rows, list(PROBABILITY_COLUMNS.values())] = normalized.loc[
+        valid_rows, list(PROBABILITY_COLUMNS.values())
+    ].div(row_sums[valid_rows], axis=0)
+    normalized.loc[~valid_rows, list(PROBABILITY_COLUMNS.values())] = [1.0 / len(OUTCOME_ORDER)] * len(OUTCOME_ORDER)
+    return normalized
+
+
+def _outcome_to_index(outcome: str) -> int:
+    return OUTCOME_ORDER.index(str(outcome))
+
+
+def _brier_score(probabilities: np.ndarray, labels: np.ndarray) -> float:
+    one_hot = np.zeros_like(probabilities)
+    for row_index, label_index in enumerate(labels):
+        one_hot[row_index, label_index] = 1.0
+    return float(np.mean(np.sum((probabilities - one_hot) ** 2, axis=1)))
+
+
+def build_standardized_evaluation_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty:
+        return frame.copy()
+
+    standardized = _normalize_probabilities(frame)
+    if "predicted_outcome" not in standardized.columns:
+        probability_values = standardized[list(PROBABILITY_COLUMNS.values())].to_numpy()
+        predicted_indices = np.argmax(probability_values, axis=1)
+        standardized["predicted_outcome"] = [OUTCOME_ORDER[index] for index in predicted_indices]
+
+    standardized["actual_outcome"] = standardized["actual_outcome"].astype(str)
+    standardized["predicted_outcome"] = standardized["predicted_outcome"].astype(str)
+    standardized["top_probability"] = standardized[list(PROBABILITY_COLUMNS.values())].max(axis=1)
+    standardized["correct_prediction"] = standardized["actual_outcome"] == standardized["predicted_outcome"]
+    standardized["margin_error"] = pd.to_numeric(standardized["predicted_margin"], errors="coerce").fillna(0.0) - (
+        pd.to_numeric(standardized["actual_margin"], errors="coerce").fillna(0.0)
+    )
+    standardized["abs_margin_error"] = standardized["margin_error"].abs()
+    return standardized
+
+
+def compute_evaluation_summary(frame: pd.DataFrame) -> dict[str, object]:
+    if frame.empty:
+        return {
+            "games": 0,
+            "winner_accuracy": None,
+            "draw_recall": None,
+            "draw_precision": None,
+            "log_loss": None,
+            "brier_score": None,
+            "margin_mae": None,
+            "margin_rmse": None,
+        }
+
+    standardized = build_standardized_evaluation_frame(frame)
+    labels = standardized["actual_outcome"].map(_outcome_to_index).to_numpy(dtype=int)
+    probabilities = standardized[list(PROBABILITY_COLUMNS.values())].to_numpy(dtype=float)
+
+    draw_mask = standardized["actual_outcome"] == "draw"
+    predicted_draw_mask = standardized["predicted_outcome"] == "draw"
+    margin_errors = standardized["margin_error"].to_numpy(dtype=float)
+
+    summary: dict[str, object] = {
+        "games": int(len(standardized)),
+        "winner_accuracy": float(standardized["correct_prediction"].mean()),
+        "draw_recall": float((standardized.loc[draw_mask, "predicted_outcome"] == "draw").mean())
+        if draw_mask.any()
+        else None,
+        "draw_precision": float((standardized.loc[predicted_draw_mask, "actual_outcome"] == "draw").mean())
+        if predicted_draw_mask.any()
+        else None,
+        "log_loss": float(log_loss(labels, probabilities, labels=[0, 1, 2])),
+        "brier_score": _brier_score(probabilities, labels),
+        "margin_mae": float(np.mean(np.abs(margin_errors))),
+        "margin_rmse": float(np.sqrt(np.mean(margin_errors**2))),
+    }
+
+    if "feature_source" in standardized.columns:
+        summary["feature_source_counts"] = (
+            standardized["feature_source"].value_counts(dropna=False).sort_index().to_dict()
+        )
+    if "age_group" in standardized.columns:
+        summary["age_group_counts"] = standardized["age_group"].value_counts(dropna=False).sort_index().to_dict()
+
+    return summary
+
+
+def build_calibration_table(frame: pd.DataFrame, bucket_edges: Iterable[float] | None = None) -> pd.DataFrame:
+    standardized = build_standardized_evaluation_frame(frame)
+    if standardized.empty:
+        return pd.DataFrame()
+
+    bucket_edges = list(bucket_edges or [0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.90, 1.01])
+    bucket_labels = [
+        f"{int(bucket_edges[index] * 100)}-{int(min(bucket_edges[index + 1], 1.0) * 100)}%"
+        for index in range(len(bucket_edges) - 1)
+    ]
+    standardized["probability_bucket"] = pd.cut(
+        standardized["top_probability"],
+        bins=bucket_edges,
+        labels=bucket_labels,
+        right=False,
+        include_lowest=True,
+    )
+
+    grouped = standardized.groupby("probability_bucket", observed=True)
+    rows = []
+    for bucket_name, bucket_df in grouped:
+        if bucket_df.empty:
+            continue
+        rows.append(
+            {
+                "probability_bucket": str(bucket_name),
+                "games": int(len(bucket_df)),
+                "predicted_probability": float(bucket_df["top_probability"].mean()),
+                "actual_accuracy": float(bucket_df["correct_prediction"].mean()),
+                "calibration_gap": float(bucket_df["top_probability"].mean() - bucket_df["correct_prediction"].mean()),
+                "draw_rate": float((bucket_df["actual_outcome"] == "draw").mean()),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_group_metrics(frame: pd.DataFrame, group_column: str) -> pd.DataFrame:
+    standardized = build_standardized_evaluation_frame(frame)
+    if standardized.empty or group_column not in standardized.columns:
+        return pd.DataFrame()
+
+    rows = []
+    for group_value, group_df in standardized.groupby(group_column, dropna=False):
+        if group_df.empty:
+            continue
+        summary = compute_evaluation_summary(group_df)
+        rows.append(
+            {
+                group_column: group_value,
+                "games": summary["games"],
+                "winner_accuracy": summary["winner_accuracy"],
+                "draw_recall": summary["draw_recall"],
+                "draw_precision": summary["draw_precision"],
+                "log_loss": summary["log_loss"],
+                "brier_score": summary["brier_score"],
+                "margin_mae": summary["margin_mae"],
+                "margin_rmse": summary["margin_rmse"],
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_outcome_metrics(frame: pd.DataFrame) -> pd.DataFrame:
+    standardized = build_standardized_evaluation_frame(frame)
+    if standardized.empty:
+        return pd.DataFrame()
+
+    rows = []
+    for outcome in OUTCOME_ORDER:
+        actual_mask = standardized["actual_outcome"] == outcome
+        predicted_mask = standardized["predicted_outcome"] == outcome
+        rows.append(
+            {
+                "outcome": outcome,
+                "actual_games": int(actual_mask.sum()),
+                "predicted_games": int(predicted_mask.sum()),
+                "recall": float((standardized.loc[actual_mask, "predicted_outcome"] == outcome).mean())
+                if actual_mask.any()
+                else None,
+                "precision": float((standardized.loc[predicted_mask, "actual_outcome"] == outcome).mean())
+                if predicted_mask.any()
+                else None,
+                "avg_probability": float(standardized.loc[:, PROBABILITY_COLUMNS[outcome]].mean()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def write_evaluation_bundle(frame: pd.DataFrame, output_dir: Path, prefix: str = "benchmark") -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    standardized = build_standardized_evaluation_frame(frame)
+    summary = compute_evaluation_summary(standardized)
+    calibration_table = build_calibration_table(standardized)
+    outcome_metrics = build_outcome_metrics(standardized)
+    age_metrics = build_group_metrics(standardized, "age_group")
+    feature_source_metrics = build_group_metrics(standardized, "feature_source")
+
+    summary_path = output_dir / f"{prefix}_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    markdown_lines = [
+        f"# {prefix.replace('_', ' ').title()} Summary",
+        "",
+        f"- Games: {summary['games']}",
+        (
+            f"- Winner accuracy: {summary['winner_accuracy']:.4f}"
+            if summary["winner_accuracy"] is not None
+            else "- Winner accuracy: n/a"
+        ),
+        f"- Draw recall: {summary['draw_recall']:.4f}" if summary["draw_recall"] is not None else "- Draw recall: n/a",
+        (
+            f"- Draw precision: {summary['draw_precision']:.4f}"
+            if summary["draw_precision"] is not None
+            else "- Draw precision: n/a"
+        ),
+        f"- Log loss: {summary['log_loss']:.4f}" if summary["log_loss"] is not None else "- Log loss: n/a",
+        f"- Brier score: {summary['brier_score']:.4f}" if summary["brier_score"] is not None else "- Brier score: n/a",
+        f"- Margin MAE: {summary['margin_mae']:.4f}" if summary["margin_mae"] is not None else "- Margin MAE: n/a",
+        f"- Margin RMSE: {summary['margin_rmse']:.4f}" if summary["margin_rmse"] is not None else "- Margin RMSE: n/a",
+    ]
+    (output_dir / f"{prefix}_summary.md").write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")
+
+    if not calibration_table.empty:
+        calibration_table.to_csv(output_dir / f"{prefix}_calibration.csv", index=False)
+    if not outcome_metrics.empty:
+        outcome_metrics.to_csv(output_dir / f"{prefix}_outcomes.csv", index=False)
+    if not age_metrics.empty:
+        age_metrics.to_csv(output_dir / f"{prefix}_by_age.csv", index=False)
+    if not feature_source_metrics.empty:
+        feature_source_metrics.to_csv(output_dir / f"{prefix}_by_feature_source.csv", index=False)
+
+    return summary

--- a/src/predictions/point_in_time_calibration.py
+++ b/src/predictions/point_in_time_calibration.py
@@ -1,0 +1,206 @@
+"""Calibration utilities for point-in-time match model probabilities."""
+
+from __future__ import annotations
+
+import json
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+from sklearn.metrics import log_loss
+
+from src.predictions.evaluation_reporting import (
+    OUTCOME_ORDER,
+    PROBABILITY_COLUMNS,
+    build_standardized_evaluation_frame,
+    compute_evaluation_summary,
+)
+
+CalibrationMethod = Literal["temperature", "isotonic"]
+
+
+def _normalize_probabilities(probabilities: np.ndarray) -> np.ndarray:
+    clipped = np.clip(probabilities, 1e-9, 1.0)
+    row_sums = clipped.sum(axis=1, keepdims=True)
+    return np.divide(
+        clipped,
+        row_sums,
+        out=np.full_like(clipped, 1.0 / clipped.shape[1]),
+        where=row_sums > 0,
+    )
+
+
+def _brier_score(probabilities: np.ndarray, labels: np.ndarray) -> float:
+    one_hot = np.zeros_like(probabilities)
+    for row_index, class_index in enumerate(labels):
+        one_hot[row_index, class_index] = 1.0
+    return float(np.mean(np.sum((probabilities - one_hot) ** 2, axis=1)))
+
+
+@dataclass
+class CalibrationResult:
+    method: CalibrationMethod
+    before_metrics: dict[str, object]
+    after_metrics: dict[str, object]
+    artifact_path: str
+    metadata_path: str
+
+
+class PointInTimeProbabilityCalibrator:
+    def __init__(self, method: CalibrationMethod = "temperature"):
+        self.method = method
+        self.temperature = 1.0
+        self.isotonic_models: list[IsotonicRegression] = []
+
+    def _labels_from_frame(self, frame: pd.DataFrame) -> np.ndarray:
+        standardized = build_standardized_evaluation_frame(frame)
+        return standardized["actual_outcome"].map(OUTCOME_ORDER.index).to_numpy(dtype=int)
+
+    def _probabilities_from_frame(self, frame: pd.DataFrame) -> np.ndarray:
+        standardized = build_standardized_evaluation_frame(frame)
+        return standardized[list(PROBABILITY_COLUMNS.values())].to_numpy(dtype=float)
+
+    def _apply_temperature(self, probabilities: np.ndarray, temperature: float) -> np.ndarray:
+        logits = np.log(np.clip(probabilities, 1e-9, 1.0))
+        scaled = logits / max(temperature, 1e-6)
+        scaled -= scaled.max(axis=1, keepdims=True)
+        exp_values = np.exp(scaled)
+        return _normalize_probabilities(exp_values)
+
+    def _fit_temperature(self, probabilities: np.ndarray, labels: np.ndarray) -> None:
+        best_temperature = 1.0
+        best_loss = float("inf")
+
+        for temperature in np.linspace(0.6, 2.8, 111):
+            calibrated = self._apply_temperature(probabilities, float(temperature))
+            candidate_loss = float(log_loss(labels, calibrated, labels=[0, 1, 2]))
+            if candidate_loss < best_loss:
+                best_loss = candidate_loss
+                best_temperature = float(temperature)
+
+        self.temperature = best_temperature
+
+    def _fit_isotonic(self, probabilities: np.ndarray, labels: np.ndarray) -> None:
+        self.isotonic_models = []
+        for class_index in range(len(OUTCOME_ORDER)):
+            model = IsotonicRegression(out_of_bounds="clip")
+            model.fit(probabilities[:, class_index], (labels == class_index).astype(float))
+            self.isotonic_models.append(model)
+
+    def fit(self, evaluation_frame: pd.DataFrame) -> None:
+        probabilities = self._probabilities_from_frame(evaluation_frame)
+        labels = self._labels_from_frame(evaluation_frame)
+
+        if self.method == "temperature":
+            self._fit_temperature(probabilities, labels)
+            return
+        if self.method == "isotonic":
+            self._fit_isotonic(probabilities, labels)
+            return
+        raise ValueError(f"Unsupported calibration method: {self.method}")
+
+    def transform_probabilities(self, probabilities: np.ndarray) -> np.ndarray:
+        probabilities = _normalize_probabilities(probabilities)
+        if self.method == "temperature":
+            return self._apply_temperature(probabilities, self.temperature)
+        if self.method == "isotonic":
+            if not self.isotonic_models:
+                raise ValueError("Isotonic calibrator has not been fit")
+            calibrated_columns = [
+                self.isotonic_models[class_index].predict(probabilities[:, class_index])
+                for class_index in range(len(OUTCOME_ORDER))
+            ]
+            return _normalize_probabilities(np.column_stack(calibrated_columns))
+        raise ValueError(f"Unsupported calibration method: {self.method}")
+
+    def transform_frame(self, evaluation_frame: pd.DataFrame) -> pd.DataFrame:
+        standardized = build_standardized_evaluation_frame(evaluation_frame)
+        probabilities = standardized[list(PROBABILITY_COLUMNS.values())].to_numpy(dtype=float)
+        calibrated = self.transform_probabilities(probabilities)
+        calibrated_frame = standardized.copy()
+        calibrated_frame["prob_team_a_win"] = calibrated[:, 0]
+        calibrated_frame["prob_draw"] = calibrated[:, 1]
+        calibrated_frame["prob_team_b_win"] = calibrated[:, 2]
+        calibrated_frame["predicted_outcome"] = [
+            OUTCOME_ORDER[class_index] for class_index in np.argmax(calibrated, axis=1)
+        ]
+        return build_standardized_evaluation_frame(calibrated_frame)
+
+    def metrics_for_frame(self, evaluation_frame: pd.DataFrame) -> dict[str, object]:
+        return compute_evaluation_summary(evaluation_frame)
+
+    def save(self, output_dir: str, prefix: str = "point_in_time_model_calibration") -> tuple[str, str]:
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        artifact_path = output_path / f"{prefix}.pkl"
+        metadata_path = output_path / f"{prefix}.json"
+
+        with open(artifact_path, "wb") as handle:
+            pickle.dump(
+                {
+                    "method": self.method,
+                    "temperature": self.temperature,
+                    "isotonic_models": self.isotonic_models,
+                },
+                handle,
+            )
+
+        metadata = {
+            "method": self.method,
+            "temperature": self.temperature,
+            "isotonic_model_count": len(self.isotonic_models),
+        }
+        metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        return str(artifact_path), str(metadata_path)
+
+    @classmethod
+    def load(cls, artifact_path: str) -> "PointInTimeProbabilityCalibrator":
+        with open(artifact_path, "rb") as handle:
+            payload = pickle.load(handle)
+
+        calibrator = cls(method=payload["method"])
+        calibrator.temperature = float(payload.get("temperature", 1.0))
+        calibrator.isotonic_models = payload.get("isotonic_models", [])
+        return calibrator
+
+
+def calibrate_evaluation_frame(
+    evaluation_frame: pd.DataFrame,
+    output_dir: str,
+    method: CalibrationMethod = "temperature",
+    prefix: str = "point_in_time_model_calibration",
+) -> CalibrationResult:
+    calibrator = PointInTimeProbabilityCalibrator(method=method)
+    standardized = build_standardized_evaluation_frame(evaluation_frame)
+    before_metrics = compute_evaluation_summary(standardized)
+    calibrator.fit(standardized)
+    calibrated_frame = calibrator.transform_frame(standardized)
+    after_metrics = compute_evaluation_summary(calibrated_frame)
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    calibrated_csv_path = output_path / f"{prefix}_evaluation.csv"
+    calibrated_frame.to_csv(calibrated_csv_path, index=False)
+
+    artifact_path, metadata_path = calibrator.save(output_dir, prefix=prefix)
+    metadata = {
+        "method": method,
+        "before_metrics": before_metrics,
+        "after_metrics": after_metrics,
+        "temperature": calibrator.temperature,
+        "isotonic_model_count": len(calibrator.isotonic_models),
+        "calibrated_evaluation_csv": str(calibrated_csv_path),
+    }
+    Path(metadata_path).write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    return CalibrationResult(
+        method=method,
+        before_metrics=before_metrics,
+        after_metrics=after_metrics,
+        artifact_path=artifact_path,
+        metadata_path=metadata_path,
+    )

--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -1,0 +1,755 @@
+"""
+Point-in-time match model training harness.
+
+This module is intentionally offline-only for now. It builds a leakage-safe
+training frame from `prediction_feature_history` snapshots plus historical games,
+then trains a 3-way match outcome model and score regressors. The live compare
+predictor remains unchanged until the backfill is large enough to validate a swap.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import pickle
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.metrics import accuracy_score, log_loss, mean_absolute_error, mean_squared_error
+
+try:
+    from xgboost import XGBClassifier, XGBRegressor
+
+    HAS_XGBOOST = True
+except ImportError:  # pragma: no cover - exercised only when xgboost is missing
+    HAS_XGBOOST = False
+
+from scripts.predictor_python import (
+    Game as PredictorGame,
+)
+from scripts.predictor_python import calculate_common_opponent_signal, calculate_head_to_head, calculate_recent_form
+from src.predictions.evaluation_reporting import write_evaluation_bundle
+
+logger = logging.getLogger(__name__)
+
+
+OUTCOME_TEAM_A_WIN = 0
+OUTCOME_DRAW = 1
+OUTCOME_TEAM_B_WIN = 2
+
+OUTCOME_LABELS = {
+    OUTCOME_TEAM_A_WIN: "team_a_win",
+    OUTCOME_DRAW: "draw",
+    OUTCOME_TEAM_B_WIN: "team_b_win",
+}
+
+FEATURE_EXCLUDE_COLUMNS = {
+    "game_id",
+    "game_date",
+    "team_a_id",
+    "team_b_id",
+    "team_a_name",
+    "team_b_name",
+    "team_a_snapshot_date",
+    "team_b_snapshot_date",
+    "example_orientation",
+    "actual_score_a",
+    "actual_score_b",
+    "actual_margin",
+    "actual_outcome",
+    "actual_outcome_label",
+}
+
+SNAPSHOT_NUMERIC_FIELDS = [
+    "power_score_final",
+    "sos_norm",
+    "offense_norm",
+    "defense_norm",
+    "glicko_rating",
+    "glicko_rd",
+    "glicko_volatility",
+    "games_played",
+    "wins",
+    "losses",
+    "draws",
+    "win_percentage",
+    "rank_in_cohort_final",
+    "same_age_games",
+    "same_age_game_share",
+    "same_age_unique_opponents",
+    "same_age_top100_opp_count",
+    "same_age_top500_opp_count",
+    "same_age_avg_opp_power_adj",
+    "repeat_opponent_share",
+    "positive_ml_evidence_scale",
+    "publication_cap_rank",
+    "publication_cap_score",
+    "exp_margin",
+    "exp_win_rate",
+    "exp_goals_for",
+    "exp_goals_against",
+]
+
+PREDICTIVE_PRIOR_FIELDS = [
+    "exp_margin",
+    "exp_win_rate",
+    "exp_goals_for",
+    "exp_goals_against",
+]
+
+
+@dataclass
+class DatasetBuildResult:
+    dataset: pd.DataFrame
+    summary: Dict[str, object]
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    if value is None or pd.isna(value):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value: object, default: int = 0) -> int:
+    if value is None or pd.isna(value):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _snapshot_age_days(snapshot_row: dict, game_date: str) -> float:
+    snapshot_date = snapshot_row.get("snapshot_date")
+    if not snapshot_date:
+        return 0.0
+    try:
+        return max(
+            0.0,
+            float((pd.Timestamp(game_date).normalize() - pd.Timestamp(snapshot_date).normalize()).days),
+        )
+    except Exception:
+        return 0.0
+
+
+def _is_active_status(status_value: object) -> float:
+    return 1.0 if str(status_value or "").strip().lower() == "active" else 0.0
+
+
+def _is_female_gender(gender_value: object) -> float:
+    normalized = str(gender_value or "").strip().lower()
+    return 1.0 if normalized in {"female", "f", "girls", "girl", "g"} else 0.0
+
+
+def _extract_age_numeric(age_value: object) -> int:
+    if age_value is None or pd.isna(age_value):
+        return 0
+    try:
+        return int(age_value)
+    except (TypeError, ValueError):
+        pass
+
+    match = re.search(r"\d+", str(age_value))
+    return int(match.group()) if match else 0
+
+
+def _snapshot_as_of(snapshot_index: Dict[str, List[dict]], team_id: str, target_date: str) -> Optional[dict]:
+    entries = snapshot_index.get(team_id)
+    if not entries:
+        return None
+
+    target_ts = pd.Timestamp(target_date).normalize()
+    candidate = None
+
+    for entry in entries:
+        snapshot_ts = entry.get("snapshot_ts")
+        if snapshot_ts is None or pd.isna(snapshot_ts):
+            snapshot_date = entry.get("snapshot_date")
+            if not snapshot_date:
+                continue
+            try:
+                snapshot_ts = pd.Timestamp(snapshot_date).normalize()
+            except Exception:
+                continue
+
+        if snapshot_ts <= target_ts:
+            candidate = entry
+            continue
+        break
+
+    return candidate
+
+
+def _paired_snapshot_features(team_a_snapshot: dict, team_b_snapshot: dict) -> Dict[str, float]:
+    features: Dict[str, float] = {}
+
+    for field_name in SNAPSHOT_NUMERIC_FIELDS:
+        team_a_value = _to_float(team_a_snapshot.get(field_name))
+        team_b_value = _to_float(team_b_snapshot.get(field_name))
+        features[f"team_a_{field_name}"] = team_a_value
+        features[f"team_b_{field_name}"] = team_b_value
+        features[f"{field_name}_diff"] = team_a_value - team_b_value
+        features[f"{field_name}_sum"] = team_a_value + team_b_value
+
+    features.update(
+        {
+            "team_a_is_active": _is_active_status(team_a_snapshot.get("status")),
+            "team_b_is_active": _is_active_status(team_b_snapshot.get("status")),
+            "both_active": _is_active_status(team_a_snapshot.get("status"))
+            * _is_active_status(team_b_snapshot.get("status")),
+            "team_a_is_female": _is_female_gender(team_a_snapshot.get("gender")),
+            "team_b_is_female": _is_female_gender(team_b_snapshot.get("gender")),
+            "same_gender_matchup": 1.0
+            if str(team_a_snapshot.get("gender") or "").lower() == str(team_b_snapshot.get("gender") or "").lower()
+            else 0.0,
+            "snapshot_age_days_team_a": _snapshot_age_days(team_a_snapshot, team_a_snapshot.get("_game_date", "")),
+            "snapshot_age_days_team_b": _snapshot_age_days(team_b_snapshot, team_b_snapshot.get("_game_date", "")),
+            "age_group_numeric": max(
+                _extract_age_numeric(team_a_snapshot.get("age_group")),
+                _extract_age_numeric(team_b_snapshot.get("age_group")),
+            ),
+        }
+    )
+
+    offense_diff = _to_float(team_a_snapshot.get("offense_norm")) - _to_float(team_b_snapshot.get("offense_norm"))
+    defense_diff = _to_float(team_a_snapshot.get("defense_norm")) - _to_float(team_b_snapshot.get("defense_norm"))
+    features.update(
+        {
+            "offense_vs_defense_edge": _to_float(team_a_snapshot.get("offense_norm"))
+            - _to_float(team_b_snapshot.get("defense_norm")),
+            "defense_vs_offense_edge": _to_float(team_a_snapshot.get("defense_norm"))
+            - _to_float(team_b_snapshot.get("offense_norm")),
+            "rank_advantage": _to_float(team_b_snapshot.get("rank_in_cohort_final"), default=9999.0)
+            - _to_float(team_a_snapshot.get("rank_in_cohort_final"), default=9999.0),
+            "glicko_confidence_gap": _to_float(team_b_snapshot.get("glicko_rd"))
+            - _to_float(team_a_snapshot.get("glicko_rd")),
+            "power_sos_interaction_diff": (
+                _to_float(team_a_snapshot.get("power_score_final")) * _to_float(team_a_snapshot.get("sos_norm"))
+            )
+            - (
+                _to_float(team_b_snapshot.get("power_score_final")) * _to_float(team_b_snapshot.get("sos_norm"))
+            ),
+            "offense_defense_balance_diff": offense_diff - defense_diff,
+            "team_a_has_predictive_prior": 1.0
+            if any(pd.notna(team_a_snapshot.get(field_name)) for field_name in PREDICTIVE_PRIOR_FIELDS)
+            else 0.0,
+            "team_b_has_predictive_prior": 1.0
+            if any(pd.notna(team_b_snapshot.get(field_name)) for field_name in PREDICTIVE_PRIOR_FIELDS)
+            else 0.0,
+        }
+    )
+
+    return features
+
+
+def _dedupe_games(games: Iterable[PredictorGame]) -> List[PredictorGame]:
+    deduped: Dict[str, PredictorGame] = {}
+    for game in games:
+        deduped[game.id] = game
+    return sorted(deduped.values(), key=lambda item: item.game_date, reverse=True)
+
+
+def _outcome_label(score_a: int, score_b: int) -> Tuple[int, str]:
+    if score_a > score_b:
+        return OUTCOME_TEAM_A_WIN, OUTCOME_LABELS[OUTCOME_TEAM_A_WIN]
+    if score_b > score_a:
+        return OUTCOME_TEAM_B_WIN, OUTCOME_LABELS[OUTCOME_TEAM_B_WIN]
+    return OUTCOME_DRAW, OUTCOME_LABELS[OUTCOME_DRAW]
+
+
+def build_point_in_time_dataset(
+    games_df: pd.DataFrame,
+    snapshot_index: Dict[str, List[dict]],
+    team_names: Optional[Dict[str, str]] = None,
+    include_mirrored_examples: bool = True,
+) -> DatasetBuildResult:
+    """
+    Build a leakage-safe training frame from point-in-time snapshots.
+
+    Each game is converted into one example from team A's perspective. By default,
+    a mirrored example is also added so the model cannot learn an arbitrary input
+    order bias from historical home/away labels.
+    """
+    if games_df.empty:
+        return DatasetBuildResult(
+            dataset=pd.DataFrame(),
+            summary={
+                "games_seen": 0,
+                "games_used": 0,
+                "examples_built": 0,
+                "skipped_missing_snapshot": 0,
+                "unique_snapshot_dates_used": 0,
+            },
+        )
+
+    team_names = team_names or {}
+    games_df = games_df.sort_values("game_date").reset_index(drop=True)
+    per_team_history: Dict[str, List[PredictorGame]] = defaultdict(list)
+    rows: List[Dict[str, object]] = []
+    snapshot_dates_used: set[str] = set()
+    skipped_missing_snapshot = 0
+    games_used = 0
+
+    def build_example(
+        team_a_id: str,
+        team_b_id: str,
+        team_a_snapshot: dict,
+        team_b_snapshot: dict,
+        game_row: pd.Series,
+        score_a: int,
+        score_b: int,
+        orientation: str,
+    ) -> Dict[str, object]:
+        team_a_prior_games = list(per_team_history.get(team_a_id, []))
+        team_b_prior_games = list(per_team_history.get(team_b_id, []))
+        combined_prior_games = _dedupe_games(team_a_prior_games + team_b_prior_games)
+
+        recent_form_a = calculate_recent_form(team_a_id, team_a_prior_games)
+        recent_form_b = calculate_recent_form(team_b_id, team_b_prior_games)
+        h2h = calculate_head_to_head(team_a_id, team_b_id, combined_prior_games)
+        common_opponents = calculate_common_opponent_signal(team_a_id, team_b_id, combined_prior_games)
+        actual_outcome_code, actual_outcome_name = _outcome_label(score_a, score_b)
+
+        enriched_team_a_snapshot = {**team_a_snapshot, "_game_date": game_row["game_date"]}
+        enriched_team_b_snapshot = {**team_b_snapshot, "_game_date": game_row["game_date"]}
+        features = _paired_snapshot_features(enriched_team_a_snapshot, enriched_team_b_snapshot)
+
+        features.update(
+            {
+                "team_a_recent_form": recent_form_a,
+                "team_b_recent_form": recent_form_b,
+                "recent_form_diff": recent_form_a - recent_form_b,
+                "head_to_head_advantage": _to_float(h2h.get("advantage")),
+                "head_to_head_games": _to_float(h2h.get("gamesPlayed")),
+                "head_to_head_avg_margin": _to_float(h2h.get("avgMargin")),
+                "common_opponent_advantage": _to_float(common_opponents.get("advantage")),
+                "common_opponent_shared": _to_float(common_opponents.get("sharedOpponents")),
+                "common_opponent_compared_games": _to_float(common_opponents.get("comparedGames")),
+                "common_opponent_avg_margin_diff": _to_float(common_opponents.get("avgMarginDiff")),
+                "common_opponent_points_diff": _to_float(common_opponents.get("pointsPerGameDiff")),
+                "common_opponent_reliability": _to_float(common_opponents.get("reliability")),
+                "team_a_prior_game_count": float(len(team_a_prior_games)),
+                "team_b_prior_game_count": float(len(team_b_prior_games)),
+                "combined_prior_game_count": float(len(combined_prior_games)),
+                "game_id": str(game_row["id"]),
+                "game_date": str(game_row["game_date"]),
+                "team_a_id": team_a_id,
+                "team_b_id": team_b_id,
+                "team_a_name": team_names.get(team_a_id),
+                "team_b_name": team_names.get(team_b_id),
+                "team_a_snapshot_date": team_a_snapshot.get("snapshot_date"),
+                "team_b_snapshot_date": team_b_snapshot.get("snapshot_date"),
+                "example_orientation": orientation,
+                "actual_score_a": int(score_a),
+                "actual_score_b": int(score_b),
+                "actual_margin": int(score_a - score_b),
+                "actual_outcome": actual_outcome_name,
+                "actual_outcome_label": int(actual_outcome_code),
+            }
+        )
+
+        return features
+
+    for _, game_row in games_df.iterrows():
+        if pd.isna(game_row.get("home_team_master_id")) or pd.isna(game_row.get("away_team_master_id")):
+            continue
+        if pd.isna(game_row.get("home_score")) or pd.isna(game_row.get("away_score")):
+            continue
+
+        home_id = str(game_row["home_team_master_id"])
+        away_id = str(game_row["away_team_master_id"])
+        game_date = str(game_row["game_date"])
+        home_score = int(game_row["home_score"])
+        away_score = int(game_row["away_score"])
+
+        home_snapshot = _snapshot_as_of(snapshot_index, home_id, game_date)
+        away_snapshot = _snapshot_as_of(snapshot_index, away_id, game_date)
+
+        if home_snapshot is None or away_snapshot is None:
+            skipped_missing_snapshot += 1
+        else:
+            rows.append(
+                build_example(
+                    team_a_id=home_id,
+                    team_b_id=away_id,
+                    team_a_snapshot=home_snapshot,
+                    team_b_snapshot=away_snapshot,
+                    game_row=game_row,
+                    score_a=home_score,
+                    score_b=away_score,
+                    orientation="original",
+                )
+            )
+            if include_mirrored_examples:
+                rows.append(
+                    build_example(
+                        team_a_id=away_id,
+                        team_b_id=home_id,
+                        team_a_snapshot=away_snapshot,
+                        team_b_snapshot=home_snapshot,
+                        game_row=game_row,
+                        score_a=away_score,
+                        score_b=home_score,
+                        orientation="mirrored",
+                    )
+                )
+
+            games_used += 1
+            if home_snapshot.get("snapshot_date"):
+                snapshot_dates_used.add(str(home_snapshot["snapshot_date"]))
+            if away_snapshot.get("snapshot_date"):
+                snapshot_dates_used.add(str(away_snapshot["snapshot_date"]))
+
+        predictor_game = PredictorGame(
+            id=str(game_row["id"]),
+            home_team_master_id=home_id,
+            away_team_master_id=away_id,
+            home_score=home_score,
+            away_score=away_score,
+            game_date=game_date,
+        )
+        per_team_history[home_id].append(predictor_game)
+        per_team_history[away_id].append(predictor_game)
+
+    dataset = pd.DataFrame(rows)
+    if not dataset.empty:
+        for column_name in dataset.columns:
+            if column_name in FEATURE_EXCLUDE_COLUMNS:
+                continue
+            try:
+                dataset[column_name] = pd.to_numeric(dataset[column_name])
+            except (TypeError, ValueError):
+                continue
+
+    summary = {
+        "games_seen": int(len(games_df)),
+        "games_used": int(games_used),
+        "examples_built": int(len(dataset)),
+        "skipped_missing_snapshot": int(skipped_missing_snapshot),
+        "unique_snapshot_dates_used": int(len(snapshot_dates_used)),
+    }
+    return DatasetBuildResult(dataset=dataset, summary=summary)
+
+
+class PointInTimeMatchModel:
+    """Train and persist a 3-way point-in-time match model."""
+
+    def __init__(self, model_dir: str = "models/point_in_time_match_predictor"):
+        self.model_dir = model_dir
+        self.feature_names: List[str] = []
+        self.class_labels: List[int] = []
+        self.classifier = None
+        self.margin_regressor = None
+        self.score_a_regressor = None
+        self.score_b_regressor = None
+        self.training_metadata: Dict[str, object] = {}
+        self.last_evaluation_frame = pd.DataFrame()
+        os.makedirs(model_dir, exist_ok=True)
+
+    def _feature_columns(self, dataset_df: pd.DataFrame) -> List[str]:
+        return [column for column in dataset_df.columns if column not in FEATURE_EXCLUDE_COLUMNS]
+
+    def _build_classifier(self, random_state: int):
+        if HAS_XGBOOST:
+            return XGBClassifier(
+                n_estimators=260,
+                max_depth=6,
+                learning_rate=0.05,
+                subsample=0.85,
+                colsample_bytree=0.85,
+                reg_alpha=0.1,
+                reg_lambda=1.2,
+                min_child_weight=2,
+                gamma=0.05,
+                random_state=random_state,
+                n_jobs=-1,
+                eval_metric="mlogloss",
+            )
+
+        logger.warning("XGBoost is unavailable; falling back to RandomForestClassifier for offline harness")
+        return RandomForestClassifier(
+            n_estimators=250,
+            max_depth=12,
+            min_samples_leaf=2,
+            random_state=random_state,
+            n_jobs=-1,
+        )
+
+    def _build_regressor(self, random_state: int):
+        if HAS_XGBOOST:
+            return XGBRegressor(
+                n_estimators=240,
+                max_depth=6,
+                learning_rate=0.05,
+                subsample=0.85,
+                colsample_bytree=0.85,
+                reg_alpha=0.1,
+                reg_lambda=1.2,
+                min_child_weight=2,
+                gamma=0.05,
+                random_state=random_state,
+                n_jobs=-1,
+                eval_metric="rmse",
+            )
+
+        logger.warning("XGBoost is unavailable; falling back to RandomForestRegressor for offline harness")
+        return RandomForestRegressor(
+            n_estimators=250,
+            max_depth=12,
+            min_samples_leaf=2,
+            random_state=random_state,
+            n_jobs=-1,
+        )
+
+    def _chronological_split(
+        self,
+        dataset_df: pd.DataFrame,
+        test_ratio: float,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        ordered_df = dataset_df.sort_values(["game_date", "game_id", "example_orientation"]).reset_index(drop=True)
+        if len(ordered_df) < 2:
+            raise ValueError("Need at least 2 examples to split train/test chronologically")
+
+        split_index = int(len(ordered_df) * (1.0 - test_ratio))
+        split_index = min(max(split_index, 1), len(ordered_df) - 1)
+        return ordered_df.iloc[:split_index].copy(), ordered_df.iloc[split_index:].copy()
+
+    def _expand_class_probabilities(self, encoded_probabilities: np.ndarray) -> np.ndarray:
+        if encoded_probabilities.ndim == 1:
+            encoded_probabilities = np.column_stack([1.0 - encoded_probabilities, encoded_probabilities])
+
+        expanded = np.zeros((encoded_probabilities.shape[0], 3), dtype=float)
+        for position, class_value in enumerate(self.class_labels):
+            expanded[:, class_value] = encoded_probabilities[:, position]
+        return expanded
+
+    def _normalize_probabilities(self, probabilities: np.ndarray) -> np.ndarray:
+        clipped = np.clip(probabilities, 1e-9, 1.0)
+        row_sums = clipped.sum(axis=1, keepdims=True)
+        return np.divide(
+            clipped,
+            row_sums,
+            out=np.full_like(clipped, 1.0 / clipped.shape[1]),
+            where=row_sums > 0,
+        )
+
+    def _prepare_matrix(self, dataset_df: pd.DataFrame) -> pd.DataFrame:
+        feature_frame = dataset_df[self.feature_names].copy()
+        return feature_frame.fillna(0.0).astype(float)
+
+    def _build_evaluation_frame(
+        self,
+        test_df: pd.DataFrame,
+        probabilities: np.ndarray,
+        predicted_labels: np.ndarray,
+        predicted_margin: np.ndarray,
+        predicted_score_a: np.ndarray,
+        predicted_score_b: np.ndarray,
+    ) -> pd.DataFrame:
+        age_group_numeric = pd.to_numeric(test_df.get("age_group_numeric"), errors="coerce").fillna(0).astype(int)
+        age_group = age_group_numeric.apply(lambda value: f"u{value}" if value > 0 else "unknown")
+        evaluation_frame = pd.DataFrame(
+            {
+                "game_id": test_df["game_id"].astype(str).to_numpy(),
+                "game_date": test_df["game_date"].astype(str).to_numpy(),
+                "age_group": age_group.to_numpy(),
+                "feature_source": "point_in_time_snapshot",
+                "actual_outcome": test_df["actual_outcome"].astype(str).to_numpy(),
+                "predicted_outcome": [OUTCOME_LABELS[int(label)].replace("_win", "") for label in predicted_labels],
+                "prob_team_a_win": probabilities[:, OUTCOME_TEAM_A_WIN],
+                "prob_draw": probabilities[:, OUTCOME_DRAW],
+                "prob_team_b_win": probabilities[:, OUTCOME_TEAM_B_WIN],
+                "predicted_margin": predicted_margin,
+                "actual_margin": test_df["actual_margin"].astype(float).to_numpy(),
+                "predicted_score_a": predicted_score_a,
+                "predicted_score_b": predicted_score_b,
+                "actual_score_a": test_df["actual_score_a"].astype(float).to_numpy(),
+                "actual_score_b": test_df["actual_score_b"].astype(float).to_numpy(),
+            }
+        )
+        return evaluation_frame
+
+    def _brier_score(self, y_true: np.ndarray, probabilities: np.ndarray) -> float:
+        one_hot = np.zeros_like(probabilities)
+        for row_index, class_index in enumerate(y_true):
+            one_hot[row_index, class_index] = 1.0
+        return float(np.mean(np.sum((probabilities - one_hot) ** 2, axis=1)))
+
+    def train(
+        self,
+        dataset_df: pd.DataFrame,
+        test_ratio: float = 0.2,
+        random_state: int = 42,
+        min_examples: int = 100,
+    ) -> Dict[str, object]:
+        if dataset_df.empty:
+            raise ValueError("Point-in-time dataset is empty")
+        if len(dataset_df) < min_examples:
+            raise ValueError(
+                f"Insufficient examples for training: found {len(dataset_df):,}, need at least {min_examples:,}"
+            )
+
+        train_df, test_df = self._chronological_split(dataset_df, test_ratio=test_ratio)
+        self.feature_names = self._feature_columns(train_df)
+
+        X_train = train_df[self.feature_names].fillna(0.0).astype(float)
+        X_test = test_df[self.feature_names].fillna(0.0).astype(float)
+
+        y_train = train_df["actual_outcome_label"].astype(int).to_numpy()
+        y_test = test_df["actual_outcome_label"].astype(int).to_numpy()
+
+        unique_labels = sorted(np.unique(y_train).tolist())
+        if len(unique_labels) < 2:
+            raise ValueError(
+                "Training data does not contain enough class diversity. "
+                f"Observed only outcome labels: {unique_labels}"
+            )
+
+        self.class_labels = unique_labels
+        label_to_encoded = {label: index for index, label in enumerate(self.class_labels)}
+        y_train_encoded = np.array([label_to_encoded[label] for label in y_train], dtype=int)
+
+        self.classifier = self._build_classifier(random_state=random_state)
+        self.margin_regressor = self._build_regressor(random_state=random_state)
+        self.score_a_regressor = self._build_regressor(random_state=random_state)
+        self.score_b_regressor = self._build_regressor(random_state=random_state)
+
+        self.classifier.fit(X_train, y_train_encoded)
+        self.margin_regressor.fit(X_train, train_df["actual_margin"].astype(float))
+        self.score_a_regressor.fit(X_train, train_df["actual_score_a"].astype(float))
+        self.score_b_regressor.fit(X_train, train_df["actual_score_b"].astype(float))
+
+        encoded_probabilities = self.classifier.predict_proba(X_test)
+        probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
+        predicted_labels = np.argmax(probabilities, axis=1)
+        predicted_margin = self.margin_regressor.predict(X_test)
+        predicted_score_a = self.score_a_regressor.predict(X_test)
+        predicted_score_b = self.score_b_regressor.predict(X_test)
+        self.last_evaluation_frame = self._build_evaluation_frame(
+            test_df=test_df,
+            probabilities=probabilities,
+            predicted_labels=predicted_labels,
+            predicted_margin=predicted_margin,
+            predicted_score_a=predicted_score_a,
+            predicted_score_b=predicted_score_b,
+        )
+
+        metrics = {
+            "winner_accuracy": float(accuracy_score(y_test, predicted_labels)),
+            "log_loss": float(log_loss(y_test, probabilities, labels=[0, 1, 2])),
+            "brier_score": self._brier_score(y_test, probabilities),
+            "draw_recall": float(np.mean(predicted_labels[y_test == OUTCOME_DRAW] == OUTCOME_DRAW))
+            if np.any(y_test == OUTCOME_DRAW)
+            else None,
+            "draw_precision": float(np.mean(y_test[predicted_labels == OUTCOME_DRAW] == OUTCOME_DRAW))
+            if np.any(predicted_labels == OUTCOME_DRAW)
+            else None,
+            "margin_mae": float(mean_absolute_error(test_df["actual_margin"], predicted_margin)),
+            "margin_rmse": float(math.sqrt(mean_squared_error(test_df["actual_margin"], predicted_margin))),
+            "score_a_mae": float(mean_absolute_error(test_df["actual_score_a"], predicted_score_a)),
+            "score_b_mae": float(mean_absolute_error(test_df["actual_score_b"], predicted_score_b)),
+            "train_examples": int(len(train_df)),
+            "test_examples": int(len(test_df)),
+            "class_labels": [OUTCOME_LABELS[label] for label in self.class_labels],
+            "feature_count": int(len(self.feature_names)),
+        }
+
+        self.training_metadata = {
+            "metrics": metrics,
+            "train_examples": int(len(train_df)),
+            "test_examples": int(len(test_df)),
+            "feature_names": self.feature_names,
+            "class_labels": self.class_labels,
+        }
+        return metrics
+
+    @classmethod
+    def load(cls, artifact_path: str) -> "PointInTimeMatchModel":
+        with open(artifact_path, "rb") as handle:
+            payload = pickle.load(handle)
+
+        model = cls(model_dir=str(Path(artifact_path).resolve().parent))
+        model.classifier = payload["classifier"]
+        model.margin_regressor = payload["margin_regressor"]
+        model.score_a_regressor = payload["score_a_regressor"]
+        model.score_b_regressor = payload["score_b_regressor"]
+        model.feature_names = payload["feature_names"]
+        model.class_labels = payload["class_labels"]
+        model.training_metadata = payload.get("training_metadata", {})
+        return model
+
+    def predict_frame(self, dataset_df: pd.DataFrame) -> pd.DataFrame:
+        if self.classifier is None:
+            raise ValueError("Model has not been trained or loaded")
+        matrix = self._prepare_matrix(dataset_df)
+        encoded_probabilities = self.classifier.predict_proba(matrix)
+        probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
+        predicted_labels = np.argmax(probabilities, axis=1)
+        predicted_margin = self.margin_regressor.predict(matrix)
+        predicted_score_a = self.score_a_regressor.predict(matrix)
+        predicted_score_b = self.score_b_regressor.predict(matrix)
+        return self._build_evaluation_frame(
+            test_df=dataset_df,
+            probabilities=probabilities,
+            predicted_labels=predicted_labels,
+            predicted_margin=predicted_margin,
+            predicted_score_a=predicted_score_a,
+            predicted_score_b=predicted_score_b,
+        )
+
+    def write_evaluation_report(self, output_dir: str, prefix: str = "point_in_time_model") -> dict[str, object]:
+        if self.last_evaluation_frame.empty:
+            raise ValueError("No evaluation frame available. Train or predict first.")
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        evaluation_csv_path = output_path / f"{prefix}_evaluation.csv"
+        self.last_evaluation_frame.to_csv(evaluation_csv_path, index=False)
+        summary = write_evaluation_bundle(self.last_evaluation_frame, output_path, prefix=prefix)
+        return {
+            "evaluation_csv_path": str(evaluation_csv_path),
+            "summary": summary,
+        }
+
+    def save(self, artifact_name: str = "point_in_time_match_model") -> Dict[str, str]:
+        if self.classifier is None:
+            raise ValueError("Model has not been trained")
+
+        artifact_base = Path(self.model_dir) / artifact_name
+        pickle_path = artifact_base.with_suffix(".pkl")
+        metadata_path = artifact_base.with_name(f"{artifact_base.name}_metadata.json")
+
+        payload = {
+            "classifier": self.classifier,
+            "margin_regressor": self.margin_regressor,
+            "score_a_regressor": self.score_a_regressor,
+            "score_b_regressor": self.score_b_regressor,
+            "feature_names": self.feature_names,
+            "class_labels": self.class_labels,
+            "training_metadata": self.training_metadata,
+        }
+
+        with open(pickle_path, "wb") as handle:
+            pickle.dump(payload, handle)
+
+        metadata = {
+            **self.training_metadata,
+            "feature_count": len(self.feature_names),
+            "class_labels": [OUTCOME_LABELS[label] for label in self.class_labels],
+        }
+        metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+        return {
+            "pickle_path": str(pickle_path),
+            "metadata_path": str(metadata_path),
+        }

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Optional
 import pandas as pd
 
 from src.rankings.constants import AGE_TO_ANCHOR
+from src.rankings.predictive_priors import ensure_predictive_priors
 from src.rankings.shared import normalize_gender
 
 if TYPE_CHECKING:
@@ -932,6 +933,8 @@ def v53e_to_rankings_full_format(
     if "global_power_score" not in rankings_df.columns:
         rankings_df["global_power_score"] = None
 
+    rankings_df = ensure_predictive_priors(rankings_df)
+
     # =================================================================
     # ANCHOR PASS-THROUGH ASSERTION
     # =================================================================
@@ -1024,6 +1027,10 @@ def v53e_to_rankings_full_format(
         "global_power_score",
         "power_score_true",
         "power_score_final",
+        "exp_margin",
+        "exp_win_rate",
+        "exp_goals_for",
+        "exp_goals_against",
         "same_age_games",
         "same_age_game_share",
         "same_age_unique_opponents",

--- a/src/rankings/prediction_feature_history.py
+++ b/src/rankings/prediction_feature_history.py
@@ -16,9 +16,9 @@ from typing import Optional
 
 import pandas as pd
 
-logger = logging.getLogger(__name__)
+from src.rankings.predictive_priors import LEAGUE_AVG_TOTAL_GOALS, ensure_predictive_priors
 
-LEAGUE_AVG_TOTAL_GOALS = 3.1
+logger = logging.getLogger(__name__)
 OPTIONAL_PREDICTION_EVIDENCE_COLUMNS = {
     "same_age_games",
     "same_age_game_share",
@@ -129,7 +129,7 @@ def build_prediction_feature_snapshot_records(
     if rankings_df.empty:
         return []
 
-    df = rankings_df.copy()
+    df = ensure_predictive_priors(rankings_df)
 
     if "games_played" not in df.columns and "gp" in df.columns:
         df["games_played"] = df["gp"]

--- a/src/rankings/predictive_priors.py
+++ b/src/rankings/predictive_priors.py
@@ -1,0 +1,246 @@
+"""Derived predictive priors for ranking snapshots and exports.
+
+These priors are team-level expectations against a neutral cohort opponent.
+They are intentionally conservative fallbacks so offline snapshots, exported
+rankings, and future models can use the same predictive fields even when the
+underlying ranking pipeline did not explicitly populate them.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import pandas as pd
+
+LEAGUE_AVG_TOTAL_GOALS = 3.1
+GLICKO_BASELINE = 1500.0
+GLICKO_SCALE = 400.0
+PREDICTIVE_MARGIN_SCALE = 1.05
+PREDICTIVE_MARGIN_CLIP = 2.75
+PREDICTIVE_WIN_DIVISOR = 1.1
+
+
+def _safe_float(value: object, default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    try:
+        if pd.isna(value):
+            return default
+    except TypeError:
+        pass
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp(value: float, min_value: float, max_value: float) -> float:
+    return max(min_value, min(max_value, value))
+
+
+def _safe_games_played(row: pd.Series) -> int:
+    games_played = _safe_float(row.get("games_played"))
+    if games_played is None:
+        games_played = _safe_float(row.get("gp"), 0.0)
+    return int(games_played or 0.0)
+
+
+def _derive_win_rate(row: pd.Series) -> float:
+    win_percentage = _safe_float(row.get("win_percentage"))
+    if win_percentage is not None:
+        return _clamp(win_percentage / 100.0, 0.0, 1.0)
+
+    wins = _safe_float(row.get("wins"), 0.0) or 0.0
+    draws = _safe_float(row.get("draws"), 0.0) or 0.0
+    games_played = max(0, _safe_games_played(row))
+    if games_played <= 0:
+        return 0.5
+    return _clamp((wins + (0.5 * draws)) / games_played, 0.0, 1.0)
+
+
+def _compute_evidence_reliability(row: pd.Series) -> float:
+    evidence_values = [
+        row.get("same_age_games"),
+        row.get("same_age_game_share"),
+        row.get("same_age_unique_opponents"),
+        row.get("same_age_top100_opp_count"),
+        row.get("same_age_top500_opp_count"),
+        row.get("same_age_avg_opp_power_adj"),
+        row.get("repeat_opponent_share"),
+        row.get("positive_ml_evidence_scale"),
+        row.get("publication_cap_rank"),
+        row.get("publication_cap_score"),
+    ]
+    if not any(value is not None and not pd.isna(value) for value in evidence_values):
+        return 1.0
+
+    reliability = 1.0
+    same_age_games = max(0.0, _safe_float(row.get("same_age_games"), 0.0) or 0.0)
+    same_age_share = _clamp(_safe_float(row.get("same_age_game_share"), 0.0) or 0.0, 0.0, 1.0)
+    same_age_opponents = max(0.0, _safe_float(row.get("same_age_unique_opponents"), 0.0) or 0.0)
+    top100 = max(0.0, _safe_float(row.get("same_age_top100_opp_count"), 0.0) or 0.0)
+    top500 = max(0.0, _safe_float(row.get("same_age_top500_opp_count"), 0.0) or 0.0)
+    avg_opp_power = _safe_float(row.get("same_age_avg_opp_power_adj"))
+    repeat_share = _clamp(_safe_float(row.get("repeat_opponent_share"), 0.0) or 0.0, 0.0, 1.0)
+    ml_evidence_scale = _clamp(_safe_float(row.get("positive_ml_evidence_scale"), 1.0) or 1.0, 0.0, 1.1)
+
+    reliability += min(same_age_games / 8.0, 1.0) * 0.03
+    reliability += same_age_share * 0.06
+    reliability += min(same_age_opponents / 6.0, 1.0) * 0.05
+    reliability += min(top100 / 3.0, 1.0) * 0.06
+    reliability += min(top500 / 6.0, 1.0) * 0.04
+    if avg_opp_power is not None:
+        reliability += _clamp(avg_opp_power - 0.5, -0.06, 0.06)
+    reliability -= repeat_share * 0.12
+    reliability *= _clamp(0.82 + ml_evidence_scale * 0.18, 0.82, 1.02)
+
+    power_score_final = _safe_float(row.get("power_score_final"))
+    publication_cap_score = _safe_float(row.get("publication_cap_score"))
+    if power_score_final is not None and publication_cap_score is not None:
+        reliability -= _clamp((power_score_final - publication_cap_score) * 1.2, 0.0, 0.1)
+
+    publication_cap_rank = _safe_float(row.get("publication_cap_rank"))
+    if publication_cap_rank is not None:
+        if publication_cap_rank <= 100:
+            reliability -= 0.06
+        elif publication_cap_rank <= 200:
+            reliability -= 0.04
+        else:
+            reliability -= 0.02
+
+    return _clamp(reliability, 0.72, 1.08)
+
+
+def _compute_expected_goals(
+    offense_norm: Optional[float],
+    defense_norm: Optional[float],
+    exp_margin: Optional[float],
+) -> tuple[Optional[float], Optional[float]]:
+    if offense_norm is None or defense_norm is None or exp_margin is None:
+        return None, None
+
+    expected_total_goals = LEAGUE_AVG_TOTAL_GOALS * ((offense_norm + defense_norm) / 2.0)
+    exp_goals_for = expected_total_goals / (1.0 + math.exp(-exp_margin))
+    exp_goals_against = expected_total_goals - exp_goals_for
+    return exp_goals_for, exp_goals_against
+
+
+def _derive_margin_components(row: pd.Series) -> float:
+    reliability = _compute_evidence_reliability(row)
+    power_score = _safe_float(row.get("power_score_final"), 0.5) or 0.5
+    sos_norm = _safe_float(row.get("sos_norm"), 0.5) or 0.5
+
+    offense_norm = _safe_float(row.get("offense_norm"))
+    if offense_norm is None:
+        offense_norm = _safe_float(row.get("off_norm"), 0.5) or 0.5
+
+    defense_norm = _safe_float(row.get("defense_norm"))
+    if defense_norm is None:
+        defense_norm = _safe_float(row.get("def_norm"), 0.5) or 0.5
+
+    glicko_rating = _safe_float(row.get("glicko_rating"))
+    if glicko_rating is None:
+        glicko_rating = _safe_float(row.get("mu"))
+    glicko_rd = _safe_float(row.get("glicko_rd"))
+    if glicko_rd is None:
+        glicko_rd = _safe_float(row.get("sigma"), 350.0)
+
+    games_played = _safe_games_played(row)
+    win_rate = _derive_win_rate(row)
+
+    power_signal = _clamp((power_score - 0.5) * 2.4, -0.75, 0.75)
+    sos_signal = _clamp((sos_norm - 0.5) * 0.35, -0.18, 0.18)
+
+    style_signal = _clamp(
+        ((offense_norm - defense_norm) * 0.9) + ((((offense_norm + defense_norm) / 2.0) - 0.5) * 0.35),
+        -0.35,
+        0.35,
+    )
+    record_signal = _clamp((win_rate - 0.5) * min(1.0, games_played / 12.0) * 0.35, -0.22, 0.22)
+
+    glicko_signal = 0.0
+    if glicko_rating is not None:
+        reliability_from_rd = 1.0
+        if glicko_rd is not None:
+            reliability_from_rd = _clamp(1.0 - (glicko_rd / 350.0), 0.15, 1.0)
+        glicko_signal = _clamp(((glicko_rating - GLICKO_BASELINE) / GLICKO_SCALE) * reliability_from_rd, -0.55, 0.55)
+
+    combined_signal = (
+        power_signal
+        + (0.65 * glicko_signal)
+        + sos_signal
+        + (0.55 * style_signal)
+        + record_signal
+    )
+    return _clamp(
+        combined_signal * PREDICTIVE_MARGIN_SCALE * reliability,
+        -PREDICTIVE_MARGIN_CLIP,
+        PREDICTIVE_MARGIN_CLIP,
+    )
+
+
+def ensure_predictive_priors(rankings_df: pd.DataFrame) -> pd.DataFrame:
+    """Populate predictive prior fields when they are missing.
+
+    Existing non-null values are preserved. Missing expected goals are derived
+    from the final margin and normalized offense/defense values.
+    """
+    if rankings_df.empty:
+        return rankings_df.copy()
+
+    enriched_df = rankings_df.copy()
+
+    if "offense_norm" not in enriched_df.columns and "off_norm" in enriched_df.columns:
+        enriched_df["offense_norm"] = enriched_df["off_norm"]
+    if "defense_norm" not in enriched_df.columns and "def_norm" in enriched_df.columns:
+        enriched_df["defense_norm"] = enriched_df["def_norm"]
+
+    derived_margin = enriched_df.apply(_derive_margin_components, axis=1)
+    if "exp_margin" not in enriched_df.columns:
+        enriched_df["exp_margin"] = derived_margin
+    else:
+        enriched_df["exp_margin"] = enriched_df["exp_margin"].where(enriched_df["exp_margin"].notna(), derived_margin)
+
+    derived_win_rate = enriched_df["exp_margin"].apply(
+        lambda margin: _clamp(1.0 / (1.0 + math.exp(-(float(margin) / PREDICTIVE_WIN_DIVISOR))), 0.01, 0.99)
+        if margin is not None and not pd.isna(margin)
+        else None
+    )
+    if "exp_win_rate" not in enriched_df.columns:
+        enriched_df["exp_win_rate"] = derived_win_rate
+    else:
+        enriched_df["exp_win_rate"] = enriched_df["exp_win_rate"].where(
+            enriched_df["exp_win_rate"].notna(),
+            derived_win_rate,
+        )
+
+    derived_goals = enriched_df.apply(
+        lambda row: _compute_expected_goals(
+            _safe_float(row.get("offense_norm")),
+            _safe_float(row.get("defense_norm")),
+            _safe_float(row.get("exp_margin")),
+        ),
+        axis=1,
+    )
+    derived_goals_for = derived_goals.apply(lambda values: values[0])
+    derived_goals_against = derived_goals.apply(lambda values: values[1])
+
+    if "exp_goals_for" not in enriched_df.columns:
+        enriched_df["exp_goals_for"] = derived_goals_for
+    else:
+        enriched_df["exp_goals_for"] = enriched_df["exp_goals_for"].where(
+            enriched_df["exp_goals_for"].notna(),
+            derived_goals_for,
+        )
+
+    if "exp_goals_against" not in enriched_df.columns:
+        enriched_df["exp_goals_against"] = derived_goals_against
+    else:
+        enriched_df["exp_goals_against"] = enriched_df["exp_goals_against"].where(
+            enriched_df["exp_goals_against"].notna(),
+            derived_goals_against,
+        )
+
+    return enriched_df

--- a/supabase/migrations/20260408020000_create_match_prediction_shadow_log.sql
+++ b/supabase/migrations/20260408020000_create_match_prediction_shadow_log.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS match_prediction_shadow_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    user_id UUID NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+    request_ip TEXT NULL,
+    team_a_id UUID NOT NULL,
+    team_b_id UUID NOT NULL,
+    predictor_version TEXT NOT NULL,
+    shadow_model_version TEXT NULL,
+    shadow_status TEXT NOT NULL DEFAULT 'pending',
+    live_response JSONB NOT NULL,
+    team_a_input JSONB NOT NULL,
+    team_b_input JSONB NOT NULL,
+    request_context JSONB NOT NULL DEFAULT '{}'::jsonb,
+    shadow_prediction JSONB NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_match_prediction_shadow_log_created_at
+    ON match_prediction_shadow_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_match_prediction_shadow_log_shadow_status
+    ON match_prediction_shadow_log (shadow_status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_match_prediction_shadow_log_teams
+    ON match_prediction_shadow_log (team_a_id, team_b_id, created_at DESC);
+
+ALTER TABLE match_prediction_shadow_log ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE match_prediction_shadow_log IS
+    'Fail-open shadow logging for /compare match predictions. Stores live request inputs and prediction payloads so candidate models can be evaluated side-by-side before rollout.';

--- a/tests/unit/test_data_adapter_predictive_priors.py
+++ b/tests/unit/test_data_adapter_predictive_priors.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from src.rankings.data_adapter import v53e_to_rankings_full_format
+
+
+def test_v53e_to_rankings_full_format_derives_predictive_priors_when_missing():
+    teams_df = pd.DataFrame(
+        [
+            {
+                "team_id": "team-1",
+                "age": "13",
+                "gender": "Male",
+                "status": "Active",
+                "powerscore_adj": 0.72,
+                "power_score_final": 0.72,
+                "sos_norm": 0.61,
+                "off_norm": 0.68,
+                "def_norm": 0.62,
+                "wins": 9,
+                "losses": 2,
+                "draws": 2,
+                "games_played": 13,
+                "glicko_rating": 1592.0,
+                "glicko_rd": 62.0,
+                "same_age_games": 10,
+                "same_age_game_share": 0.77,
+                "same_age_unique_opponents": 6,
+                "same_age_top100_opp_count": 2,
+                "same_age_top500_opp_count": 5,
+                "same_age_avg_opp_power_adj": 0.7,
+                "repeat_opponent_share": 0.1,
+                "positive_ml_evidence_scale": 0.88,
+            }
+        ]
+    )
+
+    result = v53e_to_rankings_full_format(teams_df)
+
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row["exp_margin"] is not None
+    assert row["exp_margin"] > 0
+    assert row["exp_win_rate"] is not None
+    assert 0.5 < row["exp_win_rate"] < 1.0
+    assert row["exp_goals_for"] is not None
+    assert row["exp_goals_against"] is not None

--- a/tests/unit/test_evaluation_reporting.py
+++ b/tests/unit/test_evaluation_reporting.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from src.predictions.evaluation_reporting import (
+    build_calibration_table,
+    build_standardized_evaluation_frame,
+    compute_evaluation_summary,
+)
+
+
+def test_compute_evaluation_summary_handles_three_way_probabilities():
+    frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_a",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.72,
+                "prob_draw": 0.14,
+                "prob_team_b_win": 0.14,
+                "predicted_margin": 1.2,
+                "actual_margin": 1,
+            },
+            {
+                "game_id": "g2",
+                "game_date": "2026-04-02",
+                "actual_outcome": "draw",
+                "predicted_outcome": "draw",
+                "prob_team_a_win": 0.31,
+                "prob_draw": 0.42,
+                "prob_team_b_win": 0.27,
+                "predicted_margin": 0.0,
+                "actual_margin": 0,
+            },
+        ]
+    )
+
+    summary = compute_evaluation_summary(frame)
+
+    assert summary["games"] == 2
+    assert summary["winner_accuracy"] == 1.0
+    assert summary["draw_recall"] == 1.0
+    assert summary["draw_precision"] == 1.0
+    assert summary["log_loss"] is not None
+    assert summary["brier_score"] is not None
+
+
+def test_build_standardized_evaluation_frame_normalizes_missing_rows():
+    frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_b",
+                "prob_team_a_win": 0.0,
+                "prob_draw": 0.0,
+                "prob_team_b_win": 0.0,
+                "predicted_margin": -0.5,
+                "actual_margin": -1,
+            }
+        ]
+    )
+
+    standardized = build_standardized_evaluation_frame(frame)
+
+    assert standardized.loc[0, "predicted_outcome"] in {"team_a", "draw", "team_b"}
+    assert abs(
+        standardized.loc[0, ["prob_team_a_win", "prob_draw", "prob_team_b_win"]].sum() - 1.0
+    ) < 1e-9
+
+
+def test_build_calibration_table_groups_probability_buckets():
+    frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_a",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.68,
+                "prob_draw": 0.12,
+                "prob_team_b_win": 0.20,
+                "predicted_margin": 0.8,
+                "actual_margin": 1,
+            },
+            {
+                "game_id": "g2",
+                "game_date": "2026-04-02",
+                "actual_outcome": "team_b",
+                "predicted_outcome": "team_b",
+                "prob_team_a_win": 0.18,
+                "prob_draw": 0.14,
+                "prob_team_b_win": 0.68,
+                "predicted_margin": -0.8,
+                "actual_margin": -1,
+            },
+        ]
+    )
+
+    calibration = build_calibration_table(frame)
+
+    assert not calibration.empty
+    assert "probability_bucket" in calibration.columns

--- a/tests/unit/test_point_in_time_calibration.py
+++ b/tests/unit/test_point_in_time_calibration.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from src.predictions.point_in_time_calibration import calibrate_evaluation_frame
+
+
+def test_calibrate_evaluation_frame_writes_improved_artifacts(tmp_path):
+    evaluation_frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_a",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.80,
+                "prob_draw": 0.10,
+                "prob_team_b_win": 0.10,
+                "predicted_margin": 1.1,
+                "actual_margin": 1,
+            },
+            {
+                "game_id": "g2",
+                "game_date": "2026-04-02",
+                "actual_outcome": "draw",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.60,
+                "prob_draw": 0.20,
+                "prob_team_b_win": 0.20,
+                "predicted_margin": 0.6,
+                "actual_margin": 0,
+            },
+            {
+                "game_id": "g3",
+                "game_date": "2026-04-03",
+                "actual_outcome": "team_b",
+                "predicted_outcome": "team_b",
+                "prob_team_a_win": 0.15,
+                "prob_draw": 0.15,
+                "prob_team_b_win": 0.70,
+                "predicted_margin": -1.0,
+                "actual_margin": -1,
+            },
+        ]
+    )
+
+    result = calibrate_evaluation_frame(
+        evaluation_frame=evaluation_frame,
+        output_dir=str(tmp_path),
+        method="temperature",
+        prefix="calibration_test",
+    )
+
+    assert result.method == "temperature"
+    assert tmp_path.joinpath("calibration_test.pkl").exists()
+    assert tmp_path.joinpath("calibration_test.json").exists()
+    assert tmp_path.joinpath("calibration_test_evaluation.csv").exists()
+    assert result.before_metrics["games"] == 3
+    assert result.after_metrics["games"] == 3

--- a/tests/unit/test_point_in_time_match_model.py
+++ b/tests/unit/test_point_in_time_match_model.py
@@ -1,0 +1,126 @@
+import pandas as pd
+
+from src.predictions.point_in_time_match_model import build_point_in_time_dataset
+
+
+def _snapshot(snapshot_date: str, team_id: str, age_group: str = "14", gender: str = "Male", **overrides):
+    base = {
+        "snapshot_date": snapshot_date,
+        "team_id": team_id,
+        "age_group": age_group,
+        "gender": gender,
+        "status": "Active",
+        "rank_in_cohort_final": 25,
+        "power_score_final": 0.6,
+        "sos_norm": 0.55,
+        "offense_norm": 0.58,
+        "defense_norm": 0.57,
+        "glicko_rating": 1520,
+        "glicko_rd": 80,
+        "glicko_volatility": 0.06,
+        "wins": 10,
+        "losses": 2,
+        "draws": 1,
+        "games_played": 13,
+        "win_percentage": 0.77,
+        "same_age_games": 10,
+        "same_age_game_share": 0.8,
+        "same_age_unique_opponents": 8,
+        "same_age_top100_opp_count": 2,
+        "same_age_top500_opp_count": 5,
+        "same_age_avg_opp_power_adj": 0.58,
+        "repeat_opponent_share": 0.2,
+        "positive_ml_evidence_scale": 0.7,
+        "publication_cap_rank": 50,
+        "publication_cap_score": 0.7,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_build_point_in_time_dataset_is_chronological_and_mirrored():
+    games_df = pd.DataFrame(
+        [
+            {
+                "id": "g1",
+                "game_date": "2026-04-02",
+                "home_team_master_id": "a",
+                "away_team_master_id": "c",
+                "home_score": 3,
+                "away_score": 1,
+            },
+            {
+                "id": "g2",
+                "game_date": "2026-04-03",
+                "home_team_master_id": "b",
+                "away_team_master_id": "c",
+                "home_score": 1,
+                "away_score": 1,
+            },
+            {
+                "id": "g3",
+                "game_date": "2026-04-04",
+                "home_team_master_id": "a",
+                "away_team_master_id": "b",
+                "home_score": 2,
+                "away_score": 0,
+            },
+        ]
+    )
+
+    snapshot_index = {
+        "a": [_snapshot("2026-04-01", "a", power_score_final=0.63, glicko_rating=1550)],
+        "b": [_snapshot("2026-04-01", "b", power_score_final=0.58, glicko_rating=1510)],
+        "c": [_snapshot("2026-04-01", "c", power_score_final=0.54, glicko_rating=1490)],
+    }
+
+    result = build_point_in_time_dataset(
+        games_df,
+        snapshot_index=snapshot_index,
+        team_names={"a": "Alpha", "b": "Bravo", "c": "Charlie"},
+        include_mirrored_examples=True,
+    )
+
+    dataset = result.dataset
+    assert result.summary["games_seen"] == 3
+    assert result.summary["games_used"] == 3
+    assert result.summary["examples_built"] == 6
+    assert len(dataset) == 6
+
+    first_original = dataset[(dataset["game_id"] == "g1") & (dataset["example_orientation"] == "original")].iloc[0]
+    assert first_original["team_a_recent_form"] == 0.0
+    assert first_original["team_b_recent_form"] == 0.0
+    assert first_original["common_opponent_shared"] == 0.0
+
+    g3_original = dataset[(dataset["game_id"] == "g3") & (dataset["example_orientation"] == "original")].iloc[0]
+    g3_mirrored = dataset[(dataset["game_id"] == "g3") & (dataset["example_orientation"] == "mirrored")].iloc[0]
+
+    assert g3_original["team_a_recent_form"] > g3_original["team_b_recent_form"]
+    assert g3_original["common_opponent_shared"] == 1.0
+    assert g3_original["common_opponent_advantage"] > 0.0
+    assert g3_original["actual_outcome"] == "team_a_win"
+    assert g3_mirrored["actual_outcome"] == "team_b_win"
+    assert g3_original["power_score_final_diff"] == -g3_mirrored["power_score_final_diff"]
+
+
+def test_build_point_in_time_dataset_skips_games_without_snapshot():
+    games_df = pd.DataFrame(
+        [
+            {
+                "id": "g1",
+                "game_date": "2026-04-02",
+                "home_team_master_id": "a",
+                "away_team_master_id": "b",
+                "home_score": 2,
+                "away_score": 1,
+            }
+        ]
+    )
+
+    snapshot_index = {
+        "a": [_snapshot("2026-04-01", "a")],
+    }
+
+    result = build_point_in_time_dataset(games_df, snapshot_index=snapshot_index, include_mirrored_examples=True)
+    assert result.dataset.empty
+    assert result.summary["skipped_missing_snapshot"] == 1

--- a/tests/unit/test_prediction_feature_history.py
+++ b/tests/unit/test_prediction_feature_history.py
@@ -120,3 +120,45 @@ def test_build_prediction_feature_snapshot_records_skips_blank_team_ids_and_pres
     assert record["win_percentage"] is None
     assert record["exp_goals_for"] == 1.4
     assert record["exp_goals_against"] == 0.9
+
+
+def test_build_prediction_feature_snapshot_records_derives_missing_predictive_priors():
+    rankings_df = pd.DataFrame(
+        [
+            {
+                "team_id": "team-3",
+                "age": 12,
+                "gender": "Male",
+                "power_score_final": 0.74,
+                "sos_norm": 0.63,
+                "offense_norm": 0.69,
+                "defense_norm": 0.61,
+                "glicko_rating": 1608.0,
+                "glicko_rd": 58.0,
+                "wins": 10,
+                "losses": 3,
+                "draws": 2,
+                "games_played": 15,
+                "same_age_games": 11,
+                "same_age_game_share": 0.73,
+                "same_age_unique_opponents": 7,
+                "same_age_top100_opp_count": 2,
+                "same_age_top500_opp_count": 5,
+                "same_age_avg_opp_power_adj": 0.71,
+                "repeat_opponent_share": 0.12,
+                "positive_ml_evidence_scale": 0.9,
+            }
+        ]
+    )
+
+    records = build_prediction_feature_snapshot_records(rankings_df, snapshot_date=pd.Timestamp("2026-04-08").date())
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["exp_margin"] is not None
+    assert record["exp_margin"] > 0
+    assert record["exp_win_rate"] is not None
+    assert 0.5 < record["exp_win_rate"] < 1.0
+    assert record["exp_goals_for"] is not None
+    assert record["exp_goals_against"] is not None
+    assert record["exp_goals_for"] > record["exp_goals_against"]


### PR DESCRIPTION
## Summary
- add the point-in-time match model training and evaluation harness
- add benchmark reporting and probability calibration tooling
- fill predictive-prior parity gaps for snapshots and rankings exports
- add optional shadow logging for /api/match-prediction

## Testing
- python -m pytest C:\\PitchRank\\tests\\unit\\test_prediction_feature_history.py C:\\PitchRank\\tests\\unit\\test_data_adapter_predictive_priors.py C:\\PitchRank\\tests\\unit\\test_point_in_time_match_model.py C:\\PitchRank\\tests\\unit\\test_evaluation_reporting.py C:\\PitchRank\\tests\\unit\\test_point_in_time_calibration.py -q
- python -m py_compile C:\\PitchRank\\src\\predictions\\point_in_time_calibration.py C:\\PitchRank\\src\\predictions\\evaluation_reporting.py C:\\PitchRank\\src\\rankings\\predictive_priors.py
- python -m ruff check C:\\PitchRank\\src\\rankings\\predictive_priors.py C:\\PitchRank\\src\\predictions\\evaluation_reporting.py C:\\PitchRank\\src\\predictions\\point_in_time_calibration.py C:\\PitchRank\\src\\predictions\\point_in_time_match_model.py C:\\PitchRank\\scripts\\backtest_predictor.py C:\\PitchRank\\scripts\\train_point_in_time_match_model.py C:\\PitchRank\\scripts\\calibrate_point_in_time_match_model.py C:\\PitchRank\\tests\\unit\\test_prediction_feature_history.py C:\\PitchRank\\tests\\unit\\test_data_adapter_predictive_priors.py C:\\PitchRank\\tests\\unit\\test_evaluation_reporting.py C:\\PitchRank\\tests\\unit\\test_point_in_time_calibration.py
- cd C:\\PitchRank\\frontend && npm run test -- matchPredictionService.test.ts matchPredictionShadow.test.ts
- cd C:\\PitchRank\\frontend && npm run typecheck