### PR TITLE
Add seeding-focused match evaluation metrics

### DIFF
--- a/src/predictions/evaluation_reporting.py
+++ b/src/predictions/evaluation_reporting.py
@@ -23,6 +23,8 @@ OUTCOME_ALIASES = {
     "team_b": "team_b",
     "team_b_win": "team_b",
 }
+BLOWOUT_THRESHOLDS = (3, 5)
+COMPETITIVE_MARGIN_MAX = 1.0
 
 
 def _normalize_probabilities(frame: pd.DataFrame) -> pd.DataFrame:
@@ -53,6 +55,12 @@ def _brier_score(probabilities: np.ndarray, labels: np.ndarray) -> float:
     return float(np.mean(np.sum((probabilities - one_hot) ** 2, axis=1)))
 
 
+def _numeric_column(frame: pd.DataFrame, column_name: str) -> pd.Series:
+    if column_name not in frame.columns:
+        return pd.Series(np.nan, index=frame.index, dtype=float)
+    return pd.to_numeric(frame[column_name], errors="coerce")
+
+
 def build_standardized_evaluation_frame(frame: pd.DataFrame) -> pd.DataFrame:
     if frame.empty:
         return frame.copy()
@@ -71,10 +79,43 @@ def build_standardized_evaluation_frame(frame: pd.DataFrame) -> pd.DataFrame:
     )
     standardized["top_probability"] = standardized[list(PROBABILITY_COLUMNS.values())].max(axis=1)
     standardized["correct_prediction"] = standardized["actual_outcome"] == standardized["predicted_outcome"]
-    standardized["margin_error"] = pd.to_numeric(standardized["predicted_margin"], errors="coerce").fillna(0.0) - (
-        pd.to_numeric(standardized["actual_margin"], errors="coerce").fillna(0.0)
-    )
+    predicted_margin = _numeric_column(standardized, "predicted_margin").fillna(0.0)
+    actual_margin = _numeric_column(standardized, "actual_margin").fillna(0.0)
+    standardized["predicted_margin"] = predicted_margin
+    standardized["actual_margin"] = actual_margin
+    standardized["margin_error"] = predicted_margin - actual_margin
     standardized["abs_margin_error"] = standardized["margin_error"].abs()
+    standardized["predicted_abs_margin"] = predicted_margin.abs()
+    standardized["actual_abs_margin"] = actual_margin.abs()
+
+    predicted_score_a = _numeric_column(standardized, "predicted_score_a")
+    predicted_score_b = _numeric_column(standardized, "predicted_score_b")
+    actual_score_a = _numeric_column(standardized, "actual_score_a")
+    actual_score_b = _numeric_column(standardized, "actual_score_b")
+    standardized["predicted_score_a"] = predicted_score_a
+    standardized["predicted_score_b"] = predicted_score_b
+    standardized["actual_score_a"] = actual_score_a
+    standardized["actual_score_b"] = actual_score_b
+    standardized["predicted_score_a_rounded"] = predicted_score_a.round()
+    standardized["predicted_score_b_rounded"] = predicted_score_b.round()
+    standardized["score_a_error"] = predicted_score_a - actual_score_a
+    standardized["score_b_error"] = predicted_score_b - actual_score_b
+    standardized["abs_score_a_error"] = standardized["score_a_error"].abs()
+    standardized["abs_score_b_error"] = standardized["score_b_error"].abs()
+    standardized["predicted_total_goals"] = predicted_score_a + predicted_score_b
+    standardized["actual_total_goals"] = actual_score_a + actual_score_b
+    standardized["total_goals_error"] = standardized["predicted_total_goals"] - standardized["actual_total_goals"]
+    standardized["abs_total_goals_error"] = standardized["total_goals_error"].abs()
+    standardized["exact_score_hit"] = (
+        standardized["predicted_score_a_rounded"].eq(actual_score_a)
+        & standardized["predicted_score_b_rounded"].eq(actual_score_b)
+    )
+    standardized["score_within_one_goal_hit"] = (
+        standardized["predicted_score_a_rounded"].sub(actual_score_a).abs().le(1.0)
+        & standardized["predicted_score_b_rounded"].sub(actual_score_b).abs().le(1.0)
+    )
+    standardized["predicted_competitive_game"] = standardized["predicted_abs_margin"] <= COMPETITIVE_MARGIN_MAX
+    standardized["actual_competitive_game"] = standardized["actual_abs_margin"] <= COMPETITIVE_MARGIN_MAX
     return standardized
 
 
@@ -98,6 +139,9 @@ def compute_evaluation_summary(frame: pd.DataFrame) -> dict[str, object]:
     draw_mask = standardized["actual_outcome"] == "draw"
     predicted_draw_mask = standardized["predicted_outcome"] == "draw"
     margin_errors = standardized["margin_error"].to_numpy(dtype=float)
