### PR TITLE
Add prospective match prediction workflows

### DIFF
--- a/.github/workflows/auto-gotsport-upcoming-event-scrape.yml
+++ b/.github/workflows/auto-gotsport-upcoming-event-scrape.yml
@@ -1,0 +1,103 @@
+name: Upcoming GotSport Event Fixture Scrape
+
+on:
+  workflow_dispatch:
+    inputs:
+      days_ahead:
+        description: "How many days ahead to search for events"
+        required: false
+        default: "7"
+      max_events:
+        description: "Maximum number of events to scrape (0 = no limit)"
+        required: false
+        default: "25"
+      max_runtime:
+        description: "Maximum runtime in minutes"
+        required: false
+        default: "100"
+      tracked_events:
+        description: "Optional tracking file path for dedupe across runs"
+        required: false
+        default: ""
+
+jobs:
+  scrape-upcoming-events:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install beautifulsoup4 lxml requests certifi
+
+      - name: Create data directories
+        run: |
+          mkdir -p data/raw
+          mkdir -p data/cache
+          mkdir -p logs
+
+      - name: Run upcoming event fixture scraper
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
+          GOTSPORT_DELAY_MIN: "0.1"
+          GOTSPORT_DELAY_MAX: "0.2"
+          GOTSPORT_MAX_RETRIES: "2"
+          GOTSPORT_TIMEOUT: "12"
+          GOTSPORT_MAX_SCHEDULE_PAGES: "25"
+          GOTSPORT_PAGE_DELAY: "0.05"
+          GOTSPORT_EVENT_TIMEOUT: "240"
+          INPUT_DAYS_AHEAD: ${{ inputs.days_ahead }}
+          INPUT_MAX_EVENTS: ${{ inputs.max_events }}
+          INPUT_MAX_RUNTIME: ${{ inputs.max_runtime }}
+          INPUT_TRACKED_EVENTS: ${{ inputs.tracked_events }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          EXTRA_ARGS=""
+          if [ -n "${INPUT_TRACKED_EVENTS}" ]; then
+            EXTRA_ARGS="--tracked-events ${INPUT_TRACKED_EVENTS}"
+          fi
+          python scripts/scrape_upcoming_gotsport_events.py \
+            --days-ahead "${INPUT_DAYS_AHEAD}" \
+            --max-events "${INPUT_MAX_EVENTS}" \
+            --max-runtime "${INPUT_MAX_RUNTIME}" \
+            ${EXTRA_ARGS} || exit 1
+
+      - name: Upload scraped data
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: gotsport-upcoming-events-${{ github.run_number }}
+          path: |
+            data/raw/upcoming_events_*.jsonl
+            data/raw/upcoming_events_*_summary.json
+            data/raw/upcoming_events_tracked.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: gotsport-upcoming-events-logs-${{ github.run_number }}
+          path: logs/*.log
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Report results
+        if: always()
+        run: |
+          echo "Upcoming GotSport event fixture scrape completed."
+          echo "Check the artifacts above for scheduled-game output and logs."

--- a/.github/workflows/evaluate-prospective-match-predictions.yml
+++ b/.github/workflows/evaluate-prospective-match-predictions.yml
@@ -1,0 +1,130 @@
+name: Evaluate Prospective Match Predictions
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Optional settled-row limit"
+        required: false
+        default: ""
+        type: string
+      artifact_name:
+        description: "Optional evaluation artifact name override"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: prospective-evaluation
+  cancel-in-progress: false
+
+jobs:
+  evaluate-prospective-match-predictions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          python -c "import supabase, pandas, numpy; print('Prospective evaluation imports successful')"
+
+      - name: Evaluate settled rows
+        id: evaluate
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          OUTPUT_DIR="$RUNNER_TEMP/prospective_evaluation"
+          SUMMARY_PATH="$RUNNER_TEMP/prospective_evaluation_summary.json"
+
+          CMD=(
+            python scripts/evaluate_prospective_match_predictions.py
+            --output-dir "$OUTPUT_DIR"
+            --summary-path "$SUMMARY_PATH"
+          )
+
+          if [ -n "${{ github.event.inputs.limit }}" ]; then
+            CMD+=(--limit "${{ github.event.inputs.limit }}")
+          fi
+
+          printf 'Running command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"
+
+          echo "output_dir=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload evaluation artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ github.event.inputs.artifact_name != '' && github.event.inputs.artifact_name || format('prospective-evaluation-{0}', github.run_id) }}
+          path: ${{ steps.evaluate.outputs.output_dir }}
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Write run summary
+        if: always()
+        env:
+          SUMMARY_PATH: ${{ steps.evaluate.outputs.summary_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path(os.environ.get("SUMMARY_PATH", ""))
+          lines = [
+              "## Prospective Evaluation",
+              "",
+          ]
+
+          if summary_path.is_file():
+              summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              heuristic = summary.get("heuristic_summary") or {}
+              offline = summary.get("offline_summary") or {}
+              head_to_head = summary.get("head_to_head") or {}
+              lines.extend(
+                  [
+                      f"- Settled rows: {summary.get('settled_rows')}",
+                      f"- Heuristic rows: {summary.get('heuristic_rows')}",
+                      f"- Offline rows: {summary.get('offline_rows')}",
+                      f"- Heuristic winner accuracy: {heuristic.get('winner_accuracy')}",
+                      f"- Offline winner accuracy: {offline.get('winner_accuracy')}",
+                      f"- Heuristic draw recall: {heuristic.get('draw_recall')}",
+                      f"- Offline draw recall: {offline.get('draw_recall')}",
+                      f"- Heuristic log loss: {heuristic.get('log_loss')}",
+                      f"- Offline log loss: {offline.get('log_loss')}",
+                      f"- Winner disagreement rate: {head_to_head.get('winner_disagreement_rate')}",
+                      f"- Avg draw-prob delta (offline - heuristic): {head_to_head.get('avg_draw_probability_delta_offline_minus_heuristic')}",
+                  ]
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          PY

--- a/.github/workflows/prepare-prospective-match-predictions.yml
+++ b/.github/workflows/prepare-prospective-match-predictions.yml
@@ -1,0 +1,273 @@
+name: Prepare Prospective Match Predictions
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixture_run_id:
+        description: "Workflow run ID that produced the upcoming-event JSONL artifact"
+        required: true
+        type: string
+      fixture_artifact_name:
+        description: "Optional fixture artifact name override"
+        required: false
+        default: ""
+        type: string
+      fixture_jsonl_name:
+        description: "Optional JSONL filename inside the fixture artifact"
+        required: false
+        default: ""
+        type: string
+      limit:
+        description: "Optional max number of fixtures to ingest"
+        required: false
+        default: ""
+        type: string
+      lookback_days:
+        description: "Historical window for recent-game context"
+        required: false
+        default: "365"
+        type: string
+      training_run_id:
+        description: "Optional model-training run ID to freeze offline predictions"
+        required: false
+        default: ""
+        type: string
+      model_artifact_name:
+        description: "Optional model artifact name override"
+        required: false
+        default: ""
+        type: string
+      apply_calibration:
+        description: "Apply point_in_time_model_calibration.pkl when freezing offline predictions"
+        required: false
+        default: false
+        type: boolean
+      offline_model_version:
+        description: "Optional explicit offline model version label"
+        required: false
+        default: ""
+        type: string
+      force_offline_refresh:
+        description: "Recompute offline predictions even if rows already have completed offline payloads"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Build fixture rows without writing them to the database"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: prospective-match-prepare
+  cancel-in-progress: false
+
+jobs:
+  prepare-prospective-match-predictions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          python -c "import supabase, pandas, numpy, psycopg2; print('Prospective prepare imports successful')"
+
+      - name: Download fixture artifact
+        id: fixtures
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIXTURE_RUN_ID: ${{ github.event.inputs.fixture_run_id }}
+          INPUT_ARTIFACT_NAME: ${{ github.event.inputs.fixture_artifact_name }}
+          INPUT_JSONL_NAME: ${{ github.event.inputs.fixture_jsonl_name }}
+        run: |
+          ARTIFACT_NAME="$INPUT_ARTIFACT_NAME"
+          if [ -z "$ARTIFACT_NAME" ]; then
+            RUN_NUMBER="$(gh run view "$FIXTURE_RUN_ID" --repo "$GITHUB_REPOSITORY" --json number --jq '.number')"
+            ARTIFACT_NAME="gotsport-upcoming-events-$RUN_NUMBER"
+          fi
+
+          DOWNLOAD_ROOT="$RUNNER_TEMP/prospective_fixtures"
+          mkdir -p "$DOWNLOAD_ROOT"
+
+          gh run download "$FIXTURE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir "$DOWNLOAD_ROOT"
+
+          if [ -n "$INPUT_JSONL_NAME" ]; then
+            FIXTURE_FILE="$(find "$DOWNLOAD_ROOT" -type f -name "$INPUT_JSONL_NAME" -print -quit)"
+          else
+            FIXTURE_FILE="$(find "$DOWNLOAD_ROOT" -type f -name 'upcoming_events_*.jsonl' | sort | tail -n 1)"
+          fi
+
+          if [ -z "$FIXTURE_FILE" ]; then
+            echo "Fixture JSONL not found under: $DOWNLOAD_ROOT"
+            find "$DOWNLOAD_ROOT" -maxdepth 3 -mindepth 1 -print
+            exit 1
+          fi
+
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "fixture_file=$FIXTURE_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Download model artifact
+        id: model
+        if: ${{ github.event.inputs.training_run_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRAINING_RUN_ID: ${{ github.event.inputs.training_run_id }}
+          INPUT_ARTIFACT_NAME: ${{ github.event.inputs.model_artifact_name }}
+          APPLY_CALIBRATION: ${{ github.event.inputs.apply_calibration }}
+        run: |
+          ARTIFACT_NAME="$INPUT_ARTIFACT_NAME"
+          if [ -z "$ARTIFACT_NAME" ]; then
+            ARTIFACT_NAME="point-in-time-match-model-$TRAINING_RUN_ID"
+          fi
+
+          DOWNLOAD_ROOT="$RUNNER_TEMP/prospective_model"
+          mkdir -p "$DOWNLOAD_ROOT"
+
+          gh run download "$TRAINING_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir "$DOWNLOAD_ROOT"
+
+          MODEL_ARTIFACT="$(find "$DOWNLOAD_ROOT" -type f -name 'point_in_time_match_model.pkl' -print -quit)"
+          if [ -z "$MODEL_ARTIFACT" ]; then
+            echo "Model artifact not found under: $DOWNLOAD_ROOT"
+            find "$DOWNLOAD_ROOT" -maxdepth 3 -mindepth 1 -print
+            exit 1
+          fi
+
+          CALIBRATION_ARTIFACT=""
+          if [ "$APPLY_CALIBRATION" = "true" ]; then
+            CALIBRATION_ARTIFACT="$(find "$(dirname "$MODEL_ARTIFACT")" -type f -name 'point_in_time_model_calibration.pkl' -print -quit)"
+            if [ -z "$CALIBRATION_ARTIFACT" ]; then
+              echo "Calibration artifact requested but not found next to model artifact"
+              exit 1
+            fi
+          fi
+
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "model_artifact=$MODEL_ARTIFACT" >> "$GITHUB_OUTPUT"
+          echo "calibration_artifact=$CALIBRATION_ARTIFACT" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare prospective fixtures
+        id: run
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          SUMMARY_PATH="$RUNNER_TEMP/prospective_prepare_summary.json"
+
+          CMD=(
+            python scripts/prepare_prospective_match_predictions.py
+            --fixtures-file "${{ steps.fixtures.outputs.fixture_file }}"
+            --source-artifact-path "${{ steps.fixtures.outputs.artifact_name }}"
+            --lookback-days "${{ github.event.inputs.lookback_days }}"
+            --summary-path "$SUMMARY_PATH"
+          )
+
+          if [ -n "${{ github.event.inputs.limit }}" ]; then
+            CMD+=(--limit "${{ github.event.inputs.limit }}")
+          fi
+
+          if [ -n "${{ steps.model.outputs.model_artifact }}" ]; then
+            CMD+=(--model-artifact "${{ steps.model.outputs.model_artifact }}")
+          fi
+
+          if [ -n "${{ steps.model.outputs.calibration_artifact }}" ]; then
+            CMD+=(--calibration-artifact "${{ steps.model.outputs.calibration_artifact }}")
+          fi
+
+          if [ -n "${{ github.event.inputs.offline_model_version }}" ]; then
+            CMD+=(--offline-model-version "${{ github.event.inputs.offline_model_version }}")
+          fi
+
+          if [ "${{ github.event.inputs.force_offline_refresh }}" = "true" ]; then
+            CMD+=(--force-offline-refresh)
+          fi
+
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            CMD+=(--dry-run)
+          fi
+
+          printf 'Running command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"
+
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload prepare summary
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: prospective-prepare-summary-${{ github.run_id }}
+          path: ${{ steps.run.outputs.summary_path }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Write run summary
+        if: always()
+        env:
+          SUMMARY_PATH: ${{ steps.run.outputs.summary_path }}
+          FIXTURE_ARTIFACT_NAME: ${{ steps.fixtures.outputs.artifact_name }}
+          MODEL_ARTIFACT_NAME: ${{ steps.model.outputs.artifact_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path(os.environ.get("SUMMARY_PATH", ""))
+          lines = [
+              "## Prospective Fixture Preparation",
+              "",
+              f"- Fixture artifact: `{os.environ.get('FIXTURE_ARTIFACT_NAME', '')}`",
+          ]
+          model_artifact_name = os.environ.get("MODEL_ARTIFACT_NAME", "")
+          if model_artifact_name:
+              lines.append(f"- Model artifact: `{model_artifact_name}`")
+
+          if summary_path.is_file():
+              summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              lines.extend(
+                  [
+                      f"- Fixtures seen: {summary.get('fixtures_seen')}",
+                      f"- Resolved: {summary.get('resolved')}",
+                      f"- Partial: {summary.get('partial')}",
+                      f"- Unresolved: {summary.get('unresolved')}",
+                      f"- Offline completed: {summary.get('offline_completed')}",
+                      f"- Offline errored: {summary.get('offline_errored')}",
+                      f"- Offline skipped: {summary.get('offline_skipped')}",
+                  ]
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          PY

--- a/.github/workflows/process-prospective-heuristic-predictions.yml
+++ b/.github/workflows/process-prospective-heuristic-predictions.yml
@@ -1,0 +1,126 @@
+name: Process Prospective Heuristic Predictions
+
+on:
+  workflow_dispatch:
+    inputs:
+      heuristic_status:
+        description: "heuristic_prediction_status to process"
+        required: false
+        default: "pending"
+        type: choice
+        options:
+          - pending
+          - error
+      limit:
+        description: "Maximum number of rows to process"
+        required: false
+        default: "100"
+        type: string
+      heuristic_model_version:
+        description: "Optional heuristic model version label override"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: prospective-heuristic-processing
+  cancel-in-progress: false
+
+jobs:
+  process-prospective-heuristic-predictions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Freeze heuristic predictions
+        id: heuristic
+        working-directory: frontend
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          SUMMARY_PATH="$RUNNER_TEMP/prospective_heuristic_summary.json"
+
+          CMD=(
+            npm run process:prospective:heuristic --
+            --status "${{ github.event.inputs.heuristic_status }}"
+            --limit "${{ github.event.inputs.limit }}"
+            --summary-path "$SUMMARY_PATH"
+          )
+
+          if [ -n "${{ github.event.inputs.heuristic_model_version }}" ]; then
+            CMD+=(--heuristic-model-version "${{ github.event.inputs.heuristic_model_version }}")
+          fi
+
+          printf 'Running command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"
+
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload heuristic summary
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: prospective-heuristic-summary-${{ github.run_id }}
+          path: ${{ steps.heuristic.outputs.summary_path }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Write run summary
+        if: always()
+        env:
+          SUMMARY_PATH: ${{ steps.heuristic.outputs.summary_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path(os.environ.get("SUMMARY_PATH", ""))
+          lines = [
+              "## Prospective Heuristic Freeze",
+              "",
+          ]
+
+          if summary_path.is_file():
+              summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              lines.extend(
+                  [
+                      f"- Requested status: `{summary.get('requestedStatus')}`",
+                      f"- Requested limit: {summary.get('requestedLimit')}",
+                      f"- Heuristic model version: `{summary.get('heuristicModelVersion')}`",
+                      f"- Rows fetched: {summary.get('fetchedRows')}",
+                      f"- Rows processed: {summary.get('processed')}",
+                      f"- Rows completed: {summary.get('completed')}",
+                      f"- Rows errored: {summary.get('errored')}",
+                  ]
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          PY

--- a/.github/workflows/settle-prospective-match-predictions.yml
+++ b/.github/workflows/settle-prospective-match-predictions.yml
@@ -1,0 +1,114 @@
+name: Settle Prospective Match Predictions
+
+on:
+  workflow_dispatch:
+    inputs:
+      evaluation_status:
+        description: "evaluation_status bucket to process"
+        required: false
+        default: "pending_result"
+        type: choice
+        options:
+          - pending_result
+          - result_not_found
+          - ambiguous_result
+      limit:
+        description: "Maximum number of rows to process"
+        required: false
+        default: "200"
+        type: string
+
+concurrency:
+  group: prospective-settlement
+  cancel-in-progress: false
+
+jobs:
+  settle-prospective-match-predictions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          python -c "import supabase; print('Prospective settlement imports successful')"
+
+      - name: Settle prospective rows
+        id: settle
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          SUMMARY_PATH="$RUNNER_TEMP/prospective_settlement_summary.json"
+
+          python scripts/settle_prospective_match_predictions.py \
+            --status "${{ github.event.inputs.evaluation_status }}" \
+            --limit "${{ github.event.inputs.limit }}" \
+            --summary-path "$SUMMARY_PATH"
+
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload settlement summary
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: prospective-settlement-summary-${{ github.run_id }}
+          path: ${{ steps.settle.outputs.summary_path }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Write run summary
+        if: always()
+        env:
+          SUMMARY_PATH: ${{ steps.settle.outputs.summary_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path(os.environ.get("SUMMARY_PATH", ""))
+          lines = [
+              "## Prospective Settlement",
+              "",
+          ]
+
+          if summary_path.is_file():
+              summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              lines.extend(
+                  [
+                      f"- Requested status: `{summary.get('requested_status')}`",
+                      f"- Requested limit: {summary.get('requested_limit')}",
+                      f"- Rows fetched: {summary.get('fetched_rows')}",
+                      f"- Rows processed: {summary.get('processed')}",
+                      f"- Rows settled: {summary.get('settled')}",
+                      f"- Result not found: {summary.get('not_found')}",
+                      f"- Ambiguous: {summary.get('ambiguous')}",
+                  ]
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          PY

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.5.0",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "5.9.3",
         "vitest": "^4.1.2"
@@ -370,6 +371,448 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -6472,6 +6915,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -12306,6 +12791,41 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "test:e2e:report": "playwright show-report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "process:prospective:heuristic": "tsx -r ./scripts/server-only-shim.cjs scripts/process-prospective-heuristic-predictions.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -77,6 +78,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.5.0",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
     "vitest": "^4.1.2"

--- a/frontend/scripts/process-prospective-heuristic-predictions.ts
+++ b/frontend/scripts/process-prospective-heuristic-predictions.ts
@@ -1,0 +1,220 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import {
+  MATCH_PREDICTION_VERSION,
+  buildMatchPredictionWithShadowContext,
+} from '../lib/matchPredictionService';
+
+type ProspectiveFixtureRow = {
+  id: string;
+  fixture_key: string;
+  home_team_master_id: string | null;
+  away_team_master_id: string | null;
+};
+
+type ScriptOptions = {
+  status: string;
+  limit: number;
+  heuristicModelVersion?: string;
+  summaryPath?: string;
+};
+
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    if (!key || process.env[key] != null) continue;
+    let value = line.slice(separatorIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+function bootstrapEnv(): void {
+  loadEnvFile(path.resolve(process.cwd(), '.env.local'));
+  loadEnvFile(path.resolve(process.cwd(), '..', '.env.local'));
+}
+
+function getSupabase(): SupabaseClient {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_KEY ||
+    process.env.SUPABASE_KEY;
+  if (!url || !key) {
+    throw new Error('Missing SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL or service key');
+  }
+  return createClient(url, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+function parseArgs(argv: string[]): ScriptOptions {
+  const options: ScriptOptions = {
+    status: 'pending',
+    limit: 100,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--status' && next) {
+      options.status = next;
+      index += 1;
+    } else if (arg === '--limit' && next) {
+      options.limit = Number.parseInt(next, 10);
+      index += 1;
+    } else if (arg === '--heuristic-model-version' && next) {
+      options.heuristicModelVersion = next;
+      index += 1;
+    } else if (arg === '--summary-path' && next) {
+      options.summaryPath = next;
+      index += 1;
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit <= 0) {
+    throw new Error(`Invalid --limit value: ${options.limit}`);
+  }
+  return options;
+}
+
+function errorPayload(error: unknown, modelVersion: string) {
+  const message = error instanceof Error ? error.message : String(error);
+  const type = error instanceof Error ? error.name : 'Error';
+  return {
+    modelVersion,
+    error: {
+      type,
+      message,
+    },
+  };
+}
+
+function isMissingTableError(error: unknown, tableName: string): boolean {
+  const message = String((error as { message?: string } | null)?.message ?? error ?? '').toLowerCase();
+  return (
+    (message.includes('could not find the table') || message.includes('schema cache')) &&
+    message.includes(tableName.toLowerCase())
+  );
+}
+
+async function fetchPendingRows(
+  supabase: SupabaseClient,
+  status: string,
+  limit: number
+): Promise<ProspectiveFixtureRow[]> {
+  const { data, error } = await supabase
+    .from('prospective_match_predictions')
+    .select('id, fixture_key, home_team_master_id, away_team_master_id')
+    .eq('resolution_status', 'resolved')
+    .eq('heuristic_prediction_status', status)
+    .order('game_date', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    if (isMissingTableError(error, 'prospective_match_predictions')) {
+      throw new Error(
+        'prospective_match_predictions table is missing. Apply the new Supabase migration before running heuristic freezing.'
+      );
+    }
+    throw error;
+  }
+  return (data ?? []) as ProspectiveFixtureRow[];
+}
+
+async function updateRow(
+  supabase: SupabaseClient,
+  rowId: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const { error } = await supabase.from('prospective_match_predictions').update(payload).eq('id', rowId);
+  if (error) {
+    throw error;
+  }
+}
+
+async function processRows(options: ScriptOptions) {
+  bootstrapEnv();
+  if (!process.env.SUPABASE_URL && !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+    throw new Error('Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY && !process.env.SUPABASE_SERVICE_KEY && !process.env.SUPABASE_KEY) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY, SUPABASE_SERVICE_KEY, or SUPABASE_KEY');
+  }
+  const supabase = getSupabase();
+  const modelVersion = options.heuristicModelVersion || MATCH_PREDICTION_VERSION;
+  const rows = await fetchPendingRows(supabase, options.status, options.limit);
+  const summary = {
+    requestedStatus: options.status,
+    requestedLimit: options.limit,
+    heuristicModelVersion: modelVersion,
+    fetchedRows: rows.length,
+    processed: 0,
+    completed: 0,
+    errored: 0,
+    rowIds: [] as string[],
+  };
+
+  for (const row of rows) {
+    summary.processed += 1;
+    summary.rowIds.push(row.id);
+
+    try {
+      if (!row.home_team_master_id || !row.away_team_master_id) {
+        throw new Error(`Row ${row.fixture_key} is missing resolved team IDs`);
+      }
+
+      const result = await buildMatchPredictionWithShadowContext(
+        supabase,
+        row.home_team_master_id,
+        row.away_team_master_id
+      );
+
+      await updateRow(supabase, row.id, {
+        heuristic_prediction_status: 'completed',
+        heuristic_model_version: modelVersion,
+        heuristic_prediction: {
+          modelVersion,
+          response: result.response,
+          shadowContext: result.shadowContext,
+        },
+        heuristic_predicted_at: new Date().toISOString(),
+      });
+
+      summary.completed += 1;
+    } catch (error) {
+      await updateRow(supabase, row.id, {
+        heuristic_prediction_status: 'error',
+        heuristic_model_version: modelVersion,
+        heuristic_prediction: errorPayload(error, modelVersion),
+        heuristic_predicted_at: new Date().toISOString(),
+      });
+      summary.errored += 1;
+    }
+  }
+
+  if (options.summaryPath) {
+    const resolvedPath = path.resolve(process.cwd(), options.summaryPath);
+    fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+    fs.writeFileSync(resolvedPath, JSON.stringify(summary, null, 2), 'utf8');
+  }
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+processRows(parseArgs(process.argv.slice(2))).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/frontend/scripts/process-prospective-heuristic-predictions.ts
+++ b/frontend/scripts/process-prospective-heuristic-predictions.ts
@@ -1,10 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import {
-  MATCH_PREDICTION_VERSION,
-  buildMatchPredictionWithShadowContext,
-} from '../lib/matchPredictionService';
+import { MATCH_PREDICTION_VERSION, buildMatchPredictionWithShadowContext } from '../lib/matchPredictionService';
 
 type ProspectiveFixtureRow = {
   id: string;
@@ -45,10 +42,7 @@ function bootstrapEnv(): void {
 
 function getSupabase(): SupabaseClient {
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.SUPABASE_SERVICE_KEY ||
-    process.env.SUPABASE_KEY;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY;
   if (!url || !key) {
     throw new Error('Missing SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL or service key');
   }
@@ -134,11 +128,7 @@ async function fetchPendingRows(
   return (data ?? []) as ProspectiveFixtureRow[];
 }
 
-async function updateRow(
-  supabase: SupabaseClient,
-  rowId: string,
-  payload: Record<string, unknown>
-): Promise<void> {
+async function updateRow(supabase: SupabaseClient, rowId: string, payload: Record<string, unknown>): Promise<void> {
   const { error } = await supabase.from('prospective_match_predictions').update(payload).eq('id', rowId);
   if (error) {
     throw error;

--- a/frontend/scripts/server-only-shim.cjs
+++ b/frontend/scripts/server-only-shim.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const Module = require('node:module');
 
 const originalLoad = Module._load;

--- a/frontend/scripts/server-only-shim.cjs
+++ b/frontend/scripts/server-only-shim.cjs
@@ -1,0 +1,10 @@
+const Module = require('node:module');
+
+const originalLoad = Module._load;
+
+Module._load = function patchedServerOnlyLoad(request, parent, isMain) {
+  if (request === 'server-only') {
+    return {};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};

--- a/scripts/evaluate_prospective_match_predictions.py
+++ b/scripts/evaluate_prospective_match_predictions.py
@@ -1,0 +1,238 @@
+"""
+Evaluate prospective heuristic vs offline match predictions on settled fixtures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.predictions.evaluation_reporting import compute_evaluation_summary, write_evaluation_bundle  # noqa: E402
+from supabase import Client, create_client  # noqa: E402
+
+
+def _supabase_client() -> Client:
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY")
+    return create_client(supabase_url, supabase_key)
+
+
+def _safe_json(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _actual_outcome(home_score: Optional[int], away_score: Optional[int]) -> Optional[str]:
+    if home_score is None or away_score is None:
+        return None
+    if home_score > away_score:
+        return "team_a"
+    if away_score > home_score:
+        return "team_b"
+    return "draw"
+
+
+def _is_missing_table(error: Exception, table_name: str) -> bool:
+    message = str(error).lower()
+    return ("could not find the table" in message or "schema cache" in message) and table_name.lower() in message
+
+
+def _extract_prediction_payload(row: Dict[str, Any], model_name: str) -> Optional[Dict[str, Any]]:
+    if model_name == "heuristic":
+        payload = _safe_json(row.get("heuristic_prediction"))
+        prediction = _safe_json(_safe_json(payload.get("response")).get("prediction"))
+        model_version = payload.get("modelVersion") or row.get("heuristic_model_version")
+    else:
+        payload = _safe_json(row.get("offline_prediction"))
+        prediction = _safe_json(payload.get("prediction"))
+        model_version = payload.get("modelVersion") or row.get("offline_model_version")
+
+    if not prediction:
+        return None
+
+    win_a = prediction.get("winProbabilityA")
+    win_b = prediction.get("winProbabilityB")
+    draw = prediction.get("drawProbability")
+    if draw is None and win_a is not None and win_b is not None:
+        draw = max(0.0, 1.0 - float(win_a) - float(win_b))
+
+    expected_score = _safe_json(prediction.get("expectedScore"))
+    fixture_payload = _safe_json(row.get("fixture_payload"))
+    home_row = _safe_json(fixture_payload.get("home_row"))
+
+    actual_home_score = row.get("actual_home_score")
+    actual_away_score = row.get("actual_away_score")
+    return {
+        "fixture_key": row.get("fixture_key"),
+        "game_date": row.get("game_date"),
+        "competition": row.get("competition"),
+        "division_name": row.get("division_name"),
+        "age_group": home_row.get("age_group"),
+        "feature_source": model_name,
+        "model_version": model_version,
+        "actual_score_a": actual_home_score,
+        "actual_score_b": actual_away_score,
+        "actual_margin": (actual_home_score - actual_away_score)
+        if actual_home_score is not None and actual_away_score is not None
+        else None,
+        "actual_outcome": _actual_outcome(actual_home_score, actual_away_score),
+        "predicted_outcome": prediction.get("predictedWinner"),
+        "prob_team_a_win": win_a,
+        "prob_draw": draw,
+        "prob_team_b_win": win_b,
+        "predicted_score_a": expected_score.get("teamA"),
+        "predicted_score_b": expected_score.get("teamB"),
+        "predicted_margin": prediction.get("expectedMargin"),
+        "blowout_3plus_probability": prediction.get("blowoutProbability3Plus"),
+        "blowout_5plus_probability": prediction.get("blowoutProbability5Plus"),
+        "predicted_blowout_3plus": prediction.get("predictedBlowout3Plus"),
+        "predicted_blowout_5plus": prediction.get("predictedBlowout5Plus"),
+    }
+
+
+def _fetch_rows(supabase: Client, limit: Optional[int]) -> List[Dict[str, Any]]:
+    query = (
+        supabase.table("prospective_match_predictions")
+        .select(
+            "fixture_key, game_date, competition, division_name, fixture_payload, "
+            "heuristic_prediction_status, heuristic_model_version, heuristic_prediction, "
+            "offline_prediction_status, offline_model_version, offline_prediction, "
+            "actual_home_score, actual_away_score, evaluation_status"
+        )
+        .eq("evaluation_status", "settled")
+        .order("game_date", desc=False)
+    )
+    if limit:
+        query = query.limit(limit)
+    try:
+        response = query.execute()
+    except Exception as error:
+        if _is_missing_table(error, "prospective_match_predictions"):
+            raise RuntimeError(
+                "prospective_match_predictions table is missing. Apply the new Supabase migration before running evaluation."
+            ) from error
+        raise
+    return list(response.data or [])
+
+
+def evaluate_rows(rows: List[Dict[str, Any]], output_dir: Path) -> Dict[str, Any]:
+    heuristic_rows: List[Dict[str, Any]] = []
+    offline_rows: List[Dict[str, Any]] = []
+    comparison_rows: List[Dict[str, Any]] = []
+
+    for row in rows:
+        heuristic_prediction = _extract_prediction_payload(row, "heuristic")
+        offline_prediction = _extract_prediction_payload(row, "offline")
+
+        if heuristic_prediction and row.get("heuristic_prediction_status") == "completed":
+            heuristic_rows.append(heuristic_prediction)
+        if offline_prediction and row.get("offline_prediction_status") == "completed":
+            offline_rows.append(offline_prediction)
+
+        if heuristic_prediction and offline_prediction:
+            comparison_rows.append(
+                {
+                    "fixture_key": row.get("fixture_key"),
+                    "game_date": row.get("game_date"),
+                    "competition": row.get("competition"),
+                    "division_name": row.get("division_name"),
+                    "actual_outcome": heuristic_prediction.get("actual_outcome"),
+                    "heuristic_predicted_outcome": heuristic_prediction.get("predicted_outcome"),
+                    "offline_predicted_outcome": offline_prediction.get("predicted_outcome"),
+                    "heuristic_draw_probability": heuristic_prediction.get("prob_draw"),
+                    "offline_draw_probability": offline_prediction.get("prob_draw"),
+                    "heuristic_expected_score_a": heuristic_prediction.get("predicted_score_a"),
+                    "heuristic_expected_score_b": heuristic_prediction.get("predicted_score_b"),
+                    "offline_expected_score_a": offline_prediction.get("predicted_score_a"),
+                    "offline_expected_score_b": offline_prediction.get("predicted_score_b"),
+                }
+            )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    heuristic_frame = pd.DataFrame(heuristic_rows)
+    offline_frame = pd.DataFrame(offline_rows)
+    heuristic_summary = write_evaluation_bundle(heuristic_frame, output_dir, prefix="prospective_heuristic") if not heuristic_frame.empty else compute_evaluation_summary(heuristic_frame)
+    offline_summary = write_evaluation_bundle(offline_frame, output_dir, prefix="prospective_offline") if not offline_frame.empty else compute_evaluation_summary(offline_frame)
+
+    comparison_frame = pd.DataFrame(comparison_rows)
+    if not comparison_frame.empty:
+        comparison_frame.to_csv(output_dir / "prospective_head_to_head.csv", index=False)
+
+    head_to_head = {
+        "fixtures_with_both_predictions": int(len(comparison_frame)),
+        "winner_disagreement_rate": float(
+            (
+                comparison_frame["heuristic_predicted_outcome"]
+                != comparison_frame["offline_predicted_outcome"]
+            ).mean()
+        )
+        if not comparison_frame.empty
+        else None,
+        "avg_draw_probability_delta_offline_minus_heuristic": float(
+            (
+                pd.to_numeric(comparison_frame["offline_draw_probability"], errors="coerce")
+                - pd.to_numeric(comparison_frame["heuristic_draw_probability"], errors="coerce")
+            ).mean()
+        )
+        if not comparison_frame.empty
+        else None,
+    }
+
+    summary = {
+        "settled_rows": len(rows),
+        "heuristic_rows": len(heuristic_frame),
+        "offline_rows": len(offline_frame),
+        "heuristic_summary": heuristic_summary,
+        "offline_summary": offline_summary,
+        "head_to_head": head_to_head,
+    }
+    (output_dir / "prospective_head_to_head_summary.json").write_text(
+        json.dumps(summary, indent=2),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate prospective heuristic vs offline predictions")
+    parser.add_argument("--output-dir", default="models/prospective_evaluation", help="Output directory for reports")
+    parser.add_argument("--limit", type=int, default=None, help="Optional settled-row limit")
+    parser.add_argument("--summary-path", default=None, help="Optional path to write JSON summary")
+    args = parser.parse_args()
+
+    rows = _fetch_rows(_supabase_client(), args.limit)
+    summary = evaluate_rows(rows, Path(args.output_dir))
+    if args.summary_path:
+        summary_path = Path(args.summary_path)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_prospective_match_predictions.py
+++ b/scripts/prepare_prospective_match_predictions.py
@@ -1,0 +1,1005 @@
+"""
+Prepare prospective match-prediction fixtures from upcoming-event artifacts.
+
+This script ingests a JSONL file from scrape_upcoming_gotsport_events.py,
+deduplicates it to one row per fixture, resolves provider team IDs to
+PitchRank master team IDs, optionally freezes the offline point-in-time model,
+and stores the result in prospective_match_predictions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import pandas as pd
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.process_match_prediction_shadow import (  # noqa: E402
+    _apply_optional_calibration,
+    _build_shadow_payload,
+    _derive_shadow_model_version,
+)
+from scripts.predictor_python import Game as PredictorGame  # noqa: E402
+from src.predictions.point_in_time_calibration import PointInTimeProbabilityCalibrator  # noqa: E402
+from src.predictions.point_in_time_match_model import (  # noqa: E402
+    PointInTimeMatchModel,
+    build_point_in_time_matchup_row,
+)
+from src.utils.merge_resolver import MergeResolver  # noqa: E402
+from supabase import Client, create_client  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+OPTIONAL_RANKINGS_FULL_FIELDS = (
+    "team_id, age_group, gender, rank_in_cohort_final, power_score_final, glicko_rating, glicko_rd, "
+    "glicko_volatility, sos_norm, off_norm, def_norm, wins, losses, draws, games_played, "
+    "same_age_games, same_age_game_share, same_age_unique_opponents, same_age_top100_opp_count, "
+    "same_age_top500_opp_count, same_age_avg_opp_power_adj, repeat_opponent_share, "
+    "positive_ml_evidence_scale, publication_cap_rank, publication_cap_score"
+)
+BASE_RANKINGS_FULL_FIELDS = (
+    "team_id, age_group, gender, rank_in_cohort_final, power_score_final, glicko_rating, glicko_rd, "
+    "glicko_volatility, sos_norm, off_norm, def_norm, wins, losses, draws, games_played"
+)
+
+
+@dataclass
+class FixtureRecord:
+    fixture_key: str
+    provider_code: str
+    source_system: str
+    source_artifact_path: Optional[str]
+    source_event_id: Optional[str]
+    source_match_key: Optional[str]
+    game_date: str
+    competition: str
+    division_name: str
+    venue: str
+    home_provider_team_id: str
+    away_provider_team_id: str
+    home_team_name: str
+    away_team_name: str
+    fixture_payload: Dict[str, Any]
+
+
+@dataclass
+class TeamResolution:
+    team_id_master: Optional[str]
+    resolution_method: Optional[str]
+
+
+def _supabase_client() -> Client:
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY")
+    return create_client(supabase_url, supabase_key)
+
+
+def _normalize_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _sanitize_key_part(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", _normalize_text(value)).strip("-") or "unknown"
+
+
+def _safe_json_loads(line: str) -> Optional[Dict[str, Any]]:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _extract_event_id_from_row(row: Dict[str, Any]) -> Optional[str]:
+    match_id = str(row.get("match_id") or "").strip()
+    if match_id:
+        match = re.match(r"(\d+)_", match_id)
+        if match:
+            return match.group(1)
+
+    source_url = str(row.get("source_url") or "").strip()
+    match = re.search(r"/events/(\d+)", source_url)
+    return match.group(1) if match else None
+
+
+def _group_key_for_row(row: Dict[str, Any]) -> Tuple[str, ...]:
+    team_marker_a = str(row.get("team_id_source") or row.get("team_id") or row.get("team_name") or "")
+    team_marker_b = str(row.get("opponent_id_source") or row.get("opponent_id") or row.get("opponent_name") or "")
+    team_pair = tuple(sorted([_normalize_text(team_marker_a), _normalize_text(team_marker_b)]))
+    return (
+        _normalize_text(row.get("provider") or "gotsport"),
+        str(row.get("game_date") or ""),
+        _normalize_text(row.get("competition") or row.get("event_name") or ""),
+        _normalize_text(row.get("division_name") or ""),
+        _normalize_text(row.get("venue") or ""),
+        *team_pair,
+    )
+
+
+def _canonical_fixture_key(fixture: FixtureRecord) -> str:
+    parts = [
+        fixture.provider_code,
+        fixture.source_event_id or "eventless",
+        fixture.game_date,
+        fixture.home_provider_team_id or fixture.home_team_name,
+        fixture.away_provider_team_id or fixture.away_team_name,
+        fixture.venue or "",
+        fixture.division_name or "",
+    ]
+    return "|".join(_sanitize_key_part(part) for part in parts)
+
+
+def load_fixtures_from_jsonl(fixtures_file: Path, source_artifact_path: Optional[str]) -> List[FixtureRecord]:
+    grouped_rows: Dict[Tuple[str, ...], List[Dict[str, Any]]] = {}
+    for raw_line in fixtures_file.read_text(encoding="utf-8").splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        row = _safe_json_loads(raw_line)
+        if row is None:
+            continue
+        grouped_rows.setdefault(_group_key_for_row(row), []).append(row)
+
+    fixtures: List[FixtureRecord] = []
+    for rows in grouped_rows.values():
+        home_row = next((row for row in rows if str(row.get("home_away") or "").upper() == "H"), None)
+        away_row = next((row for row in rows if str(row.get("home_away") or "").upper() == "A"), None)
+        base_row = home_row or rows[0]
+
+        if home_row:
+            home_provider_team_id = str(home_row.get("team_id_source") or home_row.get("team_id") or "")
+            away_provider_team_id = str(home_row.get("opponent_id_source") or home_row.get("opponent_id") or "")
+            home_team_name = str(home_row.get("team_name") or "")
+            away_team_name = str(home_row.get("opponent_name") or "")
+            source_match_key = str(home_row.get("match_id") or "")
+        else:
+            home_provider_team_id = str(base_row.get("opponent_id_source") or base_row.get("opponent_id") or "")
+            away_provider_team_id = str(base_row.get("team_id_source") or base_row.get("team_id") or "")
+            home_team_name = str(base_row.get("opponent_name") or "")
+            away_team_name = str(base_row.get("team_name") or "")
+            source_match_key = str(base_row.get("match_id") or "")
+
+        fixture = FixtureRecord(
+            fixture_key="",
+            provider_code=str(base_row.get("provider") or "gotsport"),
+            source_system="gotsport_event_schedule",
+            source_artifact_path=source_artifact_path,
+            source_event_id=_extract_event_id_from_row(base_row),
+            source_match_key=source_match_key or None,
+            game_date=str(base_row.get("game_date") or ""),
+            competition=str(base_row.get("competition") or base_row.get("event_name") or ""),
+            division_name=str(base_row.get("division_name") or ""),
+            venue=str(base_row.get("venue") or ""),
+            home_provider_team_id=home_provider_team_id,
+            away_provider_team_id=away_provider_team_id,
+            home_team_name=home_team_name,
+            away_team_name=away_team_name,
+            fixture_payload={
+                "home_row": home_row,
+                "away_row": away_row,
+                "rows": rows,
+            },
+        )
+        fixture.fixture_key = _canonical_fixture_key(fixture)
+        fixtures.append(fixture)
+
+    fixtures.sort(key=lambda fixture: (fixture.game_date, fixture.competition, fixture.home_team_name, fixture.away_team_name))
+    return fixtures
+
+
+def _chunked(values: Iterable[str], size: int) -> Iterable[List[str]]:
+    batch: List[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _is_missing_optional_prediction_column(error: Exception) -> bool:
+    message = str(error).lower()
+    return (
+        ("column" in message or "schema cache" in message or "could not find" in message)
+        and (
+            "same_age_" in message
+            or "positive_ml_evidence_scale" in message
+            or "publication_cap_" in message
+        )
+    )
+
+
+def _is_missing_review_status_column(error: Exception) -> bool:
+    message = str(error).lower()
+    return ("column" in message or "schema cache" in message or "could not find" in message) and "review_status" in message
+
+
+def _is_missing_table(error: Exception, table_name: str) -> bool:
+    message = str(error).lower()
+    return ("could not find the table" in message or "schema cache" in message) and table_name.lower() in message
+
+
+def _to_python(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _to_python(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_to_python(item) for item in value]
+    if isinstance(value, bool) or value is None:
+        return value
+    try:
+        if pd.isna(value):
+            return None
+    except Exception:
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:
+            pass
+    return value
+
+
+def _normalize_gender_code(raw_gender: Any) -> str:
+    normalized = str(raw_gender or "").strip().lower()
+    if normalized in {"female", "f", "g", "girls", "girl"}:
+        return "F"
+    if normalized in {"male", "m", "b", "boys", "boy"}:
+        return "M"
+    return "M"
+
+
+def _normalize_age_value(raw_age: Any) -> Optional[int]:
+    if raw_age is None:
+        return None
+    text = str(raw_age).strip().lower()
+    if not text:
+        return None
+    text = text.replace("u", "")
+    match = re.search(r"(\d+)", text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _normalize_age_group_label(raw_age: Any) -> str:
+    age_value = _normalize_age_value(raw_age)
+    return str(age_value) if age_value is not None else ""
+
+
+def _build_actual_outcome(home_score: Optional[int], away_score: Optional[int]) -> Optional[str]:
+    if home_score is None or away_score is None:
+        return None
+    if home_score > away_score:
+        return "team_a"
+    if away_score > home_score:
+        return "team_b"
+    return "draw"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _fetch_provider_id(supabase: Client, provider_code: str) -> Optional[str]:
+    response = supabase.table("providers").select("id").eq("code", provider_code).maybe_single().execute()
+    data = response.data or {}
+    return str(data.get("id") or "") or None
+
+
+def _fetch_existing_rows(
+    supabase: Client,
+    fixture_keys: Iterable[str],
+) -> Dict[str, Dict[str, Any]]:
+    keys = [str(value) for value in fixture_keys if value]
+    if not keys:
+        return {}
+
+    rows: Dict[str, Dict[str, Any]] = {}
+    select_fields = (
+        "fixture_key, heuristic_prediction_status, heuristic_model_version, heuristic_prediction, "
+        "heuristic_predicted_at, offline_prediction_status, offline_model_version, offline_prediction, "
+        "offline_predicted_at, actual_game_id, actual_home_score, actual_away_score, actual_outcome, "
+        "actual_recorded_at, evaluation_status, evaluation_notes"
+    )
+    for batch in _chunked(keys, 100):
+        response = (
+            supabase.table("prospective_match_predictions")
+            .select(select_fields)
+            .in_("fixture_key", batch)
+            .execute()
+        )
+        for row in response.data or []:
+            fixture_key = str(row.get("fixture_key") or "")
+            if fixture_key:
+                rows[fixture_key] = row
+    return rows
+
+
+def _fetch_alias_rows(
+    supabase: Client,
+    provider_id: str,
+    provider_team_ids: Iterable[str],
+) -> List[Dict[str, Any]]:
+    ids = [str(value) for value in provider_team_ids if value]
+    if not ids:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    select_fields = "provider_team_id, team_id_master, match_method, review_status"
+    for batch in _chunked(ids, 100):
+        query = (
+            supabase.table("team_alias_map")
+            .select(select_fields)
+            .eq("provider_id", provider_id)
+            .in_("provider_team_id", batch)
+        )
+        try:
+            response = query.execute()
+        except Exception as error:
+            if _is_missing_review_status_column(error):
+                response = (
+                    supabase.table("team_alias_map")
+                    .select("provider_team_id, team_id_master, match_method")
+                    .eq("provider_id", provider_id)
+                    .in_("provider_team_id", batch)
+                    .execute()
+                )
+            else:
+                raise
+        rows.extend(response.data or [])
+    return rows
+
+
+def _resolve_provider_team_ids(
+    supabase: Client,
+    provider_id: str,
+    provider_team_ids: Iterable[str],
+    merge_resolver: MergeResolver,
+) -> Dict[str, TeamResolution]:
+    ids = sorted({str(value).strip() for value in provider_team_ids if str(value or "").strip()})
+    if not ids:
+        return {}
+
+    resolutions: Dict[str, TeamResolution] = {}
+    alias_rows = _fetch_alias_rows(supabase, provider_id, ids)
+    alias_by_provider_id: Dict[str, Dict[str, Any]] = {}
+    for row in alias_rows:
+        provider_team_id = str(row.get("provider_team_id") or "").strip()
+        if not provider_team_id:
+            continue
+        current = alias_by_provider_id.get(provider_team_id)
+        current_review = str((current or {}).get("review_status") or "").lower()
+        candidate_review = str(row.get("review_status") or "").lower()
+        if current is None or candidate_review == "approved" or (current_review != "approved" and not current_review):
+            alias_by_provider_id[provider_team_id] = row
+
+    for provider_team_id, row in alias_by_provider_id.items():
+        canonical_id = merge_resolver.resolve(str(row.get("team_id_master") or "")) or None
+        method = str(row.get("match_method") or "alias").strip() or "alias"
+        review_status = str(row.get("review_status") or "").strip().lower()
+        if review_status == "approved":
+            method = f"alias_approved:{method}"
+        elif review_status:
+            method = f"alias_{review_status}:{method}"
+        else:
+            method = f"alias:{method}"
+        resolutions[provider_team_id] = TeamResolution(team_id_master=canonical_id, resolution_method=method)
+
+    unresolved_ids = [provider_team_id for provider_team_id in ids if provider_team_id not in resolutions]
+    for batch in _chunked(unresolved_ids, 100):
+        response = (
+            supabase.table("teams")
+            .select("team_id_master, provider_team_id")
+            .eq("provider_id", provider_id)
+            .in_("provider_team_id", batch)
+            .execute()
+        )
+        for row in response.data or []:
+            provider_team_id = str(row.get("provider_team_id") or "").strip()
+            canonical_id = merge_resolver.resolve(str(row.get("team_id_master") or "")) or None
+            if provider_team_id and provider_team_id not in resolutions:
+                resolutions[provider_team_id] = TeamResolution(
+                    team_id_master=canonical_id,
+                    resolution_method="teams_provider_id",
+                )
+
+    for provider_team_id in ids:
+        resolutions.setdefault(provider_team_id, TeamResolution(team_id_master=None, resolution_method=None))
+    return resolutions
+
+
+def _fetch_recent_games(
+    supabase: Client,
+    team_ids: Iterable[str],
+    lookback_days: int,
+) -> List[PredictorGame]:
+    ids = sorted({str(team_id) for team_id in team_ids if team_id})
+    if not ids:
+        return []
+
+    cutoff_date = (datetime.now(timezone.utc).date() - timedelta(days=lookback_days)).isoformat()
+    rows_by_id: Dict[str, Dict[str, Any]] = {}
+    select_fields = "id, game_date, home_team_master_id, away_team_master_id, home_score, away_score, is_excluded"
+
+    for batch in _chunked(ids, 100):
+        for column_name in ("home_team_master_id", "away_team_master_id"):
+            response = (
+                supabase.table("games")
+                .select(select_fields)
+                .gte("game_date", cutoff_date)
+                .eq("is_excluded", False)
+                .in_(column_name, batch)
+                .execute()
+            )
+            for row in response.data or []:
+                game_id = str(row.get("id") or "")
+                if not game_id:
+                    continue
+                if row.get("home_score") is None or row.get("away_score") is None:
+                    continue
+                rows_by_id[game_id] = row
+
+    games = [
+        PredictorGame(
+            id=str(row.get("id") or ""),
+            home_team_master_id=row.get("home_team_master_id"),
+            away_team_master_id=row.get("away_team_master_id"),
+            home_score=int(row["home_score"]) if row.get("home_score") is not None else None,
+            away_score=int(row["away_score"]) if row.get("away_score") is not None else None,
+            game_date=str(row.get("game_date") or ""),
+        )
+        for row in rows_by_id.values()
+    ]
+    games.sort(key=lambda game: game.game_date, reverse=True)
+    return games
+
+
+def _fetch_rankings_full_rows(
+    supabase: Client,
+    team_ids: Iterable[str],
+) -> Dict[str, Dict[str, Any]]:
+    ids = sorted({str(team_id) for team_id in team_ids if team_id})
+    if not ids:
+        return {}
+
+    rows: Dict[str, Dict[str, Any]] = {}
+
+    def _attempt(selector: str, batch: List[str]) -> List[Dict[str, Any]]:
+        response = (
+            supabase.table("rankings_full")
+            .select(selector)
+            .in_("team_id", batch)
+            .execute()
+        )
+        return list(response.data or [])
+
+    for batch in _chunked(ids, 100):
+        try:
+            batch_rows = _attempt(OPTIONAL_RANKINGS_FULL_FIELDS, batch)
+        except Exception as error:
+            if _is_missing_optional_prediction_column(error):
+                batch_rows = _attempt(BASE_RANKINGS_FULL_FIELDS, batch)
+            else:
+                raise
+        for row in batch_rows:
+            team_id = str(row.get("team_id") or "")
+            if team_id:
+                rows[team_id] = row
+    return rows
+
+
+def _fetch_team_contexts(
+    supabase: Client,
+    team_ids: Iterable[str],
+) -> Dict[str, Dict[str, Any]]:
+    ids = sorted({str(team_id) for team_id in team_ids if team_id})
+    if not ids:
+        return {}
+
+    team_rows: Dict[str, Dict[str, Any]] = {}
+    predictive_rows: Dict[str, Dict[str, Any]] = {}
+    rankings_rows = _fetch_rankings_full_rows(supabase, ids)
+
+    for batch in _chunked(ids, 100):
+        team_response = (
+            supabase.table("teams")
+            .select("team_id_master, team_name, club_name, state, state_code, age_group, gender, last_scraped_at")
+            .in_("team_id_master", batch)
+            .execute()
+        )
+        for row in team_response.data or []:
+            team_id = str(row.get("team_id_master") or "")
+            if team_id:
+                team_rows[team_id] = row
+
+        predictive_response = (
+            supabase.table("team_predictive_view")
+            .select("team_id_master, exp_margin, exp_win_rate, exp_goals_for, exp_goals_against")
+            .in_("team_id_master", batch)
+        )
+        try:
+            predictive_result = predictive_response.execute()
+        except Exception as error:
+            if _is_missing_table(error, "team_predictive_view"):
+                predictive_result = type("PredictiveResult", (), {"data": []})()
+            else:
+                raise
+        for row in predictive_result.data or []:
+            team_id = str(row.get("team_id_master") or "")
+            if team_id:
+                predictive_rows[team_id] = row
+
+    contexts: Dict[str, Dict[str, Any]] = {}
+    for team_id in ids:
+        team_row = team_rows.get(team_id)
+        if team_row is None:
+            continue
+        rankings_row = rankings_rows.get(team_id, {})
+        predictive_row = predictive_rows.get(team_id, {})
+
+        wins = rankings_row.get("wins") or 0
+        losses = rankings_row.get("losses") or 0
+        draws = rankings_row.get("draws") or 0
+        games_played = rankings_row.get("games_played") or 0
+        win_percentage = None
+        if games_played:
+            win_percentage = ((float(wins) + float(draws) * 0.5) / float(games_played)) * 100.0
+
+        contexts[team_id] = {
+            "team_id_master": team_id,
+            "team_name": team_row.get("team_name"),
+            "club_name": team_row.get("club_name"),
+            "state": team_row.get("state") or team_row.get("state_code"),
+            "age": _normalize_age_value(rankings_row.get("age_group") or team_row.get("age_group")),
+            "gender": _normalize_gender_code(rankings_row.get("gender") or team_row.get("gender")),
+            "rank_in_cohort_final": rankings_row.get("rank_in_cohort_final"),
+            "power_score_final": rankings_row.get("power_score_final"),
+            "glicko_rating": rankings_row.get("glicko_rating"),
+            "glicko_rd": rankings_row.get("glicko_rd"),
+            "glicko_volatility": rankings_row.get("glicko_volatility"),
+            "sos_norm": rankings_row.get("sos_norm"),
+            "sos_norm_state": rankings_row.get("sos_norm"),
+            "offense_norm": rankings_row.get("off_norm"),
+            "defense_norm": rankings_row.get("def_norm"),
+            "same_age_games": rankings_row.get("same_age_games"),
+            "same_age_game_share": rankings_row.get("same_age_game_share"),
+            "same_age_unique_opponents": rankings_row.get("same_age_unique_opponents"),
+            "same_age_top100_opp_count": rankings_row.get("same_age_top100_opp_count"),
+            "same_age_top500_opp_count": rankings_row.get("same_age_top500_opp_count"),
+            "same_age_avg_opp_power_adj": rankings_row.get("same_age_avg_opp_power_adj"),
+            "repeat_opponent_share": rankings_row.get("repeat_opponent_share"),
+            "positive_ml_evidence_scale": rankings_row.get("positive_ml_evidence_scale"),
+            "publication_cap_rank": rankings_row.get("publication_cap_rank"),
+            "publication_cap_score": rankings_row.get("publication_cap_score"),
+            "wins": wins,
+            "losses": losses,
+            "draws": draws,
+            "games_played": games_played,
+            "last_scraped_at": team_row.get("last_scraped_at"),
+            "win_percentage": win_percentage,
+            "exp_margin": predictive_row.get("exp_margin"),
+            "exp_win_rate": predictive_row.get("exp_win_rate"),
+            "exp_goals_for": predictive_row.get("exp_goals_for"),
+            "exp_goals_against": predictive_row.get("exp_goals_against"),
+        }
+    return contexts
+
+
+def _build_snapshot_payload(team_context: Dict[str, Any], snapshot_date: str) -> Dict[str, Any]:
+    return {
+        "snapshot_date": snapshot_date,
+        "team_id": str(team_context.get("team_id_master") or ""),
+        "team_name": team_context.get("team_name"),
+        "club_name": team_context.get("club_name"),
+        "age_group": _normalize_age_group_label(team_context.get("age")),
+        "gender": "Female" if _normalize_gender_code(team_context.get("gender")) == "F" else "Male",
+        "status": "Active",
+        "rank_in_cohort_final": team_context.get("rank_in_cohort_final"),
+        "power_score_final": team_context.get("power_score_final"),
+        "sos_norm": team_context.get("sos_norm"),
+        "offense_norm": team_context.get("offense_norm"),
+        "defense_norm": team_context.get("defense_norm"),
+        "glicko_rating": team_context.get("glicko_rating"),
+        "glicko_rd": team_context.get("glicko_rd"),
+        "glicko_volatility": team_context.get("glicko_volatility"),
+        "wins": team_context.get("wins"),
+        "losses": team_context.get("losses"),
+        "draws": team_context.get("draws"),
+        "games_played": team_context.get("games_played"),
+        "win_percentage": team_context.get("win_percentage"),
+        "same_age_games": team_context.get("same_age_games"),
+        "same_age_game_share": team_context.get("same_age_game_share"),
+        "same_age_unique_opponents": team_context.get("same_age_unique_opponents"),
+        "same_age_top100_opp_count": team_context.get("same_age_top100_opp_count"),
+        "same_age_top500_opp_count": team_context.get("same_age_top500_opp_count"),
+        "same_age_avg_opp_power_adj": team_context.get("same_age_avg_opp_power_adj"),
+        "repeat_opponent_share": team_context.get("repeat_opponent_share"),
+        "positive_ml_evidence_scale": team_context.get("positive_ml_evidence_scale"),
+        "publication_cap_rank": team_context.get("publication_cap_rank"),
+        "publication_cap_score": team_context.get("publication_cap_score"),
+        "exp_margin": team_context.get("exp_margin"),
+        "exp_win_rate": team_context.get("exp_win_rate"),
+        "exp_goals_for": team_context.get("exp_goals_for"),
+        "exp_goals_against": team_context.get("exp_goals_against"),
+    }
+
+
+def _build_snapshot_index(
+    team_contexts: Dict[str, Dict[str, Any]],
+    snapshot_date: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    snapshot_ts = pd.Timestamp(snapshot_date)
+    snapshot_index: Dict[str, List[Dict[str, Any]]] = {}
+    for team_id, team_context in team_contexts.items():
+        snapshot_index[team_id] = [
+            {
+                "team_id": team_id,
+                "snapshot_date": snapshot_date,
+                "snapshot_ts": snapshot_ts,
+                "power_score_final": team_context.get("power_score_final"),
+                "age_group": _normalize_age_group_label(team_context.get("age")),
+            }
+        ]
+    return snapshot_index
+
+
+def _build_offline_prediction(
+    fixture: FixtureRecord,
+    *,
+    home_team_id: str,
+    away_team_id: str,
+    team_contexts: Dict[str, Dict[str, Any]],
+    recent_games: List[PredictorGame],
+    snapshot_index: Dict[str, List[Dict[str, Any]]],
+    model: PointInTimeMatchModel,
+    calibrator: Optional[PointInTimeProbabilityCalibrator],
+    model_version: str,
+) -> Dict[str, Any]:
+    if home_team_id not in team_contexts:
+        raise ValueError(f"Missing team context for home team {home_team_id}")
+    if away_team_id not in team_contexts:
+        raise ValueError(f"Missing team context for away team {away_team_id}")
+
+    game_date = fixture.game_date or datetime.now(timezone.utc).date().isoformat()
+    home_snapshot = _build_snapshot_payload(team_contexts[home_team_id], game_date)
+    away_snapshot = _build_snapshot_payload(team_contexts[away_team_id], game_date)
+    matchup_frame = pd.DataFrame(
+        [
+            build_point_in_time_matchup_row(
+                team_a_id=home_team_id,
+                team_b_id=away_team_id,
+                team_a_snapshot=home_snapshot,
+                team_b_snapshot=away_snapshot,
+                all_games=recent_games,
+                game_date=game_date,
+                snapshot_index=snapshot_index,
+                team_names={
+                    home_team_id: team_contexts[home_team_id].get("team_name"),
+                    away_team_id: team_contexts[away_team_id].get("team_name"),
+                },
+                game_id=f"prospective:{fixture.fixture_key}",
+                example_orientation="prospective",
+            )
+        ]
+    )
+    prediction_frame = model.predict_frame(matchup_frame)
+    prediction_frame = _apply_optional_calibration(prediction_frame, model, calibrator)
+    prediction_row = prediction_frame.iloc[0]
+    return _build_shadow_payload(
+        prediction_row,
+        model_version=model_version,
+        calibrated=calibrator is not None,
+    )
+
+
+def _upsert_rows(
+    supabase: Client,
+    rows: List[Dict[str, Any]],
+) -> None:
+    for batch in _chunked(rows, 100):
+        supabase.table("prospective_match_predictions").upsert(batch, on_conflict="fixture_key").execute()
+
+
+def prepare_prospective_match_predictions(
+    *,
+    fixtures_file: Path,
+    source_artifact_path: Optional[str],
+    limit: Optional[int],
+    lookback_days: int,
+    model_artifact: Optional[Path],
+    calibration_artifact: Optional[Path],
+    offline_model_version: Optional[str],
+    force_offline_refresh: bool,
+    dry_run: bool,
+) -> Dict[str, Any]:
+    fixtures = load_fixtures_from_jsonl(fixtures_file, source_artifact_path or str(fixtures_file))
+    if limit is not None:
+        fixtures = fixtures[:limit]
+
+    supabase = _supabase_client()
+    merge_resolver = MergeResolver(supabase)
+    merge_resolver.load_merge_map()
+
+    try:
+        existing_rows = _fetch_existing_rows(supabase, [fixture.fixture_key for fixture in fixtures])
+    except Exception as error:
+        if dry_run and _is_missing_table(error, "prospective_match_predictions"):
+            logger.warning("prospective_match_predictions table not found; continuing dry-run without existing rows")
+            existing_rows = {}
+        else:
+            raise RuntimeError(
+                "prospective_match_predictions table is missing. Apply the new Supabase migration before running this script."
+            ) from error
+
+    provider_ids_by_code: Dict[str, Optional[str]] = {}
+    for provider_code in sorted({fixture.provider_code for fixture in fixtures}):
+        provider_ids_by_code[provider_code] = _fetch_provider_id(supabase, provider_code)
+
+    resolution_index: Dict[Tuple[str, str], TeamResolution] = {}
+    for provider_code, provider_id in provider_ids_by_code.items():
+        provider_team_ids = {
+            fixture.home_provider_team_id
+            for fixture in fixtures
+            if fixture.provider_code == provider_code and fixture.home_provider_team_id
+        }
+        provider_team_ids.update(
+            fixture.away_provider_team_id
+            for fixture in fixtures
+            if fixture.provider_code == provider_code and fixture.away_provider_team_id
+        )
+        if provider_id:
+            resolutions = _resolve_provider_team_ids(supabase, provider_id, provider_team_ids, merge_resolver)
+        else:
+            resolutions = {provider_team_id: TeamResolution(None, None) for provider_team_id in provider_team_ids}
+        for provider_team_id, resolution in resolutions.items():
+            resolution_index[(provider_code, provider_team_id)] = resolution
+
+    resolved_team_ids = sorted(
+        {
+            resolution.team_id_master
+            for resolution in resolution_index.values()
+            if resolution.team_id_master
+        }
+    )
+    recent_games = _fetch_recent_games(supabase, resolved_team_ids, lookback_days)
+    involved_team_ids = set(resolved_team_ids)
+    for game in recent_games:
+        if game.home_team_master_id:
+            involved_team_ids.add(str(game.home_team_master_id))
+        if game.away_team_master_id:
+            involved_team_ids.add(str(game.away_team_master_id))
+
+    team_contexts = _fetch_team_contexts(supabase, involved_team_ids)
+    snapshot_index = _build_snapshot_index(team_contexts, datetime.now(timezone.utc).date().isoformat())
+
+    model = None
+    calibrator = None
+    resolved_model_version = None
+    if model_artifact:
+        model = PointInTimeMatchModel.load(str(model_artifact))
+        calibrator = (
+            PointInTimeProbabilityCalibrator.load(str(calibration_artifact))
+            if calibration_artifact
+            else None
+        )
+        resolved_model_version = _derive_shadow_model_version(
+            model_artifact,
+            offline_model_version,
+            calibration_artifact,
+        )
+
+    now_iso = _now_iso()
+    rows_to_upsert: List[Dict[str, Any]] = []
+    summary = {
+        "fixtures_seen": len(fixtures),
+        "resolved": 0,
+        "partial": 0,
+        "unresolved": 0,
+        "offline_completed": 0,
+        "offline_errored": 0,
+        "offline_skipped": 0,
+        "rows_to_upsert": 0,
+        "fixtures_file": str(fixtures_file),
+        "model_artifact": str(model_artifact) if model_artifact else None,
+        "calibration_artifact": str(calibration_artifact) if calibration_artifact else None,
+    }
+
+    for fixture in fixtures:
+        home_resolution = resolution_index.get((fixture.provider_code, fixture.home_provider_team_id), TeamResolution(None, None))
+        away_resolution = resolution_index.get((fixture.provider_code, fixture.away_provider_team_id), TeamResolution(None, None))
+
+        if home_resolution.team_id_master and away_resolution.team_id_master:
+            resolution_status = "resolved"
+            summary["resolved"] += 1
+        elif home_resolution.team_id_master or away_resolution.team_id_master:
+            resolution_status = "partial"
+            summary["partial"] += 1
+        else:
+            resolution_status = "unresolved"
+            summary["unresolved"] += 1
+
+        existing_row = existing_rows.get(fixture.fixture_key, {})
+
+        row_payload: Dict[str, Any] = {
+            "fixture_key": fixture.fixture_key,
+            "provider_code": fixture.provider_code,
+            "source_system": fixture.source_system,
+            "source_artifact_path": fixture.source_artifact_path,
+            "source_event_id": fixture.source_event_id,
+            "source_match_key": fixture.source_match_key,
+            "game_date": fixture.game_date,
+            "competition": fixture.competition or None,
+            "division_name": fixture.division_name or None,
+            "venue": fixture.venue or None,
+            "home_provider_team_id": fixture.home_provider_team_id,
+            "away_provider_team_id": fixture.away_provider_team_id,
+            "home_team_name": fixture.home_team_name,
+            "away_team_name": fixture.away_team_name,
+            "home_team_master_id": home_resolution.team_id_master,
+            "away_team_master_id": away_resolution.team_id_master,
+            "home_resolution_method": home_resolution.resolution_method,
+            "away_resolution_method": away_resolution.resolution_method,
+            "resolution_status": resolution_status,
+            "fixture_payload": _to_python(fixture.fixture_payload),
+            "heuristic_prediction_status": existing_row.get("heuristic_prediction_status") or "pending",
+            "heuristic_model_version": existing_row.get("heuristic_model_version"),
+            "heuristic_prediction": existing_row.get("heuristic_prediction"),
+            "heuristic_predicted_at": existing_row.get("heuristic_predicted_at"),
+            "offline_prediction_status": existing_row.get("offline_prediction_status") or "pending",
+            "offline_model_version": existing_row.get("offline_model_version"),
+            "offline_prediction": existing_row.get("offline_prediction"),
+            "offline_predicted_at": existing_row.get("offline_predicted_at"),
+            "actual_game_id": existing_row.get("actual_game_id"),
+            "actual_home_score": existing_row.get("actual_home_score"),
+            "actual_away_score": existing_row.get("actual_away_score"),
+            "actual_outcome": existing_row.get("actual_outcome"),
+            "actual_recorded_at": existing_row.get("actual_recorded_at"),
+            "evaluation_status": existing_row.get("evaluation_status")
+            or ("pending_result" if resolution_status == "resolved" else "pending_resolution"),
+            "evaluation_notes": existing_row.get("evaluation_notes") or {},
+        }
+
+        should_refresh_offline = bool(model is not None and resolution_status == "resolved")
+        if row_payload["offline_prediction_status"] == "completed" and not force_offline_refresh:
+            should_refresh_offline = False
+
+        if should_refresh_offline and model and resolved_model_version:
+            try:
+                payload = _build_offline_prediction(
+                    fixture,
+                    home_team_id=str(home_resolution.team_id_master),
+                    away_team_id=str(away_resolution.team_id_master),
+                    team_contexts=team_contexts,
+                    recent_games=recent_games,
+                    snapshot_index=snapshot_index,
+                    model=model,
+                    calibrator=calibrator,
+                    model_version=resolved_model_version,
+                )
+                row_payload["offline_prediction_status"] = "completed"
+                row_payload["offline_model_version"] = resolved_model_version
+                row_payload["offline_prediction"] = payload
+                row_payload["offline_predicted_at"] = now_iso
+                summary["offline_completed"] += 1
+            except Exception as error:
+                logger.exception("Failed to build offline prediction for %s", fixture.fixture_key)
+                row_payload["offline_prediction_status"] = "error"
+                row_payload["offline_model_version"] = resolved_model_version
+                row_payload["offline_prediction"] = {
+                    "modelVersion": resolved_model_version,
+                    "error": {
+                        "type": error.__class__.__name__,
+                        "message": str(error),
+                    },
+                }
+                row_payload["offline_predicted_at"] = now_iso
+                summary["offline_errored"] += 1
+        else:
+            summary["offline_skipped"] += 1
+
+        rows_to_upsert.append(row_payload)
+
+    summary["rows_to_upsert"] = len(rows_to_upsert)
+    if not dry_run and rows_to_upsert:
+        try:
+            _upsert_rows(supabase, rows_to_upsert)
+        except Exception as error:
+            if _is_missing_table(error, "prospective_match_predictions"):
+                raise RuntimeError(
+                    "prospective_match_predictions table is missing. Apply the new Supabase migration before running this script."
+                ) from error
+            raise
+
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare prospective match-prediction fixtures from upcoming-event JSONL")
+    parser.add_argument("--fixtures-file", required=True, help="Path to upcoming-event JSONL artifact")
+    parser.add_argument(
+        "--source-artifact-path",
+        default=None,
+        help="Optional source artifact path recorded on prospective rows",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Optional max number of fixtures to ingest")
+    parser.add_argument("--lookback-days", type=int, default=365, help="Historical window for recent games")
+    parser.add_argument(
+        "--model-artifact",
+        default=None,
+        help="Optional point_in_time_match_model.pkl path to freeze offline predictions",
+    )
+    parser.add_argument(
+        "--calibration-artifact",
+        default=None,
+        help="Optional point_in_time_model_calibration.pkl path",
+    )
+    parser.add_argument(
+        "--offline-model-version",
+        default=None,
+        help="Optional explicit offline model version label",
+    )
+    parser.add_argument(
+        "--force-offline-refresh",
+        action="store_true",
+        help="Recompute offline predictions even when rows already have completed offline payloads",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Build everything but skip database writes")
+    parser.add_argument("--summary-path", default=None, help="Optional path to write JSON summary")
+    args = parser.parse_args()
+
+    fixtures_file = Path(args.fixtures_file)
+    if not fixtures_file.exists():
+        raise FileNotFoundError(f"Fixtures file not found: {fixtures_file}")
+
+    model_artifact = Path(args.model_artifact) if args.model_artifact else None
+    if model_artifact and not model_artifact.exists():
+        raise FileNotFoundError(f"Model artifact not found: {model_artifact}")
+
+    calibration_artifact = Path(args.calibration_artifact) if args.calibration_artifact else None
+    if calibration_artifact and not calibration_artifact.exists():
+        raise FileNotFoundError(f"Calibration artifact not found: {calibration_artifact}")
+
+    summary = prepare_prospective_match_predictions(
+        fixtures_file=fixtures_file,
+        source_artifact_path=args.source_artifact_path,
+        limit=args.limit,
+        lookback_days=args.lookback_days,
+        model_artifact=model_artifact,
+        calibration_artifact=calibration_artifact,
+        offline_model_version=args.offline_model_version,
+        force_offline_refresh=args.force_offline_refresh,
+        dry_run=args.dry_run,
+    )
+    if args.summary_path:
+        summary_path = Path(args.summary_path)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scrape_upcoming_gotsport_events.py
+++ b/scripts/scrape_upcoming_gotsport_events.py
@@ -1,0 +1,1243 @@
+#!/usr/bin/env python3
+"""
+Upcoming GotSport event scraper.
+
+This is intentionally separate from the production weekly event scraper. It looks
+forward for upcoming events, scrapes scheduled fixtures from their schedule pages,
+and writes artifacts for prospective evaluation without importing anything into the
+main games pipeline.
+"""
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+import time
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+from urllib.parse import urlencode
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+# Global timeout tracking
+_start_time: Optional[datetime] = None
+_max_runtime_seconds: int = 9000  # 2.5 hours default (leave 30min buffer for 3h limit)
+_timeout_triggered: bool = False
+
+
+def check_timeout() -> bool:
+    """Check if we've exceeded the maximum runtime. Returns True if timed out."""
+    global _timeout_triggered
+    if _start_time is None:
+        return False
+    elapsed = (datetime.now() - _start_time).total_seconds()
+    if elapsed > _max_runtime_seconds:
+        _timeout_triggered = True
+        return True
+    return False
+
+
+def get_elapsed_time() -> str:
+    """Get elapsed time as a human-readable string."""
+    if _start_time is None:
+        return "0s"
+    elapsed = int((datetime.now() - _start_time).total_seconds())
+    hours, remainder = divmod(elapsed, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours}h {minutes}m {seconds}s"
+    elif minutes > 0:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+import os  # noqa: E402
+
+import requests  # noqa: E402
+from bs4 import BeautifulSoup  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
+from rich import box  # noqa: E402
+from rich.console import Console  # noqa: E402
+from rich.panel import Panel  # noqa: E402
+from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn  # noqa: E402
+from rich.table import Table  # noqa: E402
+
+from src.scrapers.gotsport_event import GotSportEventScraper  # noqa: E402
+from supabase import create_client  # noqa: E402
+
+console = Console()
+load_dotenv()
+
+# Load .env.local if it exists
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def event_overlaps_window(
+    event_start_date: Optional[date],
+    event_end_date: Optional[date],
+    search_date: date,
+    window_start: date,
+    window_end: date,
+) -> bool:
+    """Return True when the event overlaps the upcoming discovery window."""
+    effective_start = event_start_date or event_end_date or search_date
+    effective_end = event_end_date or event_start_date or search_date
+    return effective_start <= window_end and effective_end >= window_start
+
+
+def _parse_game_date(game_date: str) -> Optional[date]:
+    """Parse the game_date field emitted by the GotSport schedule scraper."""
+    if not game_date:
+        return None
+    try:
+        return datetime.fromisoformat(game_date[:10]).date()
+    except ValueError:
+        return None
+
+
+def filter_games_to_window(games: List, window_start: date, window_end: date) -> List:
+    """Keep only scheduled games that fall inside the target upcoming window."""
+    filtered_games = []
+    for game in games:
+        parsed_date = _parse_game_date(game.game_date)
+        if parsed_date is None:
+            continue
+        if window_start <= parsed_date <= window_end:
+            filtered_games.append(game)
+    return filtered_games
+
+
+class EventDiscovery:
+    """Discover GotSport events by searching their events page"""
+
+    BASE_URL = "https://home.gotsoccer.com"
+    EVENTS_SEARCH_URL = "https://home.gotsoccer.com/events.aspx"
+
+    def __init__(
+        self,
+        skip_date_extraction: bool = False,
+        window_start: Optional[date] = None,
+        window_end: Optional[date] = None,
+    ):
+        """
+        Initialize event discovery.
+
+        Args:
+            skip_date_extraction: If True, skip extracting event dates during discovery
+                                 (much faster, dates will be extracted during scraping)
+        """
+        self.skip_date_extraction = skip_date_extraction
+        self.window_start = window_start or date.today()
+        self.window_end = window_end or self.window_start
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                ),
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+        )
+
+        # Cached scraper for event date extraction (created lazily)
+        self._cached_scraper: Optional[GotSportEventScraper] = None
+        self._cached_supabase = None
+
+    def _get_scraper(self) -> GotSportEventScraper:
+        """Get or create a cached scraper instance for date extraction."""
+        if self._cached_scraper is None:
+            if self._cached_supabase is None:
+                self._cached_supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_ROLE_KEY"))
+            self._cached_scraper = GotSportEventScraper(self._cached_supabase, "gotsport")
+        return self._cached_scraper
+
+    def resolve_event_id(self, rankings_event_id: str) -> str:
+        """
+        Resolve the actual system.gotsport.com event ID from a rankings page EventID
+
+        The rankings page redirects to rankings.gotsport.com/events/{id}, which contains
+        the actual event ID we need for system.gotsport.com/org_event/events/{id}
+
+        Args:
+            rankings_event_id: EventID from rankings page (e.g., "97871")
+
+        Returns:
+            Actual event ID for system.gotsport.com (e.g., "42498"), or rankings_event_id if not found
+        """
+        rankings_url = f"https://home.gotsoccer.com/rankings/event.aspx?EventID={rankings_event_id}"
+
+        try:
+            response = self.session.get(rankings_url, timeout=30, allow_redirects=True)
+            response.raise_for_status()
+
+            # The rankings page redirects to rankings.gotsport.com/events/{id}
+            # Extract the event ID from the redirected URL
+            final_url = response.url
+
+            # Pattern 1: rankings.gotsport.com/events/{id}
+            match = re.search(r"rankings\.gotsport\.com/events/(\d+)", final_url, re.I)
+            if match:
+                return match.group(1)
+
+            # Pattern 2: system.gotsport.com/org_event/events/{id} (direct redirect)
+            match = re.search(r"system\.gotsport\.com/org_event/events/(\d+)", final_url, re.I)
+            if match:
+                return match.group(1)
+
+            # Pattern 3: Look for event ID in the URL path
+            match = re.search(r"/events?/(\d+)", final_url, re.I)
+            if match:
+                return match.group(1)
+
+            # Look for "Event Home" button or other links to system.gotsport.com
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # Look for links to system.gotsport.com/org_event/events/
+            event_links = soup.find_all("a", href=re.compile(r"system\.gotsport\.com/org_event/events/\d+", re.I))
+            for link in event_links:
+                href = link.get("href", "")
+                match = re.search(r"/org_event/events/(\d+)", href)
+                if match:
+                    return match.group(1)
+
+            # Look for button with onclick or data attributes that might contain the event ID
+            buttons = soup.find_all(["button", "a"], attrs={"onclick": True})
+            for button in buttons:
+                onclick = button.get("onclick", "")
+                match = re.search(r"/org_event/events/(\d+)", onclick, re.I)
+                if match:
+                    return match.group(1)
+
+        except Exception as e:
+            logger.debug(f"Error resolving event ID {rankings_event_id}: {e}")
+
+        # Fallback: return the original ID (might work, might not)
+        return rankings_event_id
+
+    def _parse_events_from_page(
+        self, soup: BeautifulSoup, search_date: date, seen_event_ids: set, max_events_per_page: int = 20
+    ) -> tuple[List[Dict[str, str]], int, int, int]:
+        """
+        Parse events from a single page of search results
+
+        Args:
+            soup: BeautifulSoup object of the page
+            search_date: Date being searched
+            seen_event_ids: Set of already-seen event IDs to avoid duplicates
+            max_events_per_page: Max events to process per page (prevents runaway processing)
+
+        Returns:
+            Tuple of (events_list, events_found_count, events_filtered_future, events_filtered_archived)
+        """
+        events = []
+        events_found_count = 0
+        events_filtered_future = 0
+        events_filtered_archived = 0
+        events_processed_this_page = 0
+
+        # Look for event links with EventID
+        event_links = soup.find_all("a", href=re.compile(r"EventID=", re.I))
+        logger.info(f"Found {len(event_links)} event links with EventID= on this page")
+
+        # ALWAYS check for alternative link patterns (not just when EventID links are empty)
+        # GotSport uses multiple link formats: EventID=, /events/, rankings.gotsport.com/events/, etc.
+        all_links = soup.find_all("a", href=True)
+        event_links_alt = [link for link in all_links if "event" in link.get("href", "").lower()]
+        logger.info(f"Found {len(event_links_alt)} links with 'event' in href")
+
+        # Check all alternative links (not just first 20) for event IDs
+        # This catches rankings.gotsport.com/events/46102 format and others
+        for alt_link in event_links_alt:
+            href = alt_link.get("href", "")
+            event_id_match = None
+
+            # Skip if already in event_links (avoid duplicates)
+            if alt_link in event_links:
+                continue
+
+            # Try various patterns to extract event ID
+            patterns = [
+                r"EventID=(\d+)",  # Original pattern: EventID=12345
+                r"event_id=(\d+)",  # Lowercase variant
+                r"[?&]id=(\d+)",  # Generic id parameter
+                r"/events/(\d+)",  # /events/12345 or rankings.gotsport.com/events/12345
+                r"/event/(\d+)",  # /event/12345
+                r"rankings\.gotsport\.com/events/(\d+)",  # rankings.gotsport.com/events/12345
+                r"system\.gotsport\.com/org_event/events/(\d+)",  # system.gotsport.com/org_event/events/12345
+                r"/events\.aspx[?&].*?(\d{4,})",  # /events.aspx with numeric ID
+            ]
+
+            for pattern in patterns:
+                match = re.search(pattern, href, re.I)
+                if match:
+                    potential_id = match.group(1)
+                    # Validate it looks like an event ID (at least 4 digits)
+                    if potential_id.isdigit() and len(potential_id) >= 4:
+                        event_id_match = potential_id
+                        logger.debug(f"Found potential event ID {event_id_match} in link: {href[:100]}")
+                        break
+
+            if event_id_match:
+                # Found a potential event ID via alternative pattern
+                # Add it to event_links so it gets processed below
+                event_links.append(alt_link)
+                logger.debug(f"Added alternative link with event ID {event_id_match}")
+
+        logger.info(f"Total event links found (including alternatives): {len(event_links)}")
+
+        # Log a sample of the HTML structure for debugging if still no events
+        if len(event_links) == 0:
+            # Try to find event-related content
+            event_divs = soup.find_all(["div", "article", "section"], class_=re.compile(r"event", re.I))
+            logger.info(f"Found {len(event_divs)} divs/articles/sections with 'event' in class name")
+
+            # Log sample of alternative links for debugging
+            if event_links_alt:
+                logger.info("Sample alternative links (first 10):")
+                for link in event_links_alt[:10]:
+                    logger.info(f"  - {link.get('href', '')[:100]}")
+
+        for link in event_links:
+            # Check for timeout before processing each event (expensive operation)
+            if check_timeout():
+                logger.warning(f"Timeout reached during event parsing for {search_date}")
+                break
+
+            # Limit events processed per page to prevent runaway processing
+            if events_processed_this_page >= max_events_per_page:
+                logger.info(
+                    f"Reached max_events_per_page limit ({max_events_per_page}) - skipping remaining events on page"
+                )
+                break
+
+            href = link.get("href", "")
+
+            # Try multiple patterns to extract event ID
+            rankings_event_id = None
+            patterns = [
+                r"EventID=(\d+)",  # Original pattern: EventID=12345
+                r"event_id=(\d+)",  # Lowercase: event_id=12345
+                r"[?&]id=(\d+)",  # Generic: ?id=12345 or &id=12345
+                r"/events/(\d+)",  # Path: /events/12345
+                r"/event/(\d+)",  # Path: /event/12345
+            ]
+
+            for pattern in patterns:
+                match = re.search(pattern, href, re.I)
+                if match:
+                    potential_id = match.group(1)
+                    # Validate it looks like an event ID (at least 4 digits)
+                    if potential_id.isdigit() and len(potential_id) >= 4:
+                        rankings_event_id = potential_id
+                        break
+
+            if rankings_event_id and rankings_event_id not in seen_event_ids:
+                events_processed_this_page += 1
+                events_found_count += 1
+                # Get event name
+                event_name = link.get_text(strip=True)
+                if not event_name or len(event_name) < 3:
+                    parent = link.find_parent(["div", "article", "section"])
+                    if parent:
+                        heading = parent.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+                        if heading:
+                            event_name = heading.get_text(strip=True)
+                        else:
+                            event_name = parent.get_text(strip=True)[:100]
+
+                if not event_name:
+                    event_name = f"Event {rankings_event_id}"
+
+                # Resolve the actual event ID
+                console.print(f"[dim]Resolving event ID for {event_name}...[/dim]")
+                actual_event_id = self.resolve_event_id(rankings_event_id)
+
+                # Verify event page is accessible (not redirected to home page)
+                event_url = f"https://system.gotsport.com/org_event/events/{actual_event_id}"
+                try:
+                    test_response = self.session.get(event_url, timeout=10, allow_redirects=True)
+                    if "org_event/events" not in test_response.url or test_response.url == "https://home.gotsport.com/":
+                        logger.info(
+                            f"Skipping event {event_name} ({actual_event_id}) "
+                            f"- page redirects to home (event may be archived)"
+                        )
+                        events_filtered_archived += 1
+                        continue
+                except Exception as e:
+                    logger.debug(f"Could not verify event page accessibility: {e}")
+                    # Continue anyway - might be a temporary issue
+
+                # Try to extract actual event dates (will use search_date as fallback)
+                event_date = search_date.isoformat()
+                event_start_date = None
+                event_end_date = None
+                if not self.skip_date_extraction:
+                    try:
+                        # Use cached scraper instead of creating new instances each time
+                        scraper = self._get_scraper()
+                        event_dates = scraper.extract_event_dates(actual_event_id)
+                        if event_dates:
+                            event_start_date, event_end_date = event_dates
+                            # Use start date for display, but store both
+                            event_date = event_start_date.isoformat()
+                            logger.debug(f"Found actual event dates: {event_start_date} to {event_end_date}")
+                    except Exception as e:
+                        logger.debug(f"Could not extract event dates, using search date: {e}")
+
+                if not event_overlaps_window(
+                    event_start_date,
+                    event_end_date,
+                    search_date,
+                    self.window_start,
+                    self.window_end,
+                ):
+                    logger.info(
+                        "Skipping event %s outside upcoming window %s to %s",
+                        event_name,
+                        self.window_start,
+                        self.window_end,
+                    )
+                    events_filtered_future += 1
+                    continue
+
+                events.append(
+                    {
+                        "event_id": actual_event_id,
+                        "event_name": event_name,
+                        "event_url": event_url,
+                        "date": event_date,
+                        "start_date": event_start_date.isoformat() if event_start_date else None,
+                        "end_date": event_end_date.isoformat() if event_end_date else None,
+                        "rankings_event_id": rankings_event_id,  # Keep original for reference
+                    }
+                )
+                seen_event_ids.add(rankings_event_id)
+                seen_event_ids.add(actual_event_id)  # Also track resolved ID
+
+                time.sleep(0.5)  # Rate limiting between resolutions
+
+        # Also check JavaScript for event IDs
+        scripts = soup.find_all("script")
+        for script in scripts:
+            if script.string:
+                matches = re.findall(r'EventID["\']?\s*[:=]\s*["\']?(\d+)', script.string, re.IGNORECASE)
+                for rankings_event_id in matches:
+                    if rankings_event_id not in seen_event_ids:
+                        actual_event_id = self.resolve_event_id(rankings_event_id)
+
+                        # Try to extract actual event dates (will use search_date as fallback)
+                        event_date = search_date.isoformat()
+                        event_start_date = None
+                        event_end_date = None
+                        if not self.skip_date_extraction:
+                            try:
+                                # Use cached scraper instead of creating new instances each time
+                                scraper = self._get_scraper()
+                                event_dates = scraper.extract_event_dates(actual_event_id)
+                                if event_dates:
+                                    event_start_date, event_end_date = event_dates
+                                    event_date = event_start_date.isoformat()
+                                    logger.debug(f"Found actual event dates: {event_start_date} to {event_end_date}")
+                            except Exception as e:
+                                logger.debug(f"Could not extract event dates, using search date: {e}")
+
+                        event_name_js = f"Event {rankings_event_id}"  # Default name for JS-discovered events
+                        if not event_overlaps_window(
+                            event_start_date,
+                            event_end_date,
+                            search_date,
+                            self.window_start,
+                            self.window_end,
+                        ):
+                            logger.debug(
+                                "Skipping event %s outside upcoming window %s to %s",
+                                event_name_js,
+                                self.window_start,
+                                self.window_end,
+                            )
+                            continue
+
+                        # Try to get event name from the page
+                        event_name_js = f"Event {rankings_event_id}"
+                        try:
+                            event_url_test = f"https://system.gotsport.com/org_event/events/{actual_event_id}"
+                            test_response = self.session.get(event_url_test, timeout=10, allow_redirects=True)
+                            if "org_event/events" in test_response.url:
+                                test_soup = BeautifulSoup(test_response.text, "html.parser")
+                                title = test_soup.find("title")
+                                if title:
+                                    event_name_js = title.get_text(strip=True)
+                        except Exception:
+                            pass  # Use default name if we can't get it
+
+                        events.append(
+                            {
+                                "event_id": actual_event_id,
+                                "event_name": event_name_js,
+                                "event_url": f"https://system.gotsport.com/org_event/events/{actual_event_id}",
+                                "date": event_date,
+                                "start_date": event_start_date.isoformat() if event_start_date else None,
+                                "end_date": event_end_date.isoformat() if event_end_date else None,
+                                "rankings_event_id": rankings_event_id,
+                            }
+                        )
+                        seen_event_ids.add(rankings_event_id)
+                        seen_event_ids.add(actual_event_id)
+                        time.sleep(0.5)
+
+        return events, events_found_count, events_filtered_future, events_filtered_archived
+
+    def _find_max_page_number(self, soup: BeautifulSoup) -> int:
+        """
+        Find the maximum page number from pagination links
+
+        Args:
+            soup: BeautifulSoup object of the page
+
+        Returns:
+            Maximum page number found, or 1 if no pagination found
+        """
+        max_page = 1
+
+        # Look for pagination links with Page parameter
+        pagination_links = soup.find_all("a", href=re.compile(r"Page=", re.I))
+        for link in pagination_links:
+            href = link.get("href", "")
+            # Extract page number from href like "Page=2" or "Page=4"
+            match = re.search(r"Page=(\d+)", href, re.I)
+            if match:
+                page_num = int(match.group(1))
+                if page_num > max_page:
+                    max_page = page_num
+
+        # Also check for pagination text like "Page 1 of 5" or "1 of 5"
+        pagination_text = soup.find_all(string=re.compile(r"page\s+\d+\s+of\s+\d+", re.I))
+        for text in pagination_text:
+            match = re.search(r"page\s+\d+\s+of\s+(\d+)", text, re.I)
+            if match:
+                page_num = int(match.group(1))
+                if page_num > max_page:
+                    max_page = page_num
+
+        # Check for pagination in text content
+        page_text = soup.get_text()
+        match = re.search(r"page\s+\d+\s+of\s+(\d+)", page_text, re.I)
+        if match:
+            page_num = int(match.group(1))
+            if page_num > max_page:
+                max_page = page_num
+
+        return max_page
+
+    def discover_events_by_date(self, search_date: date) -> List[Dict[str, str]]:
+        """
+        Discover events for a specific date (with pagination support)
+
+        Args:
+            search_date: Date to search for events
+
+        Returns:
+            List of dicts with 'event_id', 'event_name', 'event_url', 'date'
+        """
+        all_events = []
+        events_found_count = 0
+        events_filtered_future = 0
+        events_filtered_archived = 0
+
+        # Format date as MM/DD/YYYY for GotSport
+        # Use format that works on Windows (no leading zero removal)
+        date_str = f"{search_date.month}/{search_date.day}/{search_date.year}"  # e.g., "11/1/2025"
+
+        console.print(f"[dim]Searching for events on {date_str}...[/dim]")
+
+        base_params = {"search": "", "type": "Tournament", "date": date_str, "age": "", "featured": ""}
+
+        # Initialize seen_event_ids before processing
+        seen_event_ids = set()
+
+        try:
+            # Start with page 1 (or no Page parameter)
+            page = 1
+            max_pages = 1  # Will be updated after first page
+
+            while page <= max_pages:
+                params = base_params.copy()
+                if page > 1:
+                    params["Page"] = str(page)
+
+                full_url = f"{self.EVENTS_SEARCH_URL}?{urlencode(params)}"
+                logger.info(f"Fetching page {page}: {full_url}")
+                response = self.session.get(self.EVENTS_SEARCH_URL, params=params, timeout=30)
+                response.raise_for_status()
+
+                soup = BeautifulSoup(response.text, "html.parser")
+
+                # On first page, determine max pages
+                if page == 1:
+                    max_pages = self._find_max_page_number(soup)
+                    logger.info(f"Found pagination: {max_pages} total pages")
+                    if max_pages > 1:
+                        console.print(f"[cyan]Found {max_pages} pages of results, fetching all pages...[/cyan]")
+
+                # Parse events from this page
+                page_events, page_found, page_future, page_archived = self._parse_events_from_page(
+                    soup, search_date, seen_event_ids
+                )
+
+                all_events.extend(page_events)
+                events_found_count += page_found
+                events_filtered_future += page_future
+                events_filtered_archived += page_archived
+
+                logger.info(f"Page {page}: Found {len(page_events)} events (total so far: {len(all_events)})")
+
+                # If no events found on this page and we're past page 1, stop
+                if len(page_events) == 0 and page > 1:
+                    logger.info(f"No events found on page {page}, stopping pagination")
+                    break
+
+                page += 1
+
+                # Rate limiting between pages
+                if page <= max_pages:
+                    time.sleep(1)
+
+        except Exception as e:
+            logger.error(f"Error discovering events for {search_date}: {e}", exc_info=True)
+
+        # Log summary
+        if events_found_count > 0:
+            logger.info(
+                f"Date {date_str}: Found {events_found_count} events, {len(all_events)} included, "
+                f"{events_filtered_future} filtered (future), {events_filtered_archived} filtered (archived)"
+            )
+            if events_filtered_future > 0:
+                console.print(f"[yellow]  ⚠️  {events_filtered_future} events filtered (future dates)[/yellow]")
+        elif len(all_events) == 0:
+            logger.warning(
+                f"Date {date_str}: No event links found in search results. "
+                f"GotSport may have changed their page structure or no events exist for this date."
+            )
+            console.print(f"[yellow]  ⚠️  No events found for {date_str}[/yellow]")
+
+        return all_events
+
+    def discover_events_in_range(self, start_date: date, end_date: date, max_events: int = 0) -> List[Dict[str, str]]:
+        """
+        Discover events in a date range
+
+        Args:
+            start_date: Start date
+            end_date: End date
+            max_events: Stop discovery early once this many events found (0 = no limit)
+
+        Returns:
+            List of events (deduplicated by event_id)
+        """
+        all_events = []
+        seen_event_ids = set()
+
+        current_date = start_date
+        while current_date <= end_date:
+            # Check for global timeout before processing each day
+            if check_timeout():
+                logger.warning(f"Timeout reached during discovery at {current_date}")
+                console.print(
+                    f"[yellow]⚠️  Timeout reached during discovery "
+                    f"- returning {len(all_events)} events found so far[/yellow]"
+                )
+                break
+
+            date_events = self.discover_events_by_date(current_date)
+
+            for event in date_events:
+                if event["event_id"] not in seen_event_ids:
+                    all_events.append(event)
+                    seen_event_ids.add(event["event_id"])
+
+                    # Early exit if we've found enough events
+                    if max_events > 0 and len(all_events) >= max_events:
+                        logger.info(f"Reached max_events limit ({max_events}) during discovery - stopping early")
+                        console.print(f"[cyan]Found {max_events} events - stopping discovery early to save time[/cyan]")
+                        return all_events
+
+            current_date += timedelta(days=1)
+            time.sleep(0.3)  # Reduced rate limiting (was 0.5s)
+
+        return all_events
+
+
+def load_scraped_events(file_path: Optional[Path]) -> Set[str]:
+    """Load list of already-scraped event IDs"""
+    if file_path is None or not file_path.exists():
+        return set()
+
+    try:
+        with open(file_path, "r") as f:
+            data = json.load(f)
+            return set(data.get("scraped_event_ids", []))
+    except Exception as e:
+        logger.warning(f"Error loading scraped events: {e}")
+        return set()
+
+
+def load_blocked_events(file_path: Optional[Path]) -> Set[str]:
+    """Load list of blocked event IDs that should never be scraped"""
+    if file_path is None or not file_path.exists():
+        return set()
+
+    try:
+        with open(file_path, "r") as f:
+            data = json.load(f)
+            blocked = set(data.get("blocked_event_ids", []))
+            if blocked:
+                logger.info(f"Loaded {len(blocked)} blocked events")
+            return blocked
+    except Exception as e:
+        logger.warning(f"Error loading blocked events: {e}")
+        return set()
+
+
+def save_scraped_event(file_path: Optional[Path], event_id: str):
+    """Save an event ID to the scraped events file"""
+    if file_path is None:
+        return
+    scraped = load_scraped_events(file_path)
+    scraped.add(event_id)
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w") as f:
+        json.dump({"scraped_event_ids": list(scraped), "last_updated": datetime.now().isoformat()}, f, indent=2)
+
+
+def scrape_upcoming_events(
+    days_ahead: int = 7,
+    output_file: Optional[str] = None,
+    tracked_events_file: Optional[str] = None,
+    manual_event_ids: Optional[List[str]] = None,
+    max_events: int = 0,
+    max_runtime_minutes: int = 150,
+    skip_date_extraction: bool = True,
+):
+    """
+    Scrape scheduled fixtures from upcoming GotSport events.
+
+    Args:
+        days_ahead: How many days ahead to look for events.
+        output_file: Output file path (default: auto-generated).
+        tracked_events_file: Optional file to track event IDs between runs. Leave unset
+            to revisit future events as schedules update.
+        manual_event_ids: Event IDs to scrape manually if discovery misses them.
+        max_events: Maximum number of events to scrape (0 = no limit).
+        max_runtime_minutes: Maximum runtime in minutes.
+        skip_date_extraction: Skip date extraction during discovery for faster runs.
+    """
+    global _start_time, _max_runtime_seconds
+    _start_time = datetime.now()
+    _max_runtime_seconds = max_runtime_minutes * 60
+
+    window_start = date.today()
+    window_end = window_start + timedelta(days=days_ahead)
+    max_events_str = f", max {max_events} events" if max_events > 0 else ""
+    console.print(
+        Panel.fit(
+            f"[bold green]Upcoming GotSport Event Fixture Scraper[/bold green]\n"
+            f"[dim]Looking for events from {window_start} to {window_end}{max_events_str}[/dim]\n"
+            f"[dim]Scheduled-game window: {window_start} through {window_end}[/dim]\n"
+            f"[dim]Max runtime: {max_runtime_minutes} minutes[/dim]",
+            style="green",
+        )
+    )
+
+    tracked_events_path = Path(tracked_events_file) if tracked_events_file else None
+    scraped_event_ids = load_scraped_events(tracked_events_path)
+    blocked_event_ids = load_blocked_events(tracked_events_path)
+
+    if tracked_events_path:
+        console.print(f"[dim]Already tracked {len(scraped_event_ids)} upcoming events[/dim]")
+    else:
+        console.print("[dim]Tracking disabled so future events can be revisited on later runs[/dim]")
+    if blocked_event_ids:
+        console.print(f"[dim]Blocked {len(blocked_event_ids)} problematic events[/dim]\n")
+    else:
+        console.print()
+
+    console.print("[bold cyan]Step 1: Discovering Upcoming Events[/bold cyan]")
+    start_date = window_start
+    end_date = window_end
+    console.print(f"[cyan]Searching for events from {start_date} to {end_date}...[/cyan]")
+
+    # Use skip_date_extraction for faster discovery (dates extracted during scraping)
+    # Pass max_events to stop discovery early once we have enough events
+    discovery = EventDiscovery(
+        skip_date_extraction=skip_date_extraction,
+        window_start=window_start,
+        window_end=window_end,
+    )
+    all_events = discovery.discover_events_in_range(start_date, end_date, max_events=max_events)
+    console.print(f"[dim]Elapsed time: {get_elapsed_time()}[/dim]")
+
+    logger.info(f"Discovery complete: Found {len(all_events)} total events in date range {start_date} to {end_date}")
+
+    # Add manually specified event IDs
+    if manual_event_ids:
+        console.print(f"[cyan]Adding {len(manual_event_ids)} manually specified event IDs...[/cyan]")
+        supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_ROLE_KEY"))
+        scraper = GotSportEventScraper(supabase, "gotsport")
+
+        for event_id in manual_event_ids:
+            if event_id in blocked_event_ids:
+                console.print(f"  [yellow]⚠️ Skipping blocked event {event_id}[/yellow]")
+                continue
+            try:
+                event_url = f"https://system.gotsport.com/org_event/events/{event_id}"
+                response = scraper.session.get(event_url, timeout=10, allow_redirects=True)
+                if "org_event/events" in response.url and response.url != "https://home.gotsport.com/":
+                    soup = BeautifulSoup(response.text, "html.parser")
+                    title = soup.find("title")
+                    event_name = title.get_text(strip=True) if title else f"Event {event_id}"
+
+                    event_dates = scraper.extract_event_dates(event_id)
+                    event_start_date = None
+                    event_end_date = None
+                    if event_dates:
+                        event_start_date, event_end_date = event_dates
+
+                    if not event_overlaps_window(
+                        event_start_date,
+                        event_end_date,
+                        window_start,
+                        window_start,
+                        window_end,
+                    ):
+                        console.print(
+                            f"  [yellow]Skipping {event_name} - outside upcoming window "
+                            f"({window_start} to {window_end})[/yellow]"
+                        )
+                        continue
+
+                    manual_event = {
+                        "event_id": event_id,
+                        "event_name": event_name,
+                        "event_url": event_url,
+                        "date": event_start_date.isoformat() if event_start_date else window_start.isoformat(),
+                        "start_date": event_start_date.isoformat() if event_start_date else None,
+                        "end_date": event_end_date.isoformat() if event_end_date else None,
+                        "rankings_event_id": None,
+                        "manual": True,
+                    }
+
+                    if not any(e["event_id"] == event_id for e in all_events):
+                        all_events.append(manual_event)
+                        console.print(f"  [green]✅ Added manual event: {event_name} ({event_id})[/green]")
+                    else:
+                        console.print(f"  [dim]Event {event_id} already discovered[/dim]")
+                else:
+                    console.print(f"  [yellow]⚠️  Event {event_id} not accessible (may be archived or invalid)[/yellow]")
+            except Exception as e:
+                logger.warning(f"Error adding manual event {event_id}: {e}")
+                console.print(f"  [red]❌ Error adding event {event_id}: {e}[/red]")
+
+    excluded_event_ids = scraped_event_ids | blocked_event_ids
+    new_events = [e for e in all_events if e["event_id"] not in excluded_event_ids]
+
+    # Log any blocked events that were filtered out
+    blocked_in_discovery = [e for e in all_events if e["event_id"] in blocked_event_ids]
+    if blocked_in_discovery:
+        console.print(f"[yellow]⚠️ Skipped {len(blocked_in_discovery)} blocked events[/yellow]")
+        for event in blocked_in_discovery:
+            console.print(f"  [dim]- {event['event_id']}: {event['event_name']}[/dim]")
+
+    console.print(f"[green]✅ Found {len(new_events)} upcoming events (out of {len(all_events)} total)[/green]\n")
+
+    if not new_events:
+        console.print("[yellow]No upcoming events to scrape.[/yellow]")
+        return None
+
+    # Apply max_events limit if specified
+    if max_events > 0 and len(new_events) > max_events:
+        console.print(f"[yellow]⚠️  Limiting to {max_events} events (from {len(new_events)} found)[/yellow]")
+        new_events = new_events[:max_events]
+
+    # Display new events
+    table = Table(title="Upcoming Events Found", box=box.ROUNDED, show_header=True)
+    table.add_column("Event ID", style="cyan")
+    table.add_column("Event Name", style="yellow")
+    table.add_column("Date", style="green")
+
+    for event in new_events[:20]:  # Show first 20
+        table.add_row(
+            event["event_id"],
+            event["event_name"][:50] + "..." if len(event["event_name"]) > 50 else event["event_name"],
+            event["date"],
+        )
+
+    if len(new_events) > 20:
+        table.add_row("...", f"... and {len(new_events) - 20} more", "...")
+
+    console.print(table)
+    console.print()
+
+    # Step 2: Scrape scheduled games from upcoming events
+    console.print("[bold cyan]Step 2: Scraping Scheduled Games from Event Pages[/bold cyan]")
+
+    supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_ROLE_KEY"))
+
+    # Control team ID resolution via environment variable
+    # When True: Uses registration IDs directly (fast but may not match alias map)
+    # When False (default): Resolves registration IDs to API team IDs (slower but matches team imports)
+    skip_team_id_resolution = os.getenv("GOTSPORT_SKIP_TEAM_ID_RESOLUTION", "false").lower() == "true"
+    if skip_team_id_resolution:
+        console.print(
+            "[yellow]⚠️  Team ID resolution DISABLED - using registration IDs (may not match alias map)[/yellow]"
+        )
+    else:
+        console.print("[green]✓ Team ID resolution ENABLED - resolving to API team IDs[/green]")
+
+    scraper = GotSportEventScraper(supabase, "gotsport", skip_team_id_resolution=skip_team_id_resolution)
+
+    since_date = datetime.combine(window_start, datetime.min.time())
+
+    all_games = []
+    event_results = []
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("[cyan]Scraping events...", total=len(new_events))
+
+        # Per-event timeout from environment variable (default: 300 seconds = 5 minutes)
+        event_timeout_seconds = int(os.getenv("GOTSPORT_EVENT_TIMEOUT", "300"))
+
+        for i, event in enumerate(new_events, 1):
+            # Check for timeout before processing each event
+            if check_timeout():
+                console.print(f"\n[yellow]⚠️  Timeout reached ({get_elapsed_time()}) - stopping scraping[/yellow]")
+                console.print(f"[yellow]   Processed {i - 1}/{len(new_events)} events before timeout[/yellow]")
+                break
+
+            event_id = event["event_id"]
+            event_name = event["event_name"]
+
+            progress.update(
+                task, description=f"[cyan]Scraping {event_name[:40]}... ({i}/{len(new_events)}) [{get_elapsed_time()}]"
+            )
+
+            event_start_time = datetime.now()
+
+            try:
+                # Scrape games directly from schedule pages (FAST PATH)
+                # This is more reliable than extract_event_teams and avoids redundant HTTP requests
+                games = scraper.scrape_games_from_schedule_pages(event_id, event_name=event_name, since_date=since_date)
+                games = filter_games_to_window(games, window_start, window_end)
+
+                event_elapsed = (datetime.now() - event_start_time).total_seconds()
+
+                # Check if event took too long - warn but don't fail
+                if event_elapsed > event_timeout_seconds:
+                    console.print(
+                        f"  [yellow]⚠️  Event {event_name[:30]} took {event_elapsed:.0f}s "
+                        f"(limit: {event_timeout_seconds}s)[/yellow]"
+                    )
+
+                teams_count = len(set(g.team_id for g in games if g.team_id)) if games else 0
+
+                if games:
+                    event_results.append(
+                        {
+                            "event_id": event_id,
+                            "event_name": event_name,
+                            "teams_count": teams_count,
+                            "games_count": len(games),
+                            "status": "success",
+                        }
+                    )
+                    all_games.extend(games)
+                    console.print(
+                        f"  [dim]{event_name}: {teams_count} teams, {len(games)} upcoming games ({event_elapsed:.1f}s)[/dim]"
+                    )
+                    save_scraped_event(tracked_events_path, event_id)
+                else:
+                    event_results.append(
+                        {
+                            "event_id": event_id,
+                            "event_name": event_name,
+                            "teams_count": 0,
+                            "games_count": 0,
+                            "status": "no_games",
+                        }
+                    )
+                    console.print(f"  [yellow]⚠️  {event_name}: No upcoming games in window ({event_elapsed:.1f}s)[/yellow]")
+
+            except Exception as e:
+                logger.error(f"Error scraping event {event_id}: {e}")
+                event_results.append(
+                    {
+                        "event_id": event_id,
+                        "event_name": event_name,
+                        "teams_count": 0,
+                        "games_count": 0,
+                        "status": "error",
+                        "error": str(e),
+                    }
+                )
+                console.print(f"  [red]Error scraping {event_name}: {e}[/red]")
+
+            progress.advance(task)
+
+            # Minimal rate limiting between events (scraper has internal delays)
+            time.sleep(0.5)
+
+    events_processed = len(event_results)
+    timeout_msg = " (stopped early due to timeout)" if _timeout_triggered else ""
+    console.print(
+        f"\n[bold green]✅ Scraped {len(all_games)} total upcoming games from "
+        f"{events_processed}/{len(new_events)} events{timeout_msg}[/bold green]"
+    )
+    console.print(f"[dim]Total elapsed time: {get_elapsed_time()}[/dim]\n")
+
+    # Summary table
+    summary_table = Table(title="Upcoming Scrape Summary", box=box.ROUNDED, show_header=True)
+    summary_table.add_column("Event", style="cyan")
+    summary_table.add_column("Teams", style="green", justify="right")
+    summary_table.add_column("Games", style="yellow", justify="right")
+    summary_table.add_column("Status", style="blue")
+
+    for result in event_results:
+        status_icon = {"success": "✅", "no_games": "⚠️", "error": "❌"}.get(result["status"], "?")
+
+        summary_table.add_row(
+            result["event_name"][:40], str(result["teams_count"]), str(result["games_count"]), status_icon
+        )
+
+    console.print(summary_table)
+    console.print()
+
+    # Save games to file
+    if not output_file:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_file = f"data/raw/upcoming_events_{timestamp}.jsonl"
+
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    console.print(f"[dim]Writing {len(all_games)} upcoming games to {output_file}...[/dim]")
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        for game in all_games:
+            game_dict = {
+                "provider": "gotsport",
+                "team_id": game.team_id,
+                "team_id_source": game.team_id,
+                "opponent_id": game.opponent_id,
+                "opponent_id_source": game.opponent_id,
+                "team_name": game.team_name or "",
+                "opponent_name": game.opponent_name or "",
+                "game_date": game.game_date,
+                "home_away": game.home_away,
+                "goals_for": game.goals_for,
+                "goals_against": game.goals_against,
+                "result": game.result or "U",
+                "competition": game.competition or "",
+                "division_name": game.meta.get("division_name", "") if game.meta else "",
+                "match_id": game.meta.get("match_id", "") if game.meta else "",
+                "event_name": game.meta.get("event_name", "") if game.meta else "",
+                "venue": game.venue or "",
+                "source_url": game.meta.get("source_url", "") if game.meta else "",
+                "scraped_at": game.meta.get("scraped_at", datetime.now().isoformat())
+                if game.meta
+                else datetime.now().isoformat(),
+                "club_name": game.meta.get("club_name", "") if game.meta else "",
+                "opponent_club_name": game.meta.get("opponent_club_name", "") if game.meta else "",
+                "age_group": game.meta.get("age_group") if game.meta else None,
+                "gender": game.meta.get("gender") if game.meta else None,
+            }
+            f.write(json.dumps(game_dict) + "\n")
+
+    console.print(f"[bold green]✅ Saved to {output_file}[/bold green]")
+
+    # Save summary
+    summary_file = output_file.replace(".jsonl", "_summary.json")
+    with open(summary_file, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "scrape_date": datetime.now().isoformat(),
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "days_ahead": days_ahead,
+                "total_events": len(new_events),
+                "total_games": len(all_games),
+                "tracking_enabled": tracked_events_path is not None,
+                "events": event_results,
+            },
+            f,
+            indent=2,
+        )
+
+    console.print(f"[dim]Summary saved to {summary_file}[/dim]")
+    console.print("[dim]No import was run. This path is artifact-only for prospective testing.[/dim]")
+    return output_file
+
+
+def import_games(games_file: str, provider: str) -> bool:
+    """
+    Import games to database using import_games_enhanced.py
+
+    Args:
+        games_file: Path to JSONL file with games
+        provider: Provider ID (e.g., 'gotsport')
+
+    Returns:
+        True if import succeeded, False otherwise
+    """
+    if not games_file or not Path(games_file).exists():
+        console.print("[yellow]No games file to import. Skipping import step.[/yellow]")
+        return False
+
+    try:
+        console.print(f"[green]Importing games from {games_file}...[/green]")
+
+        # Call import script via subprocess
+        script_path = Path(__file__).parent / "import_games_enhanced.py"
+        cmd = [
+            sys.executable,
+            str(script_path),
+            games_file,
+            provider,
+            "--stream",
+            "--batch-size",
+            "500",
+            "--concurrency",
+            "4",
+            "--checkpoint",
+        ]
+
+        # Run import script and capture output to parse metrics
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        # Print the import script output (includes metrics)
+        if result.stdout:
+            console.print(result.stdout)
+
+        if result.returncode == 0:
+            # Parse metrics from output for summary
+            import re
+
+            games_processed = None
+            games_accepted = None
+            duplicates_skipped = None
+
+            if result.stdout:
+                # Extract metrics from output
+                processed_match = re.search(r"Games processed:\s*([\d,]+)", result.stdout)
+                accepted_match = re.search(r"Games accepted:\s*([\d,]+)", result.stdout)
+                duplicates_match = re.search(r"Duplicates skipped:\s*([\d,]+)", result.stdout)
+
+                if processed_match:
+                    games_processed = int(processed_match.group(1).replace(",", ""))
+                if accepted_match:
+                    games_accepted = int(accepted_match.group(1).replace(",", ""))
+                if duplicates_match:
+                    duplicates_skipped = int(duplicates_match.group(1).replace(",", ""))
+
+            # Display summary
+            if games_processed is not None:
+                console.print("\n[bold cyan]Import Summary:[/bold cyan]")
+                console.print(f"  [green]Games processed: {games_processed:,}[/green]")
+                if games_accepted is not None:
+                    console.print(f"  [green]New games imported: {games_accepted:,}[/green]")
+                if duplicates_skipped is not None:
+                    dedup_rate = (duplicates_skipped / games_processed * 100) if games_processed > 0 else 0
+                    console.print(f"  [yellow]Duplicates skipped: {duplicates_skipped:,} ({dedup_rate:.1f}%)[/yellow]")
+
+            console.print("[green]✅ Games imported successfully[/green]")
+            return True
+        else:
+            console.print(f"[red]❌ Import failed with return code {result.returncode}[/red]")
+            if result.stderr:
+                logger.error(f"Import stderr: {result.stderr}")
+                console.print(f"[dim]{result.stderr[:500]}[/dim]")
+            return False
+
+    except Exception as e:
+        console.print(f"[red]❌ Error importing games: {e}[/red]")
+        logger.error(f"Import error: {e}", exc_info=True)
+        return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Scrape scheduled fixtures from upcoming GotSport events",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Default: Next 7 days of events, artifact-only output
+  python scripts/scrape_upcoming_gotsport_events.py
+
+  # Look ahead 14 days
+  python scripts/scrape_upcoming_gotsport_events.py --days-ahead 14
+
+  # Limit to 20 events with 2-hour max runtime
+  python scripts/scrape_upcoming_gotsport_events.py --max-events 20 --max-runtime 120
+
+  # Persist event tracking between runs if you explicitly want dedupe
+  python scripts/scrape_upcoming_gotsport_events.py \\
+      --tracked-events data/raw/upcoming_events_tracked.json
+        """,
+    )
+
+    parser.add_argument("--days-ahead", type=int, default=7, help="How many days ahead to look for events (default: 7)")
+    parser.add_argument("--output", type=str, default=None, help="Output file path (default: auto-generated)")
+    parser.add_argument(
+        "--tracked-events",
+        type=str,
+        default=None,
+        help="Optional file to track event IDs between runs",
+    )
+    parser.add_argument(
+        "--manual-event-ids",
+        type=str,
+        nargs="+",
+        help="Manually specify event IDs to scrape (for known missed events, e.g., --manual-event-ids 45163 45164)",
+    )
+    parser.add_argument(
+        "--max-events", type=int, default=0, help="Maximum number of events to scrape (0 = no limit, default: 0)"
+    )
+    parser.add_argument(
+        "--max-runtime", type=int, default=150, help="Maximum runtime in minutes (default: 150 = 2.5 hours)"
+    )
+    parser.add_argument(
+        "--extract-dates",
+        dest="skip_date_extraction",
+        action="store_false",
+        help="Extract event dates during discovery (slower but more accurate filtering)",
+    )
+
+    args = parser.parse_args()
+
+    # Default to True (skip date extraction) unless --extract-dates is specified
+    skip_date_extraction = getattr(args, "skip_date_extraction", True)
+
+    scrape_upcoming_events(
+        days_ahead=args.days_ahead,
+        output_file=args.output,
+        tracked_events_file=args.tracked_events,
+        manual_event_ids=args.manual_event_ids,
+        max_events=args.max_events,
+        max_runtime_minutes=args.max_runtime,
+        skip_date_extraction=skip_date_extraction,
+    )

--- a/scripts/settle_prospective_match_predictions.py
+++ b/scripts/settle_prospective_match_predictions.py
@@ -1,0 +1,350 @@
+"""
+Settle prospective match predictions against actual game results.
+
+This script matches rows in prospective_match_predictions to scored games in the
+main games table and records the actual result in fixture orientation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from supabase import Client, create_client  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _supabase_client() -> Client:
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY")
+    return create_client(supabase_url, supabase_key)
+
+
+def _normalize_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def _safe_json(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _build_actual_outcome(home_score: Optional[int], away_score: Optional[int]) -> Optional[str]:
+    if home_score is None or away_score is None:
+        return None
+    if home_score > away_score:
+        return "team_a"
+    if away_score > home_score:
+        return "team_b"
+    return "draw"
+
+
+def _chunked(values: Iterable[str], size: int) -> Iterable[List[str]]:
+    batch: List[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _is_missing_table(error: Exception, table_name: str) -> bool:
+    message = str(error).lower()
+    return ("could not find the table" in message or "schema cache" in message) and table_name.lower() in message
+
+
+def _fetch_rows(supabase: Client, status: str, limit: int) -> List[Dict[str, Any]]:
+    try:
+        response = (
+            supabase.table("prospective_match_predictions")
+            .select(
+                "id, fixture_key, game_date, competition, division_name, home_provider_team_id, away_provider_team_id, "
+                "home_team_master_id, away_team_master_id, evaluation_notes"
+            )
+            .eq("evaluation_status", status)
+            .lte("game_date", date.today().isoformat())
+            .order("game_date", desc=False)
+            .limit(limit)
+            .execute()
+        )
+    except Exception as error:
+        if _is_missing_table(error, "prospective_match_predictions"):
+            raise RuntimeError(
+                "prospective_match_predictions table is missing. Apply the new Supabase migration before running settlement."
+            ) from error
+        raise
+    return list(response.data or [])
+
+
+def _fetch_games(
+    supabase: Client,
+    *,
+    game_date: str,
+    home_team_master_id: Optional[str],
+    away_team_master_id: Optional[str],
+    home_provider_team_id: Optional[str],
+    away_provider_team_id: Optional[str],
+) -> List[Tuple[Dict[str, Any], bool, str]]:
+    candidates: Dict[str, Tuple[Dict[str, Any], bool, str]] = {}
+    select_fields = (
+        "id, game_date, home_team_master_id, away_team_master_id, home_provider_id, away_provider_id, "
+        "home_score, away_score, competition, division_name, event_name"
+    )
+
+    def add_rows(rows: List[Dict[str, Any]], reversed_orientation: bool, source: str) -> None:
+        for row in rows:
+            game_id = str(row.get("id") or "")
+            if game_id and row.get("home_score") is not None and row.get("away_score") is not None:
+                candidates.setdefault(game_id, (row, reversed_orientation, source))
+
+    if home_team_master_id and away_team_master_id:
+        direct = (
+            supabase.table("games")
+            .select(select_fields)
+            .eq("game_date", game_date)
+            .eq("home_team_master_id", home_team_master_id)
+            .eq("away_team_master_id", away_team_master_id)
+            .execute()
+        )
+        add_rows(list(direct.data or []), False, "team_ids_direct")
+
+        reverse = (
+            supabase.table("games")
+            .select(select_fields)
+            .eq("game_date", game_date)
+            .eq("home_team_master_id", away_team_master_id)
+            .eq("away_team_master_id", home_team_master_id)
+            .execute()
+        )
+        add_rows(list(reverse.data or []), True, "team_ids_reverse")
+
+    if home_provider_team_id and away_provider_team_id:
+        direct = (
+            supabase.table("games")
+            .select(select_fields)
+            .eq("game_date", game_date)
+            .eq("home_provider_id", home_provider_team_id)
+            .eq("away_provider_id", away_provider_team_id)
+            .execute()
+        )
+        add_rows(list(direct.data or []), False, "provider_ids_direct")
+
+        reverse = (
+            supabase.table("games")
+            .select(select_fields)
+            .eq("game_date", game_date)
+            .eq("home_provider_id", away_provider_team_id)
+            .eq("away_provider_id", home_provider_team_id)
+            .execute()
+        )
+        add_rows(list(reverse.data or []), True, "provider_ids_reverse")
+
+    return list(candidates.values())
+
+
+def _candidate_score(fixture: Dict[str, Any], candidate: Dict[str, Any], source: str) -> int:
+    score = 0
+    if source.startswith("team_ids_"):
+        score += 6
+    elif source.startswith("provider_ids_"):
+        score += 4
+
+    if _normalize_text(candidate.get("competition")) == _normalize_text(fixture.get("competition")):
+        score += 2
+    if _normalize_text(candidate.get("event_name")) == _normalize_text(fixture.get("competition")):
+        score += 1
+    if _normalize_text(candidate.get("division_name")) == _normalize_text(fixture.get("division_name")):
+        score += 2
+    return score
+
+
+def _pick_candidate(
+    fixture: Dict[str, Any],
+    candidates: List[Tuple[Dict[str, Any], bool, str]],
+) -> Tuple[Optional[Dict[str, Any]], Optional[bool], Optional[str], List[Dict[str, Any]]]:
+    if not candidates:
+        return None, None, None, []
+
+    scored = []
+    for candidate, reversed_orientation, source in candidates:
+        scored.append(
+            {
+                "candidate": candidate,
+                "reversed_orientation": reversed_orientation,
+                "source": source,
+                "score": _candidate_score(fixture, candidate, source),
+            }
+        )
+    scored.sort(key=lambda item: (item["score"], item["source"]), reverse=True)
+
+    if len(scored) > 1 and scored[0]["score"] == scored[1]["score"]:
+        return None, None, None, scored
+
+    best = scored[0]
+    return best["candidate"], bool(best["reversed_orientation"]), str(best["source"]), scored
+
+
+def _update_row(
+    supabase: Client,
+    row_id: str,
+    payload: Dict[str, Any],
+) -> None:
+    supabase.table("prospective_match_predictions").update(payload).eq("id", row_id).execute()
+
+
+def settle_rows(
+    *,
+    supabase: Client,
+    status: str,
+    limit: int,
+) -> Dict[str, Any]:
+    rows = _fetch_rows(supabase, status, limit)
+    summary = {
+        "requested_status": status,
+        "requested_limit": limit,
+        "fetched_rows": len(rows),
+        "processed": 0,
+        "settled": 0,
+        "not_found": 0,
+        "ambiguous": 0,
+        "row_ids": [],
+    }
+
+    for row in rows:
+        row_id = str(row["id"])
+        summary["processed"] += 1
+        summary["row_ids"].append(row_id)
+
+        candidates = _fetch_games(
+            supabase,
+            game_date=str(row.get("game_date") or ""),
+            home_team_master_id=row.get("home_team_master_id"),
+            away_team_master_id=row.get("away_team_master_id"),
+            home_provider_team_id=row.get("home_provider_team_id"),
+            away_provider_team_id=row.get("away_provider_team_id"),
+        )
+        candidate, reversed_orientation, source, scored_candidates = _pick_candidate(row, candidates)
+        existing_notes = _safe_json(row.get("evaluation_notes"))
+
+        if candidate is None and scored_candidates:
+            _update_row(
+                supabase,
+                row_id,
+                {
+                    "evaluation_status": "ambiguous_result",
+                    "evaluation_notes": {
+                        **existing_notes,
+                        "settlement": {
+                            "status": "ambiguous",
+                            "candidates": [
+                                {
+                                    "game_id": entry["candidate"].get("id"),
+                                    "score": entry["score"],
+                                    "source": entry["source"],
+                                    "reversed_orientation": entry["reversed_orientation"],
+                                }
+                                for entry in scored_candidates[:5]
+                            ],
+                        },
+                    },
+                },
+            )
+            summary["ambiguous"] += 1
+            continue
+
+        if candidate is None:
+            _update_row(
+                supabase,
+                row_id,
+                {
+                    "evaluation_status": "result_not_found",
+                    "evaluation_notes": {
+                        **existing_notes,
+                        "settlement": {
+                            "status": "not_found",
+                            "checked_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        },
+                    },
+                },
+            )
+            summary["not_found"] += 1
+            continue
+
+        home_score = int(candidate["away_score"]) if reversed_orientation else int(candidate["home_score"])
+        away_score = int(candidate["home_score"]) if reversed_orientation else int(candidate["away_score"])
+        _update_row(
+            supabase,
+            row_id,
+            {
+                "actual_game_id": candidate.get("id"),
+                "actual_home_score": home_score,
+                "actual_away_score": away_score,
+                "actual_outcome": _build_actual_outcome(home_score, away_score),
+                "actual_recorded_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "evaluation_status": "settled",
+                "evaluation_notes": {
+                    **existing_notes,
+                    "settlement": {
+                        "status": "settled",
+                        "source": source,
+                        "reversed_orientation": bool(reversed_orientation),
+                        "matched_game_id": candidate.get("id"),
+                    },
+                },
+            },
+        )
+        summary["settled"] += 1
+
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Settle prospective match predictions against actual results")
+    parser.add_argument("--status", default="pending_result", help="evaluation_status to pull")
+    parser.add_argument("--limit", type=int, default=200, help="maximum number of rows to process")
+    parser.add_argument("--summary-path", default=None, help="Optional path to write JSON summary")
+    args = parser.parse_args()
+
+    summary = settle_rows(
+        supabase=_supabase_client(),
+        status=args.status,
+        limit=args.limit,
+    )
+    if args.summary_path:
+        summary_path = Path(args.summary_path)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260410000000_create_prospective_match_predictions.sql
+++ b/supabase/migrations/20260410000000_create_prospective_match_predictions.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS prospective_match_predictions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    fixture_key TEXT NOT NULL UNIQUE,
+    provider_code TEXT NOT NULL DEFAULT 'gotsport',
+    source_system TEXT NOT NULL DEFAULT 'gotsport_event_schedule',
+    source_artifact_path TEXT NULL,
+    source_event_id TEXT NULL,
+    source_match_key TEXT NULL,
+
+    game_date DATE NOT NULL,
+    competition TEXT NULL,
+    division_name TEXT NULL,
+    venue TEXT NULL,
+
+    home_provider_team_id TEXT NOT NULL,
+    away_provider_team_id TEXT NOT NULL,
+    home_team_name TEXT NOT NULL,
+    away_team_name TEXT NOT NULL,
+    home_team_master_id UUID NULL REFERENCES teams(team_id_master) ON DELETE SET NULL,
+    away_team_master_id UUID NULL REFERENCES teams(team_id_master) ON DELETE SET NULL,
+    home_resolution_method TEXT NULL,
+    away_resolution_method TEXT NULL,
+    resolution_status TEXT NOT NULL DEFAULT 'pending',
+
+    fixture_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    heuristic_prediction_status TEXT NOT NULL DEFAULT 'pending',
+    heuristic_model_version TEXT NULL,
+    heuristic_prediction JSONB NULL,
+    heuristic_predicted_at TIMESTAMPTZ NULL,
+
+    offline_prediction_status TEXT NOT NULL DEFAULT 'pending',
+    offline_model_version TEXT NULL,
+    offline_prediction JSONB NULL,
+    offline_predicted_at TIMESTAMPTZ NULL,
+
+    actual_game_id UUID NULL REFERENCES games(id) ON DELETE SET NULL,
+    actual_home_score INTEGER NULL,
+    actual_away_score INTEGER NULL,
+    actual_outcome TEXT NULL,
+    actual_recorded_at TIMESTAMPTZ NULL,
+    evaluation_status TEXT NOT NULL DEFAULT 'pending_result',
+    evaluation_notes JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_game_date
+    ON prospective_match_predictions (game_date ASC);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_resolution_status
+    ON prospective_match_predictions (resolution_status, game_date ASC);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_heuristic_status
+    ON prospective_match_predictions (heuristic_prediction_status, game_date ASC);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_offline_status
+    ON prospective_match_predictions (offline_prediction_status, game_date ASC);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_actual_status
+    ON prospective_match_predictions (evaluation_status, game_date ASC);
+
+CREATE INDEX IF NOT EXISTS idx_prospective_match_predictions_provider_pair
+    ON prospective_match_predictions (provider_code, home_provider_team_id, away_provider_team_id, game_date ASC);
+
+CREATE OR REPLACE FUNCTION update_prospective_match_predictions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_prospective_match_predictions_updated_at
+    ON prospective_match_predictions;
+
+CREATE TRIGGER update_prospective_match_predictions_updated_at
+    BEFORE UPDATE ON prospective_match_predictions
+    FOR EACH ROW EXECUTE FUNCTION update_prospective_match_predictions_updated_at();
+
+ALTER TABLE prospective_match_predictions ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE prospective_match_predictions IS
+    'Prospective evaluation fixtures with frozen heuristic/offline predictions and eventual actual results.';

--- a/tests/unit/test_evaluate_prospective_match_predictions.py
+++ b/tests/unit/test_evaluate_prospective_match_predictions.py
@@ -1,0 +1,59 @@
+from scripts.evaluate_prospective_match_predictions import _extract_prediction_payload
+
+
+def test_extract_prediction_payload_handles_heuristic_and_offline_shapes():
+    row = {
+        "fixture_key": "fixture-1",
+        "game_date": "2026-04-15",
+        "competition": "Spring Showcase",
+        "division_name": "U12 Gold",
+        "actual_home_score": 2,
+        "actual_away_score": 1,
+        "fixture_payload": {
+            "home_row": {
+                "age_group": "u12",
+            }
+        },
+        "heuristic_model_version": "heuristic_v3_shadow_ready",
+        "heuristic_prediction": {
+            "modelVersion": "heuristic_v3_shadow_ready",
+            "response": {
+                "prediction": {
+                    "predictedWinner": "team_a",
+                    "winProbabilityA": 0.58,
+                    "drawProbability": 0.22,
+                    "winProbabilityB": 0.20,
+                    "expectedScore": {"teamA": 2, "teamB": 1},
+                    "expectedMargin": 0.8,
+                }
+            },
+        },
+        "offline_model_version": "pitm_v1",
+        "offline_prediction": {
+            "modelVersion": "pitm_v1",
+            "prediction": {
+                "predictedWinner": "draw",
+                "winProbabilityA": 0.31,
+                "drawProbability": 0.39,
+                "winProbabilityB": 0.30,
+                "expectedScore": {"teamA": 1, "teamB": 1},
+                "expectedMargin": 0.0,
+                "blowoutProbability3Plus": 0.04,
+                "predictedBlowout3Plus": False,
+            },
+        },
+    }
+
+    heuristic = _extract_prediction_payload(row, "heuristic")
+    offline = _extract_prediction_payload(row, "offline")
+
+    assert heuristic is not None
+    assert heuristic["predicted_outcome"] == "team_a"
+    assert heuristic["actual_outcome"] == "team_a"
+    assert heuristic["predicted_score_a"] == 2
+    assert heuristic["age_group"] == "u12"
+
+    assert offline is not None
+    assert offline["predicted_outcome"] == "draw"
+    assert offline["prob_draw"] == 0.39
+    assert offline["predicted_blowout_3plus"] is False

--- a/tests/unit/test_prepare_prospective_match_predictions.py
+++ b/tests/unit/test_prepare_prospective_match_predictions.py
@@ -1,0 +1,49 @@
+import json
+
+from scripts.prepare_prospective_match_predictions import load_fixtures_from_jsonl
+
+
+def test_load_fixtures_from_jsonl_dedupes_home_and_away_rows(tmp_path):
+    fixtures_file = tmp_path / "fixtures.jsonl"
+    rows = [
+        {
+            "provider": "gotsport",
+            "team_id_source": "111",
+            "opponent_id_source": "222",
+            "team_name": "Home Team",
+            "opponent_name": "Away Team",
+            "home_away": "H",
+            "game_date": "2026-04-15",
+            "competition": "Spring Showcase",
+            "division_name": "U12 Gold",
+            "venue": "Field 1",
+            "match_id": "555_111_222_2026-04-15",
+            "source_url": "https://system.gotsport.com/org_event/events/555/schedules",
+        },
+        {
+            "provider": "gotsport",
+            "team_id_source": "222",
+            "opponent_id_source": "111",
+            "team_name": "Away Team",
+            "opponent_name": "Home Team",
+            "home_away": "A",
+            "game_date": "2026-04-15",
+            "competition": "Spring Showcase",
+            "division_name": "U12 Gold",
+            "venue": "Field 1",
+            "match_id": "555_111_222_2026-04-15",
+            "source_url": "https://system.gotsport.com/org_event/events/555/schedules",
+        },
+    ]
+    fixtures_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    fixtures = load_fixtures_from_jsonl(fixtures_file, "artifact.jsonl")
+
+    assert len(fixtures) == 1
+    fixture = fixtures[0]
+    assert fixture.source_event_id == "555"
+    assert fixture.home_provider_team_id == "111"
+    assert fixture.away_provider_team_id == "222"
+    assert fixture.home_team_name == "Home Team"
+    assert fixture.away_team_name == "Away Team"
+    assert fixture.fixture_key.startswith("gotsport|555|2026-04-15")

--- a/tests/unit/test_scrape_upcoming_gotsport_events.py
+++ b/tests/unit/test_scrape_upcoming_gotsport_events.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from datetime import date
+
+from scripts.scrape_upcoming_gotsport_events import event_overlaps_window, filter_games_to_window
+
+
+@dataclass
+class DummyGame:
+    game_date: str
+
+
+def test_event_overlaps_window_with_actual_dates():
+    assert event_overlaps_window(
+        event_start_date=date(2026, 4, 12),
+        event_end_date=date(2026, 4, 13),
+        search_date=date(2026, 4, 10),
+        window_start=date(2026, 4, 10),
+        window_end=date(2026, 4, 17),
+    )
+    assert not event_overlaps_window(
+        event_start_date=date(2026, 4, 20),
+        event_end_date=date(2026, 4, 21),
+        search_date=date(2026, 4, 10),
+        window_start=date(2026, 4, 10),
+        window_end=date(2026, 4, 17),
+    )
+
+
+def test_filter_games_to_window_keeps_only_target_dates():
+    games = [
+        DummyGame("2026-04-09"),
+        DummyGame("2026-04-10"),
+        DummyGame("2026-04-14"),
+        DummyGame("2026-04-18"),
+        DummyGame(""),
+    ]
+
+    filtered = filter_games_to_window(games, date(2026, 4, 10), date(2026, 4, 17))
+
+    assert [game.game_date for game in filtered] == ["2026-04-10", "2026-04-14"]

--- a/tests/unit/test_settle_prospective_match_predictions.py
+++ b/tests/unit/test_settle_prospective_match_predictions.py
@@ -1,0 +1,38 @@
+from scripts.settle_prospective_match_predictions import _pick_candidate
+
+
+def test_pick_candidate_prefers_exact_team_match_and_division():
+    fixture = {
+        "competition": "Spring Showcase",
+        "division_name": "U12 Gold",
+    }
+    candidates = [
+        (
+            {
+                "id": "provider-only",
+                "competition": "Spring Showcase",
+                "division_name": "U12 Gold",
+                "event_name": "Spring Showcase",
+            },
+            False,
+            "provider_ids_direct",
+        ),
+        (
+            {
+                "id": "team-exact",
+                "competition": "Spring Showcase",
+                "division_name": "U12 Gold",
+                "event_name": "Spring Showcase",
+            },
+            False,
+            "team_ids_direct",
+        ),
+    ]
+
+    candidate, reversed_orientation, source, scored = _pick_candidate(fixture, candidates)
+
+    assert candidate is not None
+    assert candidate["id"] == "team-exact"
+    assert reversed_orientation is False
+    assert source == "team_ids_direct"
+    assert scored[0]["score"] > scored[1]["score"]


### PR DESCRIPTION
## Summary
- add a separate upcoming GotSport event scraper path for future fixtures
- add a prospective match prediction table, prepare/settle/evaluate scripts, and a frontend heuristic freezer
- add manual GitHub Actions workflows for preparing, processing, settling, and evaluating prospective predictions

## Validation
- applied `20260410000000_create_prospective_match_predictions.sql` directly to the remote database
- `python -m pytest tests/unit/test_prepare_prospective_match_predictions.py tests/unit/test_settle_prospective_match_predictions.py tests/unit/test_evaluate_prospective_match_predictions.py tests/unit/test_scrape_upcoming_gotsport_events.py`
- `python -m py_compile scripts/prepare_prospective_match_predictions.py scripts/settle_prospective_match_predictions.py scripts/evaluate_prospective_match_predictions.py`
- `npm run typecheck`
- local smoke: prepare inserted 3 prospective rows and heuristic processing completed 1 row successfully