### PR TITLE
Fix yearly price ID validation

### DIFF
--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -25,11 +25,19 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
     }
 
-    // Validate against known price IDs (uses env var fallback chain)
+    // Validate against known price IDs (check both server-side and client-side env vars
+    // in case they differ between STRIPE_PRICE_* and NEXT_PUBLIC_STRIPE_PRICE_*)
     const { MONTHLY, YEARLY } = getStripePriceIds();
-    const VALID_PRICE_IDS = [MONTHLY, YEARLY].filter(Boolean);
+    const VALID_PRICE_IDS = new Set(
+      [
+        MONTHLY,
+        YEARLY,
+        process.env.NEXT_PUBLIC_STRIPE_PRICE_MONTHLY,
+        process.env.NEXT_PUBLIC_STRIPE_PRICE_YEARLY,
+      ].filter(Boolean)
+    );
 
-    if (!VALID_PRICE_IDS.includes(priceId)) {
+    if (!VALID_PRICE_IDS.has(priceId)) {
       return NextResponse.json({ error: 'Invalid price ID' }, { status: 400 });
     }
 

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -113,9 +113,9 @@ export async function POST(req: Request) {
     }
 
     // --- Anonymous checkout: no account yet ---
+    // In subscription mode, Stripe automatically creates a customer when none is provided
     const session = await stripe.checkout.sessions.create({
       ...baseSessionParams(priceId),
-      customer_creation: 'always',
       metadata: { anonymous_checkout: 'true' },
       subscription_data: {
         trial_period_days: 7,


### PR DESCRIPTION
## Summary

- Validates price IDs against both `STRIPE_PRICE_*` and `NEXT_PUBLIC_STRIPE_PRICE_*` env vars
- These can have different values, causing yearly checkout to fail with "Invalid price ID"

🤖 Generated with [Claude Code](https://claude.com/claude-code)