+    score_rows = standardized[
+        ["predicted_score_a", "predicted_score_b", "actual_score_a", "actual_score_b"]
+    ].notna().all(axis=1)
 
     summary: dict[str, object] = {
         "games": int(len(standardized)),
@@ -113,6 +157,59 @@ def compute_evaluation_summary(frame: pd.DataFrame) -> dict[str, object]:
         "margin_mae": float(np.mean(np.abs(margin_errors))),
         "margin_rmse": float(np.sqrt(np.mean(margin_errors**2))),
     }
+
+    if score_rows.any():
+        score_frame = standardized.loc[score_rows]
+        summary.update(
+            {
+                "score_a_mae": float(score_frame["abs_score_a_error"].mean()),
+                "score_b_mae": float(score_frame["abs_score_b_error"].mean()),
+                "total_goals_mae": float(score_frame["abs_total_goals_error"].mean()),
+                "exact_score_accuracy": float(score_frame["exact_score_hit"].mean()),
+                "score_within_one_goal_rate": float(score_frame["score_within_one_goal_hit"].mean()),
+            }
+        )
+    else:
+        summary.update(
+            {
+                "score_a_mae": None,
+                "score_b_mae": None,
+                "total_goals_mae": None,
+                "exact_score_accuracy": None,
+                "score_within_one_goal_rate": None,
+            }
+        )
+
+    actual_competitive_mask = standardized["actual_competitive_game"]
+    predicted_competitive_mask = standardized["predicted_competitive_game"]
+    summary["competitive_game_recall"] = (
+        float((standardized.loc[actual_competitive_mask, "predicted_competitive_game"]).mean())
+        if actual_competitive_mask.any()
+        else None
+    )
+    summary["competitive_game_precision"] = (
+        float((standardized.loc[predicted_competitive_mask, "actual_competitive_game"]).mean())
+        if predicted_competitive_mask.any()
+        else None
+    )
+    summary["actual_competitive_game_rate"] = float(actual_competitive_mask.mean())
+    summary["predicted_competitive_game_rate"] = float(predicted_competitive_mask.mean())
+
+    for threshold in BLOWOUT_THRESHOLDS:
+        actual_blowout_mask = standardized["actual_abs_margin"] >= float(threshold)
+        predicted_blowout_mask = standardized["predicted_abs_margin"] >= float(threshold)
+        summary[f"actual_blowout_{threshold}plus_rate"] = float(actual_blowout_mask.mean())
+        summary[f"predicted_blowout_{threshold}plus_rate"] = float(predicted_blowout_mask.mean())
+        summary[f"blowout_{threshold}plus_recall"] = (
+            float((standardized.loc[actual_blowout_mask, "predicted_abs_margin"] >= float(threshold)).mean())
+            if actual_blowout_mask.any()
+            else None
+        )
+        summary[f"blowout_{threshold}plus_precision"] = (
+            float((standardized.loc[predicted_blowout_mask, "actual_abs_margin"] >= float(threshold)).mean())
+            if predicted_blowout_mask.any()
+            else None
+        )
 
     if "feature_source" in standardized.columns:
         summary["feature_source_counts"] = (
@@ -182,6 +279,12 @@ def build_group_metrics(frame: pd.DataFrame, group_column: str) -> pd.DataFrame:
                 "brier_score": summary["brier_score"],
                 "margin_mae": summary["margin_mae"],
                 "margin_rmse": summary["margin_rmse"],
+                "total_goals_mae": summary.get("total_goals_mae"),
+                "exact_score_accuracy": summary.get("exact_score_accuracy"),
+                "competitive_game_recall": summary.get("competitive_game_recall"),
+                "competitive_game_precision": summary.get("competitive_game_precision"),
+                "blowout_3plus_recall": summary.get("blowout_3plus_recall"),
+                "blowout_3plus_precision": summary.get("blowout_3plus_precision"),
             }
         )
 
