### PR TITLE
Replace mission control with model snapshot dashboard

### DIFF
--- a/frontend/app/api/mission-control/model-snapshot/route.ts
+++ b/frontend/app/api/mission-control/model-snapshot/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { buildMissionControlSnapshot, type ProspectiveSnapshotRow } from '@/lib/mission-control/modelSnapshot';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
+
+export const dynamic = 'force-dynamic';
+
+const PROSPECTIVE_PAGE_SIZE = 1000;
+
+async function fetchAllProspectiveRows(): Promise<ProspectiveSnapshotRow[]> {
+  const supabase = createServiceSupabase();
+  const rows: ProspectiveSnapshotRow[] = [];
+
+  for (let offset = 0; ; offset += PROSPECTIVE_PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('prospective_match_predictions')
+      .select(
+        'fixture_key, game_date, resolution_status, heuristic_prediction_status, heuristic_model_version, heuristic_prediction, heuristic_predicted_at, offline_prediction_status, offline_model_version, offline_prediction, offline_predicted_at, actual_home_score, actual_away_score, actual_outcome, evaluation_status'
+      )
+      .order('game_date', { ascending: false })
+      .range(offset, offset + PROSPECTIVE_PAGE_SIZE - 1);
+
+    if (error) throw error;
+    const batch = (data ?? []) as ProspectiveSnapshotRow[];
+    rows.push(...batch);
+    if (batch.length < PROSPECTIVE_PAGE_SIZE) break;
+  }
+
+  return rows;
+}
+
+async function fetchPredictionFeatureHistoryCount(): Promise<number | null> {
+  const supabase = createServiceSupabase();
+  const { count, error } = await supabase.from('prediction_feature_history').select('team_id', { count: 'exact', head: true });
+  if (error) throw error;
+  return count ?? null;
+}
+
+async function fetchScoredGamesCount(filters?: { fromDate?: string }): Promise<number | null> {
+  const supabase = createServiceSupabase();
+  let query = supabase.from('games').select('id', { count: 'exact', head: true }).not('home_score', 'is', null).not('away_score', 'is', null);
+  if (filters?.fromDate) {
+    query = query.gte('game_date', filters.fromDate);
+  }
+  const { count, error } = await query;
+  if (error) throw error;
+  return count ?? null;
+}
+
+async function fetchPitCoverage() {
+  const supabase = createServiceSupabase();
+  const [{ data: firstSnapshotRows, error: firstError }, { data: lastSnapshotRows, error: lastError }, snapshotRows] =
+    await Promise.all([
+      supabase.from('prediction_feature_history').select('snapshot_date').order('snapshot_date', { ascending: true }).limit(1),
+      supabase.from('prediction_feature_history').select('snapshot_date').order('snapshot_date', { ascending: false }).limit(1),
+      fetchPredictionFeatureHistoryCount(),
+    ]);
+
+  if (firstError) throw firstError;
+  if (lastError) throw lastError;
+
+  const windowStart = firstSnapshotRows?.[0]?.snapshot_date ?? null;
+  const windowEnd = lastSnapshotRows?.[0]?.snapshot_date ?? null;
+
+  const now = new Date();
+  const last365 = new Date(Date.UTC(now.getUTCFullYear() - 1, now.getUTCMonth(), now.getUTCDate())).toISOString().slice(0, 10);
+
+  const [totalScoredGames, trainableScoredGames, last365ScoredGames, last365TrainableGames] = await Promise.all([
+    fetchScoredGamesCount(),
+    windowStart ? fetchScoredGamesCount({ fromDate: windowStart }) : Promise.resolve(null),
+    fetchScoredGamesCount({ fromDate: last365 }),
+    windowStart ? fetchScoredGamesCount({ fromDate: windowStart > last365 ? windowStart : last365 }) : Promise.resolve(null),
+  ]);
+
+  return {
+    snapshotRows,
+    windowStart,
+    windowEnd,
+    totalScoredGames,
+    trainableScoredGames,
+    last365ScoredGames,
+    last365TrainableGames,
+  };
+}
+
+export async function GET() {
+  const auth = await requireAdmin();
+  if (auth.error) return auth.error;
+
+  try {
+    const [rows, pitCoverage] = await Promise.all([fetchAllProspectiveRows(), fetchPitCoverage()]);
+    const snapshot = buildMissionControlSnapshot(rows, pitCoverage);
+    return NextResponse.json(snapshot);
+  } catch (error) {
+    console.error('Mission control snapshot error:', error);
+    return NextResponse.json({ error: 'Failed to build mission control snapshot' }, { status: 500 });
+  }
+}

