### PR TITLE
Fix anonymous checkout: remove customer_creation param

### DIFF
--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -113,9 +113,9 @@ export async function POST(req: Request) {
     }
 
     // --- Anonymous checkout: no account yet ---
+    // In subscription mode, Stripe automatically creates a customer when none is provided
     const session = await stripe.checkout.sessions.create({
       ...baseSessionParams(priceId),
-      customer_creation: 'always',
       metadata: { anonymous_checkout: 'true' },
       subscription_data: {
         trial_period_days: 7,


### PR DESCRIPTION
## Summary

- Removes `customer_creation: 'always'` from anonymous checkout session — this param is only valid in Stripe's `payment` mode, not `subscription` mode
- In subscription mode, Stripe automatically creates a customer when none is provided
- One-line fix for the 400 error introduced in #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)