### PR TITLE
Fix SEO meta tags — deduplicate brand, noindex auth pages, expand state descriptions

### DIFF
--- a/frontend/app/login/layout.tsx
+++ b/frontend/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Log In',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -30,9 +30,16 @@ function getStateInfo(stateCode: string): { code: string; name: string } | null 
  * Keyed by lowercase state code. Falls back to generic template if not listed.
  */
 const STATE_DESCRIPTIONS: Record<string, string> = {
-  co: 'Colorado youth soccer rankings for every age group—Rapids, Real Colorado, Colorado Storm and more. PowerScore ratings updated weekly from real game results. Find your club now.',
-  tx: 'Texas youth soccer rankings for every age group—FC Dallas, Solar SC, Lonestar and more. PowerScore ratings updated weekly from real game results. Find your club now.',
-  md: 'Maryland youth soccer rankings for every age group—Baltimore Armour, Pipeline SC, MSC and more. PowerScore ratings updated weekly from real game results. Find your club now.',
+  co: 'Colorado youth soccer rankings for every age group — Rapids Youth, Real Colorado, Colorado Storm and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  tx: 'Texas youth soccer rankings for every age group — FC Dallas, Solar SC, Lonestar and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  md: 'Maryland youth soccer rankings for every age group — Baltimore Armour, Pipeline SC, MSC and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  ca: 'California youth soccer rankings for every age group — LA Galaxy, San Diego Surf, Beach FC and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  ny: 'New York youth soccer rankings for every age group — Manhattan SC, SUSA, Albertson and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  ga: 'Georgia youth soccer rankings for every age group — Atlanta United, Concorde Fire, United Futbol and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  nj: 'New Jersey youth soccer rankings for every age group — PDA, STA, Players Development and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  az: 'Arizona youth soccer rankings for every age group — SC Del Sol, Scottsdale Blackhawks, Real Salt Lake AZ and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  pa: 'Pennsylvania youth soccer rankings for every age group — Philadelphia Union, FC DELCO, Bethlehem and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
+  fl: 'Florida youth soccer rankings for every age group — Weston FC, South Florida Football Academy, Orlando City and more. 77K+ teams rated by PowerScore from real game results. Updated every Monday.',
 };
 
 /**
@@ -44,20 +51,24 @@ export async function generateMetadata({ params }: StateOverviewPageProps): Prom
 
   const stateInfo = getStateInfo(region);
   if (!stateInfo) {
-    return { title: 'Not Found | PitchRank' };
+    return { title: 'Not Found' };
   }
 
   const canonicalUrl = `${BASE_URL}/rankings/${region.toLowerCase()}`;
   const isNational = region.toLowerCase() === 'national';
 
   const title = isNational
-    ? 'National Youth Soccer Rankings | PitchRank'
-    : `${stateInfo.name} Youth Soccer Rankings | PitchRank`;
+    ? 'National Youth Soccer Rankings 2026 — Updated Weekly'
+    : `${stateInfo.name} Youth Soccer Rankings 2026 — Updated Weekly`;
 
   const description = isNational
     ? 'National youth soccer rankings for all age groups. 77K+ teams ranked across 700K+ games analyzed. See where your team stands. Updated weekly.'
     : (STATE_DESCRIPTIONS[region.toLowerCase()] ??
       `${stateInfo.name} youth soccer rankings - Find where your team ranks among 77K+ teams. PowerScore ratings updated weekly from 700K+ analyzed games. Start now!`);
+
+  const ogTitle = isNational
+    ? 'National Youth Soccer Rankings 2026 | PitchRank'
+    : `${stateInfo.name} Youth Soccer Rankings 2026 | PitchRank`;
 
   return {
     title,
@@ -66,16 +77,25 @@ export async function generateMetadata({ params }: StateOverviewPageProps): Prom
       canonical: canonicalUrl,
     },
     openGraph: {
-      title,
+      title: ogTitle,
       description,
       url: canonicalUrl,
       siteName: 'PitchRank',
       type: 'website',
+      images: [
+        {
+          url: `${BASE_URL}/opengraph-image.png`,
+          width: 1200,
+          height: 630,
+          alt: ogTitle,
+        },
+      ],
     },
     twitter: {
       card: 'summary_large_image',
-      title,
+      title: ogTitle,
       description,
+      images: [`${BASE_URL}/opengraph-image.png`],
     },
   };
 }

--- a/frontend/app/rankings/layout.tsx
+++ b/frontend/app/rankings/layout.tsx
@@ -9,25 +9,25 @@ import { BASE_URL } from '@/lib/constants';
  * NOTE: Uses absolute URLs for canonical/OG to avoid Google indexing issues
  */
 export const metadata: Metadata = {
-  title: 'Youth Soccer Rankings: 101,000+ Teams Ranked by PowerScore',
+  title: '2026 Youth Soccer Rankings by State & Age Group',
   description:
-    'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored from 726,730+ real game results—updated weekly. Find where your club ranks.',
+    'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
   alternates: {
     canonical: `${BASE_URL}/rankings`,
   },
   openGraph: {
-    title: 'Youth Soccer Rankings: 101,000+ Teams Ranked by PowerScore',
+    title: '2026 Youth Soccer Rankings by State & Age Group | PitchRank',
     description:
-      'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored from 726,730+ real game results—updated weekly.',
+      'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
     url: `${BASE_URL}/rankings`,
     siteName: 'PitchRank',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Youth Soccer Rankings | 101K+ Teams Ranked',
+    title: '2026 Youth Soccer Rankings by State & Age Group | PitchRank',
     description:
-      'Youth soccer rankings for every state, age group, and gender. 101,354 teams scored weekly from real game results.',
+      'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
   },
 };
 