@@ -214,12 +317,55 @@ def build_outcome_metrics(frame: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
+def build_margin_band_metrics(frame: pd.DataFrame) -> pd.DataFrame:
+    standardized = build_standardized_evaluation_frame(frame)
+    if standardized.empty:
+        return pd.DataFrame()
+
+    rows = []
+    actual_competitive_mask = standardized["actual_competitive_game"]
+    predicted_competitive_mask = standardized["predicted_competitive_game"]
+    rows.append(
+        {
+            "band": "competitive_1plus",
+            "actual_rate": float(actual_competitive_mask.mean()),
+            "predicted_rate": float(predicted_competitive_mask.mean()),
+            "recall": float((standardized.loc[actual_competitive_mask, "predicted_competitive_game"]).mean())
+            if actual_competitive_mask.any()
+            else None,
+            "precision": float((standardized.loc[predicted_competitive_mask, "actual_competitive_game"]).mean())
+            if predicted_competitive_mask.any()
+            else None,
+        }
+    )
+
+    for threshold in BLOWOUT_THRESHOLDS:
+        actual_mask = standardized["actual_abs_margin"] >= float(threshold)
+        predicted_mask = standardized["predicted_abs_margin"] >= float(threshold)
+        rows.append(
+            {
+                "band": f"blowout_{threshold}plus",
+                "actual_rate": float(actual_mask.mean()),
+                "predicted_rate": float(predicted_mask.mean()),
+                "recall": float((standardized.loc[actual_mask, "predicted_abs_margin"] >= float(threshold)).mean())
+                if actual_mask.any()
+                else None,
+                "precision": float((standardized.loc[predicted_mask, "actual_abs_margin"] >= float(threshold)).mean())
+                if predicted_mask.any()
+                else None,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
 def write_evaluation_bundle(frame: pd.DataFrame, output_dir: Path, prefix: str = "benchmark") -> dict[str, object]:
     output_dir.mkdir(parents=True, exist_ok=True)
     standardized = build_standardized_evaluation_frame(frame)
     summary = compute_evaluation_summary(standardized)
     calibration_table = build_calibration_table(standardized)
     outcome_metrics = build_outcome_metrics(standardized)
+    margin_band_metrics = build_margin_band_metrics(standardized)
     age_metrics = build_group_metrics(standardized, "age_group")
     feature_source_metrics = build_group_metrics(standardized, "feature_source")
 
@@ -245,6 +391,26 @@ def write_evaluation_bundle(frame: pd.DataFrame, output_dir: Path, prefix: str =
         f"- Brier score: {summary['brier_score']:.4f}" if summary["brier_score"] is not None else "- Brier score: n/a",
         f"- Margin MAE: {summary['margin_mae']:.4f}" if summary["margin_mae"] is not None else "- Margin MAE: n/a",
         f"- Margin RMSE: {summary['margin_rmse']:.4f}" if summary["margin_rmse"] is not None else "- Margin RMSE: n/a",
+        (
+            f"- Total-goals MAE: {summary['total_goals_mae']:.4f}"
+            if summary["total_goals_mae"] is not None
+            else "- Total-goals MAE: n/a"
+        ),
+        (
+            f"- Exact score accuracy: {summary['exact_score_accuracy']:.4f}"
+            if summary["exact_score_accuracy"] is not None
+            else "- Exact score accuracy: n/a"
+        ),
+        (
+            f"- Competitive-game recall: {summary['competitive_game_recall']:.4f}"
+            if summary["competitive_game_recall"] is not None
+            else "- Competitive-game recall: n/a"
+        ),
+        (
+            f"- Blowout 3+ recall: {summary['blowout_3plus_recall']:.4f}"
+            if summary["blowout_3plus_recall"] is not None
+            else "- Blowout 3+ recall: n/a"
+        ),
     ]
     (output_dir / f"{prefix}_summary.md").write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")
 
@@ -252,6 +418,8 @@ def write_evaluation_bundle(frame: pd.DataFrame, output_dir: Path, prefix: str =
         calibration_table.to_csv(output_dir / f"{prefix}_calibration.csv", index=False)
     if not outcome_metrics.empty:
         outcome_metrics.to_csv(output_dir / f"{prefix}_outcomes.csv", index=False)
+    if not margin_band_metrics.empty:
+        margin_band_metrics.to_csv(output_dir / f"{prefix}_margin_bands.csv", index=False)
     if not age_metrics.empty:
         age_metrics.to_csv(output_dir / f"{prefix}_by_age.csv", index=False)
     if not feature_source_metrics.empty:

--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -23,7 +23,6 @@ from typing import Dict, Iterable, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.metrics import accuracy_score, log_loss, mean_absolute_error, mean_squared_error
 
 try:
     from xgboost import XGBClassifier, XGBRegressor
@@ -33,10 +32,16 @@ except ImportError:  # pragma: no cover - exercised only when xgboost is missing
     HAS_XGBOOST = False
 
 from scripts.predictor_python import (
+    COMMON_OPPONENT_RECENCY_DAYS,
+    _latest_game_timestamp,
+    calculate_common_opponent_signal,
+    calculate_head_to_head,
+    calculate_recent_form,
+)
+from scripts.predictor_python import (
     Game as PredictorGame,
 )
-from scripts.predictor_python import calculate_common_opponent_signal, calculate_head_to_head, calculate_recent_form
-from src.predictions.evaluation_reporting import write_evaluation_bundle
+from src.predictions.evaluation_reporting import compute_evaluation_summary, write_evaluation_bundle
 
 logger = logging.getLogger(__name__)
 
@@ -388,6 +393,220 @@ def _poisson_draw_gate_mask(
     )
 
 
+def _build_common_opponent_feature_summary(
+    team_a_id: str,
+    team_b_id: str,
+    all_games: List[PredictorGame],
+    snapshot_index: Dict[str, List[dict]],
+    target_date: str,
+    team_age_numeric: int,
+) -> Dict[str, float]:
+    latest_timestamp = _latest_game_timestamp(all_games)
+    team_a_opponents: Dict[str, Dict[str, float]] = {}
+    team_b_opponents: Dict[str, Dict[str, float]] = {}
+
+    for game in all_games:
+        if game.home_score is None or game.away_score is None:
+            continue
+
+        involves_team_a = game.home_team_master_id == team_a_id or game.away_team_master_id == team_a_id
+        involves_team_b = game.home_team_master_id == team_b_id or game.away_team_master_id == team_b_id
+        if (not involves_team_a and not involves_team_b) or (involves_team_a and involves_team_b):
+            continue
+
+        subject_team_id = team_a_id if involves_team_a else team_b_id
+        is_home = game.home_team_master_id == subject_team_id
+        opponent_id = game.away_team_master_id if is_home else game.home_team_master_id
+        if opponent_id is None or opponent_id in {team_a_id, team_b_id}:
+            continue
+
+        team_score = game.home_score if is_home else game.away_score
+        opp_score = game.away_score if is_home else game.home_score
+        if team_score is None or opp_score is None:
+            continue
+
+        try:
+            game_timestamp = float(pd.Timestamp(game.game_date).timestamp())
+            days_since = (
+                max(0.0, (latest_timestamp - game_timestamp) / 86400.0) if latest_timestamp is not None else 0.0
+            )
+        except Exception:
+            days_since = 0.0
+
+        recency_weight = math.exp(-days_since / COMMON_OPPONENT_RECENCY_DAYS)
+        opponent_snapshot = _snapshot_as_of(snapshot_index, str(opponent_id), target_date)
+        opponent_power = _to_float(opponent_snapshot.get("power_score_final")) if opponent_snapshot else 0.5
+        opponent_age = _extract_age_numeric(opponent_snapshot.get("age_group")) if opponent_snapshot else 0
+        same_age = 1.0 if team_age_numeric > 0 and opponent_age == team_age_numeric else 0.0
+        opponent_strength_weight = float(np.clip(0.75 + opponent_power, 0.6, 1.75))
+        weighted_sample = recency_weight * opponent_strength_weight * (1.15 if same_age else 1.0)
+
+        points = 3.0 if team_score > opp_score else 1.0 if team_score == opp_score else 0.0
+        win_rate = 1.0 if team_score > opp_score else 0.0
+        draw_rate = 1.0 if team_score == opp_score else 0.0
+        goal_margin = float(team_score - opp_score)
+        bucket = team_a_opponents if subject_team_id == team_a_id else team_b_opponents
+        current = bucket.setdefault(
+            str(opponent_id),
+            {
+                "weightedPoints": 0.0,
+                "weightedMargin": 0.0,
+                "weightedGoalsFor": 0.0,
+                "weightedGoalsAgainst": 0.0,
+                "weightedWins": 0.0,
+                "weightedDraws": 0.0,
+                "weightedOpponentPower": 0.0,
+                "weightedSameAge": 0.0,
+                "totalWeight": 0.0,
+                "games": 0.0,
+            },
+        )
+        current["weightedPoints"] += points * weighted_sample
+        current["weightedMargin"] += goal_margin * weighted_sample
+        current["weightedGoalsFor"] += float(team_score) * weighted_sample
+        current["weightedGoalsAgainst"] += float(opp_score) * weighted_sample
+        current["weightedWins"] += win_rate * weighted_sample
+        current["weightedDraws"] += draw_rate * weighted_sample
+        current["weightedOpponentPower"] += opponent_power * weighted_sample
+        current["weightedSameAge"] += same_age * weighted_sample
+        current["totalWeight"] += weighted_sample
+        current["games"] += 1.0
+
+    shared_opponents = [opponent_id for opponent_id in team_a_opponents if opponent_id in team_b_opponents]
+    if not shared_opponents:
+        return {
+            "strengthWeightedSharedOpponents": 0.0,
+            "sameAgeSharedOpponents": 0.0,
+            "sameAgeSharedOpponentRate": 0.0,
+            "strengthWeightedReliability": 0.0,
+            "strengthWeightedMarginDiff": 0.0,
+            "strengthWeightedPointsPerGameDiff": 0.0,
+            "strengthWeightedGoalsForDiff": 0.0,
+            "strengthWeightedGoalsAgainstAdv": 0.0,
+            "strengthWeightedWinRateDiff": 0.0,
+            "strengthWeightedDrawRateDiff": 0.0,
+            "strengthWeightedGoalBalanceDiff": 0.0,
+            "strengthWeightedOpponentPower": 0.0,
+            "commonOpponentConsensusSignal": 0.0,
+        }
+
+    weight_sum = 0.0
+    weighted_shared_count = 0.0
+    same_age_shared_count = 0.0
+    same_age_rate_weighted = 0.0
+    weighted_reliability = 0.0
+    weighted_margin_diff = 0.0
+    weighted_points_diff = 0.0
+    weighted_goals_for_diff = 0.0
+    weighted_goals_against_adv = 0.0
+    weighted_win_rate_diff = 0.0
+    weighted_draw_rate_diff = 0.0
+    weighted_goal_balance_diff = 0.0
+    weighted_opponent_power = 0.0
+    weighted_signal = 0.0
+
+    for opponent_id in shared_opponents:
+        team_a_stats = team_a_opponents[opponent_id]
+        team_b_stats = team_b_opponents[opponent_id]
+        if team_a_stats["totalWeight"] <= 0 or team_b_stats["totalWeight"] <= 0:
+            continue
+
+        team_a_points_per_game = team_a_stats["weightedPoints"] / team_a_stats["totalWeight"]
+        team_b_points_per_game = team_b_stats["weightedPoints"] / team_b_stats["totalWeight"]
+        team_a_avg_margin = team_a_stats["weightedMargin"] / team_a_stats["totalWeight"]
+        team_b_avg_margin = team_b_stats["weightedMargin"] / team_b_stats["totalWeight"]
+        team_a_goals_for = team_a_stats["weightedGoalsFor"] / team_a_stats["totalWeight"]
+        team_b_goals_for = team_b_stats["weightedGoalsFor"] / team_b_stats["totalWeight"]
+        team_a_goals_against = team_a_stats["weightedGoalsAgainst"] / team_a_stats["totalWeight"]
+        team_b_goals_against = team_b_stats["weightedGoalsAgainst"] / team_b_stats["totalWeight"]
+        team_a_win_rate = team_a_stats["weightedWins"] / team_a_stats["totalWeight"]
+        team_b_win_rate = team_b_stats["weightedWins"] / team_b_stats["totalWeight"]
+        team_a_draw_rate = team_a_stats["weightedDraws"] / team_a_stats["totalWeight"]
+        team_b_draw_rate = team_b_stats["weightedDraws"] / team_b_stats["totalWeight"]
+        team_a_goal_balance = team_a_goals_for - team_a_goals_against
+        team_b_goal_balance = team_b_goals_for - team_b_goals_against
+
+        points_diff = team_a_points_per_game - team_b_points_per_game
+        margin_diff = team_a_avg_margin - team_b_avg_margin
+        goals_for_diff = team_a_goals_for - team_b_goals_for
+        goals_against_adv = team_b_goals_against - team_a_goals_against
+        win_rate_diff = team_a_win_rate - team_b_win_rate
+        draw_rate_diff = team_a_draw_rate - team_b_draw_rate
+        goal_balance_diff = team_a_goal_balance - team_b_goal_balance
+
+        avg_opponent_power = (
+            team_a_stats["weightedOpponentPower"] + team_b_stats["weightedOpponentPower"]
+        ) / max(team_a_stats["totalWeight"] + team_b_stats["totalWeight"], 1e-9)
+        same_age_rate = min(
+            team_a_stats["weightedSameAge"] / team_a_stats["totalWeight"],
+            team_b_stats["weightedSameAge"] / team_b_stats["totalWeight"],
+        )
+        reliability = math.sqrt(
+            max(0.0, min(1.0, (team_a_stats["games"] + team_b_stats["games"]) / 6.0))
+            * max(0.0, min(1.0, avg_opponent_power / 0.75))
+        )
+        opponent_weight = (
+            max(0.35, min(1.35, (team_a_stats["games"] + team_b_stats["games"]) / 4.0))
+            * (0.75 + avg_opponent_power)
+            * (1.0 + 0.15 * same_age_rate)
+        )
+        opponent_signal = (
+            max(-1.0, min(1.0, points_diff / 3.0)) * 0.30
+            + max(-1.0, min(1.0, margin_diff / 4.0)) * 0.25
+            + max(-1.0, min(1.0, goals_for_diff / 3.0)) * 0.15
+            + max(-1.0, min(1.0, goals_against_adv / 3.0)) * 0.15
+            + max(-1.0, min(1.0, goal_balance_diff / 4.0)) * 0.15
+        )
+
+        weight_sum += opponent_weight
+        weighted_shared_count += opponent_weight
+        same_age_shared_count += same_age_rate * opponent_weight
+        same_age_rate_weighted += same_age_rate * opponent_weight
+        weighted_reliability += reliability * opponent_weight
+        weighted_margin_diff += margin_diff * opponent_weight
+        weighted_points_diff += points_diff * opponent_weight
+        weighted_goals_for_diff += goals_for_diff * opponent_weight
+        weighted_goals_against_adv += goals_against_adv * opponent_weight
+        weighted_win_rate_diff += win_rate_diff * opponent_weight
+        weighted_draw_rate_diff += draw_rate_diff * opponent_weight
+        weighted_goal_balance_diff += goal_balance_diff * opponent_weight
+        weighted_opponent_power += avg_opponent_power * opponent_weight
+        weighted_signal += opponent_signal * opponent_weight
+
+    if weight_sum <= 0:
+        return {
+            "strengthWeightedSharedOpponents": 0.0,
+            "sameAgeSharedOpponents": 0.0,
+            "sameAgeSharedOpponentRate": 0.0,
+            "strengthWeightedReliability": 0.0,
+            "strengthWeightedMarginDiff": 0.0,
+            "strengthWeightedPointsPerGameDiff": 0.0,
+            "strengthWeightedGoalsForDiff": 0.0,
+            "strengthWeightedGoalsAgainstAdv": 0.0,
+            "strengthWeightedWinRateDiff": 0.0,
+            "strengthWeightedDrawRateDiff": 0.0,
+            "strengthWeightedGoalBalanceDiff": 0.0,
+            "strengthWeightedOpponentPower": 0.0,
+            "commonOpponentConsensusSignal": 0.0,
+        }
+
+    return {
+        "strengthWeightedSharedOpponents": float(weighted_shared_count / max(weight_sum, 1.0)),
+        "sameAgeSharedOpponents": float(same_age_shared_count / max(weight_sum, 1.0) * len(shared_opponents)),
+        "sameAgeSharedOpponentRate": float(same_age_rate_weighted / weight_sum),
+        "strengthWeightedReliability": float(weighted_reliability / weight_sum),
+        "strengthWeightedMarginDiff": float(weighted_margin_diff / weight_sum),
+        "strengthWeightedPointsPerGameDiff": float(weighted_points_diff / weight_sum),
+        "strengthWeightedGoalsForDiff": float(weighted_goals_for_diff / weight_sum),
+        "strengthWeightedGoalsAgainstAdv": float(weighted_goals_against_adv / weight_sum),
+        "strengthWeightedWinRateDiff": float(weighted_win_rate_diff / weight_sum),
+        "strengthWeightedDrawRateDiff": float(weighted_draw_rate_diff / weight_sum),
+        "strengthWeightedGoalBalanceDiff": float(weighted_goal_balance_diff / weight_sum),
+        "strengthWeightedOpponentPower": float(weighted_opponent_power / weight_sum),
+        "commonOpponentConsensusSignal": float(weighted_signal / weight_sum),
+    }
+
+
 def _dedupe_games(games: Iterable[PredictorGame]) -> List[PredictorGame]:
     deduped: Dict[str, PredictorGame] = {}
     for game in games:
@@ -454,6 +673,17 @@ def build_point_in_time_dataset(
         recent_form_b = calculate_recent_form(team_b_id, team_b_prior_games)
         h2h = calculate_head_to_head(team_a_id, team_b_id, combined_prior_games)
         common_opponents = calculate_common_opponent_signal(team_a_id, team_b_id, combined_prior_games)
+        common_opponent_details = _build_common_opponent_feature_summary(
+            team_a_id=team_a_id,
+            team_b_id=team_b_id,
+            all_games=combined_prior_games,
+            snapshot_index=snapshot_index,
+            target_date=str(game_row["game_date"]),
+            team_age_numeric=max(
+                _extract_age_numeric(team_a_snapshot.get("age_group")),
+                _extract_age_numeric(team_b_snapshot.get("age_group")),
+            ),
+        )
         actual_outcome_code, actual_outcome_name = _outcome_label(score_a, score_b)
 
         enriched_team_a_snapshot = {**team_a_snapshot, "_game_date": game_row["game_date"]}
@@ -484,6 +714,45 @@ def build_point_in_time_dataset(
                 "common_opponent_closeness": math.exp(-abs(_to_float(common_opponents.get("advantage"))) / 0.3)
                 if _to_float(common_opponents.get("sharedOpponents")) > 0
                 else 0.5,
+                "common_opponent_strength_weighted_shared": _to_float(
+                    common_opponent_details.get("strengthWeightedSharedOpponents")
+                ),
+                "common_opponent_same_age_shared": _to_float(
+                    common_opponent_details.get("sameAgeSharedOpponents")
+                ),
+                "common_opponent_same_age_rate": _to_float(
+                    common_opponent_details.get("sameAgeSharedOpponentRate")
+                ),
+                "common_opponent_strength_weighted_reliability": _to_float(
+                    common_opponent_details.get("strengthWeightedReliability")
+                ),
+                "common_opponent_strength_weighted_margin_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedMarginDiff")
+                ),
+                "common_opponent_strength_weighted_points_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedPointsPerGameDiff")
+                ),
+                "common_opponent_strength_weighted_goals_for_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedGoalsForDiff")
+                ),
+                "common_opponent_strength_weighted_goals_against_adv": _to_float(
+                    common_opponent_details.get("strengthWeightedGoalsAgainstAdv")
+                ),
+                "common_opponent_strength_weighted_win_rate_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedWinRateDiff")
+                ),
+                "common_opponent_strength_weighted_draw_rate_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedDrawRateDiff")
+                ),
+                "common_opponent_strength_weighted_goal_balance_diff": _to_float(
+                    common_opponent_details.get("strengthWeightedGoalBalanceDiff")
+                ),
+                "common_opponent_strength_weighted_opponent_power": _to_float(
+                    common_opponent_details.get("strengthWeightedOpponentPower")
+                ),
+                "common_opponent_consensus_signal": _to_float(
+                    common_opponent_details.get("commonOpponentConsensusSignal")
+                ),
                 "team_a_prior_game_count": float(len(team_a_prior_games)),
                 "team_b_prior_game_count": float(len(team_b_prior_games)),
                 "combined_prior_game_count": float(len(combined_prior_games)),
