### PR TITLE
Add match prediction shadow processor

### DIFF
--- a/.github/workflows/process-match-prediction-shadow.yml
+++ b/.github/workflows/process-match-prediction-shadow.yml
@@ -1,0 +1,175 @@
+name: Process Match Prediction Shadow Log
+
+on:
+  workflow_dispatch:
+    inputs:
+      training_run_id:
+        description: 'Training workflow run ID that produced the point-in-time model artifact'
+        required: true
+        type: string
+      artifact_name:
+        description: 'Optional artifact name override (defaults to point-in-time-match-model-<run_id>)'
+        required: false
+        default: ''
+        type: string
+      shadow_status:
+        description: 'Shadow-log status to process'
+        required: false
+        default: 'pending'
+        type: choice
+        options:
+          - pending
+          - error
+      limit:
+        description: 'Maximum number of shadow rows to process'
+        required: false
+        default: '100'
+        type: string
+      apply_calibration:
+        description: 'Apply point_in_time_model_calibration.pkl before writing shadow predictions'
+        required: false
+        default: false
+        type: boolean
+      shadow_model_version:
+        description: 'Optional shadow model version label stored on processed rows'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: match-prediction-shadow-processing
+  cancel-in-progress: false
+
+jobs:
+  process-match-prediction-shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          python -c "import supabase, pandas, numpy; print('Shadow processor imports successful')"
+
+      - name: Download selected model artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRAINING_RUN_ID: ${{ github.event.inputs.training_run_id }}
+          INPUT_ARTIFACT_NAME: ${{ github.event.inputs.artifact_name }}
+        run: |
+          ARTIFACT_NAME="$INPUT_ARTIFACT_NAME"
+          if [ -z "$ARTIFACT_NAME" ]; then
+            ARTIFACT_NAME="point-in-time-match-model-$TRAINING_RUN_ID"
+          fi
+
+          DOWNLOAD_ROOT="$RUNNER_TEMP/match_prediction_shadow"
+          mkdir -p "$DOWNLOAD_ROOT"
+
+          gh run download "$TRAINING_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir "$DOWNLOAD_ROOT"
+
+          ARTIFACT_DIR="$DOWNLOAD_ROOT/$ARTIFACT_NAME"
+          if [ ! -d "$ARTIFACT_DIR" ]; then
+            echo "Downloaded artifact directory not found: $ARTIFACT_DIR"
+            exit 1
+          fi
+
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
+        id: artifact
+
+      - name: Process pending shadow rows
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+
+          ARTIFACT_DIR="${{ steps.artifact.outputs.artifact_dir }}"
+          MODEL_ARTIFACT="$ARTIFACT_DIR/point_in_time_match_model.pkl"
+          SUMMARY_PATH="$RUNNER_TEMP/match_prediction_shadow_summary.json"
+
+          CMD=(
+            python scripts/process_match_prediction_shadow.py
+            --model-artifact "$MODEL_ARTIFACT"
+            --shadow-status "${{ github.event.inputs.shadow_status }}"
+            --limit "${{ github.event.inputs.limit }}"
+            --summary-path "$SUMMARY_PATH"
+          )
+
+          if [ "${{ github.event.inputs.apply_calibration }}" = "true" ]; then
+            CMD+=(--calibration-artifact "$ARTIFACT_DIR/point_in_time_model_calibration.pkl")
+          fi
+
+          if [ -n "${{ github.event.inputs.shadow_model_version }}" ]; then
+            CMD+=(--shadow-model-version "${{ github.event.inputs.shadow_model_version }}")
+          fi
+
+          printf 'Running command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"
+
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+        id: process
+
+      - name: Write run summary
+        if: always()
+        env:
+          SUMMARY_PATH: ${{ steps.process.outputs.summary_path }}
+          ARTIFACT_NAME: ${{ steps.artifact.outputs.artifact_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path(os.environ.get("SUMMARY_PATH", ""))
+          summary_lines = [
+              "## Match Prediction Shadow Processing",
+              "",
+              f"- Artifact: `{os.environ.get('ARTIFACT_NAME', '')}`",
+          ]
+
+          if summary_path.is_file():
+              summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              summary_lines.extend(
+                  [
+                      f"- Shadow model version: `{summary.get('shadow_model_version')}`",
+                      f"- Requested status: `{summary.get('requested_status')}`",
+                      f"- Requested limit: {summary.get('requested_limit')}",
+                      f"- Rows fetched: {summary.get('fetched_rows')}",
+                      f"- Rows processed: {summary.get('processed')}",
+                      f"- Rows completed: {summary.get('completed')}",
+                      f"- Rows errored: {summary.get('errored')}",
+                  ]
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(summary_lines))
+              handle.write("\n")
+          PY

--- a/scripts/process_match_prediction_shadow.py
+++ b/scripts/process_match_prediction_shadow.py
@@ -1,0 +1,484 @@
+"""
+Process pending /compare shadow-log rows with the offline point-in-time model.
+
+This script is intentionally fail-open: each row is handled independently and
+errors are written back to the shadow payload without interrupting the batch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.predictor_python import Game as PredictorGame  # noqa: E402
+from src.predictions.point_in_time_calibration import PointInTimeProbabilityCalibrator  # noqa: E402
+from src.predictions.point_in_time_match_model import (  # noqa: E402
+    PointInTimeMatchModel,
+    build_point_in_time_matchup_row,
+)
+from supabase import Client, create_client  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _supabase_client() -> Client:
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY")
+    return create_client(supabase_url, supabase_key)
+
+
+def _normalize_gender(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"female", "f", "g", "girls", "girl"}:
+        return "Female"
+    return "Male"
+
+
+def _normalize_age_group(value: object) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except Exception:
+        pass
+    try:
+        return str(int(value))
+    except Exception:
+        return str(value)
+
+
+def _normalize_team_snapshot(team_payload: Dict[str, Any], snapshot_date: str) -> Dict[str, Any]:
+    return {
+        "snapshot_date": snapshot_date,
+        "team_id": str(team_payload.get("team_id_master") or ""),
+        "team_name": team_payload.get("team_name"),
+        "club_name": team_payload.get("club_name"),
+        "age_group": _normalize_age_group(team_payload.get("age")),
+        "gender": _normalize_gender(team_payload.get("gender")),
+        "status": "Active",
+        "rank_in_cohort_final": team_payload.get("rank_in_cohort_final"),
+        "power_score_final": team_payload.get("power_score_final"),
+        "sos_norm": team_payload.get("sos_norm"),
+        "offense_norm": team_payload.get("offense_norm"),
+        "defense_norm": team_payload.get("defense_norm"),
+        "glicko_rating": team_payload.get("glicko_rating"),
+        "glicko_rd": team_payload.get("glicko_rd"),
+        "glicko_volatility": team_payload.get("glicko_volatility"),
+        "wins": team_payload.get("wins"),
+        "losses": team_payload.get("losses"),
+        "draws": team_payload.get("draws"),
+        "games_played": team_payload.get("games_played"),
+        "win_percentage": team_payload.get("win_percentage"),
+        "same_age_games": team_payload.get("same_age_games"),
+        "same_age_game_share": team_payload.get("same_age_game_share"),
+        "same_age_unique_opponents": team_payload.get("same_age_unique_opponents"),
+        "same_age_top100_opp_count": team_payload.get("same_age_top100_opp_count"),
+        "same_age_top500_opp_count": team_payload.get("same_age_top500_opp_count"),
+        "same_age_avg_opp_power_adj": team_payload.get("same_age_avg_opp_power_adj"),
+        "repeat_opponent_share": team_payload.get("repeat_opponent_share"),
+        "positive_ml_evidence_scale": team_payload.get("positive_ml_evidence_scale"),
+        "publication_cap_rank": team_payload.get("publication_cap_rank"),
+        "publication_cap_score": team_payload.get("publication_cap_score"),
+        "exp_margin": team_payload.get("exp_margin"),
+        "exp_win_rate": team_payload.get("exp_win_rate"),
+        "exp_goals_for": team_payload.get("exp_goals_for"),
+        "exp_goals_against": team_payload.get("exp_goals_against"),
+    }
+
+
+def _safe_request_context(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _fetch_shadow_rows(supabase: Client, status: str, limit: int) -> List[Dict[str, Any]]:
+    response = (
+        supabase.table("match_prediction_shadow_log")
+        .select("id, created_at, team_a_id, team_b_id, team_a_input, team_b_input, request_context")
+        .eq("shadow_status", status)
+        .order("created_at", desc=False)
+        .limit(limit)
+        .execute()
+    )
+    return list(response.data or [])
+
+
+def _fetch_games_by_ids(supabase: Client, game_ids: Iterable[str]) -> List[PredictorGame]:
+    ids = [str(game_id) for game_id in game_ids if game_id]
+    if not ids:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    batch_size = 100
+    for index in range(0, len(ids), batch_size):
+        batch = ids[index : index + batch_size]
+        response = (
+            supabase.table("games")
+            .select("id, game_date, home_team_master_id, away_team_master_id, home_score, away_score")
+            .in_("id", batch)
+            .execute()
+        )
+        rows.extend(response.data or [])
+
+    return [
+        PredictorGame(
+            id=str(row.get("id") or ""),
+            home_team_master_id=row.get("home_team_master_id"),
+            away_team_master_id=row.get("away_team_master_id"),
+            home_score=int(row["home_score"]) if row.get("home_score") is not None else None,
+            away_score=int(row["away_score"]) if row.get("away_score") is not None else None,
+            game_date=str(row.get("game_date") or ""),
+        )
+        for row in rows
+        if row.get("id")
+    ]
+
+
+def _fetch_snapshot_index(
+    supabase: Client,
+    team_ids: Iterable[str],
+    snapshot_date: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    ids = sorted({str(team_id) for team_id in team_ids if team_id})
+    if not ids:
+        return {}
+
+    rankings_rows: List[Dict[str, Any]] = []
+    batch_size = 100
+    for index in range(0, len(ids), batch_size):
+        batch = ids[index : index + batch_size]
+        response = (
+            supabase.table("rankings_full")
+            .select("team_id, power_score_final, age_group")
+            .in_("team_id", batch)
+            .execute()
+        )
+        rankings_rows.extend(response.data or [])
+
+    snapshot_ts = pd.Timestamp(snapshot_date)
+    snapshot_index: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rankings_rows:
+        team_id = str(row.get("team_id") or "")
+        if not team_id:
+            continue
+        snapshot_index[team_id] = [
+            {
+                "team_id": team_id,
+                "snapshot_date": snapshot_date,
+                "snapshot_ts": snapshot_ts,
+                "power_score_final": row.get("power_score_final"),
+                "age_group": row.get("age_group"),
+            }
+        ]
+    return snapshot_index
+
+
+def _build_matchup_frame(
+    row: Dict[str, Any],
+    games: List[PredictorGame],
+    snapshot_index: Dict[str, List[Dict[str, Any]]],
+) -> pd.DataFrame:
+    created_at = str(row.get("created_at") or "")
+    snapshot_date = created_at.split("T")[0] if "T" in created_at else created_at[:10]
+    snapshot_date = snapshot_date or pd.Timestamp.utcnow().strftime("%Y-%m-%d")
+
+    team_a_input = row.get("team_a_input") or {}
+    team_b_input = row.get("team_b_input") or {}
+    team_a_snapshot = _normalize_team_snapshot(team_a_input, snapshot_date)
+    team_b_snapshot = _normalize_team_snapshot(team_b_input, snapshot_date)
+    team_a_id = str(team_a_input.get("team_id_master") or row.get("team_a_id") or "")
+    team_b_id = str(team_b_input.get("team_id_master") or row.get("team_b_id") or "")
+    team_names = {
+        team_a_id: team_a_input.get("team_name"),
+        team_b_id: team_b_input.get("team_name"),
+    }
+
+    feature_row = build_point_in_time_matchup_row(
+        team_a_id=team_a_id,
+        team_b_id=team_b_id,
+        team_a_snapshot=team_a_snapshot,
+        team_b_snapshot=team_b_snapshot,
+        all_games=games,
+        game_date=snapshot_date,
+        snapshot_index=snapshot_index,
+        team_names=team_names,
+        game_id=f"shadow:{row['id']}",
+        example_orientation="shadow",
+    )
+    return pd.DataFrame([feature_row])
+
+
+def _apply_optional_calibration(
+    frame: pd.DataFrame,
+    model: PointInTimeMatchModel,
+    calibrator: Optional[PointInTimeProbabilityCalibrator],
+) -> pd.DataFrame:
+    if calibrator is None:
+        return frame
+    return calibrator.transform_frame(frame, prediction_postprocessor=model.relabel_evaluation_frame)
+
+
+def _to_python(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _to_python(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_to_python(item) for item in value]
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except Exception:
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:
+            pass
+    return value
+
+
+def _build_shadow_payload(
+    prediction_row: pd.Series,
+    *,
+    model_version: str,
+    calibrated: bool,
+) -> Dict[str, Any]:
+    predicted_winner = str(prediction_row.get("predicted_outcome") or "draw")
+    return {
+        "modelVersion": model_version,
+        "calibrated": calibrated,
+        "prediction": {
+            "predictedWinner": predicted_winner,
+            "winProbabilityA": float(prediction_row["prob_team_a_win"]),
+            "drawProbability": float(prediction_row["prob_draw"]),
+            "winProbabilityB": float(prediction_row["prob_team_b_win"]),
+            "expectedScore": {
+                "teamA": int(round(float(prediction_row["predicted_score_a"]))),
+                "teamB": int(round(float(prediction_row["predicted_score_b"]))),
+            },
+            "expectedMargin": float(prediction_row["predicted_margin"]),
+            "probabilityStrategy": str(prediction_row.get("probability_strategy") or ""),
+            "blowoutProbability3Plus": float(prediction_row.get("blowout_3plus_probability") or 0.0),
+            "blowoutProbability5Plus": float(prediction_row.get("blowout_5plus_probability") or 0.0),
+            "predictedBlowout3Plus": bool(int(prediction_row.get("predicted_blowout_3plus") or 0)),
+            "predictedBlowout5Plus": bool(int(prediction_row.get("predicted_blowout_5plus") or 0)),
+        },
+        "diagnostics": {
+            "stalemateSignal": float(prediction_row.get("stalemate_signal") or 0.0),
+            "projectedTotalGoals": float(prediction_row.get("projected_total_goals") or 0.0),
+            "expectedGoalsA": float(prediction_row.get("expected_goals_a") or 0.0),
+            "expectedGoalsB": float(prediction_row.get("expected_goals_b") or 0.0),
+            "poissonProbabilities": {
+                "teamA": float(prediction_row.get("poisson_prob_team_a_win") or 0.0),
+                "draw": float(prediction_row.get("poisson_prob_draw") or 0.0),
+                "teamB": float(prediction_row.get("poisson_prob_team_b_win") or 0.0),
+            },
+            "drawModelProbability": float(prediction_row.get("draw_model_probability") or 0.0),
+        },
+        "rawRow": _to_python(prediction_row.to_dict()),
+    }
+
+
+def _update_shadow_row(
+    supabase: Client,
+    row_id: str,
+    *,
+    shadow_status: str,
+    shadow_model_version: str,
+    shadow_prediction: Dict[str, Any],
+) -> None:
+    supabase.table("match_prediction_shadow_log").update(
+        {
+            "shadow_status": shadow_status,
+            "shadow_model_version": shadow_model_version,
+            "shadow_prediction": shadow_prediction,
+        }
+    ).eq("id", row_id).execute()
+
+
+def _derive_shadow_model_version(
+    model_artifact: Path,
+    shadow_model_version: Optional[str],
+    calibration_artifact: Optional[Path],
+) -> str:
+    if shadow_model_version:
+        return shadow_model_version
+    base = model_artifact.parent.name or model_artifact.stem
+    if calibration_artifact:
+        return f"{base}:calibrated"
+    return base
+
+
+def process_shadow_rows(
+    *,
+    supabase: Client,
+    model: PointInTimeMatchModel,
+    model_artifact: Path,
+    shadow_status: str,
+    limit: int,
+    shadow_model_version: Optional[str] = None,
+    calibration_artifact: Optional[Path] = None,
+) -> Dict[str, Any]:
+    rows = _fetch_shadow_rows(supabase, shadow_status, limit)
+    calibrator = (
+        PointInTimeProbabilityCalibrator.load(str(calibration_artifact)) if calibration_artifact else None
+    )
+    model_version = _derive_shadow_model_version(model_artifact, shadow_model_version, calibration_artifact)
+
+    summary = {
+        "requested_status": shadow_status,
+        "requested_limit": limit,
+        "model_artifact": str(model_artifact),
+        "calibration_artifact": str(calibration_artifact) if calibration_artifact else None,
+        "shadow_model_version": model_version,
+        "fetched_rows": len(rows),
+        "processed": 0,
+        "completed": 0,
+        "errored": 0,
+        "row_ids": [],
+    }
+
+    for row in rows:
+        row_id = str(row["id"])
+        summary["processed"] += 1
+        summary["row_ids"].append(row_id)
+        try:
+            request_context = _safe_request_context(row.get("request_context"))
+            games = _fetch_games_by_ids(supabase, request_context.get("relevantGameIds") or [])
+            involved_team_ids = {
+                team_id
+                for game in games
+                for team_id in (game.home_team_master_id, game.away_team_master_id)
+                if team_id
+            }
+            involved_team_ids.update(
+                [
+                    str((row.get("team_a_input") or {}).get("team_id_master") or row.get("team_a_id") or ""),
+                    str((row.get("team_b_input") or {}).get("team_id_master") or row.get("team_b_id") or ""),
+                ]
+            )
+            snapshot_date = (str(row.get("created_at") or "").split("T")[0]) or pd.Timestamp.utcnow().strftime("%Y-%m-%d")
+            snapshot_index = _fetch_snapshot_index(supabase, involved_team_ids, snapshot_date)
+            matchup_frame = _build_matchup_frame(row, games, snapshot_index)
+            prediction_frame = model.predict_frame(matchup_frame)
+            prediction_frame = _apply_optional_calibration(prediction_frame, model, calibrator)
+            prediction_row = prediction_frame.iloc[0]
+            payload = _build_shadow_payload(
+                prediction_row,
+                model_version=model_version,
+                calibrated=calibrator is not None,
+            )
+            _update_shadow_row(
+                supabase,
+                row_id,
+                shadow_status="completed",
+                shadow_model_version=model_version,
+                shadow_prediction=payload,
+            )
+            summary["completed"] += 1
+        except Exception as error:
+            logger.exception("Failed to process shadow row %s", row_id)
+            _update_shadow_row(
+                supabase,
+                row_id,
+                shadow_status="error",
+                shadow_model_version=model_version,
+                shadow_prediction={
+                    "modelVersion": model_version,
+                    "error": {
+                        "type": error.__class__.__name__,
+                        "message": str(error),
+                    },
+                },
+            )
+            summary["errored"] += 1
+
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process pending match prediction shadow-log rows")
+    parser.add_argument("--model-artifact", required=True, help="Path to point_in_time_match_model.pkl")
+    parser.add_argument(
+        "--calibration-artifact",
+        default=None,
+        help="Optional path to point_in_time_model_calibration.pkl",
+    )
+    parser.add_argument(
+        "--shadow-status",
+        default="pending",
+        help="Shadow status to pull from match_prediction_shadow_log",
+    )
+    parser.add_argument("--limit", type=int, default=100, help="Maximum number of rows to process")
+    parser.add_argument(
+        "--shadow-model-version",
+        default=None,
+        help="Version label stored on processed rows",
+    )
+    parser.add_argument(
+        "--summary-path",
+        default=None,
+        help="Optional path to write a JSON summary",
+    )
+    args = parser.parse_args()
+
+    model_artifact = Path(args.model_artifact)
+    if not model_artifact.exists():
+        raise FileNotFoundError(f"Model artifact not found: {model_artifact}")
+
+    calibration_artifact = Path(args.calibration_artifact) if args.calibration_artifact else None
+    if calibration_artifact and not calibration_artifact.exists():
+        raise FileNotFoundError(f"Calibration artifact not found: {calibration_artifact}")
+
+    supabase = _supabase_client()
+    model = PointInTimeMatchModel.load(str(model_artifact))
+    summary = process_shadow_rows(
+        supabase=supabase,
+        model=model,
+        model_artifact=model_artifact,
+        shadow_status=args.shadow_status,
+        limit=args.limit,
+        shadow_model_version=args.shadow_model_version,
+        calibration_artifact=calibration_artifact,
+    )
+
+    if args.summary_path:
+        summary_path = Path(args.summary_path)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -794,6 +794,173 @@ def _outcome_label(score_a: int, score_b: int) -> Tuple[int, str]:
     return OUTCOME_DRAW, OUTCOME_LABELS[OUTCOME_DRAW]
 
 
+def build_point_in_time_matchup_row(
+    team_a_id: str,
+    team_b_id: str,
+    team_a_snapshot: dict,
+    team_b_snapshot: dict,
+    all_games: List[PredictorGame],
+    game_date: str,
+    *,
+    snapshot_index: Optional[Dict[str, List[dict]]] = None,
+    team_names: Optional[Dict[str, str]] = None,
+    game_id: str = "shadow_matchup",
+    example_orientation: str = "shadow",
+    actual_score_a: Optional[int] = None,
+    actual_score_b: Optional[int] = None,
+) -> Dict[str, object]:
+    """
+    Build one offline-model feature row for a matchup using point-in-time snapshot fields.
+
+    This is used both by the training harness and by shadow inference so the offline
+    model sees the same feature assembly logic in both paths.
+    """
+    snapshot_index = snapshot_index or {}
+    team_names = team_names or {}
+    combined_prior_games = _dedupe_games(all_games)
+    team_a_prior_games = [
+        game
+        for game in combined_prior_games
+        if game.home_team_master_id == team_a_id or game.away_team_master_id == team_a_id
+    ]
+    team_b_prior_games = [
+        game
+        for game in combined_prior_games
+        if game.home_team_master_id == team_b_id or game.away_team_master_id == team_b_id
+    ]
+
+    recent_form_a = calculate_recent_form(team_a_id, team_a_prior_games)
+    recent_form_b = calculate_recent_form(team_b_id, team_b_prior_games)
+    h2h = calculate_head_to_head(team_a_id, team_b_id, combined_prior_games)
+    common_opponents = calculate_common_opponent_signal(team_a_id, team_b_id, combined_prior_games)
+    common_opponent_details = _build_common_opponent_feature_summary(
+        team_a_id=team_a_id,
+        team_b_id=team_b_id,
+        all_games=combined_prior_games,
+        snapshot_index=snapshot_index,
+        target_date=game_date,
+        team_age_numeric=max(
+            _extract_age_numeric(team_a_snapshot.get("age_group")),
+            _extract_age_numeric(team_b_snapshot.get("age_group")),
+        ),
+    )
+
+    enriched_team_a_snapshot = {**team_a_snapshot, "_game_date": game_date}
+    enriched_team_b_snapshot = {**team_b_snapshot, "_game_date": game_date}
+    features = _paired_snapshot_features(enriched_team_a_snapshot, enriched_team_b_snapshot)
+
+    if actual_score_a is not None and actual_score_b is not None:
+        actual_outcome_code, actual_outcome_name = _outcome_label(int(actual_score_a), int(actual_score_b))
+        actual_margin = int(actual_score_a - actual_score_b)
+        actual_score_a_value = int(actual_score_a)
+        actual_score_b_value = int(actual_score_b)
+    else:
+        actual_outcome_code = OUTCOME_DRAW
+        actual_outcome_name = OUTCOME_LABELS[OUTCOME_DRAW]
+        actual_margin = float("nan")
+        actual_score_a_value = float("nan")
+        actual_score_b_value = float("nan")
+
+    features.update(
+        {
+            "team_a_recent_form": recent_form_a,
+            "team_b_recent_form": recent_form_b,
+            "recent_form_diff": recent_form_a - recent_form_b,
+            "recent_form_gap_abs": abs(recent_form_a - recent_form_b),
+            "recent_form_closeness": math.exp(-abs(recent_form_a - recent_form_b) / 0.3),
+            "head_to_head_advantage": _to_float(h2h.get("advantage")),
+            "head_to_head_games": _to_float(h2h.get("gamesPlayed")),
+            "head_to_head_avg_margin": _to_float(h2h.get("avgMargin")),
+            "head_to_head_gap_abs": abs(_to_float(h2h.get("advantage"))),
+            "head_to_head_closeness": math.exp(-abs(_to_float(h2h.get("advantage"))) / 0.35)
+            if _to_float(h2h.get("gamesPlayed")) > 0
+            else 0.5,
+            "common_opponent_advantage": _to_float(common_opponents.get("advantage")),
+            "common_opponent_shared": _to_float(common_opponents.get("sharedOpponents")),
+            "common_opponent_compared_games": _to_float(common_opponents.get("comparedGames")),
+            "common_opponent_avg_margin_diff": _to_float(common_opponents.get("avgMarginDiff")),
+            "common_opponent_points_diff": _to_float(common_opponents.get("pointsPerGameDiff")),
+            "common_opponent_reliability": _to_float(common_opponents.get("reliability")),
+            "common_opponent_gap_abs": abs(_to_float(common_opponents.get("advantage"))),
+            "common_opponent_closeness": math.exp(-abs(_to_float(common_opponents.get("advantage"))) / 0.3)
+            if _to_float(common_opponents.get("sharedOpponents")) > 0
+            else 0.5,
+            "common_opponent_strength_weighted_shared": _to_float(
+                common_opponent_details.get("strengthWeightedSharedOpponents")
+            ),
+            "common_opponent_same_age_shared": _to_float(common_opponent_details.get("sameAgeSharedOpponents")),
+            "common_opponent_same_age_rate": _to_float(common_opponent_details.get("sameAgeSharedOpponentRate")),
+            "common_opponent_strength_weighted_reliability": _to_float(
+                common_opponent_details.get("strengthWeightedReliability")
+            ),
+            "common_opponent_strength_weighted_margin_diff": _to_float(
+                common_opponent_details.get("strengthWeightedMarginDiff")
+            ),
+            "common_opponent_strength_weighted_points_diff": _to_float(
+                common_opponent_details.get("strengthWeightedPointsPerGameDiff")
+            ),
+            "common_opponent_strength_weighted_goals_for_diff": _to_float(
+                common_opponent_details.get("strengthWeightedGoalsForDiff")
+            ),
+            "common_opponent_strength_weighted_goals_against_adv": _to_float(
+                common_opponent_details.get("strengthWeightedGoalsAgainstAdv")
+            ),
+            "common_opponent_strength_weighted_win_rate_diff": _to_float(
+                common_opponent_details.get("strengthWeightedWinRateDiff")
+            ),
+            "common_opponent_strength_weighted_draw_rate_diff": _to_float(
+                common_opponent_details.get("strengthWeightedDrawRateDiff")
+            ),
+            "common_opponent_strength_weighted_goal_balance_diff": _to_float(
+                common_opponent_details.get("strengthWeightedGoalBalanceDiff")
+            ),
+            "common_opponent_strength_weighted_opponent_power": _to_float(
+                common_opponent_details.get("strengthWeightedOpponentPower")
+            ),
+            "common_opponent_consensus_signal": _to_float(
+                common_opponent_details.get("commonOpponentConsensusSignal")
+            ),
+            "team_a_prior_game_count": float(len(team_a_prior_games)),
+            "team_b_prior_game_count": float(len(team_b_prior_games)),
+            "combined_prior_game_count": float(len(combined_prior_games)),
+            "game_id": str(game_id),
+            "game_date": str(game_date),
+            "team_a_id": team_a_id,
+            "team_b_id": team_b_id,
+            "team_a_name": team_names.get(team_a_id),
+            "team_b_name": team_names.get(team_b_id),
+            "team_a_snapshot_date": team_a_snapshot.get("snapshot_date"),
+            "team_b_snapshot_date": team_b_snapshot.get("snapshot_date"),
+            "example_orientation": example_orientation,
+            "actual_score_a": actual_score_a_value,
+            "actual_score_b": actual_score_b_value,
+            "actual_margin": actual_margin,
+            "actual_outcome": actual_outcome_name,
+            "actual_outcome_label": int(actual_outcome_code),
+        }
+    )
+
+    stalemate_components = [
+        _to_float(features.get("snapshot_strength_closeness")),
+        _to_float(features.get("goal_balance_signal")),
+        _to_float(features.get("low_total_goal_signal")),
+        _to_float(features.get("recent_form_closeness")),
+        _to_float(features.get("common_opponent_closeness")),
+        _to_float(features.get("head_to_head_closeness")),
+    ]
+    stalemate_signal = float(np.mean(stalemate_components)) * (0.7 + 0.6 * _to_float(features.get("combined_draw_rate")))
+    features["stalemate_signal"] = float(np.clip(stalemate_signal, 0.0, 1.0))
+    features["expected_draw_environment"] = float(
+        np.clip(
+            _to_float(features.get("combined_draw_rate")) * _to_float(features.get("low_total_goal_signal")),
+            0.0,
+            1.0,
+        )
+    )
+
+    return features
+
+
 def build_point_in_time_dataset(
     games_df: pd.DataFrame,
     snapshot_index: Dict[str, List[dict]],
@@ -840,132 +1007,20 @@ def build_point_in_time_dataset(
         team_a_prior_games = list(per_team_history.get(team_a_id, []))
         team_b_prior_games = list(per_team_history.get(team_b_id, []))
         combined_prior_games = _dedupe_games(team_a_prior_games + team_b_prior_games)
-
-        recent_form_a = calculate_recent_form(team_a_id, team_a_prior_games)
-        recent_form_b = calculate_recent_form(team_b_id, team_b_prior_games)
-        h2h = calculate_head_to_head(team_a_id, team_b_id, combined_prior_games)
-        common_opponents = calculate_common_opponent_signal(team_a_id, team_b_id, combined_prior_games)
-        common_opponent_details = _build_common_opponent_feature_summary(
+        return build_point_in_time_matchup_row(
             team_a_id=team_a_id,
             team_b_id=team_b_id,
+            team_a_snapshot=team_a_snapshot,
+            team_b_snapshot=team_b_snapshot,
             all_games=combined_prior_games,
+            game_date=str(game_row["game_date"]),
             snapshot_index=snapshot_index,
-            target_date=str(game_row["game_date"]),
-            team_age_numeric=max(
-                _extract_age_numeric(team_a_snapshot.get("age_group")),
-                _extract_age_numeric(team_b_snapshot.get("age_group")),
-            ),
+            team_names=team_names,
+            game_id=str(game_row["id"]),
+            example_orientation=orientation,
+            actual_score_a=score_a,
+            actual_score_b=score_b,
         )
-        actual_outcome_code, actual_outcome_name = _outcome_label(score_a, score_b)
-
-        enriched_team_a_snapshot = {**team_a_snapshot, "_game_date": game_row["game_date"]}
-        enriched_team_b_snapshot = {**team_b_snapshot, "_game_date": game_row["game_date"]}
-        features = _paired_snapshot_features(enriched_team_a_snapshot, enriched_team_b_snapshot)
-
-        features.update(
-            {
-                "team_a_recent_form": recent_form_a,
-                "team_b_recent_form": recent_form_b,
-                "recent_form_diff": recent_form_a - recent_form_b,
-                "recent_form_gap_abs": abs(recent_form_a - recent_form_b),
-                "recent_form_closeness": math.exp(-abs(recent_form_a - recent_form_b) / 0.3),
-                "head_to_head_advantage": _to_float(h2h.get("advantage")),
-                "head_to_head_games": _to_float(h2h.get("gamesPlayed")),
-                "head_to_head_avg_margin": _to_float(h2h.get("avgMargin")),
-                "head_to_head_gap_abs": abs(_to_float(h2h.get("advantage"))),
-                "head_to_head_closeness": math.exp(-abs(_to_float(h2h.get("advantage"))) / 0.35)
-                if _to_float(h2h.get("gamesPlayed")) > 0
-                else 0.5,
-                "common_opponent_advantage": _to_float(common_opponents.get("advantage")),
-                "common_opponent_shared": _to_float(common_opponents.get("sharedOpponents")),
-                "common_opponent_compared_games": _to_float(common_opponents.get("comparedGames")),
-                "common_opponent_avg_margin_diff": _to_float(common_opponents.get("avgMarginDiff")),
-                "common_opponent_points_diff": _to_float(common_opponents.get("pointsPerGameDiff")),
-                "common_opponent_reliability": _to_float(common_opponents.get("reliability")),
-                "common_opponent_gap_abs": abs(_to_float(common_opponents.get("advantage"))),
-                "common_opponent_closeness": math.exp(-abs(_to_float(common_opponents.get("advantage"))) / 0.3)
-                if _to_float(common_opponents.get("sharedOpponents")) > 0
-                else 0.5,
-                "common_opponent_strength_weighted_shared": _to_float(
-                    common_opponent_details.get("strengthWeightedSharedOpponents")
-                ),
-                "common_opponent_same_age_shared": _to_float(
-                    common_opponent_details.get("sameAgeSharedOpponents")
-                ),
-                "common_opponent_same_age_rate": _to_float(
-                    common_opponent_details.get("sameAgeSharedOpponentRate")
-                ),
-                "common_opponent_strength_weighted_reliability": _to_float(
-                    common_opponent_details.get("strengthWeightedReliability")
-                ),
-                "common_opponent_strength_weighted_margin_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedMarginDiff")
-                ),
-                "common_opponent_strength_weighted_points_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedPointsPerGameDiff")
-                ),
-                "common_opponent_strength_weighted_goals_for_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedGoalsForDiff")
-                ),
-                "common_opponent_strength_weighted_goals_against_adv": _to_float(
-                    common_opponent_details.get("strengthWeightedGoalsAgainstAdv")
-                ),
-                "common_opponent_strength_weighted_win_rate_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedWinRateDiff")
-                ),
-                "common_opponent_strength_weighted_draw_rate_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedDrawRateDiff")
-                ),
-                "common_opponent_strength_weighted_goal_balance_diff": _to_float(
-                    common_opponent_details.get("strengthWeightedGoalBalanceDiff")
-                ),
-                "common_opponent_strength_weighted_opponent_power": _to_float(
-                    common_opponent_details.get("strengthWeightedOpponentPower")
-                ),
-                "common_opponent_consensus_signal": _to_float(
-                    common_opponent_details.get("commonOpponentConsensusSignal")
-                ),
-                "team_a_prior_game_count": float(len(team_a_prior_games)),
-                "team_b_prior_game_count": float(len(team_b_prior_games)),
-                "combined_prior_game_count": float(len(combined_prior_games)),
-                "game_id": str(game_row["id"]),
-                "game_date": str(game_row["game_date"]),
-                "team_a_id": team_a_id,
-                "team_b_id": team_b_id,
-                "team_a_name": team_names.get(team_a_id),
-                "team_b_name": team_names.get(team_b_id),
-                "team_a_snapshot_date": team_a_snapshot.get("snapshot_date"),
-                "team_b_snapshot_date": team_b_snapshot.get("snapshot_date"),
-                "example_orientation": orientation,
-                "actual_score_a": int(score_a),
-                "actual_score_b": int(score_b),
-                "actual_margin": int(score_a - score_b),
-                "actual_outcome": actual_outcome_name,
-                "actual_outcome_label": int(actual_outcome_code),
-            }
-        )
-
-        stalemate_components = [
-            _to_float(features.get("snapshot_strength_closeness")),
-            _to_float(features.get("goal_balance_signal")),
-            _to_float(features.get("low_total_goal_signal")),
-            _to_float(features.get("recent_form_closeness")),
-            _to_float(features.get("common_opponent_closeness")),
-            _to_float(features.get("head_to_head_closeness")),
-        ]
-        stalemate_signal = float(np.mean(stalemate_components)) * (
-            0.7 + 0.6 * _to_float(features.get("combined_draw_rate"))
-        )
-        features["stalemate_signal"] = float(np.clip(stalemate_signal, 0.0, 1.0))
-        features["expected_draw_environment"] = float(
-            np.clip(
-                _to_float(features.get("combined_draw_rate")) * _to_float(features.get("low_total_goal_signal")),
-                0.0,
-                1.0,
-            )
-        )
-
-        return features
 
     for _, game_row in games_df.iterrows():
         if pd.isna(game_row.get("home_team_master_id")) or pd.isna(game_row.get("away_team_master_id")):

--- a/tests/unit/test_point_in_time_match_model.py
+++ b/tests/unit/test_point_in_time_match_model.py
@@ -8,6 +8,7 @@ from src.predictions.point_in_time_match_model import (
     _poisson_outcome_probabilities,
     _poisson_score_matrix,
     _score_matrix_summary,
+    build_point_in_time_matchup_row,
     build_point_in_time_dataset,
 )
 
@@ -195,6 +196,53 @@ def test_build_point_in_time_dataset_tracks_draw_oriented_signals():
     assert row["snapshot_strength_closeness"] > 0.0
     assert row["expected_draw_environment"] > 0.0
     assert row["common_opponent_same_age_rate"] == 0.0
+    assert row["common_opponent_strength_weighted_shared"] == 0.0
+    assert 0.0 <= row["stalemate_signal"] <= 1.0
+
+
+def test_build_point_in_time_matchup_row_supports_inference_without_actual_scores():
+    team_a_snapshot = _snapshot(
+        "2026-04-01",
+        "a",
+        age_group="10",
+        draws=5,
+        games_played=12,
+        exp_goals_for=1.0,
+        exp_goals_against=0.9,
+        exp_margin=0.1,
+        exp_win_rate=0.52,
+    )
+    team_b_snapshot = _snapshot(
+        "2026-04-01",
+        "b",
+        age_group="10",
+        draws=4,
+        games_played=12,
+        exp_goals_for=0.95,
+        exp_goals_against=0.95,
+        exp_margin=0.05,
+        exp_win_rate=0.51,
+    )
+    all_games = []
+
+    row = build_point_in_time_matchup_row(
+        team_a_id="a",
+        team_b_id="b",
+        team_a_snapshot=team_a_snapshot,
+        team_b_snapshot=team_b_snapshot,
+        all_games=all_games,
+        game_date="2026-04-09",
+        team_names={"a": "Alpha", "b": "Bravo"},
+        game_id="shadow-1",
+    )
+
+    assert row["game_id"] == "shadow-1"
+    assert row["team_a_name"] == "Alpha"
+    assert row["team_b_name"] == "Bravo"
+    assert row["actual_outcome"] == "draw"
+    assert np.isnan(row["actual_margin"])
+    assert row["age_group_numeric"] == 10
+    assert row["combined_prior_game_count"] == 0.0
     assert row["common_opponent_strength_weighted_shared"] == 0.0
     assert 0.0 <= row["stalemate_signal"] <= 1.0
 


### PR DESCRIPTION
## Summary
- add a workflow to process pending /compare shadow-log rows against a chosen offline model artifact
- add a Python shadow processor that downloads pending rows, rebuilds offline model features, and writes shadow predictions back to Supabase
- refactor the point-in-time model feature assembly so a single matchup can be scored with the same feature logic used in training

## Validation
- python -m pytest C:\\PitchRank_draw_model_clean\\tests\\unit\\test_point_in_time_match_model.py C:\\PitchRank_draw_model_clean\\tests\\unit\\test_point_in_time_calibration.py C:\\PitchRank_draw_model_clean\\tests\\unit\\test_evaluation_reporting.py
- python -m py_compile C:\\PitchRank_draw_model_clean\\src\\predictions\\point_in_time_match_model.py C:\\PitchRank_draw_model_clean\\scripts\\process_match_prediction_shadow.py C:\\PitchRank_draw_model_clean\\scripts\\calibrate_point_in_time_match_model.py C:\\PitchRank_draw_model_clean\\src\\predictions\\point_in_time_calibration.py