### PR TITLE
Fix shadow score display consistency

### DIFF
--- a/scripts/process_match_prediction_shadow.py
+++ b/scripts/process_match_prediction_shadow.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import sys
 from pathlib import Path
@@ -267,6 +268,52 @@ def _to_python(value: Any) -> Any:
     return value
 
 
+def _round_half_up(value: Any) -> int:
+    try:
+        numeric_value = float(value)
+    except Exception:
+        return 0
+    if math.isnan(numeric_value) or math.isinf(numeric_value):
+        return 0
+    return max(0, int(math.floor(numeric_value + 0.5)))
+
+
+def _winner_consistent_expected_score(
+    predicted_winner: str,
+    expected_goals_a: float,
+    expected_goals_b: float,
+) -> Dict[str, int]:
+    score_a = _round_half_up(expected_goals_a)
+    score_b = _round_half_up(expected_goals_b)
+
+    if predicted_winner == "team_a" and score_a <= score_b:
+        score_a = score_b + 1
+    elif predicted_winner == "team_b" and score_b <= score_a:
+        score_b = score_a + 1
+    elif predicted_winner == "draw" and score_a != score_b:
+        tied_score = _round_half_up((float(expected_goals_a) + float(expected_goals_b)) / 2.0)
+        score_a = tied_score
+        score_b = tied_score
+
+    return {
+        "teamA": score_a,
+        "teamB": score_b,
+    }
+
+
+def _winner_consistent_expected_margin(
+    predicted_winner: str,
+    expected_goals_a: float,
+    expected_goals_b: float,
+) -> float:
+    expected_goal_margin = float(expected_goals_a) - float(expected_goals_b)
+    if predicted_winner == "team_a":
+        return expected_goal_margin if expected_goal_margin > 0.0 else max(abs(expected_goal_margin), 0.05)
+    if predicted_winner == "team_b":
+        return expected_goal_margin if expected_goal_margin < 0.0 else -max(abs(expected_goal_margin), 0.05)
+    return 0.0
+
+
 def _build_shadow_payload(
     prediction_row: pd.Series,
     *,
@@ -274,6 +321,17 @@ def _build_shadow_payload(
     calibrated: bool,
 ) -> Dict[str, Any]:
     predicted_winner = str(prediction_row.get("predicted_outcome") or "draw")
+    expected_goals_a = float(prediction_row.get("expected_goals_a") or 0.0)
+    expected_goals_b = float(prediction_row.get("expected_goals_b") or 0.0)
+    displayed_score = _winner_consistent_expected_score(
+        predicted_winner=predicted_winner,
+        expected_goals_a=expected_goals_a,
+        expected_goals_b=expected_goals_b,
+    )
+    modal_score = {
+        "teamA": _round_half_up(prediction_row.get("predicted_score_a")),
+        "teamB": _round_half_up(prediction_row.get("predicted_score_b")),
+    }
     return {
         "modelVersion": model_version,
         "calibrated": calibrated,
@@ -282,11 +340,12 @@ def _build_shadow_payload(
             "winProbabilityA": float(prediction_row["prob_team_a_win"]),
             "drawProbability": float(prediction_row["prob_draw"]),
             "winProbabilityB": float(prediction_row["prob_team_b_win"]),
-            "expectedScore": {
-                "teamA": int(round(float(prediction_row["predicted_score_a"]))),
-                "teamB": int(round(float(prediction_row["predicted_score_b"]))),
-            },
-            "expectedMargin": float(prediction_row["predicted_margin"]),
+            "expectedScore": displayed_score,
+            "expectedMargin": _winner_consistent_expected_margin(
+                predicted_winner=predicted_winner,
+                expected_goals_a=expected_goals_a,
+                expected_goals_b=expected_goals_b,
+            ),
             "probabilityStrategy": str(prediction_row.get("probability_strategy") or ""),
             "blowoutProbability3Plus": float(prediction_row.get("blowout_3plus_probability") or 0.0),
             "blowoutProbability5Plus": float(prediction_row.get("blowout_5plus_probability") or 0.0),
@@ -296,8 +355,10 @@ def _build_shadow_payload(
         "diagnostics": {
             "stalemateSignal": float(prediction_row.get("stalemate_signal") or 0.0),
             "projectedTotalGoals": float(prediction_row.get("projected_total_goals") or 0.0),
-            "expectedGoalsA": float(prediction_row.get("expected_goals_a") or 0.0),
-            "expectedGoalsB": float(prediction_row.get("expected_goals_b") or 0.0),
+            "expectedGoalsA": expected_goals_a,
+            "expectedGoalsB": expected_goals_b,
+            "mostLikelyExactScore": modal_score,
+            "modelPredictedMargin": float(prediction_row.get("predicted_margin") or 0.0),
             "poissonProbabilities": {
                 "teamA": float(prediction_row.get("poisson_prob_team_a_win") or 0.0),
                 "draw": float(prediction_row.get("poisson_prob_draw") or 0.0),

--- a/tests/unit/test_process_match_prediction_shadow.py
+++ b/tests/unit/test_process_match_prediction_shadow.py
@@ -1,0 +1,79 @@
+import pandas as pd
+
+from scripts.process_match_prediction_shadow import (
+    _build_shadow_payload,
+    _winner_consistent_expected_margin,
+    _winner_consistent_expected_score,
+)
+
+
+def test_winner_consistent_expected_score_breaks_team_a_rounding_ties():
+    assert _winner_consistent_expected_score("team_a", 1.47, 0.95) == {
+        "teamA": 2,
+        "teamB": 1,
+    }
+
+
+def test_winner_consistent_expected_score_breaks_team_b_rounding_ties():
+    assert _winner_consistent_expected_score("team_b", 1.54, 1.62) == {
+        "teamA": 2,
+        "teamB": 3,
+    }
+
+
+def test_winner_consistent_expected_score_forces_draw_when_requested():
+    assert _winner_consistent_expected_score("draw", 1.8, 1.1) == {
+        "teamA": 1,
+        "teamB": 1,
+    }
+
+
+def test_winner_consistent_expected_margin_matches_predicted_outcome_sign():
+    assert _winner_consistent_expected_margin("team_a", 1.47, 0.95) > 0.0
+    assert _winner_consistent_expected_margin("team_b", 1.54, 1.62) < 0.0
+    assert _winner_consistent_expected_margin("draw", 1.8, 1.1) == 0.0
+
+
+def test_build_shadow_payload_uses_display_score_and_preserves_modal_score():
+    row = pd.Series(
+        {
+            "predicted_outcome": "team_a",
+            "prob_team_a_win": 0.47704715175775714,
+            "prob_draw": 0.2954344812878684,
+            "prob_team_b_win": 0.22751836695437444,
+            "predicted_score_a": 1.0,
+            "predicted_score_b": 1.0,
+            "predicted_margin": 0.7082579731941223,
+            "probability_strategy": "poisson_draw_gate",
+            "blowout_3plus_probability": 0.26231986294467396,
+            "blowout_5plus_probability": 0.09890575024836547,
+            "predicted_blowout_3plus": 0,
+            "predicted_blowout_5plus": 0,
+            "stalemate_signal": 0.4963766155165165,
+            "projected_total_goals": 1.2574358867852915,
+            "expected_goals_a": 1.474945352180432,
+            "expected_goals_b": 0.9507100470258216,
+            "poisson_prob_team_a_win": 0.4781175029552596,
+            "poisson_prob_draw": 0.2938536468904849,
+            "poisson_prob_team_b_win": 0.22802885015425547,
+            "draw_model_probability": 0.225744701128555,
+        }
+    )
+
+    payload = _build_shadow_payload(
+        row,
+        model_version="pitm_test",
+        calibrated=False,
+    )
+
+    assert payload["prediction"]["predictedWinner"] == "team_a"
+    assert payload["prediction"]["expectedScore"] == {
+        "teamA": 2,
+        "teamB": 1,
+    }
+    assert payload["prediction"]["expectedMargin"] > 0.0
+    assert payload["diagnostics"]["mostLikelyExactScore"] == {
+        "teamA": 1,
+        "teamB": 1,
+    }
+    assert payload["diagnostics"]["modelPredictedMargin"] == 0.7082579731941223


### PR DESCRIPTION
## Summary
- make shadow payload score display winner-consistent instead of mirroring the modal Poisson cell
- expose the raw modal exact score and raw model margin in diagnostics for debugging
- add unit coverage for winner-consistent score and margin formatting

## Testing
- python -m pytest tests/unit/test_process_match_prediction_shadow.py
- python -m py_compile scripts/process_match_prediction_shadow.py tests/unit/test_process_match_prediction_shadow.py