@@ -1257,18 +1526,22 @@ class PointInTimeMatchModel:
             strategy_outputs[strategy_name] = outputs
             probabilities_for_strategy = outputs[0]
             predicted_labels_for_strategy = np.argmax(probabilities_for_strategy, axis=1)
-            strategy_metrics[strategy_name] = {
-                "winner_accuracy": float(accuracy_score(y_test, predicted_labels_for_strategy)),
-                "log_loss": float(log_loss(y_test, probabilities_for_strategy, labels=[0, 1, 2])),
-                "brier_score": self._brier_score(y_test, probabilities_for_strategy),
-                "draw_recall": float(np.mean(predicted_labels_for_strategy[y_test == OUTCOME_DRAW] == OUTCOME_DRAW))
-                if np.any(y_test == OUTCOME_DRAW)
-                else None,
-                "draw_precision": float(np.mean(y_test[predicted_labels_for_strategy == OUTCOME_DRAW] == OUTCOME_DRAW))
-                if np.any(predicted_labels_for_strategy == OUTCOME_DRAW)
-                else None,
-                "predicted_draw_rate": float(np.mean(predicted_labels_for_strategy == OUTCOME_DRAW)),
-            }
+            strategy_evaluation_frame = self._build_evaluation_frame(
+                test_df=test_df,
+                probabilities=probabilities_for_strategy,
+                predicted_labels=predicted_labels_for_strategy,
+                predicted_margin=predicted_margin,
+                predicted_score_a=predicted_score_a,
+                predicted_score_b=predicted_score_b,
+                poisson_probabilities=outputs[1],
+                draw_model_probability=outputs[2],
+                expected_goals_a=outputs[3],
+                expected_goals_b=outputs[4],
+                probability_strategy=strategy_name,
+            )
+            strategy_summary = compute_evaluation_summary(strategy_evaluation_frame)
+            strategy_summary["predicted_draw_rate"] = float(np.mean(predicted_labels_for_strategy == OUTCOME_DRAW))
+            strategy_metrics[strategy_name] = strategy_summary
 
         (
             probabilities,
@@ -1291,23 +1564,11 @@ class PointInTimeMatchModel:
             expected_goals_b=expected_goals_b,
             probability_strategy=self.probability_strategy,
         )