--- a/frontend/app/rankings/page.tsx
+++ b/frontend/app/rankings/page.tsx
@@ -9,25 +9,25 @@ import { BASE_URL } from '@/lib/constants';
  */
 
 export const metadata: Metadata = {
-  title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+  title: '2026 Youth Soccer Rankings by State & Age Group',
   description:
-    'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday. Find where your team ranks.',
+    'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
   alternates: {
     canonical: `${BASE_URL}/rankings`,
   },
   openGraph: {
-    title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+    title: '2026 Youth Soccer Rankings by State & Age Group | PitchRank',
     description:
-      'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday.',
+      'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
     url: `${BASE_URL}/rankings`,
     siteName: 'PitchRank',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Youth Soccer Rankings 2026 — 77K+ Teams Ranked Weekly | PitchRank',
+    title: '2026 Youth Soccer Rankings by State & Age Group | PitchRank',
     description:
-      'Free youth soccer rankings for every state, age group, and gender. 77,000+ teams rated by PowerScore from real game results. Updated every Monday.',
+      'Where does your team rank? 77K+ youth soccer teams rated weekly by PowerScore. Browse rankings by state, age group U10-U19, boys and girls. Free.',
   },
 };
 

--- a/frontend/app/signup/layout.tsx
+++ b/frontend/app/signup/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign Up',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Colorado Youth Soccer Rankings 2026 — Updated Weekly | PitchRank"
+title: "Colorado Youth Soccer Rankings 2026: Best Clubs by Age"
 slug: 'colorado-youth-soccer-rankings-guide'
 excerpt: "Find where your Colorado club ranks. Rapids Youth, Real Colorado, Colorado Storm and more — rated by PowerScore from real game results. Free rankings updated every Monday."
 author: 'PitchRank Team'

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Michigan Youth Soccer Rankings 2026 — Updated Weekly | PitchRank"
+title: "Michigan Youth Soccer Rankings 2026: Best Clubs by Age"
 slug: 'michigan-youth-soccer-rankings-guide'
 excerpt: "Find where your Michigan club ranks among thousands of teams. Michigan Hawks, Vardar, DCFC and more — rated by PowerScore from real game results. Free rankings updated every Monday."
 author: 'PitchRank Team'


### PR DESCRIPTION
## Summary
- Fix duplicate `| PitchRank | PitchRank` in SERP titles caused by root layout `title.template` + manual brand suffix
- Add `noindex` to /login and /signup (auth-gated pages Google was indexing)
- Add `og:image` to all state ranking pages (was missing, broke social previews)
- Expand meta descriptions for 10 high-traffic states with local club names
- Rewrite /rankings title and description for better CTR

## Evidence
GSC audit (90 days): 467 clicks, 6,085 impressions. /rankings page had 748 impressions at 2.67% CTR with a broken duplicate-brand title. Blog posts at positions 7-8 had 2% CTR (expected 5-8%). Expected impact: +40-60 clicks/month.

## Test plan
- [ ] Verify /rankings title renders as `"2026 Youth Soccer Rankings by State & Age Group | PitchRank"` (single brand suffix)
- [ ] Verify /rankings/md title renders as `"Maryland Youth Soccer Rankings 2026 — Updated Weekly | PitchRank"`
- [ ] Verify /login has `<meta name="robots" content="noindex">` in page source
- [ ] Verify /rankings/md has `og:image` in page source
- [ ] Run `npx tsc --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)