### PR TITLE
Fix PIT historical game pagination

### DIFF
--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -65,17 +65,17 @@ async def fetch_historical_games(
 
     logger.info(f"Fetching historical games from {cutoff_date}...")
 
-    # Base query
-    query = (
-        supabase.table("games")
-        .select("id, game_date, home_team_master_id, away_team_master_id, home_score, away_score")
-        .not_.is_("home_team_master_id", "null")
-        .not_.is_("away_team_master_id", "null")
-        .not_.is_("home_score", "null")
-        .not_.is_("away_score", "null")
-        .gte("game_date", cutoff_date)
-        .order("game_date", desc=False)  # Oldest first for consistent processing
-    )
+    def build_base_query():
+        return (
+            supabase.table("games")
+            .select("id, game_date, home_team_master_id, away_team_master_id, home_score, away_score")
+            .not_.is_("home_team_master_id", "null")
+            .not_.is_("away_team_master_id", "null")
+            .not_.is_("home_score", "null")
+            .not_.is_("away_score", "null")
+            .gte("game_date", cutoff_date)
+            .order("game_date", desc=False)  # Oldest first for consistent processing
+        )
 
     # If test slice specified, filter by state and age_group via teams table
     if test_slice:
@@ -90,7 +90,7 @@ async def fetch_historical_games(
     offset = 0
 
     while True:
-        batch_query = query.range(offset, offset + batch_size - 1)
+        batch_query = build_base_query().range(offset, offset + batch_size - 1)
 
         try:
             response = batch_query.execute()

--- a/tests/unit/test_backtest_predictor.py
+++ b/tests/unit/test_backtest_predictor.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from scripts.backtest_predictor import fetch_historical_games
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    def __init__(self, batches):
+        self._batches = batches
+        self._range_calls = []
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    @property
+    def not_(self):
+        return self
+
+    def is_(self, *_args, **_kwargs):
+        return self
+
+    def gte(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def range(self, start, end):
+        self._range_calls.append((start, end))
+        return self
+
+    def execute(self):
+        if len(self._range_calls) != 1:
+            raise AssertionError(f"expected one range call per query, got {self._range_calls}")
+        start, _end = self._range_calls[0]
+        batch_index = start // 1000
+        return _FakeResponse(self._batches[batch_index] if batch_index < len(self._batches) else [])
+
+
+class _FakeSupabase:
+    def __init__(self, batches):
+        self._batches = batches
+        self.queries = []
+
+    def table(self, name):
+        assert name == "games"
+        query = _FakeQuery(self._batches)
+        self.queries.append(query)
+        return query
+
+
+def test_fetch_historical_games_rebuilds_query_each_batch():
+    batches = [
+        [
+            {
+                "id": "game-1",
+                "game_date": "2026-04-01",
+                "home_team_master_id": "home-1",
+                "away_team_master_id": "away-1",
+                "home_score": 2,
+                "away_score": 1,
+            }
+        ]
+        * 1000,
+        [
+            {
+                "id": "game-2",
+                "game_date": "2026-04-02",
+                "home_team_master_id": "home-2",
+                "away_team_master_id": "away-2",
+                "home_score": 3,
+                "away_score": 0,
+            }
+        ],
+    ]
+    supabase = _FakeSupabase(batches)
+
+    games_df = asyncio.run(fetch_historical_games(supabase, lookback_days=30))
+
+    assert len(games_df) == 1001
+    assert [query._range_calls for query in supabase.queries] == [[(0, 999)], [(1000, 1999)]]


### PR DESCRIPTION
## Summary
- rebuild the historical games query for each pagination batch instead of mutating one long-lived query object
- prevent stacked offset/limit parameters that cause PostgREST timeouts on larger training windows
- add a regression test covering one-range-per-query behavior

## Validation
- python -m pytest C:\\PitchRank_prepare_worktree\\tests\\unit\\test_backtest_predictor.py
- python -m py_compile C:\\PitchRank_prepare_worktree\\scripts\\backtest_predictor.py C:\\PitchRank_prepare_worktree\\tests\\unit\\test_backtest_predictor.py