### PR TITLE
Optimize blog SEO from GA4/GSC analysis

### DIFF
--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -2,8 +2,10 @@ import { PageHeader } from '@/components/PageHeader';
 import { BlogContent } from '@/components/BlogContent';
 import { NewsletterSubscribe } from '@/components/NewsletterSubscribe';
 import { BlogPostSchema } from '@/components/BlogPostSchema';
+import { BlogFAQSchema } from '@/components/BlogFAQSchema';
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
 import { getBlogPost, getAllBlogSlugs } from '@/lib/blog';
+import { BLOG_FAQS } from '@/lib/blog-faqs';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { BASE_URL } from '@/lib/constants';
@@ -94,6 +96,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           { name: post.title, href: `/blog/${slug}` },
         ]}
       />
+      {BLOG_FAQS[slug] && <BlogFAQSchema faqs={BLOG_FAQS[slug]} />}
       <PageHeader title={post.title} description={post.excerpt} showBackButton backHref="/blog" />
 
       <div className="max-w-4xl mx-auto mt-8">

--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -197,6 +197,14 @@ export default async function StateOverviewPage({ params }: StateOverviewPagePro
               {girlsTeamCount > 0 && `${girlsTeamCount.toLocaleString()} Girls teams`} (U12 division)
             </p>
           )}
+          {!isNational && (
+            <p className="text-sm text-muted-foreground mt-2">
+              Part of{' '}
+              <Link href="/rankings" className="text-primary hover:underline font-medium">
+                77,000+ teams ranked nationally
+              </Link>
+            </p>
+          )}
         </div>
 
         {/* Age Group Grid */}

--- a/frontend/app/rankings/page.tsx
+++ b/frontend/app/rankings/page.tsx
@@ -1,10 +1,53 @@
+import type { Metadata } from 'next';
 import { RankingsPageContent } from '@/components/RankingsPageContent';
+import { BASE_URL } from '@/lib/constants';
 
 /**
  * Rankings landing page — server component for SEO.
  * Delegates all interactivity to RankingsPageContent (client component).
  * Default view: national, U12, male — matches the most common search intent.
  */
+
+export const metadata: Metadata = {
+  title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+  description:
+    'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday. Find where your team ranks.',
+  alternates: {
+    canonical: `${BASE_URL}/rankings`,
+  },
+  openGraph: {
+    title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+    description:
+      'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday.',
+    url: `${BASE_URL}/rankings`,
+    siteName: 'PitchRank',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+    description:
+      'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday.',
+  },
+};
+
+const rankingsSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Youth Soccer Rankings',
+  description:
+    'Comprehensive youth soccer rankings across all 50 states, covering 77,000+ teams in every age group from U10 to U19. Updated weekly with real game results.',
+  url: `${BASE_URL}/rankings`,
+};
+
 export default function RankingsPage() {
-  return <RankingsPageContent region="national" ageGroup="u12" gender="male" />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(rankingsSchema).replace(/</g, '\\u003c') }}
+      />
+      <RankingsPageContent region="national" ageGroup="u12" gender="male" />
+    </>
+  );
 }

--- a/frontend/components/BlogFAQSchema.tsx
+++ b/frontend/components/BlogFAQSchema.tsx
@@ -1,0 +1,35 @@
+/**
+ * Blog-specific FAQ Schema (Structured Data)
+ * Renders FAQPage JSON-LD for blog posts that have state-specific Q&A.
+ * Helps Google display FAQ rich results in search.
+ */
+
+import type { FAQ } from '@/lib/blog-faqs';
+
+interface BlogFAQSchemaProps {
+  faqs: FAQ[];
+}
+
+export function BlogFAQSchema({ faqs }: BlogFAQSchemaProps) {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
+      }}
+    />
+  );
+}

--- a/frontend/content/blog-posts.tsx
+++ b/frontend/content/blog-posts.tsx
@@ -1195,9 +1195,9 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'california-youth-soccer-rankings-guide',
-    title: 'California Youth Soccer Rankings 2026: 15,693 Teams Ranked by PowerScore',
+    title: 'California Youth Soccer Rankings 2026 — Updated Weekly | PitchRank',
     excerpt:
-      'Where does your California club rank? LA Galaxy Academy, San Diego Surf, and 15,691 more teams scored weekly from real game results. Free state and age-group rankings updated every Monday.',
+      'Find where your California club ranks among 15,693 teams. LA Galaxy, San Diego Surf, Beach FC and more — rated by PowerScore from real game results. Free rankings updated every Monday.',
     author: 'PitchRank Team',
     date: '2026-02-21',
     readingTime: '9 min read',
