### PR TITLE
Fix leakage in prospective PIT refresh

### DIFF
--- a/scripts/prepare_prospective_match_predictions.py
+++ b/scripts/prepare_prospective_match_predictions.py
@@ -9,6 +9,7 @@ and stores the result in prospective_match_predictions.
 
 from __future__ import annotations
 
+import asyncio
 import argparse
 import json
 import logging
@@ -31,6 +32,11 @@ else:
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from scripts.backtest_predictor import (  # noqa: E402
+    build_snapshot_index as build_historical_snapshot_index,
+    fetch_prediction_feature_snapshots,
+    fetch_team_names,
+)
 from scripts.process_match_prediction_shadow import (  # noqa: E402
     _apply_optional_calibration,
     _build_shadow_payload,
@@ -40,6 +46,7 @@ from scripts.predictor_python import Game as PredictorGame  # noqa: E402
 from src.predictions.point_in_time_calibration import PointInTimeProbabilityCalibrator  # noqa: E402
 from src.predictions.point_in_time_match_model import (  # noqa: E402
     PointInTimeMatchModel,
+    _snapshot_as_of,
     build_point_in_time_matchup_row,
 )
 from src.utils.merge_resolver import MergeResolver  # noqa: E402
@@ -436,25 +443,34 @@ def _fetch_recent_games(
     supabase: Client,
     team_ids: Iterable[str],
     lookback_days: int,
+    *,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
 ) -> List[PredictorGame]:
     ids = sorted({str(team_id) for team_id in team_ids if team_id})
     if not ids:
         return []
 
-    cutoff_date = (datetime.now(timezone.utc).date() - timedelta(days=lookback_days)).isoformat()
+    if start_date:
+        cutoff_date = str(start_date)
+    else:
+        reference_date = pd.Timestamp(end_date).date() if end_date else datetime.now(timezone.utc).date()
+        cutoff_date = (reference_date - timedelta(days=lookback_days)).isoformat()
     rows_by_id: Dict[str, Dict[str, Any]] = {}
     select_fields = "id, game_date, home_team_master_id, away_team_master_id, home_score, away_score, is_excluded"
 
     for batch in _chunked(ids, 100):
         for column_name in ("home_team_master_id", "away_team_master_id"):
-            response = (
+            query = (
                 supabase.table("games")
                 .select(select_fields)
                 .gte("game_date", cutoff_date)
                 .eq("is_excluded", False)
                 .in_(column_name, batch)
-                .execute()
             )
+            if end_date:
+                query = query.lte("game_date", str(end_date))
+            response = query.execute()
             for row in response.data or []:
                 game_id = str(row.get("id") or "")
                 if not game_id:
@@ -672,21 +688,22 @@ def _build_offline_prediction(
     *,
     home_team_id: str,
     away_team_id: str,
-    team_contexts: Dict[str, Dict[str, Any]],
+    team_names: Dict[str, str],
     recent_games: List[PredictorGame],
     snapshot_index: Dict[str, List[Dict[str, Any]]],
     model: PointInTimeMatchModel,
     calibrator: Optional[PointInTimeProbabilityCalibrator],
     model_version: str,
 ) -> Dict[str, Any]:
-    if home_team_id not in team_contexts:
-        raise ValueError(f"Missing team context for home team {home_team_id}")
-    if away_team_id not in team_contexts:
-        raise ValueError(f"Missing team context for away team {away_team_id}")
-
     game_date = fixture.game_date or datetime.now(timezone.utc).date().isoformat()
-    home_snapshot = _build_snapshot_payload(team_contexts[home_team_id], game_date)
-    away_snapshot = _build_snapshot_payload(team_contexts[away_team_id], game_date)
+    home_snapshot = _snapshot_as_of(snapshot_index, home_team_id, game_date)
+    away_snapshot = _snapshot_as_of(snapshot_index, away_team_id, game_date)
+    if home_snapshot is None:
+        raise ValueError(f"Missing point-in-time snapshot for home team {home_team_id} as of {game_date}")
+    if away_snapshot is None:
+        raise ValueError(f"Missing point-in-time snapshot for away team {away_team_id} as of {game_date}")
+
+    prior_games = [game for game in recent_games if str(game.game_date) < game_date]
     matchup_frame = pd.DataFrame(
         [
             build_point_in_time_matchup_row(
@@ -694,12 +711,12 @@ def _build_offline_prediction(
                 team_b_id=away_team_id,
                 team_a_snapshot=home_snapshot,
                 team_b_snapshot=away_snapshot,
-                all_games=recent_games,
+                all_games=prior_games,
                 game_date=game_date,
                 snapshot_index=snapshot_index,
                 team_names={
-                    home_team_id: team_contexts[home_team_id].get("team_name"),
-                    away_team_id: team_contexts[away_team_id].get("team_name"),
+                    home_team_id: team_names.get(home_team_id) or fixture.home_team_name,
+                    away_team_id: team_names.get(away_team_id) or fixture.away_team_name,
                 },
                 game_id=f"prospective:{fixture.fixture_key}",
                 example_orientation="prospective",
@@ -785,7 +802,27 @@ def prepare_prospective_match_predictions(
             if resolution.team_id_master
         }
     )
-    recent_games = _fetch_recent_games(supabase, resolved_team_ids, lookback_days)
+    resolved_fixture_dates = sorted(
+        {
+            fixture.game_date
+            for fixture in fixtures
+            if resolution_index.get((fixture.provider_code, fixture.home_provider_team_id), TeamResolution(None, None)).team_id_master
+            and resolution_index.get((fixture.provider_code, fixture.away_provider_team_id), TeamResolution(None, None)).team_id_master
+            and fixture.game_date
+        }
+    )
+    min_fixture_date = resolved_fixture_dates[0] if resolved_fixture_dates else None
+    max_fixture_date = resolved_fixture_dates[-1] if resolved_fixture_dates else None
+    recent_game_start = None
+    if min_fixture_date:
+        recent_game_start = (pd.Timestamp(min_fixture_date).date() - timedelta(days=lookback_days)).isoformat()
+    recent_games = _fetch_recent_games(
+        supabase,
+        resolved_team_ids,
+        lookback_days,
+        start_date=recent_game_start,
+        end_date=max_fixture_date,
+    )
     involved_team_ids = set(resolved_team_ids)
     for game in recent_games:
         if game.home_team_master_id:
@@ -793,8 +830,20 @@ def prepare_prospective_match_predictions(
         if game.away_team_master_id:
             involved_team_ids.add(str(game.away_team_master_id))
 
-    team_contexts = _fetch_team_contexts(supabase, involved_team_ids)
-    snapshot_index = _build_snapshot_index(team_contexts, datetime.now(timezone.utc).date().isoformat())
+    team_names: Dict[str, str] = {}
+    snapshot_index: Dict[str, List[Dict[str, Any]]] = {}
+    if involved_team_ids and min_fixture_date and max_fixture_date:
+        snapshot_start = (pd.Timestamp(min_fixture_date).date() - timedelta(days=30)).isoformat()
+        snapshots_df = asyncio.run(
+            fetch_prediction_feature_snapshots(
+                supabase,
+                sorted(involved_team_ids),
+                snapshot_start,
+                max_fixture_date,
+            )
+        )
+        snapshot_index = build_historical_snapshot_index(snapshots_df)
+        team_names = asyncio.run(fetch_team_names(supabase, sorted(involved_team_ids)))
 
     model = None
     calibrator = None
@@ -893,7 +942,7 @@ def prepare_prospective_match_predictions(
                     fixture,
                     home_team_id=str(home_resolution.team_id_master),
                     away_team_id=str(away_resolution.team_id_master),
-                    team_contexts=team_contexts,
+                    team_names=team_names,
                     recent_games=recent_games,
                     snapshot_index=snapshot_index,
                     model=model,

--- a/tests/unit/test_prepare_prospective_match_predictions.py
+++ b/tests/unit/test_prepare_prospective_match_predictions.py
@@ -1,5 +1,9 @@
 import json
 
+import pandas as pd
+
+from scripts import prepare_prospective_match_predictions as prospective
+from scripts.predictor_python import Game as PredictorGame
 from scripts.prepare_prospective_match_predictions import load_fixtures_from_jsonl
 
 
@@ -47,3 +51,148 @@ def test_load_fixtures_from_jsonl_dedupes_home_and_away_rows(tmp_path):
     assert fixture.home_team_name == "Home Team"
     assert fixture.away_team_name == "Away Team"
     assert fixture.fixture_key.startswith("gotsport|555|2026-04-15")
+
+
+def test_build_offline_prediction_uses_asof_snapshots_and_only_prior_games(monkeypatch):
+    fixture = prospective.FixtureRecord(
+        fixture_key="gotsport|555|2026-04-10|home|away|field-1|u12-gold",
+        provider_code="gotsport",
+        source_system="gotsport_event_schedule",
+        source_artifact_path="artifact.jsonl",
+        source_event_id="555",
+        source_match_key="555_111_222_2026-04-10",
+        game_date="2026-04-10",
+        competition="Spring Showcase",
+        division_name="U12 Gold",
+        venue="Field 1",
+        home_provider_team_id="111",
+        away_provider_team_id="222",
+        home_team_name="Home Team",
+        away_team_name="Away Team",
+        fixture_payload={},
+    )
+    snapshot_index = {
+        "home-team": [
+            {
+                "team_id": "home-team",
+                "snapshot_date": "2026-04-09",
+                "snapshot_ts": pd.Timestamp("2026-04-09"),
+                "age_group": "12",
+                "gender": "Male",
+                "status": "Active",
+                "power_score_final": 0.55,
+            },
+            {
+                "team_id": "home-team",
+                "snapshot_date": "2026-04-11",
+                "snapshot_ts": pd.Timestamp("2026-04-11"),
+                "age_group": "12",
+                "gender": "Male",
+                "status": "Active",
+                "power_score_final": 0.99,
+            },
+        ],
+        "away-team": [
+            {
+                "team_id": "away-team",
+                "snapshot_date": "2026-04-08",
+                "snapshot_ts": pd.Timestamp("2026-04-08"),
+                "age_group": "12",
+                "gender": "Male",
+                "status": "Active",
+                "power_score_final": 0.44,
+            },
+            {
+                "team_id": "away-team",
+                "snapshot_date": "2026-04-12",
+                "snapshot_ts": pd.Timestamp("2026-04-12"),
+                "age_group": "12",
+                "gender": "Male",
+                "status": "Active",
+                "power_score_final": 0.11,
+            },
+        ],
+    }
+    recent_games = [
+        PredictorGame(
+            id="prior-game",
+            home_team_master_id="home-team",
+            away_team_master_id="common-opponent",
+            home_score=2,
+            away_score=1,
+            game_date="2026-04-09",
+        ),
+        PredictorGame(
+            id="same-day-game",
+            home_team_master_id="away-team",
+            away_team_master_id="common-opponent",
+            home_score=1,
+            away_score=1,
+            game_date="2026-04-10",
+        ),
+        PredictorGame(
+            id="future-game",
+            home_team_master_id="home-team",
+            away_team_master_id="away-team",
+            home_score=3,
+            away_score=0,
+            game_date="2026-04-11",
+        ),
+    ]
+    captured = {}
+
+    def fake_build_point_in_time_matchup_row(**kwargs):
+        captured["team_a_snapshot"] = kwargs["team_a_snapshot"]
+        captured["team_b_snapshot"] = kwargs["team_b_snapshot"]
+        captured["prior_game_ids"] = [game.id for game in kwargs["all_games"]]
+        return {"dummy_feature": 1.0}
+
+    class FakeModel:
+        def predict_frame(self, frame):
+            captured["frame_columns"] = list(frame.columns)
+            return pd.DataFrame(
+                [
+                    {
+                        "predicted_outcome": "team_a",
+                        "prob_team_a_win": 0.52,
+                        "prob_draw": 0.24,
+                        "prob_team_b_win": 0.24,
+                        "expected_goals_a": 1.6,
+                        "expected_goals_b": 1.1,
+                        "predicted_score_a": 2,
+                        "predicted_score_b": 1,
+                        "predicted_margin": 0.5,
+                        "probability_strategy": "poisson_draw_gate",
+                        "blowout_3plus_probability": 0.1,
+                        "blowout_5plus_probability": 0.02,
+                        "predicted_blowout_3plus": 0,
+                        "predicted_blowout_5plus": 0,
+                        "stalemate_signal": 0.3,
+                        "projected_total_goals": 2.7,
+                        "poisson_prob_team_a_win": 0.5,
+                        "poisson_prob_draw": 0.25,
+                        "poisson_prob_team_b_win": 0.25,
+                        "draw_model_probability": 0.24,
+                    }
+                ]
+            )
+
+    monkeypatch.setattr(prospective, "build_point_in_time_matchup_row", fake_build_point_in_time_matchup_row)
+
+    payload = prospective._build_offline_prediction(
+        fixture,
+        home_team_id="home-team",
+        away_team_id="away-team",
+        team_names={"home-team": "Home Team", "away-team": "Away Team"},
+        recent_games=recent_games,
+        snapshot_index=snapshot_index,
+        model=FakeModel(),
+        calibrator=None,
+        model_version="pitm_test_poisson_draw_gate",
+    )
+
+    assert captured["team_a_snapshot"]["snapshot_date"] == "2026-04-09"
+    assert captured["team_b_snapshot"]["snapshot_date"] == "2026-04-08"
+    assert captured["prior_game_ids"] == ["prior-game"]
+    assert payload["modelVersion"] == "pitm_test_poisson_draw_gate"
+    assert payload["prediction"]["predictedWinner"] == "team_a"


### PR DESCRIPTION
## Summary
- rebuild prospective offline predictions from point-in-time snapshots as of each fixture date
- cap recent-game context to games before the fixture date instead of using current context
- add a regression test covering as-of snapshot selection and pre-fixture game filtering

## Validation
- python -m pytest C:\\PitchRank_prepare_worktree\\tests\\unit\\test_prepare_prospective_match_predictions.py
- python -m py_compile C:\\PitchRank_prepare_worktree\\scripts\\prepare_prospective_match_predictions.py C:\\PitchRank_prepare_worktree\\tests\\unit\\test_prepare_prospective_match_predictions.py
- local prospective refresh/evaluation reruns for retrained poisson_draw_gate and hybrid