### PR TITLE
Normalize evaluation outcome aliases

### DIFF
--- a/src/predictions/evaluation_reporting.py
+++ b/src/predictions/evaluation_reporting.py
@@ -16,6 +16,13 @@ PROBABILITY_COLUMNS = {
     "draw": "prob_draw",
     "team_b": "prob_team_b_win",
 }
+OUTCOME_ALIASES = {
+    "team_a": "team_a",
+    "team_a_win": "team_a",
+    "draw": "draw",
+    "team_b": "team_b",
+    "team_b_win": "team_b",
+}
 
 
 def _normalize_probabilities(frame: pd.DataFrame) -> pd.DataFrame:
@@ -35,7 +42,8 @@ def _normalize_probabilities(frame: pd.DataFrame) -> pd.DataFrame:
 
 
 def _outcome_to_index(outcome: str) -> int:
-    return OUTCOME_ORDER.index(str(outcome))
+    normalized = OUTCOME_ALIASES.get(str(outcome), str(outcome))
+    return OUTCOME_ORDER.index(normalized)
 
 
 def _brier_score(probabilities: np.ndarray, labels: np.ndarray) -> float:
@@ -55,8 +63,12 @@ def build_standardized_evaluation_frame(frame: pd.DataFrame) -> pd.DataFrame:
         predicted_indices = np.argmax(probability_values, axis=1)
         standardized["predicted_outcome"] = [OUTCOME_ORDER[index] for index in predicted_indices]
 
-    standardized["actual_outcome"] = standardized["actual_outcome"].astype(str)
-    standardized["predicted_outcome"] = standardized["predicted_outcome"].astype(str)
+    standardized["actual_outcome"] = (
+        standardized["actual_outcome"].astype(str).map(lambda outcome: OUTCOME_ALIASES.get(outcome, outcome))
+    )
+    standardized["predicted_outcome"] = (
+        standardized["predicted_outcome"].astype(str).map(lambda outcome: OUTCOME_ALIASES.get(outcome, outcome))
+    )
     standardized["top_probability"] = standardized[list(PROBABILITY_COLUMNS.values())].max(axis=1)
     standardized["correct_prediction"] = standardized["actual_outcome"] == standardized["predicted_outcome"]
     standardized["margin_error"] = pd.to_numeric(standardized["predicted_margin"], errors="coerce").fillna(0.0) - (

--- a/tests/unit/test_evaluation_reporting.py
+++ b/tests/unit/test_evaluation_reporting.py
@@ -103,3 +103,37 @@ def test_build_calibration_table_groups_probability_buckets():
 
     assert not calibration.empty
     assert "probability_bucket" in calibration.columns
+
+
+def test_compute_evaluation_summary_normalizes_trainer_outcome_aliases():
+    frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_a_win",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.61,
+                "prob_draw": 0.20,
+                "prob_team_b_win": 0.19,
+                "predicted_margin": 0.7,
+                "actual_margin": 1,
+            },
+            {
+                "game_id": "g2",
+                "game_date": "2026-04-02",
+                "actual_outcome": "team_b_win",
+                "predicted_outcome": "team_b",
+                "prob_team_a_win": 0.21,
+                "prob_draw": 0.18,
+                "prob_team_b_win": 0.61,
+                "predicted_margin": -0.8,
+                "actual_margin": -1,
+            },
+        ]
+    )
+
+    summary = compute_evaluation_summary(frame)
+
+    assert summary["games"] == 2
+    assert summary["winner_accuracy"] == 1.0


### PR DESCRIPTION
## Summary
- normalize evaluation outcome aliases so reporting accepts both trainer and live predictor labels
- add a regression test covering team_a_win/team_b_win inputs

## Testing
- python -m pytest tests/unit/test_evaluation_reporting.py tests/unit/test_point_in_time_match_model.py -q
- python -m py_compile src/predictions/evaluation_reporting.py
- reran end-to-end smoke training and calibration successfully