--- a/frontend/app/mission-control/page.tsx
+++ b/frontend/app/mission-control/page.tsx
@@ -1,26 +1,20 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { DateRangeSelector } from '@/components/analytics/DateRangeSelector';
-import { SearchConsoleTab } from '@/components/analytics/SearchConsoleTab';
-import { TrafficTab } from '@/components/analytics/TrafficTab';
-import { FunnelTab } from '@/components/analytics/FunnelTab';
+import { ModelSnapshotDashboard } from '@/components/mission-control/ModelSnapshotDashboard';
 import { useUser, hasAdminAccess } from '@/hooks/useUser';
 
 export default function MissionControlPage() {
   const { user, profile, isLoading: userLoading } = useUser();
-  const [range, setRange] = useState('28d');
 
   if (userLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black">
         <div className="container mx-auto p-6">
           <div className="animate-pulse space-y-6">
-            <div className="h-12 bg-white/5 rounded-xl w-64" />
-            <div className="h-96 bg-white/5 rounded-xl" />
+            <div className="h-12 w-64 rounded-xl bg-white/5" />
+            <div className="h-96 rounded-xl bg-white/5" />
           </div>
         </div>
       </div>
@@ -31,9 +25,9 @@ export default function MissionControlPage() {
     return (
       <div className="min-h-screen bg-background">
         <div className="container px-4 py-16">
-          <div className="text-center max-w-md mx-auto">
-            <h1 className="text-2xl font-display mb-3">Page Not Found</h1>
-            <p className="text-muted-foreground mb-6">The page you are looking for does not exist.</p>
+          <div className="mx-auto max-w-md text-center">
+            <h1 className="mb-3 text-2xl font-display">Page Not Found</h1>
+            <p className="mb-6 text-muted-foreground">The page you are looking for does not exist.</p>
             <Link href="/">
               <Button size="lg">Go Home</Button>
             </Link>
@@ -44,52 +38,16 @@ export default function MissionControlPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">
-      <div className="container mx-auto p-6 space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="font-display text-3xl font-bold tracking-tight">Mission Control</h1>
-            <p className="mt-1 text-sm text-gray-400">Traffic, search performance, and conversion analytics</p>
-          </div>
-          <DateRangeSelector value={range} onChange={setRange} />
+    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-black text-white">
+      <div className="container mx-auto space-y-6 p-6">
+        <div className="space-y-2">
+          <h1 className="font-display text-3xl font-bold tracking-tight">Mission Control</h1>
+          <p className="max-w-3xl text-sm text-gray-400">
+            Live snapshot of model accuracy, prospective evaluation coverage, and point-in-time training readiness.
+          </p>
         </div>
 
-        {/* Tabs */}
-        <Tabs defaultValue="search-console">
-          <TabsList className="bg-white/5 border border-white/10">
-            <TabsTrigger
-              value="search-console"
-              className="data-[state=active]:bg-white/10 data-[state=active]:text-white text-gray-400"
-            >
-              Search Console
-            </TabsTrigger>
-            <TabsTrigger
-              value="traffic"
-              className="data-[state=active]:bg-white/10 data-[state=active]:text-white text-gray-400"
-            >
-              Traffic
-            </TabsTrigger>
-            <TabsTrigger
-              value="funnel"
-              className="data-[state=active]:bg-white/10 data-[state=active]:text-white text-gray-400"
-            >
-              Funnel
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="search-console" className="mt-6">
-            <SearchConsoleTab range={range} />
-          </TabsContent>
-
-          <TabsContent value="traffic" className="mt-6">
-            <TrafficTab range={range} />
-          </TabsContent>
-
-          <TabsContent value="funnel" className="mt-6">
-            <FunnelTab range={range} />
-          </TabsContent>
-        </Tabs>
+        <ModelSnapshotDashboard />
       </div>
     </div>
   );

--- a/frontend/components/mission-control/ModelSnapshotDashboard.tsx
+++ b/frontend/components/mission-control/ModelSnapshotDashboard.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useMissionControlSnapshot } from '@/hooks/useMissionControl';
+import type { MissionControlSnapshot, ModelPerformanceSummary, ModelVersionSummary } from '@/types/mission-control';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { LastUpdated } from '@/components/ui/LastUpdated';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { MetricCard } from '@/components/analytics/MetricCard';
+
+function formatPercent(value: number | null | undefined, digits = 2): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatNumber(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return value.toLocaleString();
+}
+
+function formatDecimal(value: number | null | undefined, digits = 3): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return value.toFixed(digits);
+}
+
+function formatShortDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function SectionSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-10 w-64 bg-white/10" />
+      <Skeleton className="h-48 w-full bg-white/10" />
+    </div>
+  );
+}
+
+function ComparisonTable({ heuristic, offline, sharedSettledGames }: { heuristic: ModelPerformanceSummary; offline: ModelPerformanceSummary; sharedSettledGames: number }) {
+  const rows = [
+    ['Settled games', formatNumber(sharedSettledGames), formatNumber(sharedSettledGames)],
+    ['Winner accuracy', formatPercent(heuristic.winnerAccuracy), formatPercent(offline.winnerAccuracy)],
+    ['Draw recall', formatPercent(heuristic.drawRecall), formatPercent(offline.drawRecall)],
+    ['Predicted draw rate', formatPercent(heuristic.predictedDrawRate), formatPercent(offline.predictedDrawRate)],
+    ['Log loss', formatDecimal(heuristic.logLoss), formatDecimal(offline.logLoss)],
+    ['Brier score', formatDecimal(heuristic.brierScore), formatDecimal(offline.brierScore)],
+    ['Margin MAE', formatDecimal(heuristic.marginMae), formatDecimal(offline.marginMae)],
+    ['Exact score accuracy', formatPercent(heuristic.exactScoreAccuracy), formatPercent(offline.exactScoreAccuracy)],
+  ];
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/5">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableHead className="text-gray-400">Metric</TableHead>
+            <TableHead className="text-right text-gray-400">Live heuristic</TableHead>
+            <TableHead className="text-right text-gray-400">Offline benchmark</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map(([label, heuristicValue, offlineValue]) => (
+            <TableRow key={label} className="border-white/10 hover:bg-white/5">
+              <TableCell className="text-white">{label}</TableCell>
+              <TableCell className="text-right text-gray-300">{heuristicValue}</TableCell>
+              <TableCell className="text-right text-gray-300">{offlineValue}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function VersionTable({ versions }: { versions: ModelVersionSummary[] }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/5">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableHead className="text-gray-400">Offline model version</TableHead>
+            <TableHead className="text-right text-gray-400">Games</TableHead>
+            <TableHead className="text-right text-gray-400">Winner acc.</TableHead>
+            <TableHead className="text-right text-gray-400">Draw recall</TableHead>
+            <TableHead className="text-right text-gray-400">Log loss</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {versions.slice(0, 8).map((version) => (
+            <TableRow key={version.modelVersion ?? 'unknown'} className="border-white/10 hover:bg-white/5">
+              <TableCell className="max-w-[320px] truncate text-white" title={version.modelVersion ?? 'Unknown'}>
+                {version.modelVersion ?? 'Unknown'}
+              </TableCell>
+              <TableCell className="text-right text-gray-300">{formatNumber(version.games)}</TableCell>
+              <TableCell className="text-right text-gray-300">{formatPercent(version.winnerAccuracy)}</TableCell>
+              <TableCell className="text-right text-gray-300">{formatPercent(version.drawRecall)}</TableCell>
+              <TableCell className="text-right text-gray-300">{formatDecimal(version.logLoss)}</TableCell>
+            </TableRow>
+          ))}
+          {versions.length === 0 && (
+            <TableRow className="border-white/10">
+              <TableCell colSpan={5} className="text-center text-gray-500">
+                No evaluated offline versions yet
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function StatusTable({ snapshot }: { snapshot: MissionControlSnapshot }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/5">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableHead className="text-gray-400">Pipeline state</TableHead>
+            <TableHead className="text-right text-gray-400">Count</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Settled</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.settled)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Pending result</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.pendingResult)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Pending resolution</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.pendingResolution)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Result not found</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.resultNotFound)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Ambiguous result</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.ambiguousResult)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Heuristic errors</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.heuristicError)}</TableCell>
+          </TableRow>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableCell className="text-white">Offline errors</TableCell>
+            <TableCell className="text-right text-gray-300">{formatNumber(snapshot.pipeline.offlineError)}</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function ModelSnapshotDashboard() {
+  const { data, isLoading, error, refetch } = useMissionControlSnapshot();
+
+  if (error) {
+    return <ErrorDisplay error={error} retry={refetch} />;
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-2 gap-4 xl:grid-cols-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <MetricCard key={index} title="Loading" value="—" loading />
+          ))}
+        </div>
+        <SectionSkeleton />
+        <SectionSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="border-white/20 text-gray-200">
+              Live: {data.currentHeuristicVersion ?? 'Unknown'}
+            </Badge>
+            <Badge variant="outline" className="border-emerald-400/30 text-emerald-200">
+              Offline: {data.currentOfflineVersion ?? 'Unknown'}
+            </Badge>
+          </div>
+          <p className="max-w-3xl text-sm text-gray-400">
+            Snapshot based on settled prospective fixtures with frozen pregame predictions. This is the clean head-to-head view
+            of the live heuristic path versus the current offline benchmark.
+          </p>
+        </div>
+        <LastUpdated date={data.generatedAt} label="Snapshot generated" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 xl:grid-cols-6">
+        <MetricCard title="Shared Settled Games" value={formatNumber(data.sharedSettledGames)} />
+        <MetricCard title="Live Winner Acc." value={formatPercent(data.heuristic.winnerAccuracy)} />
+        <MetricCard title="Offline Winner Acc." value={formatPercent(data.offline.winnerAccuracy)} />
+        <MetricCard title="Live Draw Recall" value={formatPercent(data.heuristic.drawRecall)} />
+        <MetricCard title="Offline Draw Recall" value={formatPercent(data.offline.drawRecall)} />
+        <MetricCard
+          title="Winner Disagreement"
+          value={formatPercent(data.headToHead.winnerDisagreementRate)}
+          subtitle="Offline minus heuristic draw lift shown below"
+        />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.6fr_1fr]">
+        <Card variant="flat" className="border-white/10 bg-white/5">
+          <CardHeader className="border-b border-white/10">
+            <CardTitle className="text-white">Current Model Comparison</CardTitle>
+            <CardDescription className="text-gray-400">
+              Offline draw probability lift: {formatPercent(data.headToHead.avgDrawProbabilityDeltaOfflineMinusHeuristic)}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6">
+            <ComparisonTable heuristic={data.heuristic} offline={data.offline} sharedSettledGames={data.sharedSettledGames} />
+          </CardContent>
+        </Card>
+
+        <Card variant="flat" className="border-white/10 bg-white/5">
+          <CardHeader className="border-b border-white/10">
+            <CardTitle className="text-white">Pipeline Snapshot</CardTitle>
+            <CardDescription className="text-gray-400">
+              Frozen fixture coverage and current evaluation backlog
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-6">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCard title="Total Fixtures" value={formatNumber(data.pipeline.totalFixtures)} />
+              <MetricCard title="Pending Result" value={formatNumber(data.pipeline.pendingResult)} />
+              <MetricCard title="Pending Resolution" value={formatNumber(data.pipeline.pendingResolution)} />
+              <MetricCard title="Result Not Found" value={formatNumber(data.pipeline.resultNotFound)} />
+            </div>
+            <StatusTable snapshot={data} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1fr_1.2fr]">
+        <Card variant="flat" className="border-white/10 bg-white/5">
+          <CardHeader className="border-b border-white/10">
+            <CardTitle className="text-white">PIT Coverage</CardTitle>
+            <CardDescription className="text-gray-400">Live snapshot coverage for leakage-safe training</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-6">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCard title="Snapshot Rows" value={formatNumber(data.pitCoverage.snapshotRows)} />
+              <MetricCard title="Scored Games" value={formatNumber(data.pitCoverage.totalScoredGames)} />
+              <MetricCard title="Trainable Games" value={formatNumber(data.pitCoverage.trainableScoredGames)} />
+              <MetricCard title="Last 365d Trainable" value={formatNumber(data.pitCoverage.last365TrainableGames)} />
+            </div>
+            <div className="rounded-lg border border-white/10 bg-black/20 p-4 text-sm text-gray-300">
+              <div className="flex items-center justify-between gap-4">
+                <span>PIT window start</span>
+                <span>{formatShortDate(data.pitCoverage.windowStart)}</span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-4">
+                <span>PIT window end</span>
+                <span>{formatShortDate(data.pitCoverage.windowEnd)}</span>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-4">
+                <span>Last 365d scored games</span>
+                <span>{formatNumber(data.pitCoverage.last365ScoredGames)}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card variant="flat" className="border-white/10 bg-white/5">
+          <CardHeader className="border-b border-white/10">
+            <CardTitle className="text-white">Offline Version Benchmarks</CardTitle>
+            <CardDescription className="text-gray-400">
+              Settled prospective performance by offline model version
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6">
+            <VersionTable versions={data.offlineVersions} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useMissionControl.ts
+++ b/frontend/hooks/useMissionControl.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { MissionControlSnapshot } from '@/types/mission-control';
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(body.error || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export function useMissionControlSnapshot() {
+  return useQuery<MissionControlSnapshot>({
+    queryKey: ['mission-control', 'model-snapshot'],
+    queryFn: () => fetchJson('/api/mission-control/model-snapshot'),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/frontend/lib/mission-control/modelSnapshot.test.ts
+++ b/frontend/lib/mission-control/modelSnapshot.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { buildMissionControlSnapshot, type ProspectiveSnapshotRow } from './modelSnapshot';
+
+describe('buildMissionControlSnapshot', () => {
+  it('builds current model summaries from settled prospective rows', () => {
+    const rows: ProspectiveSnapshotRow[] = [
+      {
+        fixture_key: 'fixture-1',
+        game_date: '2026-04-10',
+        resolution_status: 'resolved',
+        heuristic_prediction_status: 'completed',
+        heuristic_model_version: 'heuristic_v3',
+        heuristic_prediction: {
+          response: {
+            prediction: {
+              predictedWinner: 'team_a',
+              winProbabilityA: 0.6,
+              drawProbability: 0.2,
+              winProbabilityB: 0.2,
+              expectedScore: { teamA: 2, teamB: 1 },
+              expectedMargin: 1,
+            },
+          },
+          modelVersion: 'heuristic_v3',
+        },
+        heuristic_predicted_at: '2026-04-09T10:00:00Z',
+        offline_prediction_status: 'completed',
+        offline_model_version: 'pitm_hybrid',
+        offline_prediction: {
+          prediction: {
+            predictedWinner: 'draw',
+            winProbabilityA: 0.3,
+            drawProbability: 0.4,
+            winProbabilityB: 0.3,
+            expectedScore: { teamA: 1, teamB: 1 },
+            expectedMargin: 0,
+          },
+          modelVersion: 'pitm_hybrid',
+        },
+        offline_predicted_at: '2026-04-09T11:00:00Z',
+        actual_home_score: 1,
+        actual_away_score: 1,
+        actual_outcome: 'draw',
+        evaluation_status: 'settled',
+      },
+      {
+        fixture_key: 'fixture-2',
+        game_date: '2026-04-11',
+        resolution_status: 'resolved',
+        heuristic_prediction_status: 'completed',
+        heuristic_model_version: 'heuristic_v3',
+        heuristic_prediction: {
+          response: {
+            prediction: {
+              predictedWinner: 'team_b',
+              winProbabilityA: 0.1,
+              drawProbability: 0.2,
+              winProbabilityB: 0.7,
+              expectedScore: { teamA: 0, teamB: 2 },
+              expectedMargin: -2,
+            },
+          },
+          modelVersion: 'heuristic_v3',
+        },
+        heuristic_predicted_at: '2026-04-10T10:00:00Z',
+        offline_prediction_status: 'completed',
+        offline_model_version: 'pitm_hybrid',
+        offline_prediction: {
+          prediction: {
+            predictedWinner: 'team_b',
+            winProbabilityA: 0.15,
+            drawProbability: 0.25,
+            winProbabilityB: 0.6,
+            expectedScore: { teamA: 1, teamB: 2 },
+            expectedMargin: -1,
+          },
+          modelVersion: 'pitm_hybrid',
+        },
+        offline_predicted_at: '2026-04-10T11:00:00Z',
+        actual_home_score: 0,
+        actual_away_score: 2,
+        actual_outcome: 'team_b',
+        evaluation_status: 'settled',
+      },
+      {
+        fixture_key: 'fixture-3',
+        game_date: '2026-04-12',
+        resolution_status: 'unresolved',
+        heuristic_prediction_status: 'pending',
+        heuristic_model_version: null,
+        heuristic_prediction: null,
+        heuristic_predicted_at: null,
+        offline_prediction_status: 'error',
+        offline_model_version: 'pitm_hybrid',
+        offline_prediction: null,
+        offline_predicted_at: null,
+        actual_home_score: null,
+        actual_away_score: null,
+        actual_outcome: null,
+        evaluation_status: 'pending_result',
+      },
+    ];
+
+    const snapshot = buildMissionControlSnapshot(rows, {
+      snapshotRows: 100,
+      windowStart: '2025-08-01',
+      windowEnd: '2026-04-14',
+      totalScoredGames: 1000,
+      trainableScoredGames: 600,
+      last365ScoredGames: 800,
+      last365TrainableGames: 600,
+    });
+
+    expect(snapshot.currentHeuristicVersion).toBe('heuristic_v3');
+    expect(snapshot.currentOfflineVersion).toBe('pitm_hybrid');
+    expect(snapshot.sharedSettledGames).toBe(2);
+    expect(snapshot.pipeline.totalFixtures).toBe(3);
+    expect(snapshot.pipeline.pendingResult).toBe(1);
+    expect(snapshot.pipeline.pendingResolution).toBe(1);
+    expect(snapshot.pipeline.offlineError).toBe(1);
+    expect(snapshot.heuristic.games).toBe(2);
+    expect(snapshot.offline.games).toBe(2);
+    expect(snapshot.heuristic.winnerAccuracy).toBe(0.5);
+    expect(snapshot.offline.winnerAccuracy).toBe(1);
+    expect(snapshot.offline.drawRecall).toBe(1);
+    expect(snapshot.headToHead.fixturesWithBothPredictions).toBe(2);
+    expect(snapshot.headToHead.winnerDisagreementRate).toBe(0.5);
+  });
+});

--- a/frontend/lib/mission-control/modelSnapshot.ts
+++ b/frontend/lib/mission-control/modelSnapshot.ts
@@ -1,0 +1,391 @@
+import type {
+  HeadToHeadSummary,
+  MatchOutcome,
+  MissionControlSnapshot,
+  ModelPerformanceSummary,
+  ModelVersionSummary,
+  PipelineSummary,
+} from '@/types/mission-control';
+
+const EPSILON = 1e-15;
+
+export interface ProspectiveSnapshotRow {
+  fixture_key: string;
+  game_date: string | null;
+  resolution_status: string | null;
+  heuristic_prediction_status: string | null;
+  heuristic_model_version: string | null;
+  heuristic_prediction: unknown;
+  heuristic_predicted_at: string | null;
+  offline_prediction_status: string | null;
+  offline_model_version: string | null;
+  offline_prediction: unknown;
+  offline_predicted_at: string | null;
+  actual_home_score: number | null;
+  actual_away_score: number | null;
+  actual_outcome: string | null;
+  evaluation_status: string | null;
+}
+
+interface ParsedPredictionRow {
+  fixtureKey: string;
+  gameDate: string | null;
+  actualOutcome: MatchOutcome;
+  actualScoreA: number | null;
+  actualScoreB: number | null;
+  actualMargin: number | null;
+  predictedOutcome: MatchOutcome;
+  probTeamAWin: number;
+  probDraw: number;
+  probTeamBWin: number;
+  predictedScoreA: number | null;
+  predictedScoreB: number | null;
+  predictedMargin: number | null;
+  predictedAt: string | null;
+  modelVersion: string | null;
+}
+
+function safeJson(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function safeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeOutcome(value: unknown): MatchOutcome | null {
+  if (value === 'team_a' || value === 'team_a_win') return 'team_a';
+  if (value === 'team_b' || value === 'team_b_win') return 'team_b';
+  if (value === 'draw') return 'draw';
+  return null;
+}
+
+function buildActualOutcome(row: ProspectiveSnapshotRow): MatchOutcome | null {
+  const normalized = normalizeOutcome(row.actual_outcome);
+  if (normalized) return normalized;
+  if (row.actual_home_score == null || row.actual_away_score == null) return null;
+  if (row.actual_home_score > row.actual_away_score) return 'team_a';
+  if (row.actual_away_score > row.actual_home_score) return 'team_b';
+  return 'draw';
+}
+
+function normalizeProbabilities(probTeamAWin: number | null, probDraw: number | null, probTeamBWin: number | null) {
+  const rawA = Math.max(0, probTeamAWin ?? 0);
+  const rawDraw = Math.max(0, probDraw ?? 0);
+  const rawB = Math.max(0, probTeamBWin ?? 0);
+  const sum = rawA + rawDraw + rawB;
+  if (sum <= 0) {
+    return {
+      teamA: 1 / 3,
+      draw: 1 / 3,
+      teamB: 1 / 3,
+    };
+  }
+  return {
+    teamA: rawA / sum,
+    draw: rawDraw / sum,
+    teamB: rawB / sum,
+  };
+}
+
+function argmaxOutcome(probTeamAWin: number, probDraw: number, probTeamBWin: number): MatchOutcome {
+  if (probDraw >= probTeamAWin && probDraw >= probTeamBWin) return 'draw';
+  return probTeamAWin >= probTeamBWin ? 'team_a' : 'team_b';
+}
+
+function parsePrediction(row: ProspectiveSnapshotRow, kind: 'heuristic' | 'offline'): ParsedPredictionRow | null {
+  const actualOutcome = buildActualOutcome(row);
+  if (!actualOutcome) return null;
+
+  const payload = safeJson(kind === 'heuristic' ? row.heuristic_prediction : row.offline_prediction);
+  const prediction =
+    kind === 'heuristic'
+      ? safeJson(safeJson(payload.response).prediction)
+      : safeJson(payload.prediction);
+
+  if (Object.keys(prediction).length === 0) return null;
+
+  const probabilities = normalizeProbabilities(
+    safeNumber(prediction.winProbabilityA),
+    safeNumber(prediction.drawProbability),
+    safeNumber(prediction.winProbabilityB)
+  );
+
+  const expectedScore = safeJson(prediction.expectedScore);
+  const predictedOutcome = normalizeOutcome(prediction.predictedWinner) ?? argmaxOutcome(probabilities.teamA, probabilities.draw, probabilities.teamB);
+
+  return {
+    fixtureKey: row.fixture_key,
+    gameDate: row.game_date,
+    actualOutcome,
+    actualScoreA: row.actual_home_score,
+    actualScoreB: row.actual_away_score,
+    actualMargin:
+      row.actual_home_score != null && row.actual_away_score != null ? row.actual_home_score - row.actual_away_score : null,
+    predictedOutcome,
+    probTeamAWin: probabilities.teamA,
+    probDraw: probabilities.draw,
+    probTeamBWin: probabilities.teamB,
+    predictedScoreA: safeNumber(expectedScore.teamA),
+    predictedScoreB: safeNumber(expectedScore.teamB),
+    predictedMargin: safeNumber(prediction.expectedMargin),
+    predictedAt: kind === 'heuristic' ? row.heuristic_predicted_at : row.offline_predicted_at,
+    modelVersion:
+      kind === 'heuristic'
+        ? (typeof payload.modelVersion === 'string' ? payload.modelVersion : row.heuristic_model_version)
+        : (typeof payload.modelVersion === 'string' ? payload.modelVersion : row.offline_model_version),
+  };
+}
+
+function mean(values: number[]): number | null {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function roundScore(value: number | null): number | null {
+  return value == null ? null : Math.round(value);
+}
+
+function computeSummary(rows: ParsedPredictionRow[], modelVersion: string | null): ModelPerformanceSummary {
+  if (!rows.length) {
+    return {
+      modelVersion,
+      games: 0,
+      winnerAccuracy: null,
+      drawRecall: null,
+      drawPrecision: null,
+      actualDrawRate: null,
+      predictedDrawRate: null,
+      drawRateGap: null,
+      logLoss: null,
+      brierScore: null,
+      marginMae: null,
+      exactScoreAccuracy: null,
+      latestPredictedAt: null,
+    };
+  }
+
+  const correct: number[] = [];
+  const drawActualRows: ParsedPredictionRow[] = [];
+  const predictedDrawRows: ParsedPredictionRow[] = [];
+  const logLossTerms: number[] = [];
+  const brierTerms: number[] = [];
+  const marginErrors: number[] = [];
+  const exactScoreHits: number[] = [];
+
+  let latestPredictedAt: string | null = null;
+
+  for (const row of rows) {
+    correct.push(row.predictedOutcome === row.actualOutcome ? 1 : 0);
+    if (row.actualOutcome === 'draw') drawActualRows.push(row);
+    if (row.predictedOutcome === 'draw') predictedDrawRows.push(row);
+
+    const probs =
+      row.actualOutcome === 'team_a'
+        ? [row.probTeamAWin, row.probDraw, row.probTeamBWin]
+        : row.actualOutcome === 'draw'
+          ? [row.probDraw, row.probTeamAWin, row.probTeamBWin]
+          : [row.probTeamBWin, row.probTeamAWin, row.probDraw];
+    logLossTerms.push(-Math.log(Math.max(EPSILON, probs[0])));
+
+    const actual = {
+      team_a: row.actualOutcome === 'team_a' ? 1 : 0,
+      draw: row.actualOutcome === 'draw' ? 1 : 0,
+      team_b: row.actualOutcome === 'team_b' ? 1 : 0,
+    };
+    brierTerms.push(
+      (row.probTeamAWin - actual.team_a) ** 2 + (row.probDraw - actual.draw) ** 2 + (row.probTeamBWin - actual.team_b) ** 2
+    );
+
+    if (row.predictedMargin != null && row.actualMargin != null) {
+      marginErrors.push(Math.abs(row.predictedMargin - row.actualMargin));
+    }
+
+    if (
+      row.predictedScoreA != null &&
+      row.predictedScoreB != null &&
+      row.actualScoreA != null &&
+      row.actualScoreB != null
+    ) {
+      exactScoreHits.push(
+        roundScore(row.predictedScoreA) === row.actualScoreA && roundScore(row.predictedScoreB) === row.actualScoreB ? 1 : 0
+      );
+    }
+
+    if (row.predictedAt && (!latestPredictedAt || row.predictedAt > latestPredictedAt)) {
+      latestPredictedAt = row.predictedAt;
+    }
+  }
+
+  const winnerAccuracy = mean(correct);
+  const drawRecall = drawActualRows.length
+    ? drawActualRows.filter((row) => row.predictedOutcome === 'draw').length / drawActualRows.length
+    : null;
+  const drawPrecision = predictedDrawRows.length
+    ? predictedDrawRows.filter((row) => row.actualOutcome === 'draw').length / predictedDrawRows.length
+    : null;
+  const actualDrawRate = drawActualRows.length / rows.length;
+  const predictedDrawRate = predictedDrawRows.length / rows.length;
+
+  return {
+    modelVersion,
+    games: rows.length,
+    winnerAccuracy,
+    drawRecall,
+    drawPrecision,
+    actualDrawRate,
+    predictedDrawRate,
+    drawRateGap: Math.abs(predictedDrawRate - actualDrawRate),
+    logLoss: mean(logLossTerms),
+    brierScore: mean(brierTerms),
+    marginMae: mean(marginErrors),
+    exactScoreAccuracy: mean(exactScoreHits),
+    latestPredictedAt,
+  };
+}
+
+function buildVersionSummaries(rows: ProspectiveSnapshotRow[], kind: 'heuristic' | 'offline'): ModelVersionSummary[] {
+  const parsedByVersion = new Map<string, ParsedPredictionRow[]>();
+
+  for (const row of rows) {
+    if (row.evaluation_status !== 'settled') continue;
+    if ((kind === 'heuristic' ? row.heuristic_prediction_status : row.offline_prediction_status) !== 'completed') continue;
+    const parsed = parsePrediction(row, kind);
+    if (!parsed?.modelVersion) continue;
+    const bucket = parsedByVersion.get(parsed.modelVersion) ?? [];
+    bucket.push(parsed);
+    parsedByVersion.set(parsed.modelVersion, bucket);
+  }
+
+  return Array.from(parsedByVersion.entries())
+    .map(([modelVersion, bucket]) => ({
+      kind,
+      ...computeSummary(bucket, modelVersion),
+    }))
+    .sort((left, right) => {
+      const leftTime = left.latestPredictedAt ?? '';
+      const rightTime = right.latestPredictedAt ?? '';
+      if (leftTime !== rightTime) return rightTime.localeCompare(leftTime);
+      return right.games - left.games;
+    });
+}
+
+function buildHeadToHead(rows: ProspectiveSnapshotRow[], heuristicVersion: string | null, offlineVersion: string | null): {
+  sharedSettledGames: number;
+  headToHead: HeadToHeadSummary;
+  heuristicSummary: ModelPerformanceSummary;
+  offlineSummary: ModelPerformanceSummary;
+} {
+  const sharedHeuristic: ParsedPredictionRow[] = [];
+  const sharedOffline: ParsedPredictionRow[] = [];
+  const disagreement: number[] = [];
+  const drawDeltas: number[] = [];
+
+  for (const row of rows) {
+    if (
+      row.evaluation_status !== 'settled' ||
+      row.heuristic_prediction_status !== 'completed' ||
+      row.offline_prediction_status !== 'completed'
+    ) {
+      continue;
+    }
+    if (heuristicVersion && row.heuristic_model_version !== heuristicVersion) continue;
+    if (offlineVersion && row.offline_model_version !== offlineVersion) continue;
+
+    const heuristic = parsePrediction(row, 'heuristic');
+    const offline = parsePrediction(row, 'offline');
+    if (!heuristic || !offline) continue;
+
+    sharedHeuristic.push(heuristic);
+    sharedOffline.push(offline);
+    disagreement.push(heuristic.predictedOutcome === offline.predictedOutcome ? 0 : 1);
+    drawDeltas.push(offline.probDraw - heuristic.probDraw);
+  }
+
+  return {
+    sharedSettledGames: sharedHeuristic.length,
+    headToHead: {
+      fixturesWithBothPredictions: sharedHeuristic.length,
+      winnerDisagreementRate: mean(disagreement),
+      avgDrawProbabilityDeltaOfflineMinusHeuristic: mean(drawDeltas),
+    },
+    heuristicSummary: computeSummary(sharedHeuristic, heuristicVersion),
+    offlineSummary: computeSummary(sharedOffline, offlineVersion),
+  };
+}
+
+function buildPipelineSummary(rows: ProspectiveSnapshotRow[]): PipelineSummary {
+  const evaluationCounts = new Map<string, number>();
+  const resolutionCounts = new Map<string, number>();
+  let heuristicError = 0;
+  let offlineError = 0;
+
+  for (const row of rows) {
+    const evaluationStatus = row.evaluation_status ?? 'unknown';
+    evaluationCounts.set(evaluationStatus, (evaluationCounts.get(evaluationStatus) ?? 0) + 1);
+
+    const resolutionStatus = row.resolution_status ?? 'unknown';
+    resolutionCounts.set(resolutionStatus, (resolutionCounts.get(resolutionStatus) ?? 0) + 1);
+
+    if (row.heuristic_prediction_status === 'error') heuristicError += 1;
+    if (row.offline_prediction_status === 'error') offlineError += 1;
+  }
+
+  return {
+    totalFixtures: rows.length,
+    settled: evaluationCounts.get('settled') ?? 0,
+    pendingResult: evaluationCounts.get('pending_result') ?? 0,
+    pendingResolution: (resolutionCounts.get('partial') ?? 0) + (resolutionCounts.get('unresolved') ?? 0) + (resolutionCounts.get('pending') ?? 0),
+    resultNotFound: evaluationCounts.get('result_not_found') ?? 0,
+    ambiguousResult: evaluationCounts.get('ambiguous_result') ?? 0,
+    heuristicError,
+    offlineError,
+    resolutionStatusCounts: Array.from(resolutionCounts.entries())
+      .map(([status, count]) => ({ status, count }))
+      .sort((left, right) => right.count - left.count),
+  };
+}
+
+export function buildMissionControlSnapshot(
+  rows: ProspectiveSnapshotRow[],
+  pitCoverage: MissionControlSnapshot['pitCoverage']
+): MissionControlSnapshot {
+  const heuristicVersions = buildVersionSummaries(rows, 'heuristic');
+  const offlineVersions = buildVersionSummaries(rows, 'offline');
+  const currentHeuristicVersion = heuristicVersions[0]?.modelVersion ?? null;
+  const currentOfflineVersion = offlineVersions[0]?.modelVersion ?? null;
+  const { sharedSettledGames, headToHead, heuristicSummary, offlineSummary } = buildHeadToHead(
+    rows,
+    currentHeuristicVersion,
+    currentOfflineVersion
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    currentHeuristicVersion,
+    currentOfflineVersion,
+    sharedSettledGames,
+    headToHead,
+    heuristic: heuristicSummary,
+    offline: offlineSummary,
+    offlineVersions,
+    pipeline: buildPipelineSummary(rows),
+    pitCoverage,
+  };
+}

--- a/frontend/types/mission-control.ts
+++ b/frontend/types/mission-control.ts
@@ -1,0 +1,62 @@
+export type MatchOutcome = 'team_a' | 'draw' | 'team_b';
+
+export interface ModelPerformanceSummary {
+  modelVersion: string | null;
+  games: number;
+  winnerAccuracy: number | null;
+  drawRecall: number | null;
+  drawPrecision: number | null;
+  actualDrawRate: number | null;
+  predictedDrawRate: number | null;
+  drawRateGap: number | null;
+  logLoss: number | null;
+  brierScore: number | null;
+  marginMae: number | null;
+  exactScoreAccuracy: number | null;
+  latestPredictedAt: string | null;
+}
+
+export interface ModelVersionSummary extends ModelPerformanceSummary {
+  kind: 'heuristic' | 'offline';
+}
+
+export interface HeadToHeadSummary {
+  fixturesWithBothPredictions: number;
+  winnerDisagreementRate: number | null;
+  avgDrawProbabilityDeltaOfflineMinusHeuristic: number | null;
+}
+
+export interface PipelineSummary {
+  totalFixtures: number;
+  settled: number;
+  pendingResult: number;
+  pendingResolution: number;
+  resultNotFound: number;
+  ambiguousResult: number;
+  heuristicError: number;
+  offlineError: number;
+  resolutionStatusCounts: Array<{ status: string; count: number }>;
+}
+
+export interface PitCoverageSummary {
+  snapshotRows: number | null;
+  windowStart: string | null;
+  windowEnd: string | null;
+  totalScoredGames: number | null;
+  trainableScoredGames: number | null;
+  last365ScoredGames: number | null;
+  last365TrainableGames: number | null;
+}
+
+export interface MissionControlSnapshot {
+  generatedAt: string;
+  currentHeuristicVersion: string | null;
+  currentOfflineVersion: string | null;
+  sharedSettledGames: number;
+  headToHead: HeadToHeadSummary;
+  heuristic: ModelPerformanceSummary;
+  offline: ModelPerformanceSummary;
+  offlineVersions: ModelVersionSummary[];
+  pipeline: PipelineSummary;
+  pitCoverage: PitCoverageSummary;
+}


### PR DESCRIPTION
## Summary
- replace the old analytics-focused `/mission-control` page with an admin-only model snapshot dashboard
- add a new admin API route that summarizes settled prospective evaluation performance, pipeline backlog, and PIT coverage directly from Supabase
- add a focused mission-control summary test so the dashboard math stays pinned to deterministic sample data

## Validation
- `npm run lint -- app/mission-control/page.tsx app/api/mission-control/model-snapshot/route.ts components/mission-control/ModelSnapshotDashboard.tsx hooks/useMissionControl.ts lib/mission-control/modelSnapshot.ts lib/mission-control/modelSnapshot.test.ts types/mission-control.ts`
- `npm run typecheck`
- `npm run test -- lib/mission-control/modelSnapshot.test.ts`
