### PR TITLE
Fix indexing gaps: sitemap, SSR content, redirect

### DIFF
--- a/frontend/app/api/match-prediction/__tests__/route.test.ts
+++ b/frontend/app/api/match-prediction/__tests__/route.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextRequest } from 'next/server';
 import { AppError } from '@/lib/errors';
 
-const { mockRequirePremium, mockCheckRateLimit, mockBuildMatchPrediction } = vi.hoisted(() => ({
+vi.mock('server-only', () => ({}));
+
+const { mockRequirePremium, mockCheckRateLimit, mockBuildMatchPrediction, mockMaybeLogShadow } = vi.hoisted(() => ({
   mockRequirePremium: vi.fn(),
   mockCheckRateLimit: vi.fn(),
   mockBuildMatchPrediction: vi.fn(),
+  mockMaybeLogShadow: vi.fn(),
 }));
 
 vi.mock('@/lib/api/requirePremium', () => ({
@@ -17,7 +20,11 @@ vi.mock('@/lib/api/rateLimit', () => ({
 }));
 
 vi.mock('@/lib/matchPredictionService', () => ({
-  buildMatchPrediction: mockBuildMatchPrediction,
+  buildMatchPredictionWithShadowContext: mockBuildMatchPrediction,
+}));
+
+vi.mock('@/lib/matchPredictionShadow', () => ({
+  maybeLogMatchPredictionShadow: mockMaybeLogShadow,
 }));
 
 import { POST } from '../route';
@@ -100,38 +107,41 @@ describe('POST /api/match-prediction', () => {
 
   it('returns a prediction payload for a valid premium request', async () => {
     mockBuildMatchPrediction.mockResolvedValue({
-      teamA: { team_id_master: TEAM_A_ID, team_name: 'Alpha FC', club_name: 'Alpha' },
-      teamB: { team_id_master: TEAM_B_ID, team_name: 'Beta FC', club_name: 'Beta' },
-      prediction: {
-        predictedWinner: 'team_a',
-        winProbabilityA: 0.71,
-        winProbabilityB: 0.29,
-        expectedScore: { teamA: 3, teamB: 1 },
-        expectedMargin: 2,
-        confidence: 'high',
-        confidence_score: 0.82,
-        components: {
-          powerDiff: 0.1,
-          strengthSignal: 0.1,
-          sosDiff: 0.04,
-          formDiffRaw: 1.2,
-          formDiffNorm: 0.1,
-          matchupAdvantage: 0.08,
-          compositeDiff: 0.22,
-          mismatchScore: 0.31,
-        },
-        formA: 1.2,
-        formB: -0.2,
-      },
-      explanation: {
-        summary: 'Alpha FC has the edge with 71% win probability',
-        factors: [],
-        keyInsights: ['High confidence prediction'],
-        predictionQuality: {
+      response: {
+        teamA: { team_id_master: TEAM_A_ID, team_name: 'Alpha FC', club_name: 'Alpha' },
+        teamB: { team_id_master: TEAM_B_ID, team_name: 'Beta FC', club_name: 'Beta' },
+        prediction: {
+          predictedWinner: 'team_a',
+          winProbabilityA: 0.71,
+          winProbabilityB: 0.29,
+          expectedScore: { teamA: 3, teamB: 1 },
+          expectedMargin: 2,
           confidence: 'high',
-          reliability: 'Based on current calibrated model output',
+          confidence_score: 0.82,
+          components: {
+            powerDiff: 0.1,
+            strengthSignal: 0.1,
+            sosDiff: 0.04,
+            formDiffRaw: 1.2,
+            formDiffNorm: 0.1,
+            matchupAdvantage: 0.08,
+            compositeDiff: 0.22,
+            mismatchScore: 0.31,
+          },
+          formA: 1.2,
+          formB: -0.2,
+        },
+        explanation: {
+          summary: 'Alpha FC has the edge with 71% win probability',
+          factors: [],
+          keyInsights: ['High confidence prediction'],
+          predictionQuality: {
+            confidence: 'high',
+            reliability: 'Based on current calibrated model output',
+          },
         },
       },
+      shadowContext: {},
     });
 
     const response = await POST(makeRequest({ teamAId: TEAM_A_ID, teamBId: TEAM_B_ID }));

--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -1,6 +1,8 @@
 import { RankingsPageContent } from '@/components/RankingsPageContent';
 import type { Metadata } from 'next';
 import { US_STATES, BASE_URL, formatGender } from '@/lib/constants';
+import { api } from '@/lib/api';
+import { formatPowerScore } from '@/lib/utils';
 import BreadcrumbSchema from '@/components/BreadcrumbSchema';
 
 // Revalidate every hour for ISR caching
@@ -96,6 +98,28 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
   // This ensures fresh data fetching on client-side navigation between different rankings pages
   const routeKey = `${region}-${ageGroup}-${gender}`;
 
+  // Server-side fetch top 25 teams so the initial HTML has real content for Googlebot.
+  // Rendered as a static section below the interactive table — does not interfere with client-side loading.
+  const genderForAPI = (gender === 'male' ? 'M' : gender === 'female' ? 'F' : null) as 'M' | 'F' | null;
+  const regionForAPI = region.toLowerCase() === 'national' ? null : region;
+  let topTeams: Array<{
+    team_id_master: string;
+    team_name: string;
+    club_name: string | null;
+    power_score_final: number;
+  }> = [];
+  try {
+    const data = await api.getRankings(regionForAPI, ageGroup, genderForAPI, { limit: 25 });
+    topTeams = data.map((t) => ({
+      team_id_master: t.team_id_master,
+      team_name: t.team_name,
+      club_name: t.club_name,
+      power_score_final: t.power_score_final,
+    }));
+  } catch {
+    // Non-fatal — interactive table still loads client-side
+  }
+
   // Prepare structured data for SEO
   const formattedAgeGroup = formatAgeGroup(ageGroup);
   const formattedGender = formatGender(gender);
@@ -132,6 +156,28 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
       <RankingsPageContent key={routeKey} region={region} ageGroup={ageGroup} gender={gender} />
       <BreadcrumbSchema items={breadcrumbItems} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd }} />
+
+      {/* Server-rendered top teams for SEO — gives Googlebot real content in the initial HTML.
+          The interactive table above loads the full dataset client-side. */}
+      {topTeams.length > 0 && (
+        <section className="container mx-auto px-4 pb-8">
+          <h2 className="text-xl font-bold mb-4">
+            Top {locationText} {formattedAgeGroup} {formattedGender} Teams
+          </h2>
+          <ol className="space-y-1 text-sm">
+            {topTeams.map((team, idx) => (
+              <li key={team.team_id_master} className="flex items-center gap-2">
+                <span className="text-muted-foreground w-6">{idx + 1}.</span>
+                <span>{team.team_name}</span>
+                {team.club_name && <span className="text-muted-foreground">({team.club_name})</span>}
+                <span className="text-xs text-muted-foreground ml-auto">
+                  {formatPowerScore(team.power_score_final)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
     </>
   );
 }

--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -186,7 +186,7 @@ export default async function StateOverviewPage({ params }: StateOverviewPagePro
     description: isNational
       ? 'Comprehensive national youth soccer rankings by age group and gender'
       : `Youth soccer rankings for ${stateInfo.name} across all age groups`,
-    url: `https://pitchrank.io/rankings/${region.toLowerCase()}`,
+    url: `${BASE_URL}/rankings/${region.toLowerCase()}`,
   };
 
   return (

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -60,8 +60,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
+  // State/national landing pages (e.g., /rankings/ca, /rankings/national)
+  // These are content-rich server-rendered overview pages — important for SEO
+  const regionLandingPages: MetadataRoute.Sitemap = regions.map((region) => ({
+    url: `${baseUrl}/rankings/${region}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: region === 'national' ? 0.9 : 0.8,
+  }));
+
   // Generate all ranking page URLs (region × ageGroup × gender)
-  // Total: 51 regions × 9 age groups × 2 genders = 918 URLs
   const rankingPages: MetadataRoute.Sitemap = [];
 
   for (const region of regions) {
@@ -70,15 +78,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
         rankingPages.push({
           url: `${baseUrl}/rankings/${region}/${ageGroup}/${gender}`,
           lastModified: new Date(),
-          changeFrequency: 'weekly', // Rankings update weekly
-          priority: region === 'national' ? 0.8 : 0.7, // National rankings slightly higher priority
+          changeFrequency: 'weekly',
+          priority: region === 'national' ? 0.8 : 0.7,
         });
       }
     }
   }
 
   // Combine all pages
-  const allPages = [...staticPages, ...blogPages, ...rankingPages];
+  const allPages = [...staticPages, ...blogPages, ...regionLandingPages, ...rankingPages];
 
   return allPages;
 }

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Colorado Youth Soccer Rankings 2026: Best Clubs by Age"
+title: 'Colorado Youth Soccer Rankings 2026: Best Clubs by Age'
 slug: 'colorado-youth-soccer-rankings-guide'
-excerpt: "Find where your Colorado club ranks. Rapids Youth, Real Colorado, Colorado Storm and more — rated by PowerScore from real game results. Free rankings updated every Monday."
+excerpt: 'Find where your Colorado club ranks. Rapids Youth, Real Colorado, Colorado Storm and more — rated by PowerScore from real game results. Free rankings updated every Monday.'
 author: 'PitchRank Team'
 date: '2026-04-08'
 readingTime: '9 min read'

--- a/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
@@ -49,21 +49,21 @@ Florida isn't one market. It's at least four.
 
 Based on our database, the largest youth soccer organizations in Florida:
 
-| Club | Teams | Region |
-|------|-------|--------|
-| Florida Premier FC | 288 | Central FL |
-| Sporting Jax Soccer Academy | 187 | Northeast FL |
-| Jacksonville FC | 151 | Northeast FL |
-| Tampa Bay United | 107 | Central FL |
-| West Florida Flames | 89 | Gulf Coast |
-| Florida Kraze Krush | 84 | Central FL |
-| Chargers Soccer Club | 82 | South FL |
-| Coastal Rush | 71 | Gulf Coast |
-| Sol SC Florida | 69 | Central FL |
-| FC Prime | 69 | Central FL |
-| Weston FC | 66 | South FL |
-| Miami Athletic Club | 65 | South FL |
-| Miami Stars Soccer | 64 | South FL |
+| Club                        | Teams | Region       |
+| --------------------------- | ----- | ------------ |
+| Florida Premier FC          | 288   | Central FL   |
+| Sporting Jax Soccer Academy | 187   | Northeast FL |
+| Jacksonville FC             | 151   | Northeast FL |
+| Tampa Bay United            | 107   | Central FL   |
+| West Florida Flames         | 89    | Gulf Coast   |
+| Florida Kraze Krush         | 84    | Central FL   |
+| Chargers Soccer Club        | 82    | South FL     |
+| Coastal Rush                | 71    | Gulf Coast   |
+| Sol SC Florida              | 69    | Central FL   |
+| FC Prime                    | 69    | Central FL   |
+| Weston FC                   | 66    | South FL     |
+| Miami Athletic Club         | 65    | South FL     |
+| Miami Stars Soccer          | 64    | South FL     |
 
 These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to NPL, Florida State Premier League, and Florida Club Leagues at the state level.
 
@@ -111,17 +111,17 @@ The result is a **PowerScore between 0.0 and 1.0**:
 Florida's team density varies significantly by age group:
 
 | Age Group | Teams |
-|-----------|-------|
-| U10 | 317 |
-| U11 | 695 |
-| U12 | 758 |
-| U13 | 785 |
-| U14 | 675 |
-| U15 | 618 |
-| U16 | 665 |
-| U17 | 535 |
-| U18 | 298 |
-| U19 | 20 |
+| --------- | ----- |
+| U10       | 317   |
+| U11       | 695   |
+| U12       | 758   |
+| U13       | 785   |
+| U14       | 675   |
+| U15       | 618   |
+| U16       | 665   |
+| U17       | 535   |
+| U18       | 298   |
+| U19       | 20    |
 
 Peak competition is at U13 with 785 teams. Numbers thin after U17 as players specialize, move to high school programs, or step away. If your child is U13 in Florida, they're competing in one of the deepest age-group pools in the country.
 

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Michigan Youth Soccer Rankings 2026: Best Clubs by Age"
+title: 'Michigan Youth Soccer Rankings 2026: Best Clubs by Age'
 slug: 'michigan-youth-soccer-rankings-guide'
-excerpt: "Find where your Michigan club ranks among thousands of teams. Michigan Hawks, Vardar, DCFC and more — rated by PowerScore from real game results. Free rankings updated every Monday."
+excerpt: 'Find where your Michigan club ranks among thousands of teams. Michigan Hawks, Vardar, DCFC and more — rated by PowerScore from real game results. Free rankings updated every Monday.'
 author: 'PitchRank Team'
 date: '2026-04-08'
 readingTime: '9 min read'

--- a/scripts/audit_overranked_teams.py
+++ b/scripts/audit_overranked_teams.py
@@ -15,6 +15,7 @@ from typing import Any
 import pandas as pd
 from dotenv import load_dotenv
 from rich.console import Console
+
 from supabase import create_client
 
 sys.path.append(str(Path(__file__).parent.parent))
@@ -23,10 +24,10 @@ load_dotenv(Path(__file__).parent.parent / ".env")
 if not os.environ.get("SUPABASE_KEY") and os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
     os.environ["SUPABASE_KEY"] = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
 
-from src.etl.glicko_config import GlickoConfig
-from src.etl.glicko_engine import compute_game_explainability, compute_scf, select_games
-from src.rankings.data_adapter import batch_fetch_rows, fetch_games_for_rankings
-from src.utils.merge_resolver import MergeResolver
+from src.etl.glicko_config import GlickoConfig  # noqa: E402
+from src.etl.glicko_engine import compute_game_explainability, compute_scf, select_games  # noqa: E402
+from src.rankings.data_adapter import batch_fetch_rows, fetch_games_for_rankings  # noqa: E402
+from src.utils.merge_resolver import MergeResolver  # noqa: E402
 
 console = Console()
 
@@ -217,7 +218,16 @@ def fetch_all_cohort_rows(client, age_group: str, gender: str) -> pd.DataFrame:
     if not all_rows:
         return pd.DataFrame(columns=COHORT_COLS.split(","))
     df = pd.DataFrame(all_rows)
-    for col in ["powerscore_adj", "powerscore_ml", "ml_norm", "power_score_true", "rank_in_cohort_final", "glicko_rating", "glicko_rd", "glicko_volatility"]:
+    for col in [
+        "powerscore_adj",
+        "powerscore_ml",
+        "ml_norm",
+        "power_score_true",
+        "rank_in_cohort_final",
+        "glicko_rating",
+        "glicko_rd",
+        "glicko_volatility",
+    ]:
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")
     df["team_id"] = df["team_id"].astype(str)
@@ -256,7 +266,9 @@ def compute_base_rank_map(cohort_rows: pd.DataFrame) -> dict[str, int]:
 def build_comparison_ids(cohort_rows: pd.DataFrame, team_id: str, nearby: int = 5) -> list[str]:
     if cohort_rows.empty:
         return []
-    cohort_sorted = cohort_rows.sort_values(["rank_in_cohort_final", "team_id"], ascending=[True, True]).reset_index(drop=True)
+    cohort_sorted = cohort_rows.sort_values(["rank_in_cohort_final", "team_id"], ascending=[True, True]).reset_index(
+        drop=True
+    )
     top_ids = cohort_sorted.head(10)["team_id"].astype(str).tolist()
     if team_id not in set(cohort_sorted["team_id"].astype(str)):
         return top_ids
@@ -288,14 +300,15 @@ def compute_schedule_metrics(
     counts = team_window["opp_id"].astype(str).value_counts()
     ranked_rows = [rankings_map[opp_id] for opp_id in opp_ids if opp_id in rankings_map]
     ranked_unique_rows = [rankings_map[opp_id] for opp_id in counts.index if opp_id in rankings_map]
-    valid_states = [team_state_map.get(opp_id) for opp_id in opp_ids if team_state_map.get(opp_id) not in (None, "", "UNKNOWN")]
+    valid_states = [
+        team_state_map.get(opp_id) for opp_id in opp_ids if team_state_map.get(opp_id) not in (None, "", "UNKNOWN")
+    ]
     team_state = team_state_map.get(team_id)
     bridge_games = sum(1 for state in valid_states if state != team_state)
     unique_states = len(set(valid_states))
-    cross_age_mask = (
-        team_window["age"].astype(str).ne(team_window["opp_age"].astype(str))
-        | team_window["gender"].astype(str).ne(team_window["opp_gender"].astype(str))
-    )
+    cross_age_mask = team_window["age"].astype(str).ne(team_window["opp_age"].astype(str)) | team_window[
+        "gender"
+    ].astype(str).ne(team_window["opp_gender"].astype(str))
     top_rows = sorted(
         ranked_unique_rows,
         key=lambda row: (
@@ -326,9 +339,24 @@ def compute_schedule_metrics(
         unique_opponents=unique_opponents,
         ranked_opponents=len(ranked_rows),
         unranked_opponents=max(0, len(opp_ids) - len(ranked_rows)),
-        top20_count=sum(1 for row in ranked_rows if safe_float(row.get("rank_in_cohort_final")) is not None and safe_float(row.get("rank_in_cohort_final")) <= 20),
-        top100_count=sum(1 for row in ranked_rows if safe_float(row.get("rank_in_cohort_final")) is not None and safe_float(row.get("rank_in_cohort_final")) <= 100),
-        top500_count=sum(1 for row in ranked_rows if safe_float(row.get("rank_in_cohort_final")) is not None and safe_float(row.get("rank_in_cohort_final")) <= 500),
+        top20_count=sum(
+            1
+            for row in ranked_rows
+            if safe_float(row.get("rank_in_cohort_final")) is not None
+            and safe_float(row.get("rank_in_cohort_final")) <= 20
+        ),
+        top100_count=sum(
+            1
+            for row in ranked_rows
+            if safe_float(row.get("rank_in_cohort_final")) is not None
+            and safe_float(row.get("rank_in_cohort_final")) <= 100
+        ),
+        top500_count=sum(
+            1
+            for row in ranked_rows
+            if safe_float(row.get("rank_in_cohort_final")) is not None
+            and safe_float(row.get("rank_in_cohort_final")) <= 500
+        ),
         avg_opp_rank=safe_mean([safe_float(row.get("rank_in_cohort_final")) for row in ranked_rows]),
         avg_opp_power_true=safe_mean([safe_float(row.get("power_score_true")) for row in ranked_rows]),
         bridge_games=bridge_games,
@@ -374,9 +402,9 @@ def attach_cross_age_flags(explain_df: pd.DataFrame, team_games: dict[str, pd.Da
     merged["id"] = merged["id"].astype(str)
     merged["team_id"] = merged["team_id"].astype(str)
     merged = merged.merge(meta_df, on=["team_id", "id"], how="left")
-    merged["is_cross_age"] = merged["age"].astype(str).ne(merged["opp_age"].astype(str)) | merged["gender"].astype(str).ne(
-        merged["opp_gender"].astype(str)
-    )
+    merged["is_cross_age"] = merged["age"].astype(str).ne(merged["opp_age"].astype(str)) | merged["gender"].astype(
+        str
+    ).ne(merged["opp_gender"].astype(str))
     return merged
 
 
@@ -389,7 +417,9 @@ def classify_team(
     explain_df: pd.DataFrame,
 ) -> ClassificationResult:
     published_rank = int(safe_float(team_row.get("rank_in_cohort_final")) or 0)
-    ml_lift = (safe_float(team_row.get("power_score_true")) or 0.0) - (safe_float(team_row.get("powerscore_adj")) or 0.0)
+    ml_lift = (safe_float(team_row.get("power_score_true")) or 0.0) - (
+        safe_float(team_row.get("powerscore_adj")) or 0.0
+    )
     rank_gain_from_ml = (base_rank - published_rank) if base_rank and published_rank else 0
 
     explain = explain_df.copy() if explain_df is not None else pd.DataFrame()
@@ -397,7 +427,9 @@ def classify_team(
         explain["abs_contribution"] = explain["rating_contribution"].abs()
     total_abs = float(explain["abs_contribution"].sum()) if not explain.empty else 0.0
     cross_age_abs = (
-        float(explain.loc[explain["is_cross_age"].fillna(False), "abs_contribution"].sum()) if not explain.empty else 0.0
+        float(explain.loc[explain["is_cross_age"].fillna(False), "abs_contribution"].sum())
+        if not explain.empty
+        else 0.0
     )
     cross_age_contrib_share = (cross_age_abs / total_abs) if total_abs > 0 else 0.0
 
@@ -406,10 +438,7 @@ def classify_team(
         and schedule.avg_opp_power_true is not None
         and schedule.avg_opp_power_true + 0.05 < peer_medians["avg_opp_power_true"]
     )
-    few_top_opponents = (
-        (peer_medians.get("top100_count") or 0) >= 1
-        and schedule.top100_count == 0
-    )
+    few_top_opponents = (peer_medians.get("top100_count") or 0) >= 1 and schedule.top100_count == 0
     cross_age_heavy = (
         schedule.cross_age_share >= 0.25
         and peer_medians.get("cross_age_share") is not None
@@ -456,11 +485,17 @@ def classify_team(
     if low_connectivity and (repeat_heavy or weak_opp_strength or few_top_opponents):
         why = (
             f"The schedule shows weak connectivity (SCF {fmt_num(scf)}, {schedule.bridge_games} bridge games, "
-            f"{schedule.unique_opp_states} opponent states) while also leaning on softer or repetitive opponent evidence."
+            f"{schedule.unique_opp_states} opponent states) while also leaning on "
+            f"softer or repetitive opponent evidence."
         )
         return ClassificationResult("schedule-connectivity / repeat-opponent inflation", why, notes)
 
-    if base_rank is not None and published_rank and base_rank <= published_rank + 1 and (weak_opp_strength or few_top_opponents):
+    if (
+        base_rank is not None
+        and published_rank
+        and base_rank <= published_rank + 1
+        and (weak_opp_strength or few_top_opponents)
+    ):
         why = (
             f"This team is already ranked unusually high before ML (base rank {base_rank}) even though its "
             f"opponent evidence is weaker than the comparison set."
@@ -485,7 +520,9 @@ def metric_row(label: str, team_value: Any, peer_value: Any, team_fmt=fmt_num, p
     return [label, team_fmt(team_value), peer_fmt(peer_value)]
 
 
-def build_comparison_table(cohort_rows: pd.DataFrame, team_meta: dict[str, dict[str, Any]], comparison_ids: list[str]) -> str:
+def build_comparison_table(
+    cohort_rows: pd.DataFrame, team_meta: dict[str, dict[str, Any]], comparison_ids: list[str]
+) -> str:
     if cohort_rows.empty or not comparison_ids:
         return "_No comparison teams available._"
     subset = cohort_rows[cohort_rows["team_id"].astype(str).isin(comparison_ids)].copy()
@@ -607,15 +644,23 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
     if missing:
         raise RuntimeError(f"Teams not found in rankings_full: {', '.join(missing)}")
 
-    last_calc_values = [published_rows[team_id].get("last_calculated") for team_id in target_ids if published_rows[team_id].get("last_calculated")]
+    last_calc_values = [
+        published_rows[team_id].get("last_calculated")
+        for team_id in target_ids
+        if published_rows[team_id].get("last_calculated")
+    ]
     if last_calc_values:
         baseline_ts = pd.to_datetime(max(last_calc_values), utc=True)
     else:
         baseline_ts = pd.Timestamp("2026-04-07", tz="UTC")
-    baseline_day = baseline_ts.tz_localize(None).normalize() if baseline_ts.tzinfo is not None else baseline_ts.normalize()
+    baseline_day = (
+        baseline_ts.tz_localize(None).normalize() if baseline_ts.tzinfo is not None else baseline_ts.normalize()
+    )
     baseline_label = baseline_day.strftime("%Y-%m-%d")
 
-    report_path = Path(args.report_path) if args.report_path else Path(f"reports/overranked-male-teams-{baseline_label}.md")
+    report_path = (
+        Path(args.report_path) if args.report_path else Path(f"reports/overranked-male-teams-{baseline_label}.md")
+    )
     csv_path = Path(args.csv_path) if args.csv_path else Path(f"reports/overranked-male-teams-{baseline_label}.csv")
     report_path.parent.mkdir(parents=True, exist_ok=True)
     csv_path.parent.mkdir(parents=True, exist_ok=True)
@@ -633,7 +678,9 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
     games_df["opp_id"] = games_df["opp_id"].astype(str)
 
     target_meta = batch_fetch_team_meta(client, target_ids)
-    cohort_keys = sorted({(published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) for team_id in target_ids})
+    cohort_keys = sorted(
+        {(published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) for team_id in target_ids}
+    )
 
     cohort_rows_map: dict[tuple[str, str], pd.DataFrame] = {}
     comparison_ids_map: dict[str, list[str]] = {}
@@ -642,7 +689,11 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
     for cohort_key in cohort_keys:
         cohort_rows = fetch_all_cohort_rows(client, cohort_key[0], cohort_key[1])
         cohort_rows_map[cohort_key] = cohort_rows
-        cohort_target_ids = [team_id for team_id in target_ids if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key]
+        cohort_target_ids = [
+            team_id
+            for team_id in target_ids
+            if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key
+        ]
         for team_id in cohort_target_ids:
             comparison_ids = build_comparison_ids(cohort_rows, team_id, nearby=5)
             comparison_ids_map[team_id] = comparison_ids
@@ -657,12 +708,28 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
     peer_metrics_map: dict[str, dict[str, float | None]] = {}
 
     for cohort_key, cohort_rows in cohort_rows_map.items():
-        cohort_target_ids = [team_id for team_id in target_ids if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key]
-        cohort_compare_ids = sorted({comp_id for team_id in cohort_target_ids for comp_id in comparison_ids_map.get(team_id, [])})
+        cohort_target_ids = [
+            team_id
+            for team_id in target_ids
+            if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key
+        ]
+        cohort_compare_ids = sorted(
+            {comp_id for team_id in cohort_target_ids for comp_id in comparison_ids_map.get(team_id, [])}
+        )
         cohort_audit_ids = sorted(set(cohort_target_ids) | set(cohort_compare_ids))
         team_games = build_team_windows(games_df, cohort_audit_ids, cfg, baseline_day)
 
-        opponent_ids = sorted({str(opp_id) for team_id in cohort_audit_ids for opp_id in team_games[team_id]["opp_id"].astype(str).tolist()}) if cohort_audit_ids else []
+        opponent_ids = (
+            sorted(
+                {
+                    str(opp_id)
+                    for team_id in cohort_audit_ids
+                    for opp_id in team_games[team_id]["opp_id"].astype(str).tolist()
+                }
+            )
+            if cohort_audit_ids
+            else []
+        )
         opponent_rankings = batch_fetch_rankings_rows(
             client,
             opponent_ids,
@@ -672,7 +739,8 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
         all_meta.update(opponent_meta)
 
         team_state_map = {
-            team_id: (all_meta.get(team_id, {}) or {}).get("state_code") or (published_rows.get(team_id, {}) or {}).get("state_code")
+            team_id: (all_meta.get(team_id, {}) or {}).get("state_code")
+            or (published_rows.get(team_id, {}) or {}).get("state_code")
             for team_id in set(cohort_audit_ids) | set(opponent_ids)
         }
         team_ratings = {
@@ -700,7 +768,10 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
         scf_data = compute_scf(
             games_df[games_df["team_id"].isin(cohort_audit_ids)].copy(),
             team_state_map=team_state_map,
-            team_ratings={team_id: team_ratings.get(team_id, (cfg.INITIAL_MU, cfg.INITIAL_SIGMA, cfg.INITIAL_VOLATILITY)) for team_id in cohort_audit_ids},
+            team_ratings={
+                team_id: team_ratings.get(team_id, (cfg.INITIAL_MU, cfg.INITIAL_SIGMA, cfg.INITIAL_VOLATILITY))
+                for team_id in cohort_audit_ids
+            },
             cfg=cfg,
             team_games=team_games,
             tier_league_map=tier_league_map,
@@ -709,7 +780,10 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
 
         explain_df = compute_game_explainability(
             games_df[games_df["team_id"].isin(cohort_audit_ids)].copy(),
-            team_ratings={team_id: team_ratings.get(team_id, (cfg.INITIAL_MU, cfg.INITIAL_SIGMA, cfg.INITIAL_VOLATILITY)) for team_id in cohort_audit_ids},
+            team_ratings={
+                team_id: team_ratings.get(team_id, (cfg.INITIAL_MU, cfg.INITIAL_SIGMA, cfg.INITIAL_VOLATILITY))
+                for team_id in cohort_audit_ids
+            },
             cfg=cfg,
             today=baseline_day,
             team_games=team_games,
@@ -726,11 +800,17 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
                 team_state_map,
             )
             explainability_map[team_id] = (
-                explain_df[explain_df["team_id"].astype(str) == team_id].copy() if not explain_df.empty else pd.DataFrame()
+                explain_df[explain_df["team_id"].astype(str) == team_id].copy()
+                if not explain_df.empty
+                else pd.DataFrame()
             )
 
         for team_id in cohort_target_ids:
-            peer_metrics = [schedule_metrics_map[cid] for cid in comparison_ids_map.get(team_id, []) if cid in schedule_metrics_map and cid != team_id]
+            peer_metrics = [
+                schedule_metrics_map[cid]
+                for cid in comparison_ids_map.get(team_id, [])
+                if cid in schedule_metrics_map and cid != team_id
+            ]
             peer_metrics_map[team_id] = peer_metric_medians(peer_metrics)
 
     summary_rows: list[dict[str, Any]] = []
@@ -738,7 +818,11 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
 
     for cohort_key, cohort_rows in cohort_rows_map.items():
         base_rank_map = compute_base_rank_map(cohort_rows)
-        cohort_target_ids = [team_id for team_id in target_ids if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key]
+        cohort_target_ids = [
+            team_id
+            for team_id in target_ids
+            if (published_rows[team_id]["age_group"], published_rows[team_id]["gender"]) == cohort_key
+        ]
         for team_id in cohort_target_ids:
             team_row = published_rows[team_id]
             meta = all_meta.get(team_id, {})
@@ -751,7 +835,9 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
                 scf_row=replay_map.get(team_id, {}),
                 explain_df=explainability_map.get(team_id, pd.DataFrame()),
             )
-            ml_lift = (safe_float(team_row.get("power_score_true")) or 0.0) - (safe_float(team_row.get("powerscore_adj")) or 0.0)
+            ml_lift = (safe_float(team_row.get("power_score_true")) or 0.0) - (
+                safe_float(team_row.get("powerscore_adj")) or 0.0
+            )
             summary_rows.append(
                 {
                     "team_id": team_id,
@@ -800,9 +886,19 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
                     metric_row("Avg opponent power", schedule.avg_opp_power_true, peer.get("avg_opp_power_true")),
                     metric_row("Avg opponent rank", schedule.avg_opp_rank, peer.get("avg_opp_rank")),
                     metric_row("Bridge games", schedule.bridge_games, peer.get("bridge_games"), fmt_int, fmt_int),
-                    metric_row("Unique opponent states", schedule.unique_opp_states, peer.get("unique_opp_states"), fmt_int, fmt_int),
-                    metric_row("Cross-age share", schedule.cross_age_share, peer.get("cross_age_share"), fmt_pct, fmt_pct),
-                    metric_row("Repeat-opponent share", schedule.repeat_share, peer.get("repeat_share"), fmt_pct, fmt_pct),
+                    metric_row(
+                        "Unique opponent states",
+                        schedule.unique_opp_states,
+                        peer.get("unique_opp_states"),
+                        fmt_int,
+                        fmt_int,
+                    ),
+                    metric_row(
+                        "Cross-age share", schedule.cross_age_share, peer.get("cross_age_share"), fmt_pct, fmt_pct
+                    ),
+                    metric_row(
+                        "Repeat-opponent share", schedule.repeat_share, peer.get("repeat_share"), fmt_pct, fmt_pct
+                    ),
                 ],
             )
             connectivity_table = markdown_table(
@@ -829,9 +925,11 @@ async def run_audit(args: argparse.Namespace) -> tuple[Path, Path]:
                         "### Published Decomposition\n" + decomp_table,
                         "### Schedule Evidence\n" + schedule_table,
                         "### Connectivity Replay\n" + connectivity_table,
-                        "### Comparison Set\n" + build_comparison_table(cohort_rows, all_meta, comparison_ids_map.get(team_id, [])),
+                        "### Comparison Set\n"
+                        + build_comparison_table(cohort_rows, all_meta, comparison_ids_map.get(team_id, [])),
                         "### Strongest Opponents Faced\n" + build_strongest_opponents_table(schedule),
-                        "### Highest-Impact Games\n" + build_impact_games_table(explainability_map.get(team_id, pd.DataFrame()), all_meta),
+                        "### Highest-Impact Games\n"
+                        + build_impact_games_table(explainability_map.get(team_id, pd.DataFrame()), all_meta),
                     ]
                 )
             )

--- a/scripts/calibrate_point_in_time_match_model.py
+++ b/scripts/calibrate_point_in_time_match_model.py
@@ -52,7 +52,9 @@ def main() -> None:
     evaluation_frame = pd.read_csv(args.evaluation_csv)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    model_artifact_path = Path(args.model_artifact) if args.model_artifact else output_dir / "point_in_time_match_model.pkl"
+    model_artifact_path = (
+        Path(args.model_artifact) if args.model_artifact else output_dir / "point_in_time_match_model.pkl"
+    )
     prediction_postprocessor = None
     if model_artifact_path.exists():
         model = PointInTimeMatchModel.load(str(model_artifact_path))

--- a/scripts/process_match_prediction_shadow.py
+++ b/scripts/process_match_prediction_shadow.py
@@ -411,9 +411,7 @@ def process_shadow_rows(
     calibration_artifact: Optional[Path] = None,
 ) -> Dict[str, Any]:
     rows = _fetch_shadow_rows(supabase, shadow_status, limit)
-    calibrator = (
-        PointInTimeProbabilityCalibrator.load(str(calibration_artifact)) if calibration_artifact else None
-    )
+    calibrator = PointInTimeProbabilityCalibrator.load(str(calibration_artifact)) if calibration_artifact else None
     model_version = _derive_shadow_model_version(model_artifact, shadow_model_version, calibration_artifact)
 
     summary = {
@@ -437,10 +435,7 @@ def process_shadow_rows(
             request_context = _safe_request_context(row.get("request_context"))
             games = _fetch_games_by_ids(supabase, request_context.get("relevantGameIds") or [])
             involved_team_ids = {
-                team_id
-                for game in games
-                for team_id in (game.home_team_master_id, game.away_team_master_id)
-                if team_id
+                team_id for game in games for team_id in (game.home_team_master_id, game.away_team_master_id) if team_id
             }
             involved_team_ids.update(
                 [
@@ -448,7 +443,9 @@ def process_shadow_rows(
                     str((row.get("team_b_input") or {}).get("team_id_master") or row.get("team_b_id") or ""),
                 ]
             )
-            snapshot_date = (str(row.get("created_at") or "").split("T")[0]) or pd.Timestamp.utcnow().strftime("%Y-%m-%d")
+            snapshot_date = (str(row.get("created_at") or "").split("T")[0]) or pd.Timestamp.utcnow().strftime(
+                "%Y-%m-%d"
+            )
             snapshot_index = _fetch_snapshot_index(supabase, involved_team_ids, snapshot_date)
             matchup_frame = _build_matchup_frame(row, games, snapshot_index)
             prediction_frame = model.predict_frame(matchup_frame)

--- a/src/predictions/ml_match_predictor.py
+++ b/src/predictions/ml_match_predictor.py
@@ -429,7 +429,9 @@ class MLMatchPredictor:
         X_train_margin, X_val_margin, y_margin_fit, y_margin_val = train_test_split(
             X_train, y_margin_train, test_size=0.1, random_state=random_state
         )
-        self.score_margin_model.fit(X_train_margin, y_margin_fit, eval_set=[(X_val_margin, y_margin_val)], verbose=False)
+        self.score_margin_model.fit(
+            X_train_margin, y_margin_fit, eval_set=[(X_val_margin, y_margin_val)], verbose=False
+        )
 
         # Train individual score models
         print("Training home score model...")
@@ -586,8 +588,7 @@ class MLMatchPredictor:
             # Interaction features (must match build_features)
             "power_score_product": (home_features.get("power_score_final", 0.5) or 0.5)
             * (away_features.get("power_score_final", 0.5) or 0.5),
-            "sos_product": (home_features.get("sos_norm", 0.5) or 0.5)
-            * (away_features.get("sos_norm", 0.5) or 0.5),
+            "sos_product": (home_features.get("sos_norm", 0.5) or 0.5) * (away_features.get("sos_norm", 0.5) or 0.5),
             "offense_product": (home_features.get("offense_norm", 0.5) or 0.5)
             * (away_features.get("offense_norm", 0.5) or 0.5),
             "defense_product": (home_features.get("defense_norm", 0.5) or 0.5)

--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -359,25 +359,14 @@ def _paired_snapshot_features(team_a_snapshot: dict, team_b_snapshot: dict) -> D
             )
         ),
         math.exp(
-            -abs(
-                _to_float(team_a_snapshot.get("glicko_rating"))
-                - _to_float(team_b_snapshot.get("glicko_rating"))
-            )
+            -abs(_to_float(team_a_snapshot.get("glicko_rating")) - _to_float(team_b_snapshot.get("glicko_rating")))
             / 140.0
         ),
         math.exp(
-            -abs(
-                _to_float(team_a_snapshot.get("exp_margin"))
-                - _to_float(team_b_snapshot.get("exp_margin"))
-            )
-            / 1.25
+            -abs(_to_float(team_a_snapshot.get("exp_margin")) - _to_float(team_b_snapshot.get("exp_margin"))) / 1.25
         ),
         math.exp(
-            -6.0
-            * abs(
-                _to_float(team_a_snapshot.get("exp_win_rate"))
-                - _to_float(team_b_snapshot.get("exp_win_rate"))
-            )
+            -6.0 * abs(_to_float(team_a_snapshot.get("exp_win_rate")) - _to_float(team_b_snapshot.get("exp_win_rate")))
         ),
     ]
     snapshot_strength_closeness = float(np.mean(snapshot_closeness_components))
@@ -396,9 +385,7 @@ def _paired_snapshot_features(team_a_snapshot: dict, team_b_snapshot: dict) -> D
             "power_sos_interaction_diff": (
                 _to_float(team_a_snapshot.get("power_score_final")) * _to_float(team_a_snapshot.get("sos_norm"))
             )
-            - (
-                _to_float(team_b_snapshot.get("power_score_final")) * _to_float(team_b_snapshot.get("sos_norm"))
-            ),
+            - (_to_float(team_b_snapshot.get("power_score_final")) * _to_float(team_b_snapshot.get("sos_norm"))),
             "offense_defense_balance_diff": offense_diff - defense_diff,
             "team_a_has_predictive_prior": 1.0
             if any(pd.notna(team_a_snapshot.get(field_name)) for field_name in PREDICTIVE_PRIOR_FIELDS)
@@ -470,10 +457,7 @@ def _dixon_coles_rho(
     low_total_component = np.exp(-np.maximum(np.asarray(projected_total_goals, dtype=float) - 2.2, 0.0) / 0.75)
     closeness_component = np.exp(-np.asarray(expected_goal_gap_abs, dtype=float) / 0.65)
     rho_strength = (
-        0.20 * draw_component
-        + 0.35 * stalemate_component
-        + 0.25 * low_total_component
-        + 0.20 * closeness_component
+        0.20 * draw_component + 0.35 * stalemate_component + 0.25 * low_total_component + 0.20 * closeness_component
     )
     return np.clip(
         LOW_SCORE_CORRELATION_BASE + (LOW_SCORE_CORRELATION_MAX - LOW_SCORE_CORRELATION_BASE) * rho_strength,
@@ -534,9 +518,7 @@ def _score_matrix_summary(score_matrix: np.ndarray) -> Dict[str, np.ndarray]:
     predicted_score_a = (flat_indices // score_matrix.shape[2]).astype(float)
     predicted_score_b = (flat_indices % score_matrix.shape[2]).astype(float)
 
-    goal_margin_abs = np.abs(
-        np.arange(score_matrix.shape[1])[:, None] - np.arange(score_matrix.shape[2])[None, :]
-    )
+    goal_margin_abs = np.abs(np.arange(score_matrix.shape[1])[:, None] - np.arange(score_matrix.shape[2])[None, :])
     blowout_3plus_probability = score_matrix[:, goal_margin_abs >= 3].sum(axis=1)
     blowout_5plus_probability = score_matrix[:, goal_margin_abs >= 5].sum(axis=1)
 
@@ -706,9 +688,9 @@ def _build_common_opponent_feature_summary(
         draw_rate_diff = team_a_draw_rate - team_b_draw_rate
         goal_balance_diff = team_a_goal_balance - team_b_goal_balance
 
-        avg_opponent_power = (
-            team_a_stats["weightedOpponentPower"] + team_b_stats["weightedOpponentPower"]
-        ) / max(team_a_stats["totalWeight"] + team_b_stats["totalWeight"], 1e-9)
+        avg_opponent_power = (team_a_stats["weightedOpponentPower"] + team_b_stats["weightedOpponentPower"]) / max(
+            team_a_stats["totalWeight"] + team_b_stats["totalWeight"], 1e-9
+        )
         same_age_rate = min(
             team_a_stats["weightedSameAge"] / team_a_stats["totalWeight"],
             team_b_stats["weightedSameAge"] / team_b_stats["totalWeight"],
@@ -917,9 +899,7 @@ def build_point_in_time_matchup_row(
             "common_opponent_strength_weighted_opponent_power": _to_float(
                 common_opponent_details.get("strengthWeightedOpponentPower")
             ),
-            "common_opponent_consensus_signal": _to_float(
-                common_opponent_details.get("commonOpponentConsensusSignal")
-            ),
+            "common_opponent_consensus_signal": _to_float(common_opponent_details.get("commonOpponentConsensusSignal")),
             "team_a_prior_game_count": float(len(team_a_prior_games)),
             "team_b_prior_game_count": float(len(team_b_prior_games)),
             "combined_prior_game_count": float(len(combined_prior_games)),
@@ -948,7 +928,9 @@ def build_point_in_time_matchup_row(
         _to_float(features.get("common_opponent_closeness")),
         _to_float(features.get("head_to_head_closeness")),
     ]
-    stalemate_signal = float(np.mean(stalemate_components)) * (0.7 + 0.6 * _to_float(features.get("combined_draw_rate")))
+    stalemate_signal = float(np.mean(stalemate_components)) * (
+        0.7 + 0.6 * _to_float(features.get("combined_draw_rate"))
+    )
     features["stalemate_signal"] = float(np.clip(stalemate_signal, 0.0, 1.0))
     features["expected_draw_environment"] = float(
         np.clip(
@@ -1104,8 +1086,7 @@ def build_point_in_time_dataset(
         class_counts = dataset["actual_outcome"].value_counts().sort_index()
         summary["class_counts"] = {str(label): int(count) for label, count in class_counts.items()}
         summary["class_rates"] = {
-            str(label): float(count) / float(len(dataset))
-            for label, count in class_counts.items()
+            str(label): float(count) / float(len(dataset)) for label, count in class_counts.items()
         }
     return DatasetBuildResult(dataset=dataset, summary=summary)
 
@@ -1348,9 +1329,7 @@ class PointInTimeMatchModel:
         probabilities = self.draw_classifier.predict_proba(matrix)
         draw_classes = getattr(self.draw_classifier, "classes_", np.array([0, 1]))
         draw_index = (
-            int(np.where(np.asarray(draw_classes) == 1)[0][0])
-            if 1 in draw_classes
-            else probabilities.shape[1] - 1
+            int(np.where(np.asarray(draw_classes) == 1)[0][0]) if 1 in draw_classes else probabilities.shape[1] - 1
         )
         return np.asarray(probabilities[:, draw_index], dtype=float)
 
@@ -1360,9 +1339,7 @@ class PointInTimeMatchModel:
         probabilities = classifier.predict_proba(matrix)
         binary_classes = getattr(classifier, "classes_", np.array([0, 1]))
         positive_index = (
-            int(np.where(np.asarray(binary_classes) == 1)[0][0])
-            if 1 in binary_classes
-            else probabilities.shape[1] - 1
+            int(np.where(np.asarray(binary_classes) == 1)[0][0]) if 1 in binary_classes else probabilities.shape[1] - 1
         )
         return np.asarray(probabilities[:, positive_index], dtype=float)
 
@@ -1388,14 +1365,10 @@ class PointInTimeMatchModel:
         draw_probability = np.asarray(probabilities[:, OUTCOME_DRAW], dtype=float)
         draw_gap = np.max(probabilities[:, [OUTCOME_TEAM_A_WIN, OUTCOME_TEAM_B_WIN]], axis=1) - draw_probability
         projected_total_goals = (
-            pd.to_numeric(dataset_df.get("projected_total_goals"), errors="coerce")
-            .fillna(np.inf)
-            .to_numpy(dtype=float)
+            pd.to_numeric(dataset_df.get("projected_total_goals"), errors="coerce").fillna(np.inf).to_numpy(dtype=float)
         )
         stalemate_signal = (
-            pd.to_numeric(dataset_df.get("stalemate_signal"), errors="coerce")
-            .fillna(0.0)
-            .to_numpy(dtype=float)
+            pd.to_numeric(dataset_df.get("stalemate_signal"), errors="coerce").fillna(0.0).to_numpy(dtype=float)
         )
         draw_mask = (
             (draw_probability >= float(policy["min_draw_probability"]))
@@ -1425,9 +1398,7 @@ class PointInTimeMatchModel:
         if precision <= 0.0 and recall <= 0.0:
             f_beta = 0.0
         else:
-            f_beta = ((1.0 + beta_squared) * precision * recall) / (
-                (beta_squared * precision) + recall
-            )
+            f_beta = ((1.0 + beta_squared) * precision * recall) / ((beta_squared * precision) + recall)
         predicted_draw_rate = float(np.mean(predicted_draw))
         accuracy = float(np.mean(predicted_labels == actual_labels))
         actual_draw_rate = float(np.mean(actual_draw))
@@ -1636,9 +1607,7 @@ class PointInTimeMatchModel:
             if precision <= 0.0 and recall <= 0.0:
                 f_beta = 0.0
             else:
-                f_beta = ((1.0 + beta_squared) * precision * recall) / (
-                    (beta_squared * precision) + recall
-                )
+                f_beta = ((1.0 + beta_squared) * precision * recall) / ((beta_squared * precision) + recall)
             predicted_rate = float(np.mean(predicted_positive))
             rate_gap = abs(predicted_rate - target_rate)
             overshoot = max(0.0, predicted_rate - target_rate)
@@ -1769,12 +1738,10 @@ class PointInTimeMatchModel:
         viable_strategies: List[str] = []
         rejected_strategies: Dict[str, Dict[str, object]] = {}
         best_winner_accuracy = max(
-            _to_float(summary.get("winner_accuracy"), default=float("-inf"))
-            for summary in strategy_metrics.values()
+            _to_float(summary.get("winner_accuracy"), default=float("-inf")) for summary in strategy_metrics.values()
         )
         best_log_loss = min(
-            _to_float(summary.get("log_loss"), default=float("inf"))
-            for summary in strategy_metrics.values()
+            _to_float(summary.get("log_loss"), default=float("inf")) for summary in strategy_metrics.values()
         )
 
         for strategy_name in strategy_metrics:
@@ -1933,8 +1900,7 @@ class PointInTimeMatchModel:
             nan=fallback_draw_probability,
         )
         draw_model_probability = np.clip(
-            self.draw_rate_prior
-            + DRAW_MODEL_SHRINK_FACTOR * (raw_draw_model_probability - self.draw_rate_prior),
+            self.draw_rate_prior + DRAW_MODEL_SHRINK_FACTOR * (raw_draw_model_probability - self.draw_rate_prior),
             0.01,
             0.75,
         )
@@ -2211,18 +2177,12 @@ class PointInTimeMatchModel:
             predicted_score_b,
         )
         projected_total_goals = (
-            pd.to_numeric(dataset_df.get("projected_total_goals"), errors="coerce")
-            .fillna(0.0)
-            .to_numpy(dtype=float)
+            pd.to_numeric(dataset_df.get("projected_total_goals"), errors="coerce").fillna(0.0).to_numpy(dtype=float)
         )
         stalemate_signal = (
-            pd.to_numeric(dataset_df.get("stalemate_signal"), errors="coerce")
-            .fillna(0.0)
-            .to_numpy(dtype=float)
+            pd.to_numeric(dataset_df.get("stalemate_signal"), errors="coerce").fillna(0.0).to_numpy(dtype=float)
         )
-        expected_goal_gap_abs = np.abs(
-            strategy_outputs.expected_goals_a - strategy_outputs.expected_goals_b
-        )
+        expected_goal_gap_abs = np.abs(strategy_outputs.expected_goals_a - strategy_outputs.expected_goals_b)
         draw_trigger = _poisson_draw_gate_mask(
             draw_probability=strategy_outputs.probabilities[:, OUTCOME_DRAW],
             projected_total_goals=projected_total_goals,
@@ -2314,14 +2274,10 @@ class PointInTimeMatchModel:
                 "predicted_blowout_3plus": predicted_blowout_3plus,
                 "predicted_blowout_5plus": predicted_blowout_5plus,
                 "stalemate_signal": (
-                    pd.to_numeric(test_df.get("stalemate_signal"), errors="coerce")
-                    .fillna(0.0)
-                    .to_numpy()
+                    pd.to_numeric(test_df.get("stalemate_signal"), errors="coerce").fillna(0.0).to_numpy()
                 ),
                 "projected_total_goals": (
-                    pd.to_numeric(test_df.get("projected_total_goals"), errors="coerce")
-                    .fillna(0.0)
-                    .to_numpy()
+                    pd.to_numeric(test_df.get("projected_total_goals"), errors="coerce").fillna(0.0).to_numpy()
                 ),
                 "predicted_margin": predicted_margin,
                 "actual_margin": test_df["actual_margin"].astype(float).to_numpy(),
@@ -2385,8 +2341,7 @@ class PointInTimeMatchModel:
         unique_labels = sorted(np.unique(y_train).tolist())
         if len(unique_labels) < 2:
             raise ValueError(
-                "Training data does not contain enough class diversity. "
-                f"Observed only outcome labels: {unique_labels}"
+                f"Training data does not contain enough class diversity. Observed only outcome labels: {unique_labels}"
             )
 
         self.class_labels = unique_labels
@@ -2604,10 +2559,7 @@ class PointInTimeMatchModel:
                 },
             },
             "draw_decision_policy": {
-                "default": {
-                    key: float(value)
-                    for key, value in self.draw_decision_policy.get("default", {}).items()
-                },
+                "default": {key: float(value) for key, value in self.draw_decision_policy.get("default", {}).items()},
                 "by_age": {
                     str(age): {key: float(value) for key, value in policy.items()}
                     for age, policy in self.draw_decision_policy.get("by_age", {}).items()

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -221,7 +221,9 @@ def _compute_same_age_evidence_metrics(games_used_df: pd.DataFrame, teams_df: pd
     teams_work["age"] = teams_work["age"].astype(str)
     teams_work["gender"] = teams_work["gender"].astype(str)
 
-    active = teams_work[teams_work["status"] == "Active"].copy() if "status" in teams_work.columns else teams_work.copy()
+    active = (
+        teams_work[teams_work["status"] == "Active"].copy() if "status" in teams_work.columns else teams_work.copy()
+    )
     base_rank_lookup: dict[tuple[str, str], dict[str, int]] = {}
     base_power_lookup = dict(zip(teams_work["team_id"], pd.to_numeric(teams_work["powerscore_adj"], errors="coerce")))
 
@@ -248,7 +250,9 @@ def _compute_same_age_evidence_metrics(games_used_df: pd.DataFrame, teams_df: pd
         unique_same_age_opp_ids = same_age["opp_id"].dropna().astype(str).unique().tolist()
         cohort_rank_map = base_rank_lookup.get((team_age, team_gender), {})
         opp_ranks = [cohort_rank_map.get(opp_id) for opp_id in unique_same_age_opp_ids if opp_id in cohort_rank_map]
-        opp_powers = [base_power_lookup.get(opp_id) for opp_id in unique_same_age_opp_ids if opp_id in base_power_lookup]
+        opp_powers = [
+            base_power_lookup.get(opp_id) for opp_id in unique_same_age_opp_ids if opp_id in base_power_lookup
+        ]
         counts = tg["opp_id"].value_counts()
         repeat_share = float(counts[counts >= 2].sum() / len(tg)) if len(tg) else 0.0
         clean_opp_powers = [float(val) for val in opp_powers if val is not None and not pd.isna(val)]
@@ -1338,15 +1342,17 @@ async def compute_all_cohorts(
                 )
 
         teams_combined["publication_cap_score"] = teams_combined.apply(
-            lambda row: publication_cap_lookup.get(
-                (
-                    _safe_int(row.get("age_num")),
-                    str(row.get("gender")),
-                    _safe_int(row.get("publication_cap_rank")),
+            lambda row: (
+                publication_cap_lookup.get(
+                    (
+                        _safe_int(row.get("age_num")),
+                        str(row.get("gender")),
+                        _safe_int(row.get("publication_cap_rank")),
+                    )
                 )
-            )
-            if pd.notna(row.get("publication_cap_rank"))
-            else pd.NA,
+                if pd.notna(row.get("publication_cap_rank"))
+                else pd.NA
+            ),
             axis=1,
         )
 
@@ -1354,7 +1360,9 @@ async def compute_all_cohorts(
         ps_adj_series = pd.to_numeric(teams_combined.get("powerscore_adj"), errors="coerce")
         ml_blocked = ((teams_combined["positive_ml_evidence_scale"] <= 0.0) & (ps_ml_series > ps_adj_series)).sum()
         capped = pd.to_numeric(teams_combined["publication_cap_rank"], errors="coerce").notna().sum()
-        logger.info(f"🧱 Same-age evidence gates prepared: ml_blocked={int(ml_blocked)}, publication_capped={int(capped)}")
+        logger.info(
+            f"🧱 Same-age evidence gates prepared: ml_blocked={int(ml_blocked)}, publication_capped={int(capped)}"
+        )
 
     # ========== National SOS Metrics (for display only) ==========
     # NOTE: PowerScore uses cohort-level sos_norm from v53e.compute_rankings().
@@ -1516,7 +1524,8 @@ async def compute_all_cohorts(
                     if cap_mask.any():
                         base = _apply_publication_cap_band(base, teams_age)
                         logger.info(
-                            f"  📊 Age {age}: publication cap band applied to {int(cap_mask.sum())} team(s) on weak same-age evidence"
+                            f"  📊 Age {age}: publication cap band applied to "
+                            f"{int(cap_mask.sum())} team(s) on weak same-age evidence"
                         )
 
                 # Scale by anchor and clip to [0, anchor_val]


### PR DESCRIPTION
## Summary
- **52 state landing pages added to sitemap** — `/rankings/ca`, `/rankings/tx`, etc. were missing entirely from `sitemap.xml`, preventing Google from discovering them
- **Server-rendered top 25 teams on ranking pages** — Googlebot was seeing empty loading skeletons because ranking data loaded 100% client-side. Now a static HTML section with top teams renders server-side below the interactive table (zero changes to existing client-side behavior)
- **Structured data URL fix** — state overview JSON-LD used `pitchrank.io` instead of `www.pitchrank.io`
- **Vercel domain redirect fixed (already live)** — `pitchrank.io` redirect changed from 307 temporary → 308 permanent via Vercel API. Google will consolidate the ~610 impressions currently split across non-www URLs

## What this does NOT change
- `RankingsPageContent`, `RankingsTable`, and `useRankings` are completely untouched
- The interactive ranking table loads exactly as before via client-side React Query
- The new server-rendered section is additive HTML below the existing content

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes — state landing pages render as SSG
- [x] Sitemap now has 989 URLs (was ~920)
- [x] Verified 308 redirect live: `curl -sI https://pitchrank.io/` returns `308 Permanent Redirect`
- [ ] Verify Vercel preview deployment renders top teams section
- [ ] Confirm sitemap.xml includes `/rankings/ca`, `/rankings/tx`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)