-
+        summary_metrics = compute_evaluation_summary(self.last_evaluation_frame)
         metrics = {
-            "winner_accuracy": float(accuracy_score(y_test, predicted_labels)),
-            "log_loss": float(log_loss(y_test, probabilities, labels=[0, 1, 2])),
-            "brier_score": self._brier_score(y_test, probabilities),
-            "draw_recall": float(np.mean(predicted_labels[y_test == OUTCOME_DRAW] == OUTCOME_DRAW))
-            if np.any(y_test == OUTCOME_DRAW)
-            else None,
-            "draw_precision": float(np.mean(y_test[predicted_labels == OUTCOME_DRAW] == OUTCOME_DRAW))
-            if np.any(predicted_labels == OUTCOME_DRAW)
-            else None,
+            **summary_metrics,
             "actual_draw_rate": float(np.mean(y_test == OUTCOME_DRAW)),
             "predicted_draw_rate": float(np.mean(predicted_labels == OUTCOME_DRAW)),
-            "margin_mae": float(mean_absolute_error(test_df["actual_margin"], predicted_margin)),
-            "margin_rmse": float(math.sqrt(mean_squared_error(test_df["actual_margin"], predicted_margin))),
-            "score_a_mae": float(mean_absolute_error(test_df["actual_score_a"], predicted_score_a)),
-            "score_b_mae": float(mean_absolute_error(test_df["actual_score_b"], predicted_score_b)),
             "train_examples": int(len(train_df)),
             "test_examples": int(len(test_df)),
             "probability_strategy": self.probability_strategy,

--- a/tests/unit/test_evaluation_reporting.py
+++ b/tests/unit/test_evaluation_reporting.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from src.predictions.evaluation_reporting import (
     build_calibration_table,
+    build_margin_band_metrics,
     build_standardized_evaluation_frame,
     compute_evaluation_summary,
 )
@@ -137,3 +138,69 @@ def test_compute_evaluation_summary_normalizes_trainer_outcome_aliases():
 
     assert summary["games"] == 2
     assert summary["winner_accuracy"] == 1.0
+
+
+def test_compute_evaluation_summary_tracks_score_and_blowout_metrics():
+    frame = pd.DataFrame(
+        [
+            {
+                "game_id": "g1",
+                "game_date": "2026-04-01",
+                "actual_outcome": "team_a",
+                "predicted_outcome": "team_a",
+                "prob_team_a_win": 0.74,
+                "prob_draw": 0.12,
+                "prob_team_b_win": 0.14,
+                "predicted_margin": 3.2,
+                "actual_margin": 4,
+                "predicted_score_a": 4.1,
+                "predicted_score_b": 1.0,
+                "actual_score_a": 4,
+                "actual_score_b": 0,
+            },
+            {
+                "game_id": "g2",
+                "game_date": "2026-04-02",
+                "actual_outcome": "draw",
+                "predicted_outcome": "draw",
+                "prob_team_a_win": 0.28,
+                "prob_draw": 0.46,
+                "prob_team_b_win": 0.26,
+                "predicted_margin": 0.2,
+                "actual_margin": 0,
+                "predicted_score_a": 1.2,
+                "predicted_score_b": 1.0,
+                "actual_score_a": 1,
+                "actual_score_b": 1,
+            },
+            {
+                "game_id": "g3",
+                "game_date": "2026-04-03",
+                "actual_outcome": "team_b",
+                "predicted_outcome": "team_b",
+                "prob_team_a_win": 0.18,
+                "prob_draw": 0.19,
+                "prob_team_b_win": 0.63,
+                "predicted_margin": -0.8,
+                "actual_margin": -1,
+                "predicted_score_a": 1.0,
+                "predicted_score_b": 2.0,
+                "actual_score_a": 0,
+                "actual_score_b": 2,
+            },
+        ]
+    )
+
+    summary = compute_evaluation_summary(frame)
+    margin_bands = build_margin_band_metrics(frame)
+
+    assert summary["score_a_mae"] is not None
+    assert summary["score_b_mae"] is not None
+    assert summary["total_goals_mae"] is not None
+    assert summary["exact_score_accuracy"] == 1 / 3
+    assert summary["score_within_one_goal_rate"] == 1.0
+    assert summary["competitive_game_recall"] == 1.0
+    assert summary["blowout_3plus_recall"] == 1.0
+    assert summary["blowout_3plus_precision"] == 1.0
+    assert not margin_bands.empty
+    assert set(margin_bands["band"]) == {"competitive_1plus", "blowout_3plus", "blowout_5plus"}

--- a/tests/unit/test_point_in_time_match_model.py
+++ b/tests/unit/test_point_in_time_match_model.py
@@ -108,6 +108,9 @@ def test_build_point_in_time_dataset_is_chronological_and_mirrored():
     assert g3_original["team_a_recent_form"] > g3_original["team_b_recent_form"]
     assert g3_original["common_opponent_shared"] == 1.0
     assert g3_original["common_opponent_advantage"] > 0.0
+    assert g3_original["common_opponent_strength_weighted_margin_diff"] > 0.0
+    assert g3_original["common_opponent_strength_weighted_goal_balance_diff"] > 0.0
+    assert g3_original["common_opponent_consensus_signal"] > 0.0
     assert g3_original["actual_outcome"] == "team_a_win"
     assert g3_mirrored["actual_outcome"] == "team_b_win"
     assert g3_original["power_score_final_diff"] == -g3_mirrored["power_score_final_diff"]
@@ -187,6 +190,8 @@ def test_build_point_in_time_dataset_tracks_draw_oriented_signals():
     assert row["goal_balance_signal"] > 0.0
     assert row["snapshot_strength_closeness"] > 0.0
     assert row["expected_draw_environment"] > 0.0
+    assert row["common_opponent_same_age_rate"] == 0.0
+    assert row["common_opponent_strength_weighted_shared"] == 0.0
     assert 0.0 <= row["stalemate_signal"] <= 1.0
 
 


### PR DESCRIPTION
## Summary
- add richer common-opponent feature engineering to the offline point-in-time dataset builder
- expand evaluation reporting with score, competitive-game, and blowout metrics for seeding quality
- feed the shared evaluation summary back into offline strategy comparisons and tests

## Validation
- python -m py_compile src/predictions/point_in_time_match_model.py src/predictions/evaluation_reporting.py scripts/train_point_in_time_match_model.py
- python -m ruff check src/predictions/point_in_time_match_model.py src/predictions/evaluation_reporting.py scripts/train_point_in_time_match_model.py tests/unit/test_point_in_time_match_model.py tests/unit/test_evaluation_reporting.py
- ='C:\PitchRank_draw_model_clean'; python -m pytest tests/unit/test_point_in_time_match_model.py tests/unit/test_evaluation_reporting.py -q
- ='C:\PitchRank_draw_model_clean'; python scripts/train_point_in_time_match_model.py --lookback-days 190 --min-examples 20 --probability-strategy poisson_draw_gate --model-dir models/point_in_time_match_predictor_commonopp_20260408 --save-dataset
- ='C:\PitchRank_draw_model_clean'; python scripts/calibrate_point_in_time_match_model.py --evaluation-csv models/point_in_time_match_predictor_commonopp_20260408/point_in_time_model_evaluation.csv --output-dir models/point_in_time_match_predictor_commonopp_20260408 --method temperature --prefix point_in_time_model_calibration