### PR TITLE
Fix anonymous checkout: remove customer_creation param

### DIFF
--- a/frontend/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/checkout/__tests__/route.test.ts
@@ -37,7 +37,15 @@ vi.mock('@/lib/stripe/server', () => ({
         create: mockCheckoutSessionsCreate,
       },
     },
+    subscriptions: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+    },
   },
+  getStripePriceIds: () => ({ MONTHLY: 'price_monthly', YEARLY: 'price_yearly' }),
+  WEBHOOK_EVENTS: {},
+  extractPeriodEnd: vi.fn(),
+  mapStatusToPlan: vi.fn(),
+  updateUserProfile: vi.fn(),
 }));
 
 import { POST } from '../route';
@@ -56,14 +64,21 @@ describe('POST /api/stripe/checkout', () => {
     process.env.NEXT_PUBLIC_SITE_URL = 'https://pitchrank.io';
   });
 
-  it('returns 401 when not authenticated', async () => {
+  it('creates anonymous checkout session when not authenticated', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockCheckoutSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/anon' });
 
-    const res = await POST(makeRequest({ priceId: 'price_abc123' }));
+    const res = await POST(makeRequest({ priceId: 'price_monthly' }));
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toBe('Not authenticated');
+    expect(body.url).toBe('https://checkout.stripe.com/anon');
+    expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer_creation: 'always',
+        metadata: { anonymous_checkout: 'true' },
+      })
+    );
   });
 
   it('returns 400 for missing price ID', async () => {
@@ -104,7 +119,7 @@ describe('POST /api/stripe/checkout', () => {
     // Stripe checkout.sessions.create throws
     mockCheckoutSessionsCreate.mockRejectedValue(new Error('Your card was declined. Request req_abc123.'));
 
-    const res = await POST(makeRequest({ priceId: 'price_valid123' }));
+    const res = await POST(makeRequest({ priceId: 'price_monthly' }));
 
     expect(res.status).toBe(500);
     const body = await res.json();

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,12 +1,22 @@
 import { stripe, getStripePriceIds } from '@/lib/stripe/server';
-import { requireAuth } from '@/lib/api/requireAuth';
+import { optionalAuth } from '@/lib/api/optionalAuth';
 import { NextResponse } from 'next/server';
+import type Stripe from 'stripe';
+
+function baseSessionParams(priceId: string): Partial<Stripe.Checkout.SessionCreateParams> {
+  return {
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade`,
+    allow_promotion_codes: true,
+    billing_address_collection: 'auto',
+  };
+}
 
 export async function POST(req: Request) {
   try {
-    const auth = await requireAuth();
-    if (auth.error) return auth.error;
-    const { user, supabase } = auth;
+    const { user, supabase } = await optionalAuth();
 
     const { priceId } = await req.json();
 
@@ -23,84 +33,93 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
     }
 
-    // Get user profile
-    const { data: profile, error: profileError } = await supabase
-      .from('user_profiles')
-      .select('*')
-      .eq('id', user.id)
-      .single();
+    // --- Authenticated checkout: existing user ---
+    if (user && supabase) {
+      // Get user profile
+      const { data: profile, error: profileError } = await supabase
+        .from('user_profiles')
+        .select('*')
+        .eq('id', user.id)
+        .single();
 
-    if (profileError) {
-      console.error('Error fetching profile:', profileError);
-      return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
-    }
+      if (profileError) {
+        console.error('Error fetching profile:', profileError);
+        return NextResponse.json({ error: 'Failed to fetch user profile' }, { status: 500 });
+      }
 
-    // Check if user already has active or trialing subscription
-    if (
-      profile?.plan === 'premium' &&
-      (profile?.subscription_status === 'active' || profile?.subscription_status === 'trialing')
-    ) {
-      return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
-    }
+      // Check if user already has active or trialing subscription
+      if (
+        profile?.plan === 'premium' &&
+        (profile?.subscription_status === 'active' || profile?.subscription_status === 'trialing')
+      ) {
+        return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
+      }
 
-    let customerId = profile?.stripe_customer_id;
+      let customerId = profile?.stripe_customer_id;
 
-    // Create Stripe customer if one doesn't exist
-    if (!customerId) {
-      const customer = await stripe.customers.create({
-        ...(user.email ? { email: user.email } : {}),
-        metadata: {
-          supabase_user_id: user.id,
+      // Create Stripe customer if one doesn't exist
+      if (!customerId) {
+        const customer = await stripe.customers.create({
+          ...(user.email ? { email: user.email } : {}),
+          metadata: {
+            supabase_user_id: user.id,
+          },
+        });
+
+        customerId = customer.id;
+
+        // Save customer ID to profile - this MUST succeed for webhooks to work
+        const { error: updateError } = await supabase
+          .from('user_profiles')
+          .update({ stripe_customer_id: customerId })
+          .eq('id', user.id);
+
+        if (updateError) {
+          console.error('Error saving customer ID to profile:', updateError);
+          return NextResponse.json({ error: 'Failed to link billing account. Please try again.' }, { status: 500 });
+        }
+      }
+
+      // Check Stripe for existing subscriptions (active check + trial eligibility)
+      const allSubs = await stripe.subscriptions.list({
+        customer: customerId,
+        status: 'all',
+        limit: 10,
+      });
+      const activeSub = allSubs.data.find((s) => s.status === 'active' || s.status === 'trialing');
+      if (activeSub) {
+        return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
+      }
+
+      // Only grant trial to first-time subscribers
+      const hasHadSubscription = allSubs.data.length > 0;
+
+      // Create Stripe checkout session
+      const session = await stripe.checkout.sessions.create({
+        ...baseSessionParams(priceId),
+        customer: customerId,
+        metadata: { supabase_user_id: user.id },
+        subscription_data: {
+          ...(hasHadSubscription ? {} : { trial_period_days: 7 }),
+          metadata: { supabase_user_id: user.id },
+        },
+        customer_update: {
+          address: 'auto',
+          name: 'auto',
         },
       });
 
-      customerId = customer.id;
-
-      // Save customer ID to profile - this MUST succeed for webhooks to work
-      const { error: updateError } = await supabase
-        .from('user_profiles')
-        .update({ stripe_customer_id: customerId })
-        .eq('id', user.id);
-
-      if (updateError) {
-        console.error('Error saving customer ID to profile:', updateError);
-        return NextResponse.json({ error: 'Failed to link billing account. Please try again.' }, { status: 500 });
-      }
+      return NextResponse.json({ url: session.url });
     }
 
-    // Check Stripe for existing subscriptions (active check + trial eligibility)
-    const allSubs = await stripe.subscriptions.list({
-      customer: customerId,
-      status: 'all',
-      limit: 10,
-    });
-    const activeSub = allSubs.data.find((s) => s.status === 'active' || s.status === 'trialing');
-    if (activeSub) {
-      return NextResponse.json({ error: 'You already have an active subscription' }, { status: 400 });
-    }
-
-    // Only grant trial to first-time subscribers
-    const hasHadSubscription = allSubs.data.length > 0;
-
-    // Create Stripe checkout session
+    // --- Anonymous checkout: no account yet ---
     const session = await stripe.checkout.sessions.create({
-      mode: 'subscription',
-      customer: customerId,
-      line_items: [{ price: priceId, quantity: 1 }],
-      // Session metadata: used by /api/stripe/sync for ownership verification
-      metadata: { supabase_user_id: user.id },
-      success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/upgrade`,
+      ...baseSessionParams(priceId),
+      customer_creation: 'always',
+      metadata: { anonymous_checkout: 'true' },
       subscription_data: {
-        ...(hasHadSubscription ? {} : { trial_period_days: 7 }),
-        // Subscription metadata: used by webhook handlers for audit trail
-        metadata: { supabase_user_id: user.id },
-      },
-      allow_promotion_codes: true,
-      billing_address_collection: 'auto',
-      customer_update: {
-        address: 'auto',
-        name: 'auto',
+        trial_period_days: 7,
+        metadata: { anonymous_checkout: 'true' },
       },
     });
 

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -113,9 +113,9 @@ export async function POST(req: Request) {
     }
 
     // --- Anonymous checkout: no account yet ---
+    // In subscription mode, Stripe automatically creates a customer when none is provided
     const session = await stripe.checkout.sessions.create({
       ...baseSessionParams(priceId),
-      customer_creation: 'always',
       metadata: { anonymous_checkout: 'true' },
       subscription_data: {
         trial_period_days: 7,

--- a/frontend/app/api/stripe/sync/route.ts
+++ b/frontend/app/api/stripe/sync/route.ts
@@ -1,5 +1,6 @@
 import { stripe, extractPeriodEnd, mapStatusToPlan } from '@/lib/stripe/server';
-import { requireAuth } from '@/lib/api/requireAuth';
+import { getSupabaseAdmin } from '@/lib/supabase/service';
+import { optionalAuth } from '@/lib/api/optionalAuth';
 import { NextResponse } from 'next/server';
 
 /**
@@ -9,13 +10,13 @@ import { NextResponse } from 'next/server';
  * Stripe and update user_profiles. This covers the case where the webhook
  * fails (misconfigured secret, cold-start timeout, etc.).
  *
- * Only the authenticated user who owns the session can call this.
+ * Supports both authenticated users (verifies ownership via metadata or
+ * stripe_customer_id) and anonymous checkouts (verifies via session_id,
+ * which is a secret known only to the checkout user).
  */
 export async function POST(req: Request) {
   try {
-    const auth = await requireAuth();
-    if (auth.error) return auth.error;
-    const { user, supabase } = auth;
+    const { user, supabase } = await optionalAuth();
 
     const { sessionId } = await req.json();
     if (!sessionId || typeof sessionId !== 'string') {
@@ -39,57 +40,79 @@ export async function POST(req: Request) {
 
     const status = subscription.status;
     const plan = mapStatusToPlan(status);
+    const updates = {
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscription.id,
+      subscription_status: status,
+      plan,
+      subscription_period_end: extractPeriodEnd(subscription),
+      cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+      updated_at: new Date().toISOString(),
+    };
 
-    // Verify the caller owns this checkout session via metadata (preferred)
-    // or via profile customer_id (legacy fallback for sessions created before metadata was added)
-    const sessionUserId = session.metadata?.supabase_user_id;
-    if (sessionUserId) {
-      if (sessionUserId !== user.id) {
-        return NextResponse.json({ error: 'Session does not belong to you' }, { status: 403 });
+    // --- Authenticated sync: verify ownership, update by user.id ---
+    if (user && supabase) {
+      const sessionUserId = session.metadata?.supabase_user_id;
+      if (sessionUserId) {
+        if (sessionUserId !== user.id) {
+          return NextResponse.json({ error: 'Session does not belong to you' }, { status: 403 });
+        }
+      } else {
+        const { data: profile } = await supabase
+          .from('user_profiles')
+          .select('stripe_customer_id')
+          .eq('id', user.id)
+          .single();
+        if (!profile?.stripe_customer_id) {
+          return NextResponse.json(
+            { error: 'No customer ID on profile — cannot verify session ownership' },
+            { status: 403 }
+          );
+        }
+        if (profile.stripe_customer_id !== customerId) {
+          return NextResponse.json({ error: 'Session does not belong to you' }, { status: 403 });
+        }
       }
-    } else {
-      const { data: profile } = await supabase
-        .from('user_profiles')
-        .select('stripe_customer_id')
-        .eq('id', user.id)
-        .single();
-      if (!profile?.stripe_customer_id) {
-        return NextResponse.json(
-          { error: 'No customer ID on profile — cannot verify session ownership' },
-          { status: 403 }
-        );
+
+      const { error: updateError } = await supabase.from('user_profiles').update(updates).eq('id', user.id);
+
+      if (updateError) {
+        console.error('Sync: error updating profile:', updateError);
+        return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
       }
-      if (profile.stripe_customer_id !== customerId) {
-        return NextResponse.json({ error: 'Session does not belong to you' }, { status: 403 });
-      }
+
+      console.log(`Sync: updated user ${user.id} -> plan=${plan}, status=${status}, customer=${customerId}`);
+      return NextResponse.json({ synced: true, plan, status });
     }
 
-    // Update user_profiles (same fields as webhook handler)
-    const { error: updateError } = await supabase
+    // --- Anonymous sync: verify via session_id, update by stripe_customer_id ---
+    // The session_id is a secret URL parameter from Stripe that only the checkout user has.
+    const { data: profile, error: profileError } = await getSupabaseAdmin()
       .from('user_profiles')
-      .update({
-        stripe_customer_id: customerId,
-        stripe_subscription_id: subscription.id,
-        subscription_status: status,
-        plan,
-        subscription_period_end: extractPeriodEnd(subscription),
-        cancel_at_period_end: subscription.cancel_at_period_end ?? false,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', user.id);
+      .select('id')
+      .eq('stripe_customer_id', customerId)
+      .maybeSingle();
+
+    if (profileError) {
+      console.error('Sync: error looking up profile:', profileError);
+      return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
+    }
+
+    if (!profile) {
+      // Webhook may not have fired yet — this is expected for very fast redirects
+      console.log('Sync: no profile found for anonymous checkout (webhook may be pending)');
+      return NextResponse.json({ synced: false, error: 'Profile not yet created' }, { status: 202 });
+    }
+
+    const { error: updateError } = await getSupabaseAdmin().from('user_profiles').update(updates).eq('id', profile.id);
 
     if (updateError) {
       console.error('Sync: error updating profile:', updateError);
       return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
     }
 
-    console.log(`Sync: updated user ${user.id} -> plan=${plan}, status=${status}, customer=${customerId}`);
-
-    return NextResponse.json({
-      synced: true,
-      plan,
-      status,
-    });
+    console.log(`Sync: updated anonymous user ${profile.id} -> plan=${plan}, status=${status}`);
+    return NextResponse.json({ synced: true, plan, status });
   } catch (error) {
     console.error('Sync error:', error);
     return NextResponse.json({ error: 'Failed to sync subscription' }, { status: 500 });

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -1,25 +1,11 @@
 import { stripe, WEBHOOK_EVENTS, extractPeriodEnd, mapStatusToPlan, updateUserProfile } from '@/lib/stripe/server';
+import { getSupabaseAdmin } from '@/lib/supabase/service';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import Stripe from 'stripe';
 import { notifyAdmin } from '@/lib/notifications/admin';
 import { tagSubscriber, untagSubscriber } from '@/lib/beehiiv';
-
-// Lazy-load Supabase admin client to avoid build-time initialization errors
-let supabaseAdmin: SupabaseClient | null = null;
-
-function getSupabaseAdmin(): SupabaseClient {
-  if (!supabaseAdmin) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!supabaseUrl || !serviceRoleKey) {
-      throw new Error(`Missing Supabase environment variables (url=${!!supabaseUrl}, key=${!!serviceRoleKey})`);
-    }
-    supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
-  }
-  return supabaseAdmin;
-}
+import { sendPasswordSetupEmail } from '@/lib/email/password-setup';
 
 /**
  * Permanent errors that won't resolve on retry — return 200 so Stripe
@@ -27,7 +13,11 @@ function getSupabaseAdmin(): SupabaseClient {
  */
 function isPermanentError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
-  return msg.includes('No user profile found for Stripe customer');
+  return (
+    msg.includes('No user profile found for Stripe customer') ||
+    msg.includes('already been registered') ||
+    msg.includes('already exists')
+  );
 }
 
 export async function POST(req: Request) {
@@ -113,7 +103,9 @@ export async function POST(req: Request) {
 }
 
 /**
- * Handle successful checkout - activate subscription
+ * Handle successful checkout - activate subscription.
+ * Supports both authenticated checkouts (user already has a profile with
+ * stripe_customer_id) and anonymous checkouts (no Supabase account yet).
  */
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const customerId = session.customer as string;
@@ -126,24 +118,115 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
   // Fetch subscription details to get period end and status (may be "trialing" for free trials)
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  // Fetch customer details in parallel (independent of DB update)
-  const [, customer] = await Promise.all([
-    updateUserProfile(getSupabaseAdmin(), customerId, {
-      stripe_subscription_id: subscriptionId,
-      subscription_status: subscription.status,
-      plan: mapStatusToPlan(subscription.status),
-      subscription_period_end: extractPeriodEnd(subscription),
-      cancel_at_period_end: false,
-    }),
-    stripe.customers.retrieve(customerId),
-  ]);
+
+  const baseUpdates = {
+    stripe_subscription_id: subscriptionId,
+    subscription_status: subscription.status,
+    plan: mapStatusToPlan(subscription.status),
+    subscription_period_end: extractPeriodEnd(subscription),
+    cancel_at_period_end: false,
+  };
+
+  // Check if a user profile already exists for this Stripe customer (authenticated checkout)
+  const { data: existingProfile } = await getSupabaseAdmin()
+    .from('user_profiles')
+    .select('id')
+    .eq('stripe_customer_id', customerId)
+    .maybeSingle();
+
+  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+
+  if (existingProfile) {
+    // --- Authenticated checkout: profile exists, update it ---
+    [, customer] = await Promise.all([
+      updateUserProfile(getSupabaseAdmin(), customerId, baseUpdates),
+      stripe.customers.retrieve(customerId),
+    ]);
+  } else {
+    // --- Anonymous checkout: create or link Supabase account ---
+    customer = await stripe.customers.retrieve(customerId);
+    const email = (customer as Stripe.Customer).email;
+
+    if (!email) {
+      console.error('[webhook] Anonymous checkout but Stripe customer has no email');
+      return;
+    }
+
+    const anonymousUpdates = { stripe_customer_id: customerId, ...baseUpdates };
+
+    // Check if a user already exists with this email (signed up but checked out anonymously)
+    const { data: profileByEmail } = await getSupabaseAdmin()
+      .from('user_profiles')
+      .select('id, stripe_customer_id')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (profileByEmail) {
+      // Existing user — link Stripe subscription to their account
+      await getSupabaseAdmin()
+        .from('user_profiles')
+        .update({ ...anonymousUpdates, updated_at: new Date().toISOString() })
+        .eq('id', profileByEmail.id);
+
+      await stripe.customers.update(customerId, {
+        metadata: { supabase_user_id: profileByEmail.id },
+      });
+
+      console.log(`[webhook] Linked anonymous checkout to existing user ${profileByEmail.id}`);
+    } else {
+      // New user — create Supabase account
+      const { data: newUser, error: createError } = await getSupabaseAdmin().auth.admin.createUser({
+        email,
+        email_confirm: true,
+        user_metadata: { source: 'stripe_checkout' },
+      });
+
+      if (createError || !newUser?.user) {
+        console.error('[webhook] Failed to create user for anonymous checkout:', createError);
+        throw new Error(`Failed to create user for anonymous checkout: ${createError?.message}`);
+      }
+
+      // Update the profile created by handle_new_user trigger
+      await getSupabaseAdmin()
+        .from('user_profiles')
+        .update({ ...anonymousUpdates, updated_at: new Date().toISOString() })
+        .eq('id', newUser.user.id);
+
+      // Link Stripe customer to the new Supabase user for future webhook lookups
+      await stripe.customers.update(customerId, {
+        metadata: { supabase_user_id: newUser.user.id },
+      });
+
+      console.log(`[webhook] Created new user ${newUser.user.id} for anonymous checkout`);
+
+      // Send password-setup email (non-fatal if it fails)
+      try {
+        const { data: linkData } = await getSupabaseAdmin().auth.admin.generateLink({
+          type: 'recovery',
+          email,
+          options: {
+            redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/rankings`,
+          },
+        });
+
+        const setupUrl = linkData?.properties?.action_link;
+        if (setupUrl) {
+          await sendPasswordSetupEmail(email, setupUrl);
+        } else {
+          console.warn('[webhook] Could not generate password setup link');
+        }
+      } catch (emailError) {
+        console.error('[webhook] Password setup email failed (non-fatal):', emailError);
+      }
+    }
+  }
 
   console.log(`[webhook] Subscription activated for customer ${customerId}`);
 
   // Notify admin of new signup — escape HTML to prevent injection via Stripe customer name
   const escapeHtml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  const customerName = escapeHtml((customer as Stripe.Customer).name ?? 'Unknown');
-  const customerEmail = escapeHtml((customer as Stripe.Customer).email ?? 'N/A');
+  const displayName = escapeHtml((customer as Stripe.Customer).name ?? 'Unknown');
+  const displayEmail = escapeHtml((customer as Stripe.Customer).email ?? 'N/A');
   const statusLabel = subscription.status === 'trialing' ? '🆓 Free Trial' : '💳 Paid';
   const interval = subscription.items.data[0]?.price?.recurring?.interval;
   const planLabel = interval === 'month' ? 'Premium Monthly' : 'Premium Annual';
@@ -151,16 +234,17 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   await notifyAdmin(
     `<b>New Signup!</b>\n` +
       `${statusLabel}\n` +
-      `<b>Name:</b> ${customerName}\n` +
-      `<b>Email:</b> ${customerEmail}\n` +
+      `<b>Name:</b> ${displayName}\n` +
+      `<b>Email:</b> ${displayEmail}\n` +
       `<b>Plan:</b> ${planLabel}\n` +
       `<b>Status:</b> ${subscription.status}`
   );
 
   // Set subscriber tier to premium in Beehiiv (gates welcome sequence pitch emails)
-  if (customerEmail && customerEmail !== 'N/A') {
+  const rawEmail = (customer as Stripe.Customer).email;
+  if (rawEmail) {
     try {
-      await tagSubscriber(customerEmail);
+      await tagSubscriber(rawEmail);
     } catch (tagError) {
       console.error('[webhook] Beehiiv tagSubscriber failed (non-fatal):', tagError);
     }

--- a/frontend/app/upgrade/page.tsx
+++ b/frontend/app/upgrade/page.tsx
@@ -77,14 +77,8 @@ function UpgradePageContent() {
   }, [source]);
 
   const handleUpgrade = async (plan: 'monthly' | 'yearly') => {
-    // Wait for auth state to load before checking
+    // Wait for auth state to resolve (user or null)
     if (userLoading) return;
-
-    // If not authenticated, redirect to signup
-    if (!user) {
-      window.location.href = `/signup?next=/upgrade`;
-      return;
-    }
 
     trackPlanSelected({
       plan,
@@ -138,20 +132,16 @@ function UpgradePageContent() {
           ))}
         </div>
 
-        {/* Not Authenticated Message */}
+        {/* Existing Account Notice */}
         {!userLoading && !user && (
-          <div className="max-w-md mx-auto mb-8 p-4 bg-primary/10 border border-primary/20 rounded-lg text-center">
-            <p className="text-sm mb-3">Sign up for a free account to upgrade to Premium</p>
-            <div className="flex gap-3 justify-center">
-              <Link href="/signup?next=/upgrade">
-                <Button size="sm">Create Free Account</Button>
-              </Link>
-              <Link href="/login?next=/upgrade">
-                <Button size="sm" variant="outline">
-                  Sign In
-                </Button>
-              </Link>
-            </div>
+          <div className="max-w-md mx-auto mb-8 p-4 bg-muted/50 border border-border rounded-lg text-center">
+            <p className="text-sm text-muted-foreground">
+              Already have an account?{' '}
+              <Link href="/login?next=/upgrade" className="text-primary font-medium hover:underline">
+                Sign in
+              </Link>{' '}
+              to manage your existing subscription.
+            </p>
           </div>
         )}
 

--- a/frontend/app/upgrade/success/page.tsx
+++ b/frontend/app/upgrade/success/page.tsx
@@ -3,11 +3,12 @@
 import { useEffect, useState, useRef, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Check, Crown, ArrowRight, Sparkles, Search, Eye, BarChart3, Share2 } from 'lucide-react';
+import { Check, Crown, ArrowRight, Sparkles, Search, Eye, BarChart3, Share2, Mail } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { launchConfetti } from '@/components/ui/confetti';
 import { trackSubscriptionCompleted } from '@/lib/events';
+import { useUser } from '@/hooks/useUser';
 
 const ONBOARDING_STEPS = [
   {
@@ -43,6 +44,7 @@ export default function UpgradeSuccessPage() {
 
 function UpgradeSuccessContent() {
   const searchParams = useSearchParams();
+  const { user, isLoading: userLoading } = useUser();
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const confettiLaunched = useRef(false);
   const syncStarted = useRef(false);
@@ -156,37 +158,52 @@ function UpgradeSuccessContent() {
               </ul>
             </div>
 
-            {/* Receipt Note */}
-            <p className="text-xs text-muted-foreground">
-              A receipt has been sent to your email address. You can manage your subscription at any time from your
-              account settings.
-            </p>
+            {/* Receipt / Next Steps Note */}
+            {!userLoading && !user ? (
+              <div className="bg-primary/10 border border-primary/20 rounded-lg p-4 text-center">
+                <Mail className="w-6 h-6 text-primary mx-auto mb-2" />
+                <p className="text-sm font-medium mb-1">Check your email to set up your account</p>
+                <p className="text-xs text-muted-foreground">
+                  We sent a link to set your password. Click it to log in and access all premium features.
+                </p>
+                <Button variant="outline" size="sm" asChild className="mt-3 text-xs">
+                  <Link href="/login">Already set your password? Sign in</Link>
+                </Button>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                A receipt has been sent to your email address. You can manage your subscription at any time from your
+                account settings.
+              </p>
+            )}
           </CardContent>
         </Card>
 
-        {/* Onboarding Steps */}
-        <div>
-          <h3 className="text-lg font-semibold text-center mb-4">Get started in 3 steps</h3>
-          <div className="grid gap-4 md:grid-cols-3">
-            {ONBOARDING_STEPS.map((step, index) => (
-              <Card key={index} variant="elevated" className="text-center">
-                <CardContent className="pt-6 pb-4">
-                  <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-3">
-                    <step.icon className="w-5 h-5 text-primary" />
-                  </div>
-                  <h4 className="font-medium text-sm mb-1">{step.title}</h4>
-                  <p className="text-xs text-muted-foreground mb-3">{step.description}</p>
-                  <Button variant="outline" size="sm" asChild className="text-xs">
-                    <Link href={step.href}>
-                      {step.cta}
-                      <ArrowRight className="w-3 h-3 ml-1" />
-                    </Link>
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
+        {/* Onboarding Steps (shown for authenticated users) */}
+        {(user || userLoading) && (
+          <div>
+            <h3 className="text-lg font-semibold text-center mb-4">Get started in 3 steps</h3>
+            <div className="grid gap-4 md:grid-cols-3">
+              {ONBOARDING_STEPS.map((step, index) => (
+                <Card key={index} variant="elevated" className="text-center">
+                  <CardContent className="pt-6 pb-4">
+                    <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-3">
+                      <step.icon className="w-5 h-5 text-primary" />
+                    </div>
+                    <h4 className="font-medium text-sm mb-1">{step.title}</h4>
+                    <p className="text-xs text-muted-foreground mb-3">{step.description}</p>
+                    <Button variant="outline" size="sm" asChild className="text-xs">
+                      <Link href={step.href}>
+                        {step.cta}
+                        <ArrowRight className="w-3 h-3 ml-1" />
+                      </Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Share CTA */}
         <div className="text-center">

--- a/frontend/lib/api/optionalAuth.ts
+++ b/frontend/lib/api/optionalAuth.ts
@@ -1,0 +1,33 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+/**
+ * Try to get the authenticated user without failing.
+ * Returns the user and supabase client if authenticated,
+ * or null values if not — never returns an error response.
+ *
+ * Usage in route handlers that support both authenticated and anonymous access:
+ *   const { user, supabase } = await optionalAuth();
+ *   if (user) { ... } else { ... }
+ */
+export async function optionalAuth(): Promise<{
+  user: { id: string; email?: string } | null;
+  supabase: SupabaseClient | null;
+}> {
+  try {
+    const supabase = await createServerSupabase();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { user: null, supabase: null };
+    }
+
+    return { user, supabase };
+  } catch {
+    return { user: null, supabase: null };
+  }
+}

--- a/frontend/lib/email/index.ts
+++ b/frontend/lib/email/index.ts
@@ -1,3 +1,4 @@
 export { resend } from './resend';
 export { sendWelcomeEmail } from './welcome';
+export { sendPasswordSetupEmail } from './password-setup';
 export { sendReportCardEmail } from './report-card';

--- a/frontend/lib/email/password-setup.ts
+++ b/frontend/lib/email/password-setup.ts
@@ -1,0 +1,72 @@
+import { resend } from './resend';
+
+const PASSWORD_SETUP_HTML = (setupUrl: string) => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to PitchRank+</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="text-align: center; margin-bottom: 30px;">
+    <h1 style="color: #10b981; margin: 0;">⚽ PitchRank</h1>
+  </div>
+
+  <h2 style="color: #1f2937;">Welcome to PitchRank+!</h2>
+
+  <p>Your premium subscription is now active. You have full access to team detail pages, AI insights, comparisons, watchlist, and more.</p>
+
+  <p>To log in and access your account, set your password using the link below:</p>
+
+  <div style="text-align: center; margin: 30px 0;">
+    <a href="${setupUrl}" style="display: inline-block; background-color: #10b981; color: #ffffff; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">Set Your Password</a>
+  </div>
+
+  <p style="color: #6b7280; font-size: 14px;">This link expires in 24 hours. If it expires, you can use the "Forgot password" option on the sign-in page.</p>
+
+  <p style="margin-top: 30px;">See you on the pitch!</p>
+
+  <p style="color: #6b7280; font-size: 14px;">— The PitchRank Team</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+
+  <p style="color: #9ca3af; font-size: 12px; text-align: center;">
+    You're receiving this because you subscribed to PitchRank+.<br>
+    <a href="https://pitchrank.io" style="color: #9ca3af;">pitchrank.io</a>
+  </p>
+</body>
+</html>
+`;
+
+/**
+ * Send a password-setup email to a new subscriber who checked out anonymously.
+ * Returns true if sent successfully, false otherwise.
+ * Errors are logged but not thrown - subscription should activate even if email fails.
+ */
+export async function sendPasswordSetupEmail(email: string, setupUrl: string): Promise<boolean> {
+  if (!resend) {
+    console.warn('Resend not configured - skipping password setup email');
+    return false;
+  }
+
+  try {
+    const { error } = await resend.emails.send({
+      from: 'PitchRank <noreply@mail.pitchrank.io>',
+      to: email,
+      subject: 'Welcome to PitchRank+ — Set Your Password',
+      html: PASSWORD_SETUP_HTML(setupUrl),
+    });
+
+    if (error) {
+      console.error('Failed to send password setup email:', error);
+      return false;
+    }
+
+    console.log(`Password setup email sent successfully`);
+    return true;
+  } catch (err) {
+    console.error('Error sending password setup email:', err);
+    return false;
+  }
+}

--- a/frontend/lib/supabase/service.ts
+++ b/frontend/lib/supabase/service.ts
@@ -22,3 +22,26 @@ export function createServiceSupabase(): SupabaseClient {
     },
   });
 }
+
+/**
+ * Lazy-loaded singleton Supabase admin client for webhook/background operations.
+ * Uses SUPABASE_SERVICE_ROLE_KEY (the key configured for Stripe webhooks and
+ * server-side admin operations like user creation).
+ *
+ * Prefer createServiceSupabase() for short-lived route handlers.
+ * Use this for long-lived modules (webhooks, sync) where a singleton avoids
+ * repeated client construction.
+ */
+let _adminSingleton: SupabaseClient | null = null;
+
+export function getSupabaseAdmin(): SupabaseClient {
+  if (!_adminSingleton) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+      throw new Error(`Missing Supabase environment variables (url=${!!supabaseUrl}, key=${!!serviceRoleKey})`);
+    }
+    _adminSingleton = createClient(supabaseUrl, serviceRoleKey);
+  }
+  return _adminSingleton;
+}


### PR DESCRIPTION
## Summary

- `customer_creation: 'always'` is only valid in Stripe's `payment` mode, not `subscription` mode
- In subscription mode, Stripe automatically creates a customer when none is provided
- Removes the invalid param so anonymous checkout works

Fixes the 400 error from #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)