@@ -2379,9 +2379,9 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'texas-youth-soccer-rankings-guide',
-    title: 'Texas Youth Soccer Rankings 2026: 9,460 Teams Ranked by PowerScore',
+    title: 'Texas Youth Soccer Rankings 2026 — Updated Weekly | PitchRank',
     excerpt:
-      'See where your Texas club ranks—FC Dallas, Solar SC, Albion Hurricanes and 9,457 more teams scored weekly from real game results. Free state and age-group rankings updated every Monday.',
+      'Where does your Texas club rank? FC Dallas, Solar SC, Albion Hurricanes and 9,457 more teams rated by PowerScore from real game data. Free state and age-group rankings updated every Monday.',
     author: 'PitchRank Team',
     date: '2026-03-14',
     readingTime: '10 min read',

--- a/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
@@ -307,4 +307,4 @@ Because at the end of the day, rankings aren't about bragging rights. They're ab
 
 ---
 
-**About PitchRank:** We track youth soccer rankings across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Arizona team's ranking at [PitchRank.io](https://pitchrank.io).
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Arizona team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,225 @@
+---
+title: "Colorado Youth Soccer Rankings 2026 — Updated Weekly | PitchRank"
+slug: 'colorado-youth-soccer-rankings-guide'
+excerpt: "Find where your Colorado club ranks. Rapids Youth, Real Colorado, Colorado Storm and more — rated by PowerScore from real game results. Free rankings updated every Monday."
+author: 'PitchRank Team'
+date: '2026-04-08'
+readingTime: '9 min read'
+tags: ['Colorado', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'colorado youth soccer rankings',
+    'colorado soccer rankings',
+    'colorado soccer clubs',
+    'denver youth soccer',
+    'colorado soccer teams',
+  ]
+---
+
+# Colorado Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+Another tournament weekend in Commerce City is in the books. Your kid's team went 2-1, but you're left wondering: **How good is my child's team, really?**
+
+Is that U13 squad from Highlands Ranch actually better than the Aurora team you split games with? Should you be looking at Colorado Rapids Youth or sticking with your current club? And do those rankings you see online mean anything?
+
+If you've searched "Colorado soccer rankings" and come up empty, you're not alone. Here's everything Colorado parents need to know about youth soccer rankings in 2026.
+
+## Why Colorado Soccer Rankings Matter
+
+Colorado's youth soccer scene punches well above its weight. With year-round competitive play at altitude, a strong pipeline to college programs, and MLS Next/ECNL presence, the state produces serious talent. We're tracking **thousands of Colorado teams** from U9 recreational squads to U19 elite players heading to college.
+
+Rankings give you three things traditional league standings can't:
+
+1. **Context beyond your league** — Your team might dominate the Front Range league, but how do they stack up against clubs from Colorado Springs or Boulder?
+2. **Informed club decisions** — When your child outgrows their current team, rankings help identify the right level of competition
+3. **Realistic college planning** — If college soccer is the goal, you need to know where your team truly ranks
+
+> **See where your team stands now:** [View all Colorado youth soccer rankings](/rankings/co)
+
+## The Colorado Youth Soccer Landscape
+
+### Major Colorado Soccer Clubs
+
+Based on our database, here are some of the largest youth soccer organizations in Colorado:
+
+- **Colorado Rapids Youth Soccer** — The MLS club's academy and development pipeline
+- **Real Colorado** — One of the state's premier competitive programs
+- **Colorado Storm** — Established club with strong results across age groups
+- **Colorado Rush** — Part of the national Rush Soccer network
+- **Pride Soccer Club** — Growing competitive presence along the Front Range
+- **Arsenal Colorado** — Competitive club with multiple locations
+- **Colorado United FC** — Serving communities across the Denver metro
+- **Boulder County Force** — Northern Colorado's competitive hub
+
+These clubs compete in various leagues — from local recreational leagues to ECNL, MLS Next, NPL, and the Colorado State Cup run by [Colorado Soccer Association](https://www.coloradosoccer.org/).
+
+### Geographic Soccer Regions in Colorado
+
+Colorado soccer is shaped by geography more than most states:
+
+- **Denver Metro** (Denver, Littleton, Aurora, Highlands Ranch) — Highest concentration of elite clubs, multiple indoor facilities for year-round training
+- **Colorado Springs** — Strong military community drives competitive programs; Switchbacks FC youth connection
+- **Boulder/Fort Collins** — College town influence brings quality coaching; university facilities available
+- **Mountain Communities** (Vail, Aspen, Summit County) — Smaller programs with altitude training advantages and unique travel challenges
+
+## How Colorado Soccer Rankings Actually Work
+
+### What PitchRank Tracks for Colorado Teams
+
+Most ranking systems only count tournament games or require clubs to self-report results. That creates blind spots — and rankings that favor clubs with bigger marketing budgets.
+
+PitchRank is different. We track:
+
+- **Every game we can find** — League play, tournaments, friendlies, showcases
+- **Game-by-game results** across all Colorado teams
+- **11 age groups** from U9 through U19
+- **Opponent strength** — Beating Rapids Youth's top U15 team means more than beating a developmental squad
+
+### How Rankings Are Calculated (Simply)
+
+1. **Base score** — Wins, losses, draws, and goal differential give us a starting point
+2. **Strength of schedule** — We adjust based on your opponents' quality (beating strong teams boosts your ranking; losing to weak teams hurts)
+3. **Recency** — Games from last month matter more than games from 10 months ago
+4. **Consistency** — Teams that perform steadily rank higher than teams with wild swings
+
+The result? A **PowerScore between 0.0 and 1.0** where:
+
+- **0.85+** = Elite national-level team
+- **0.70-0.84** = Top competitive tier
+- **0.50-0.69** = Solid competitive team
+- **0.30-0.49** = Developing/mid-level
+- **Below 0.30** = Recreational or limited data
+
+## What Your Colorado Team's Ranking Really Means
+
+### Understanding State vs National Rankings
+
+- **State rank** — Where your team stands among all Colorado teams
+- **National rank** — Where you stand among all teams in your age group nationally
+
+**Reality check:** Being top 50 in Colorado is genuinely good. Being top 500 nationally is excellent. Being top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in Colorado isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — More teams exist at certain age levels
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [Colorado soccer rankings](/rankings/co).
+
+## Colorado's Altitude Advantage
+
+One thing that makes Colorado youth soccer unique: **altitude training at 5,280+ feet**. This isn't just trivia — it has real effects on rankings.
+
+Colorado teams that train at elevation develop superior cardiovascular fitness. When they travel to sea-level tournaments in Texas, California, or the Southeast, that fitness edge shows up in second halves and late-game results.
+
+This means:
+
+- Colorado teams often perform above expectations at national tournaments
+- Spring and summer rankings tend to be strongest (post-altitude training block)
+- Out-of-state opponents visiting Colorado may underperform, boosting home team results
+
+The algorithm doesn't adjust for altitude — it doesn't need to. The results speak for themselves.
+
+## How to Use Colorado Soccer Rankings When Choosing a Club
+
+### The Right Questions to Ask Club Directors
+
+When you're evaluating Rapids Youth vs Real Colorado vs Colorado Storm, ask:
+
+1. **"How do you use rankings in player development?"** — Good answer: "We track them to ensure competitive balance." Bad answer: "Rankings are all that matter."
+2. **"What's the average ranking of teams you play?"** — This reveals if they're scheduling appropriately challenging competition
+3. **"How have your team's rankings trended over the past year?"** — Upward trends suggest good development
+4. **"How do your Colorado rankings compare to teams in Texas or California we might face in regionals?"** — National context matters
+
+### Red Flags in Colorado's Competitive Soccer Scene
+
+Watch out for:
+
+- **Cherry-picking opponents** — Teams that only play lower-ranked teams to boost records
+- **Wild ranking swings** — Could indicate inconsistent coaching or roster instability
+- **No ranking at all** — Newer programs or teams avoiding competitive schedules
+- **Ranking guarantees** — No legitimate club can promise specific rankings
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked team. It's the team that:
+
+- Plays opponents 10-20 ranking positions above AND below them
+- Gives your child meaningful playing time (30+ minutes per game)
+- Challenges them without crushing their confidence
+- Aligns with your family's travel and financial capacity
+
+## Using PitchRank to Track Colorado Soccer Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your team by club name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift constantly. Check weekly to see how wins and losses affect your team's standing and whether your competition is getting stronger.
+
+> **Ready to check?** [See all Colorado youth soccer rankings](/rankings/co)
+
+## Common Colorado Soccer Ranking Questions
+
+### "My team dominates our local league but has a mediocre ranking. Why?"
+
+You're likely playing weaker competition. Rankings adjust for opponent strength, so beating weaker teams by 5 goals doesn't boost your ranking as much as narrowly beating a strong team.
+
+**Action:** Ask your coach to schedule tougher friendlies or move to a more competitive league.
+
+### "We lost to a lower-ranked team. Did that hurt us badly?"
+
+Depends on the context. If it's an isolated upset, rankings are forgiving. If you're consistently losing to lower-ranked teams, that's a pattern that will drop your ranking.
+
+### "Should my U11 player be on the highest-ranked team possible?"
+
+**No.** At U11, development and playing time matter way more than rankings. Put them on a team where they'll get 50+ minutes per game, not a top-ranked team where they'll sit the bench.
+
+### "How often do Colorado soccer rankings update?"
+
+PitchRank updates rankings every Monday morning with the latest game results.
+
+### "Can my club game the rankings by only playing weak teams?"
+
+No. Our algorithm detects this and penalizes teams that avoid strong competition. You can't fake strength of schedule.
+
+## The Honest Truth About Rankings and College Recruiting
+
+### The Reality Check
+
+- **Division I recruiting** — Coaches notice teams ranked in the **top 5% nationally**
+- **Division II recruiting** — Top 15-20% nationally gets attention, but individual performance matters more
+- **Division III recruiting** — Rankings barely matter; coaches focus on academics, character, and fit
+
+### What Actually Matters More
+
+College coaches prioritize:
+
+1. **Individual video** — Highlight reels of YOUR child
+2. **Academic eligibility** — GPA and test scores filter out players before rankings ever matter
+3. **Showcase attendance** — Colorado Cup, regional events, and national showcases where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+**Colorado's advantage:** Strong in-state college programs (Denver, Air Force, Colorado College, Colorado School of Mines) plus proximity to schools across the Mountain West. Use rankings to identify which Colorado clubs consistently place players in college.
+
+## Take Action: Check Your Colorado Team's Ranking
+
+1. Visit **[PitchRank.io](https://pitchrank.io)**
+2. Search for your club and age group
+3. Compare against your competition
+4. Track your team's progress throughout the season
+
+Whether your child plays for Colorado Rapids Youth, Real Colorado, Colorado Storm, or your local recreational club — [see where they rank in Colorado](/rankings/co) and make informed decisions about their soccer future.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Colorado team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,208 @@
+---
+title: "Michigan Youth Soccer Rankings 2026 — Updated Weekly | PitchRank"
+slug: 'michigan-youth-soccer-rankings-guide'
+excerpt: "Find where your Michigan club ranks among thousands of teams. Michigan Hawks, Vardar, DCFC and more — rated by PowerScore from real game results. Free rankings updated every Monday."
+author: 'PitchRank Team'
+date: '2026-04-08'
+readingTime: '9 min read'
+tags: ['Michigan', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'michigan youth soccer rankings',
+    'michigan soccer rankings',
+    'michigan soccer clubs',
+    'detroit youth soccer',
+    'michigan soccer teams',
+  ]
+---
+
+# Michigan Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+Your kid just wrapped up another weekend of games at Total Sports in Wixom. The team went 2-1 in league play. But here's the question every Michigan soccer parent asks: **How good is my child's team, really?**
+
+Is that U13 squad from Ann Arbor actually better than the Troy team you split games with? Should you be looking at Vardar or sticking with your current club? And what do those rankings you find online actually _mean_?
+
+If you've searched "Michigan soccer rankings" and felt more confused than when you started, you're not alone. Here's everything Michigan parents need to know about youth soccer rankings in 2026.
+
+## Why Michigan Soccer Rankings Matter
+
+Michigan's youth soccer scene is deep — and getting deeper. We're tracking **thousands of teams across the state** from U9 recreational squads to U19 elite players headed to college. That's Michigan Hawks, Vardar, Detroit City FC Youth, Crew SC, Michigan Wolves, and hundreds more clubs competing across 11 age groups.
+
+Rankings give you three things traditional league standings can't:
+
+1. **Context beyond your league** — Your team might dominate the West Michigan league, but how do they stack up against clubs from Metro Detroit?
+2. **Informed club decisions** — When your child outgrows their current team, rankings help identify the right level of competition
+3. **Realistic college planning** — If college soccer is the goal, you need to know where your team truly ranks
+
+> **See where your team stands now:** [View all Michigan youth soccer rankings](/rankings/mi)
+
+## The Michigan Youth Soccer Landscape
+
+### Major Michigan Soccer Clubs
+
+Based on our database, here are some of the largest youth soccer organizations in Michigan:
+
+- **Michigan Hawks** — One of the state's most recognized competitive programs
+- **Vardar SC** — Perennial powerhouse in Michigan youth soccer
+- **Detroit City FC Youth** — Growing rapidly with professional club backing
+- **Crew SC** — Strong presence across multiple age groups
+- **Michigan Wolves** — Established competitive club with deep roots
+- **FC Alliance** — Rising program in West Michigan
+- **Rush Michigan** — Part of the national Rush Soccer network
+- **Waza FC** — Metro Detroit futsal and outdoor program
+
+These clubs compete in various leagues — from local recreational leagues to ECNL, MLS Next, NPL, and the Michigan State Cup run by [Michigan State Youth Soccer Association](https://www.michiganyouthsoccer.org/).
+
+### Geographic Soccer Regions in Michigan
+
+Michigan soccer isn't monolithic. The competitive landscape varies by region:
+
+- **Metro Detroit** (Troy, Livonia, Novi, Ann Arbor) — Highest concentration of elite clubs and year-round indoor facilities
+- **West Michigan** (Grand Rapids, Kalamazoo) — Growing competitive scene with strong regional programs
+- **Mid-Michigan** (Lansing, East Lansing) — College town influence drives quality coaching
+- **Northern Michigan** — Smaller but passionate programs with unique seasonal challenges
+
+## How Michigan Soccer Rankings Actually Work
+
+### What PitchRank Tracks for Michigan Teams
+
+Most ranking systems only count tournament games or require clubs to self-report results. That creates blind spots — and rankings that favor clubs with bigger marketing budgets.
+
+PitchRank is different. We track:
+
+- **Every game we can find** — League play, tournaments, friendlies, showcases
+- **Game-by-game results** across all Michigan teams
+- **11 age groups** from U9 through U19
+- **Opponent strength** — Beating Vardar's top U15 team means more than beating a developmental squad
+
+### How Rankings Are Calculated (Simply)
+
+1. **Base score** — Wins, losses, draws, and goal differential give us a starting point
+2. **Strength of schedule** — We adjust based on your opponents' quality (beating strong teams boosts your ranking; losing to weak teams hurts)
+3. **Recency** — Games from last month matter more than games from 10 months ago
+4. **Consistency** — Teams that perform steadily rank higher than teams with wild swings
+
+The result? A **PowerScore between 0.0 and 1.0** where:
+
+- **0.85+** = Elite national-level team
+- **0.70-0.84** = Top competitive tier
+- **0.50-0.69** = Solid competitive team
+- **0.30-0.49** = Developing/mid-level
+- **Below 0.30** = Recreational or limited data
+
+## What Your Michigan Team's Ranking Really Means
+
+### Understanding State vs National Rankings
+
+- **State rank** — Where your team stands among all Michigan teams
+- **National rank** — Where you stand among all teams in your age group nationally
+
+**Reality check:** Being top 50 in Michigan is genuinely good. Being top 500 nationally is excellent. Being top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in Michigan isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — More teams exist at certain age levels
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [Michigan soccer rankings](/rankings/mi).
+
+## How to Use Michigan Soccer Rankings When Choosing a Club
+
+Rankings are one tool in your decision-making toolbox. Here's how to use them wisely.
+
+### The Right Questions to Ask Club Directors
+
+When you're evaluating Michigan Hawks vs Vardar vs Crew SC, ask:
+
+1. **"How do you use rankings in player development?"** — Good answer: "We track them to ensure competitive balance." Bad answer: "Rankings are all that matter."
+2. **"What's the average ranking of teams you play?"** — This reveals if they're scheduling appropriately challenging competition
+3. **"How have your team's rankings trended over the past year?"** — Upward trends suggest good development
+4. **"How do your Michigan rankings compare to teams in Ohio or Indiana we might face in regionals?"** — National context matters
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked team. It's the team that:
+
+- Plays opponents 10-20 ranking positions above AND below them
+- Gives your child meaningful playing time (30+ minutes per game)
+- Challenges them without crushing their confidence
+- Aligns with your family's travel and financial capacity
+
+## Michigan's Indoor Advantage
+
+One thing that makes Michigan unique: **indoor soccer season**. While southern states play year-round outdoors, Michigan teams get months of high-intensity indoor play that develops tight ball skills and quick decision-making.
+
+This shows up in rankings — Michigan teams that train indoors through winter often surge in spring rankings as those indoor skills translate to outdoor play. Don't be discouraged by mid-winter ranking dips. Spring is when Michigan teams show what they're made of.
+
+## Using PitchRank to Track Michigan Soccer Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your team by club name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift constantly. Check weekly to see how wins and losses affect your team's standing and whether your competition is getting stronger.
+
+> **Ready to check?** [See all Michigan youth soccer rankings](/rankings/mi)
+
+## Common Michigan Soccer Ranking Questions
+
+### "My team dominates our local league but has a mediocre ranking. Why?"
+
+You're likely playing weaker competition. Rankings adjust for opponent strength, so beating weaker teams by 5 goals doesn't boost your ranking as much as narrowly beating a strong team.
+
+### "We lost to a lower-ranked team. Did that hurt us badly?"
+
+Depends on the context. If it's an isolated upset, rankings are forgiving. If you're consistently losing to lower-ranked teams, that's a pattern that will drop your ranking.
+
+### "Should my U11 player be on the highest-ranked team possible?"
+
+**No.** At U11, development and playing time matter more than rankings. Put them on a team where they'll get 50+ minutes per game, not a top-ranked team where they'll sit the bench.
+
+### "How often do Michigan soccer rankings update?"
+
+PitchRank updates rankings every Monday morning with the latest game results.
+
+### "Can my club game the rankings by only playing weak teams?"
+
+No. Our algorithm detects this and penalizes teams that avoid strong competition. You can't fake strength of schedule.
+
+## The Honest Truth About Rankings and College Recruiting
+
+### The Reality Check
+
+- **Division I recruiting** — Coaches notice teams ranked in the **top 5% nationally**
+- **Division II recruiting** — Top 15-20% nationally gets attention, but individual performance matters more
+- **Division III recruiting** — Rankings barely matter; coaches focus on academics, character, and fit
+
+### What Actually Matters More
+
+College coaches prioritize:
+
+1. **Individual video** — Highlight reels of YOUR child
+2. **Academic eligibility** — GPA and test scores filter out players before rankings ever matter
+3. **Showcase attendance** — Midwest Regional League, ECNL playoffs, and national events where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+**Michigan's advantage:** Proximity to Big Ten, MAC, and GLIAC schools means access to top college programs. Use rankings to identify which Michigan clubs consistently place players in college.
+
+## Take Action: Check Your Michigan Team's Ranking
+
+1. Visit **[PitchRank.io](https://pitchrank.io)**
+2. Search for your club and age group
+3. Compare against your competition
+4. Track your team's progress throughout the season
+
+Whether your child plays for Michigan Hawks, Vardar, Detroit City FC, or your local recreational club — [see where they rank in Michigan](/rankings/mi) and make informed decisions about their soccer future.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Michigan team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/what-predicts-winning-beyond-goals.mdx
+++ b/frontend/content/blog/what-predicts-winning-beyond-goals.mdx
@@ -163,7 +163,7 @@ That's what we're building. And the data is getting more accurate every week.
 
 ## See Where Your Team Ranks
 
-Curious how your child's team is ranked using PitchRank's PowerScore methodology? Search for your team at [PitchRank.io](https://pitchrank.io) — we rank teams across all age groups, in all 50 states, using the same SOS-weighted, efficiency-adjusted model described in this post.
+Curious how your child's team is ranked using PitchRank's PowerScore methodology? Check our [youth soccer rankings](/rankings) — we rank teams across all age groups, in all 50 states, using the same SOS-weighted, efficiency-adjusted model described in this post.
 
 If you have questions about how a specific team's ranking was calculated, or why a team with a great record sits lower than expected (or vice versa), the answer is almost always in the schedule. Check who they played.
 

--- a/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
+++ b/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
@@ -204,4 +204,6 @@ In 2017, U.S. Soccer mandated a January 1 – December 31 cutoff to align with F
 
 ---
 
+**Check where your team stands after the transition:** [View youth soccer rankings](/rankings) across all states and age groups, updated weekly.
+
 _Sources: [US Club Soccer](https://usclubsoccer.org/age-group-cut-off-update-for-2026-27-season/), [US Youth Soccer](https://www.usyouthsoccer.org/news/2025/06/10/updated-decision-on-age-group-formation/), [U.S. Soccer](https://www.ussoccer.com/ecosystem-review/player-registration), [MLS NEXT](https://www.mlssoccer.com/mlsnext/news/mls-next-announces-age-group-update), [Girls Academy](https://girlsacademyleague.com/2025/09/girls-academy-to-adopt-seasonal-year-age-group-formation-beginning-in-2026-2027/)_

--- a/frontend/content/blog/youth-soccer-tryouts-2026.mdx
+++ b/frontend/content/blog/youth-soccer-tryouts-2026.mdx
@@ -197,7 +197,7 @@ Look at the coach first, the club second, and the league third. A great coach at
 
 ### Is ECNL or MLS NEXT better for my child?
 
-There's no universal answer. In some states and age groups, ECNL teams dominate. In others, MLS NEXT clubs are stronger. The only way to know is to compare the specific teams available to your child at their age group in your area. [PitchRank](https://pitchrank.io) ranks teams across all leagues using the same algorithm — check where the clubs you're considering actually stand.
+There's no universal answer. In some states and age groups, ECNL teams dominate. In others, MLS NEXT clubs are stronger. The only way to know is to compare the specific teams available to your child at their age group in your area. Our [youth soccer rankings](/rankings) cover all leagues using the same algorithm — check where the clubs you're considering actually stand.
 
 ### How much does club soccer really cost?
 

--- a/frontend/lib/blog-faqs.ts
+++ b/frontend/lib/blog-faqs.ts
@@ -1,0 +1,148 @@
+/**
+ * FAQ data for state-specific blog posts.
+ * Used to render FAQPage structured data for rich snippet eligibility.
+ * Keyed by blog post slug.
+ */
+
+export interface FAQ {
+  question: string;
+  answer: string;
+}
+
+export const BLOG_FAQS: Record<string, FAQ[]> = {
+  'texas-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Texas youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Texas teams using a PowerScore algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 9,460+ Texas teams.',
+    },
+    {
+      question: 'How many youth soccer teams are ranked in Texas?',
+      answer:
+        'PitchRank tracks over 9,460 youth soccer teams in Texas across all age groups from U10 to U19, including FC Dallas, Solar SC, Albion Hurricanes, Lonestar, Challenge SC, and hundreds more clubs.',
+    },
+    {
+      question: 'How often are Texas soccer rankings updated?',
+      answer:
+        'Texas youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'What is a good PowerScore for a Texas youth soccer team?',
+      answer:
+        'A PowerScore of 0.85+ is elite/national-level, 0.70-0.84 is top competitive tier, 0.50-0.69 is solid competitive, and 0.30-0.49 is developing. Scores are on a 0.0 to 1.0 scale.',
+    },
+    {
+      question: 'Can Texas youth soccer rankings help with college recruiting?',
+      answer:
+        'Rankings provide context for college coaches evaluating players. Division I coaches notice teams in the top 5% nationally, while Division II looks at the top 15-20%. However, individual highlight video, academics, and showcase attendance matter more than team rankings alone.',
+    },
+  ],
+  'california-youth-soccer-rankings-guide': [
+    {
+      question: 'How are California youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks California teams using a PowerScore algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 15,693+ California teams.',
+    },
+    {
+      question: 'How many youth soccer teams are ranked in California?',
+      answer:
+        'PitchRank tracks over 15,693 youth soccer teams in California — more than any other state. This includes LA Galaxy Academy, San Diego Surf, Beach FC, and hundreds more clubs across all age groups from U10 to U19.',
+    },
+    {
+      question: 'How often are California soccer rankings updated?',
+      answer:
+        'California youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'What is a good PowerScore for a California youth soccer team?',
+      answer:
+        "A PowerScore of 0.85+ is elite/national-level, 0.70-0.84 is top competitive tier, 0.50-0.69 is solid competitive, and 0.30-0.49 is developing. Given California's depth of competition, even a 0.60 is impressive.",
+    },
+    {
+      question: 'How do California youth soccer rankings compare to other states?',
+      answer:
+        'California has the most ranked teams of any state (15,693+). Cross-state comparison works through tournaments and national events that connect California teams to the rest of the country, creating a nationally interconnected ranking ecosystem.',
+    },
+  ],
+  'michigan-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Michigan youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Michigan teams using a PowerScore algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in Michigan?',
+      answer:
+        'Major Michigan youth soccer clubs include Michigan Hawks, Vardar SC, Detroit City FC Youth, Crew SC, Michigan Wolves, FC Alliance, and Rush Michigan. Rankings vary by age group — check PitchRank for current standings.',
+    },
+    {
+      question: 'How often are Michigan soccer rankings updated?',
+      answer:
+        'Michigan youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'What is a good PowerScore for a Michigan youth soccer team?',
+      answer:
+        'A PowerScore of 0.85+ is elite/national-level, 0.70-0.84 is top competitive tier, 0.50-0.69 is solid competitive, and 0.30-0.49 is developing. Scores are on a 0.0 to 1.0 scale.',
+    },
+    {
+      question: 'Does indoor soccer season affect Michigan rankings?',
+      answer:
+        'Indoor season can cause mid-winter ranking dips since fewer outdoor games are tracked. However, Michigan teams often surge in spring rankings as indoor training translates to improved outdoor performance.',
+    },
+  ],
+  'colorado-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Colorado youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Colorado teams using a PowerScore algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in Colorado?',
+      answer:
+        'Major Colorado youth soccer clubs include Colorado Rapids Youth, Real Colorado, Colorado Storm, Colorado Rush, and Pride Soccer Club. Rankings vary by age group — check PitchRank for current standings.',
+    },
+    {
+      question: 'How often are Colorado soccer rankings updated?',
+      answer:
+        'Colorado youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'What is a good PowerScore for a Colorado youth soccer team?',
+      answer:
+        'A PowerScore of 0.85+ is elite/national-level, 0.70-0.84 is top competitive tier, 0.50-0.69 is solid competitive, and 0.30-0.49 is developing. Scores are on a 0.0 to 1.0 scale.',
+    },
+    {
+      question: 'Does altitude affect Colorado soccer rankings?',
+      answer:
+        'Altitude itself does not directly factor into rankings. However, Colorado teams that train at elevation often have a fitness advantage in tournaments at lower altitudes, which can lead to better results and higher rankings over time.',
+    },
+  ],
+  'arizona-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Arizona youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Arizona teams using a PowerScore algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 1,940+ Arizona teams.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in Arizona?',
+      answer:
+        'Major Arizona youth soccer clubs include Phoenix Rising FC, CCV Stars, FBSL, Arizona Arsenal, RSL Arizona (South, North, Southern divisions), Next Level Soccer AZ, and FC Tucson. Rankings vary by age group.',
+    },
+    {
+      question: 'How often are Arizona soccer rankings updated?',
+      answer:
+        'Arizona youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'What is a good PowerScore for an Arizona youth soccer team?',
+      answer:
+        'A PowerScore of 0.85+ is elite/national-level, 0.70-0.84 is top competitive tier, 0.50-0.69 is solid competitive, and 0.30-0.49 is developing. Scores are on a 0.0 to 1.0 scale.',
+    },
+    {
+      question: 'How does Arizona compare to California and Texas in youth soccer?',
+      answer:
+        "Arizona has 1,940+ ranked teams compared to California (15,693+) and Texas (9,460+). While smaller in volume, Arizona's top clubs compete nationally. Cross-state tournaments connect Arizona teams to the broader national ranking ecosystem.",
+    },
+  ],
+};

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -47,11 +47,6 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
-        source: '/blog/michigan-youth-soccer-rankings-guide',
-        destination: '/rankings/mi',
-        permanent: true,
-      },
-      {
         source: '/blog/2026-03-31-california-youth-soccer-rankings',
         destination: '/blog/california-youth-soccer-rankings-guide',
         permanent: true,


### PR DESCRIPTION
## Summary
- **Blog CTR optimization**: Rewrote title tags and meta descriptions for TX/CA blog guides to improve click-through rates (currently 2-3% vs 5%+ expected at their positions)
- **FAQ schema**: Added FAQPage structured data (JSON-LD) to all state blog posts for Google rich snippet eligibility
- **New content**: Created Colorado and Michigan youth soccer rankings guides targeting uncontested keywords
- **Rankings page SEO**: Added metadata, OpenGraph, and CollectionPage schema to `/rankings` (previously had zero SEO metadata)
- **Internal linking**: Added contextual links to `/rankings` from all blog posts and state overview pages to boost the "youth soccer rankings" head term

## Context
GSC data showed:
- TX blog: 497 impressions, 2.4% CTR at position 7.1
- CA blog: 307 impressions, 1.6% CTR at position 7.4  
- "colorado youth soccer rankings": 19 impressions, 0 clicks, position 6.6
- /rankings page: 379 impressions, 4.75% CTR, position 19.5

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Next.js build succeeds
- [x] Prettier + ESLint pass
- [ ] Verify blog posts render correctly on preview deploy
- [ ] Validate FAQ schema with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)