### PR TITLE
Improve draw-aware point-in-time match model

### DIFF
--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -105,6 +105,11 @@ PREDICTIVE_PRIOR_FIELDS = [
     "exp_goals_against",
 ]
 
+POISSON_MAX_GOALS = 8
+DRAW_CLASS_WEIGHT_BOOST = 1.6
+DRAW_BINARY_WEIGHT_CAP = 4.0
+DRAW_MODEL_SHRINK_FACTOR = 0.3
+
 
 @dataclass
 class DatasetBuildResult:
@@ -128,6 +133,12 @@ def _to_int(value: object, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _safe_rate(numerator: float, denominator: float) -> float:
+    if denominator <= 0:
+        return 0.0
+    return float(numerator) / float(denominator)
 
 
 def _snapshot_age_days(snapshot_row: dict, game_date: str) -> float:
@@ -224,6 +235,63 @@ def _paired_snapshot_features(team_a_snapshot: dict, team_b_snapshot: dict) -> D
 
     offense_diff = _to_float(team_a_snapshot.get("offense_norm")) - _to_float(team_b_snapshot.get("offense_norm"))
     defense_diff = _to_float(team_a_snapshot.get("defense_norm")) - _to_float(team_b_snapshot.get("defense_norm"))
+    team_a_games = max(_to_float(team_a_snapshot.get("games_played")), 1.0)
+    team_b_games = max(_to_float(team_b_snapshot.get("games_played")), 1.0)
+    team_a_draw_rate = _safe_rate(_to_float(team_a_snapshot.get("draws")), team_a_games)
+    team_b_draw_rate = _safe_rate(_to_float(team_b_snapshot.get("draws")), team_b_games)
+
+    prior_goal_a_inputs = [
+        _to_float(team_a_snapshot.get("exp_goals_for"), default=float("nan")),
+        _to_float(team_b_snapshot.get("exp_goals_against"), default=float("nan")),
+        1.25
+        + 2.2 * (_to_float(team_a_snapshot.get("offense_norm")) - 0.5)
+        - 1.6 * (_to_float(team_b_snapshot.get("defense_norm")) - 0.5),
+    ]
+    prior_goal_b_inputs = [
+        _to_float(team_b_snapshot.get("exp_goals_for"), default=float("nan")),
+        _to_float(team_a_snapshot.get("exp_goals_against"), default=float("nan")),
+        1.25
+        + 2.2 * (_to_float(team_b_snapshot.get("offense_norm")) - 0.5)
+        - 1.6 * (_to_float(team_a_snapshot.get("defense_norm")) - 0.5),
+    ]
+    projected_goals_team_a = float(np.clip(np.nanmean(prior_goal_a_inputs), 0.15, 6.0))
+    projected_goals_team_b = float(np.clip(np.nanmean(prior_goal_b_inputs), 0.15, 6.0))
+    projected_total_goals = projected_goals_team_a + projected_goals_team_b
+    projected_goal_gap_abs = abs(projected_goals_team_a - projected_goals_team_b)
+
+    snapshot_closeness_components = [
+        math.exp(
+            -5.5
+            * abs(
+                _to_float(team_a_snapshot.get("power_score_final"))
+                - _to_float(team_b_snapshot.get("power_score_final"))
+            )
+        ),
+        math.exp(
+            -abs(
+                _to_float(team_a_snapshot.get("glicko_rating"))
+                - _to_float(team_b_snapshot.get("glicko_rating"))
+            )
+            / 140.0
+        ),
+        math.exp(
+            -abs(
+                _to_float(team_a_snapshot.get("exp_margin"))
+                - _to_float(team_b_snapshot.get("exp_margin"))
+            )
+            / 1.25
+        ),
+        math.exp(
+            -6.0
+            * abs(
+                _to_float(team_a_snapshot.get("exp_win_rate"))
+                - _to_float(team_b_snapshot.get("exp_win_rate"))
+            )
+        ),
+    ]
+    snapshot_strength_closeness = float(np.mean(snapshot_closeness_components))
+    low_total_goal_signal = float(math.exp(-max(projected_total_goals - 2.4, 0.0) / 1.25))
+    goal_balance_signal = float(math.exp(-projected_goal_gap_abs / 0.85))
     features.update(
         {
             "offense_vs_defense_edge": _to_float(team_a_snapshot.get("offense_norm"))
@@ -247,10 +315,57 @@ def _paired_snapshot_features(team_a_snapshot: dict, team_b_snapshot: dict) -> D
             "team_b_has_predictive_prior": 1.0
             if any(pd.notna(team_b_snapshot.get(field_name)) for field_name in PREDICTIVE_PRIOR_FIELDS)
             else 0.0,
+            "team_a_draw_rate": team_a_draw_rate,
+            "team_b_draw_rate": team_b_draw_rate,
+            "draw_rate_diff": team_a_draw_rate - team_b_draw_rate,
+            "draw_rate_sum": team_a_draw_rate + team_b_draw_rate,
+            "draw_rate_gap_abs": abs(team_a_draw_rate - team_b_draw_rate),
+            "combined_draw_rate": (team_a_draw_rate + team_b_draw_rate) / 2.0,
+            "projected_goals_team_a": projected_goals_team_a,
+            "projected_goals_team_b": projected_goals_team_b,
+            "projected_total_goals": projected_total_goals,
+            "projected_goal_gap_abs": projected_goal_gap_abs,
+            "low_total_goal_signal": low_total_goal_signal,
+            "goal_balance_signal": goal_balance_signal,
+            "snapshot_strength_closeness": snapshot_strength_closeness,
         }
     )
 
     return features
+
+
+def _poisson_probability_matrix(lambdas: np.ndarray, max_goals: int = POISSON_MAX_GOALS) -> np.ndarray:
+    clipped = np.clip(np.asarray(lambdas, dtype=float), 0.05, 8.0)
+    matrix = np.zeros((clipped.shape[0], max_goals + 1), dtype=float)
+    matrix[:, 0] = np.exp(-clipped)
+    for goal_count in range(1, max_goals):
+        matrix[:, goal_count] = matrix[:, goal_count - 1] * clipped / float(goal_count)
+    matrix[:, max_goals] = np.clip(1.0 - matrix[:, :max_goals].sum(axis=1), 0.0, 1.0)
+    return matrix
+
+
+def _poisson_outcome_probabilities(
+    team_a_expected_goals: np.ndarray,
+    team_b_expected_goals: np.ndarray,
+    max_goals: int = POISSON_MAX_GOALS,
+) -> np.ndarray:
+    probs_a = _poisson_probability_matrix(team_a_expected_goals, max_goals=max_goals)
+    probs_b = _poisson_probability_matrix(team_b_expected_goals, max_goals=max_goals)
+
+    draw_prob = np.sum(probs_a * probs_b, axis=1)
+    team_b_cumulative_less = np.cumsum(probs_b, axis=1) - probs_b
+    team_a_cumulative_less = np.cumsum(probs_a, axis=1) - probs_a
+    team_a_win_prob = np.sum(probs_a * team_b_cumulative_less, axis=1)
+    team_b_win_prob = np.sum(probs_b * team_a_cumulative_less, axis=1)
+
+    probability_frame = np.column_stack([team_a_win_prob, draw_prob, team_b_win_prob])
+    row_sums = probability_frame.sum(axis=1, keepdims=True)
+    return np.divide(
+        probability_frame,
+        row_sums,
+        out=np.full_like(probability_frame, 1.0 / 3.0),
+        where=row_sums > 0,
+    )
 
 
 def _dedupe_games(games: Iterable[PredictorGame]) -> List[PredictorGame]:
@@ -330,15 +445,25 @@ def build_point_in_time_dataset(
                 "team_a_recent_form": recent_form_a,
                 "team_b_recent_form": recent_form_b,
                 "recent_form_diff": recent_form_a - recent_form_b,
+                "recent_form_gap_abs": abs(recent_form_a - recent_form_b),
+                "recent_form_closeness": math.exp(-abs(recent_form_a - recent_form_b) / 0.3),
                 "head_to_head_advantage": _to_float(h2h.get("advantage")),
                 "head_to_head_games": _to_float(h2h.get("gamesPlayed")),
                 "head_to_head_avg_margin": _to_float(h2h.get("avgMargin")),
+                "head_to_head_gap_abs": abs(_to_float(h2h.get("advantage"))),
+                "head_to_head_closeness": math.exp(-abs(_to_float(h2h.get("advantage"))) / 0.35)
+                if _to_float(h2h.get("gamesPlayed")) > 0
+                else 0.5,
                 "common_opponent_advantage": _to_float(common_opponents.get("advantage")),
                 "common_opponent_shared": _to_float(common_opponents.get("sharedOpponents")),
                 "common_opponent_compared_games": _to_float(common_opponents.get("comparedGames")),
                 "common_opponent_avg_margin_diff": _to_float(common_opponents.get("avgMarginDiff")),
                 "common_opponent_points_diff": _to_float(common_opponents.get("pointsPerGameDiff")),
                 "common_opponent_reliability": _to_float(common_opponents.get("reliability")),
+                "common_opponent_gap_abs": abs(_to_float(common_opponents.get("advantage"))),
+                "common_opponent_closeness": math.exp(-abs(_to_float(common_opponents.get("advantage"))) / 0.3)
+                if _to_float(common_opponents.get("sharedOpponents")) > 0
+                else 0.5,
                 "team_a_prior_game_count": float(len(team_a_prior_games)),
                 "team_b_prior_game_count": float(len(team_b_prior_games)),
                 "combined_prior_game_count": float(len(combined_prior_games)),
@@ -357,6 +482,26 @@ def build_point_in_time_dataset(
                 "actual_outcome": actual_outcome_name,
                 "actual_outcome_label": int(actual_outcome_code),
             }
+        )
+
+        stalemate_components = [
+            _to_float(features.get("snapshot_strength_closeness")),
+            _to_float(features.get("goal_balance_signal")),
+            _to_float(features.get("low_total_goal_signal")),
+            _to_float(features.get("recent_form_closeness")),
+            _to_float(features.get("common_opponent_closeness")),
+            _to_float(features.get("head_to_head_closeness")),
+        ]
+        stalemate_signal = float(np.mean(stalemate_components)) * (
+            0.7 + 0.6 * _to_float(features.get("combined_draw_rate"))
+        )
+        features["stalemate_signal"] = float(np.clip(stalemate_signal, 0.0, 1.0))
+        features["expected_draw_environment"] = float(
+            np.clip(
+                _to_float(features.get("combined_draw_rate")) * _to_float(features.get("low_total_goal_signal")),
+                0.0,
+                1.0,
+            )
         )
 
         return features
@@ -439,6 +584,13 @@ def build_point_in_time_dataset(
         "skipped_missing_snapshot": int(skipped_missing_snapshot),
         "unique_snapshot_dates_used": int(len(snapshot_dates_used)),
     }
+    if not dataset.empty:
+        class_counts = dataset["actual_outcome"].value_counts().sort_index()
+        summary["class_counts"] = {str(label): int(count) for label, count in class_counts.items()}
+        summary["class_rates"] = {
+            str(label): float(count) / float(len(dataset))
+            for label, count in class_counts.items()
+        }
     return DatasetBuildResult(dataset=dataset, summary=summary)
 
 
@@ -450,9 +602,11 @@ class PointInTimeMatchModel:
         self.feature_names: List[str] = []
         self.class_labels: List[int] = []
         self.classifier = None
+        self.draw_classifier = None
         self.margin_regressor = None
         self.score_a_regressor = None
         self.score_b_regressor = None
+        self.draw_rate_prior = 0.0
         self.training_metadata: Dict[str, object] = {}
         self.last_evaluation_frame = pd.DataFrame()
         os.makedirs(model_dir, exist_ok=True)
@@ -460,9 +614,11 @@ class PointInTimeMatchModel:
     def _feature_columns(self, dataset_df: pd.DataFrame) -> List[str]:
         return [column for column in dataset_df.columns if column not in FEATURE_EXCLUDE_COLUMNS]
 
-    def _build_classifier(self, random_state: int):
+    def _build_classifier(self, random_state: int, num_classes: int):
         if HAS_XGBOOST:
             return XGBClassifier(
+                objective="multi:softprob",
+                num_class=num_classes,
                 n_estimators=260,
                 max_depth=6,
                 learning_rate=0.05,
@@ -484,6 +640,34 @@ class PointInTimeMatchModel:
             min_samples_leaf=2,
             random_state=random_state,
             n_jobs=-1,
+        )
+
+    def _build_binary_classifier(self, random_state: int):
+        if HAS_XGBOOST:
+            return XGBClassifier(
+                objective="binary:logistic",
+                n_estimators=240,
+                max_depth=5,
+                learning_rate=0.05,
+                subsample=0.85,
+                colsample_bytree=0.85,
+                reg_alpha=0.1,
+                reg_lambda=1.2,
+                min_child_weight=2,
+                gamma=0.05,
+                random_state=random_state,
+                n_jobs=-1,
+                eval_metric="logloss",
+            )
+
+        logger.warning("XGBoost is unavailable; falling back to RandomForestClassifier for draw model")
+        return RandomForestClassifier(
+            n_estimators=250,
+            max_depth=12,
+            min_samples_leaf=2,
+            random_state=random_state,
+            n_jobs=-1,
+            class_weight="balanced_subsample",
         )
 
     def _build_regressor(self, random_state: int):
@@ -548,6 +732,156 @@ class PointInTimeMatchModel:
         feature_frame = dataset_df[self.feature_names].copy()
         return feature_frame.fillna(0.0).astype(float)
 
+    def _class_balance_summary(self, labels: np.ndarray) -> Dict[str, object]:
+        unique_labels, counts = np.unique(labels, return_counts=True)
+        label_counts = {OUTCOME_LABELS[int(label)]: int(count) for label, count in zip(unique_labels, counts)}
+        total = int(np.sum(counts))
+        label_rates = {label_name: float(count) / float(total) for label_name, count in label_counts.items()}
+        return {
+            "counts": label_counts,
+            "rates": label_rates,
+        }
+
+    def _multiclass_sample_weights(self, labels: np.ndarray) -> Tuple[np.ndarray, Dict[str, float]]:
+        unique_labels, counts = np.unique(labels, return_counts=True)
+        total = float(np.sum(counts))
+        weight_map: Dict[int, float] = {}
+        for label, count in zip(unique_labels, counts):
+            base_weight = total / max(float(len(unique_labels)) * float(count), 1.0)
+            if int(label) == OUTCOME_DRAW:
+                base_weight *= DRAW_CLASS_WEIGHT_BOOST
+            weight_map[int(label)] = float(base_weight)
+        sample_weights = np.array([weight_map[int(label)] for label in labels], dtype=float)
+        named_weight_map = {OUTCOME_LABELS[label]: weight for label, weight in weight_map.items()}
+        return sample_weights, named_weight_map
+
+    def _draw_sample_weights(self, draw_targets: np.ndarray) -> Tuple[np.ndarray, Dict[str, float]]:
+        draw_count = int(np.sum(draw_targets == 1))
+        non_draw_count = int(np.sum(draw_targets == 0))
+        if draw_count <= 0:
+            return np.ones_like(draw_targets, dtype=float), {"non_draw": 1.0, "draw": 1.0}
+        positive_weight = min(
+            DRAW_BINARY_WEIGHT_CAP,
+            max(1.0, math.sqrt(float(non_draw_count) / float(draw_count))) * 1.2,
+        )
+        sample_weights = np.where(draw_targets == 1, positive_weight, 1.0).astype(float)
+        return sample_weights, {"non_draw": 1.0, "draw": float(positive_weight)}
+
+    def _predict_draw_probability(self, matrix: pd.DataFrame) -> np.ndarray:
+        if self.draw_classifier is None:
+            return np.full(len(matrix), np.nan, dtype=float)
+        probabilities = self.draw_classifier.predict_proba(matrix)
+        draw_classes = getattr(self.draw_classifier, "classes_", np.array([0, 1]))
+        draw_index = (
+            int(np.where(np.asarray(draw_classes) == 1)[0][0])
+            if 1 in draw_classes
+            else probabilities.shape[1] - 1
+        )
+        return np.asarray(probabilities[:, draw_index], dtype=float)
+
+    def _compose_outcome_probabilities(
+        self,
+        dataset_df: pd.DataFrame,
+        matrix: pd.DataFrame,
+        base_probabilities: np.ndarray,
+        predicted_score_a: np.ndarray,
+        predicted_score_b: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        prior_goal_a = (
+            pd.to_numeric(dataset_df.get("projected_goals_team_a"), errors="coerce")
+            .fillna(pd.Series(predicted_score_a))
+            .to_numpy(dtype=float)
+        )
+        prior_goal_b = (
+            pd.to_numeric(dataset_df.get("projected_goals_team_b"), errors="coerce")
+            .fillna(pd.Series(predicted_score_b))
+            .to_numpy(dtype=float)
+        )
+        expected_goals_a = np.clip(0.65 * predicted_score_a + 0.35 * prior_goal_a, 0.05, 6.0)
+        expected_goals_b = np.clip(0.65 * predicted_score_b + 0.35 * prior_goal_b, 0.05, 6.0)
+
+        poisson_probabilities = _poisson_outcome_probabilities(expected_goals_a, expected_goals_b)
+        raw_draw_model_probability = np.nan_to_num(
+            self._predict_draw_probability(matrix),
+            nan=base_probabilities[:, OUTCOME_DRAW],
+        )
+        draw_model_probability = np.clip(
+            self.draw_rate_prior
+            + DRAW_MODEL_SHRINK_FACTOR * (raw_draw_model_probability - self.draw_rate_prior),
+            0.01,
+            0.75,
+        )
+        stalemate_signal = (
+            pd.to_numeric(dataset_df.get("stalemate_signal"), errors="coerce")
+            .fillna(0.0)
+            .clip(0.0, 1.0)
+            .to_numpy(dtype=float)
+        )
+        expected_draw_environment = (
+            pd.to_numeric(dataset_df.get("expected_draw_environment"), errors="coerce")
+            .fillna(self.draw_rate_prior)
+            .clip(0.0, 1.0)
+            .to_numpy(dtype=float)
+        )
+        projected_total_goals = (
+            pd.to_numeric(dataset_df.get("projected_total_goals"), errors="coerce")
+            .fillna(pd.Series(expected_goals_a + expected_goals_b))
+            .clip(0.05, 8.0)
+            .to_numpy(dtype=float)
+        )
+
+        combined_draw_probability = (
+            0.2 * base_probabilities[:, OUTCOME_DRAW]
+            + 0.45 * poisson_probabilities[:, OUTCOME_DRAW]
+            + 0.15 * draw_model_probability
+            + 0.2 * np.maximum(expected_draw_environment, self.draw_rate_prior)
+        )
+        combined_draw_probability *= 0.85 + 0.3 * stalemate_signal
+        low_total_mask = projected_total_goals <= 2.25
+        combined_draw_probability[low_total_mask] *= 1.08
+        high_total_mask = projected_total_goals >= 3.25
+        combined_draw_probability[high_total_mask] *= 0.84
+        dynamic_draw_cap = np.where(
+            projected_total_goals <= 2.25,
+            0.42,
+            np.where(projected_total_goals <= 2.8, 0.36, 0.28),
+        )
+        combined_draw_probability = np.clip(combined_draw_probability, 0.01, dynamic_draw_cap)
+
+        win_probabilities = (
+            0.72 * base_probabilities[:, [OUTCOME_TEAM_A_WIN, OUTCOME_TEAM_B_WIN]]
+            + 0.28 * poisson_probabilities[:, [OUTCOME_TEAM_A_WIN, OUTCOME_TEAM_B_WIN]]
+        )
+        win_row_sums = win_probabilities.sum(axis=1, keepdims=True)
+        win_probabilities = np.divide(
+            win_probabilities,
+            win_row_sums,
+            out=np.full_like(win_probabilities, 0.5),
+            where=win_row_sums > 0,
+        )
+
+        combined = np.zeros_like(base_probabilities)
+        remaining_mass = 1.0 - combined_draw_probability
+        combined[:, OUTCOME_DRAW] = combined_draw_probability
+        combined[:, OUTCOME_TEAM_A_WIN] = win_probabilities[:, 0] * remaining_mass
+        combined[:, OUTCOME_TEAM_B_WIN] = win_probabilities[:, 1] * remaining_mass
+        combined = self._normalize_probabilities(combined)
+
+        draw_edge = np.max(combined[:, [OUTCOME_TEAM_A_WIN, OUTCOME_TEAM_B_WIN]], axis=1)
+        draw_trigger = (
+            (stalemate_signal >= 0.74)
+            & (projected_total_goals <= 2.15)
+            & (combined[:, OUTCOME_DRAW] + 0.02 >= draw_edge)
+        )
+        if np.any(draw_trigger):
+            combined[draw_trigger, OUTCOME_DRAW] = np.maximum(
+                combined[draw_trigger, OUTCOME_DRAW],
+                draw_edge[draw_trigger] + 1e-3,
+            )
+            combined = self._normalize_probabilities(combined)
+
+        return combined, poisson_probabilities, draw_model_probability
+
     def _build_evaluation_frame(
         self,
         test_df: pd.DataFrame,
@@ -556,6 +890,8 @@ class PointInTimeMatchModel:
         predicted_margin: np.ndarray,
         predicted_score_a: np.ndarray,
         predicted_score_b: np.ndarray,
+        poisson_probabilities: np.ndarray,
+        draw_model_probability: np.ndarray,
     ) -> pd.DataFrame:
         age_group_numeric = pd.to_numeric(test_df.get("age_group_numeric"), errors="coerce").fillna(0).astype(int)
         age_group = age_group_numeric.apply(lambda value: f"u{value}" if value > 0 else "unknown")
@@ -570,6 +906,20 @@ class PointInTimeMatchModel:
                 "prob_team_a_win": probabilities[:, OUTCOME_TEAM_A_WIN],
                 "prob_draw": probabilities[:, OUTCOME_DRAW],
                 "prob_team_b_win": probabilities[:, OUTCOME_TEAM_B_WIN],
+                "poisson_prob_team_a_win": poisson_probabilities[:, OUTCOME_TEAM_A_WIN],
+                "poisson_prob_draw": poisson_probabilities[:, OUTCOME_DRAW],
+                "poisson_prob_team_b_win": poisson_probabilities[:, OUTCOME_TEAM_B_WIN],
+                "draw_model_probability": draw_model_probability,
+                "stalemate_signal": (
+                    pd.to_numeric(test_df.get("stalemate_signal"), errors="coerce")
+                    .fillna(0.0)
+                    .to_numpy()
+                ),
+                "projected_total_goals": (
+                    pd.to_numeric(test_df.get("projected_total_goals"), errors="coerce")
+                    .fillna(0.0)
+                    .to_numpy()
+                ),
                 "predicted_margin": predicted_margin,
                 "actual_margin": test_df["actual_margin"].astype(float).to_numpy(),
                 "predicted_score_a": predicted_score_a,
@@ -608,6 +958,8 @@ class PointInTimeMatchModel:
 
         y_train = train_df["actual_outcome_label"].astype(int).to_numpy()
         y_test = test_df["actual_outcome_label"].astype(int).to_numpy()
+        class_balance = self._class_balance_summary(y_train)
+        self.draw_rate_prior = float(np.mean(y_train == OUTCOME_DRAW))
 
         unique_labels = sorted(np.unique(y_train).tolist())
         if len(unique_labels) < 2:
@@ -620,22 +972,40 @@ class PointInTimeMatchModel:
         label_to_encoded = {label: index for index, label in enumerate(self.class_labels)}
         y_train_encoded = np.array([label_to_encoded[label] for label in y_train], dtype=int)
 
-        self.classifier = self._build_classifier(random_state=random_state)
+        self.classifier = self._build_classifier(
+            random_state=random_state,
+            num_classes=len(self.class_labels),
+        )
+        self.draw_classifier = self._build_binary_classifier(random_state=random_state)
         self.margin_regressor = self._build_regressor(random_state=random_state)
         self.score_a_regressor = self._build_regressor(random_state=random_state)
         self.score_b_regressor = self._build_regressor(random_state=random_state)
+        class_sample_weights, named_class_weights = self._multiclass_sample_weights(y_train)
+        self.classifier.fit(X_train, y_train_encoded, sample_weight=class_sample_weights)
 
-        self.classifier.fit(X_train, y_train_encoded)
+        draw_targets_train = (y_train == OUTCOME_DRAW).astype(int)
+        draw_sample_weights, draw_weight_map = self._draw_sample_weights(draw_targets_train)
+        if np.any(draw_targets_train == 1) and np.any(draw_targets_train == 0):
+            self.draw_classifier.fit(X_train, draw_targets_train, sample_weight=draw_sample_weights)
+        else:
+            self.draw_classifier = None
         self.margin_regressor.fit(X_train, train_df["actual_margin"].astype(float))
         self.score_a_regressor.fit(X_train, train_df["actual_score_a"].astype(float))
         self.score_b_regressor.fit(X_train, train_df["actual_score_b"].astype(float))
 
         encoded_probabilities = self.classifier.predict_proba(X_test)
-        probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
-        predicted_labels = np.argmax(probabilities, axis=1)
+        base_probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
         predicted_margin = self.margin_regressor.predict(X_test)
         predicted_score_a = self.score_a_regressor.predict(X_test)
         predicted_score_b = self.score_b_regressor.predict(X_test)
+        probabilities, poisson_probabilities, draw_model_probability = self._compose_outcome_probabilities(
+            dataset_df=test_df,
+            matrix=X_test,
+            base_probabilities=base_probabilities,
+            predicted_score_a=predicted_score_a,
+            predicted_score_b=predicted_score_b,
+        )
+        predicted_labels = np.argmax(probabilities, axis=1)
         self.last_evaluation_frame = self._build_evaluation_frame(
             test_df=test_df,
             probabilities=probabilities,
@@ -643,6 +1013,8 @@ class PointInTimeMatchModel:
             predicted_margin=predicted_margin,
             predicted_score_a=predicted_score_a,
             predicted_score_b=predicted_score_b,
+            poisson_probabilities=poisson_probabilities,
+            draw_model_probability=draw_model_probability,
         )
 
         metrics = {
@@ -655,6 +1027,8 @@ class PointInTimeMatchModel:
             "draw_precision": float(np.mean(y_test[predicted_labels == OUTCOME_DRAW] == OUTCOME_DRAW))
             if np.any(predicted_labels == OUTCOME_DRAW)
             else None,
+            "actual_draw_rate": float(np.mean(y_test == OUTCOME_DRAW)),
+            "predicted_draw_rate": float(np.mean(predicted_labels == OUTCOME_DRAW)),
             "margin_mae": float(mean_absolute_error(test_df["actual_margin"], predicted_margin)),
             "margin_rmse": float(math.sqrt(mean_squared_error(test_df["actual_margin"], predicted_margin))),
             "score_a_mae": float(mean_absolute_error(test_df["actual_score_a"], predicted_score_a)),
@@ -663,6 +1037,9 @@ class PointInTimeMatchModel:
             "test_examples": int(len(test_df)),
             "class_labels": [OUTCOME_LABELS[label] for label in self.class_labels],
             "feature_count": int(len(self.feature_names)),
+            "training_class_balance": class_balance,
+            "multiclass_sample_weights": named_class_weights,
+            "draw_binary_sample_weights": draw_weight_map,
         }
 
         self.training_metadata = {
@@ -681,9 +1058,11 @@ class PointInTimeMatchModel:
 
         model = cls(model_dir=str(Path(artifact_path).resolve().parent))
         model.classifier = payload["classifier"]
+        model.draw_classifier = payload.get("draw_classifier")
         model.margin_regressor = payload["margin_regressor"]
         model.score_a_regressor = payload["score_a_regressor"]
         model.score_b_regressor = payload["score_b_regressor"]
+        model.draw_rate_prior = payload.get("draw_rate_prior", 0.0)
         model.feature_names = payload["feature_names"]
         model.class_labels = payload["class_labels"]
         model.training_metadata = payload.get("training_metadata", {})
@@ -694,11 +1073,18 @@ class PointInTimeMatchModel:
             raise ValueError("Model has not been trained or loaded")
         matrix = self._prepare_matrix(dataset_df)
         encoded_probabilities = self.classifier.predict_proba(matrix)
-        probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
-        predicted_labels = np.argmax(probabilities, axis=1)
+        base_probabilities = self._normalize_probabilities(self._expand_class_probabilities(encoded_probabilities))
         predicted_margin = self.margin_regressor.predict(matrix)
         predicted_score_a = self.score_a_regressor.predict(matrix)
         predicted_score_b = self.score_b_regressor.predict(matrix)
+        probabilities, poisson_probabilities, draw_model_probability = self._compose_outcome_probabilities(
+            dataset_df=dataset_df,
+            matrix=matrix,
+            base_probabilities=base_probabilities,
+            predicted_score_a=predicted_score_a,
+            predicted_score_b=predicted_score_b,
+        )
+        predicted_labels = np.argmax(probabilities, axis=1)
         return self._build_evaluation_frame(
             test_df=dataset_df,
             probabilities=probabilities,
@@ -706,6 +1092,8 @@ class PointInTimeMatchModel:
             predicted_margin=predicted_margin,
             predicted_score_a=predicted_score_a,
             predicted_score_b=predicted_score_b,
+            poisson_probabilities=poisson_probabilities,
+            draw_model_probability=draw_model_probability,
         )
 
     def write_evaluation_report(self, output_dir: str, prefix: str = "point_in_time_model") -> dict[str, object]:
@@ -731,9 +1119,11 @@ class PointInTimeMatchModel:
 
         payload = {
             "classifier": self.classifier,
+            "draw_classifier": self.draw_classifier,
             "margin_regressor": self.margin_regressor,
             "score_a_regressor": self.score_a_regressor,
             "score_b_regressor": self.score_b_regressor,
+            "draw_rate_prior": self.draw_rate_prior,
             "feature_names": self.feature_names,
             "class_labels": self.class_labels,
             "training_metadata": self.training_metadata,

--- a/tests/unit/test_point_in_time_match_model.py
+++ b/tests/unit/test_point_in_time_match_model.py
@@ -85,12 +85,17 @@ def test_build_point_in_time_dataset_is_chronological_and_mirrored():
     assert result.summary["games_seen"] == 3
     assert result.summary["games_used"] == 3
     assert result.summary["examples_built"] == 6
+    assert result.summary["class_counts"] == {"draw": 2, "team_a_win": 2, "team_b_win": 2}
+    assert result.summary["class_rates"]["draw"] == 2 / 6
     assert len(dataset) == 6
 
     first_original = dataset[(dataset["game_id"] == "g1") & (dataset["example_orientation"] == "original")].iloc[0]
     assert first_original["team_a_recent_form"] == 0.0
     assert first_original["team_b_recent_form"] == 0.0
     assert first_original["common_opponent_shared"] == 0.0
+    assert first_original["combined_draw_rate"] > 0.0
+    assert first_original["projected_total_goals"] > 0.0
+    assert 0.0 <= first_original["stalemate_signal"] <= 1.0
 
     g3_original = dataset[(dataset["game_id"] == "g3") & (dataset["example_orientation"] == "original")].iloc[0]
     g3_mirrored = dataset[(dataset["game_id"] == "g3") & (dataset["example_orientation"] == "mirrored")].iloc[0]
@@ -124,3 +129,57 @@ def test_build_point_in_time_dataset_skips_games_without_snapshot():
     result = build_point_in_time_dataset(games_df, snapshot_index=snapshot_index, include_mirrored_examples=True)
     assert result.dataset.empty
     assert result.summary["skipped_missing_snapshot"] == 1
+
+
+def test_build_point_in_time_dataset_tracks_draw_oriented_signals():
+    games_df = pd.DataFrame(
+        [
+            {
+                "id": "g1",
+                "game_date": "2026-04-02",
+                "home_team_master_id": "a",
+                "away_team_master_id": "b",
+                "home_score": 1,
+                "away_score": 1,
+            }
+        ]
+    )
+
+    snapshot_index = {
+        "a": [
+            _snapshot(
+                "2026-04-01",
+                "a",
+                draws=5,
+                games_played=12,
+                exp_goals_for=1.0,
+                exp_goals_against=0.9,
+                exp_margin=0.1,
+                exp_win_rate=0.52,
+            )
+        ],
+        "b": [
+            _snapshot(
+                "2026-04-01",
+                "b",
+                draws=4,
+                games_played=12,
+                exp_goals_for=0.95,
+                exp_goals_against=0.95,
+                exp_margin=0.05,
+                exp_win_rate=0.51,
+            )
+        ],
+    }
+
+    result = build_point_in_time_dataset(games_df, snapshot_index=snapshot_index, include_mirrored_examples=False)
+    row = result.dataset.iloc[0]
+
+    assert row["actual_outcome"] == "draw"
+    assert row["team_a_draw_rate"] > 0.3
+    assert row["team_b_draw_rate"] > 0.3
+    assert row["low_total_goal_signal"] > 0.0
+    assert row["goal_balance_signal"] > 0.0
+    assert row["snapshot_strength_closeness"] > 0.0
+    assert row["expected_draw_environment"] > 0.0
+    assert 0.0 <= row["stalemate_signal"] <= 1.0


### PR DESCRIPTION
## Summary
- add draw-oriented snapshot and matchup features to the point-in-time dataset builder
- add class weighting, a separate draw classifier, and Poisson-based outcome blending to the offline trainer
- expand trainer metrics/tests to report class balance and draw-rate behavior

## Verification
- python -m py_compile src/predictions/point_in_time_match_model.py
- python -m pytest tests/unit/test_point_in_time_match_model.py -q
- python -m ruff check src/predictions/point_in_time_match_model.py tests/unit/test_point_in_time_match_model.py
- python scripts/train_point_in_time_match_model.py --lookback-days 190 --min-examples 20 --model-dir models/point_in_time_match_predictor_multisnapshot_20260408_drawfix_v2 --save-dataset
- ='C:\PitchRank'; python scripts/calibrate_point_in_time_match_model.py --evaluation-csv models/point_in_time_match_predictor_multisnapshot_20260408_drawfix_v2/point_in_time_model_evaluation.csv --output-dir models/point_in_time_match_predictor_multisnapshot_20260408_drawfix_v2 --method temperature --prefix point_in_time_model_calibration