### PR TITLE
Add training run history to Mission Control

### DIFF
--- a/.github/workflows/train-point-in-time-match-model.yml
+++ b/.github/workflows/train-point-in-time-match-model.yml
@@ -269,6 +269,50 @@ jobs:
           step_summary.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
           PY
 
+      - name: Record training run for mission control
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+
+          MODEL_DIR="${{ github.event.inputs.model_dir }}"
+          if [ ! -f "$MODEL_DIR/training_metrics.json" ]; then
+            echo "training_metrics.json not found in $MODEL_DIR; skipping mission control record"
+            exit 0
+          fi
+
+          CMD=(
+            python scripts/record_point_in_time_training_run.py
+            --workflow-run-id "${{ github.run_id }}"
+            --workflow-run-attempt "${{ github.run_attempt }}"
+            --git-sha "${{ github.sha }}"
+            --model-dir "$MODEL_DIR"
+            --lookback-days "${{ github.event.inputs.lookback_days }}"
+            --limit "${{ github.event.inputs.limit }}"
+            --test-ratio "${{ github.event.inputs.test_ratio }}"
+            --min-examples "${{ github.event.inputs.min_examples }}"
+            --requested-probability-strategy "${{ github.event.inputs.probability_strategy }}"
+          )
+
+          if [ "${{ github.event.inputs.calibrate }}" = "true" ]; then
+            CMD+=(
+              --calibration-enabled
+              --calibration-method "${{ github.event.inputs.calibration_method }}"
+              --draw-calibration-method "${{ github.event.inputs.draw_calibration_method }}"
+            )
+          fi
+
+          printf 'Recording command:\n'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+
+          "${CMD[@]}"
+
       - name: Upload model artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/frontend/app/api/mission-control/model-snapshot/route.ts
+++ b/frontend/app/api/mission-control/model-snapshot/route.ts
@@ -1,11 +1,49 @@
 import { NextResponse } from 'next/server';
 import { buildMissionControlSnapshot, type ProspectiveSnapshotRow } from '@/lib/mission-control/modelSnapshot';
+import type { TrainingRunSummary } from '@/types/mission-control';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { createServiceSupabase } from '@/lib/supabase/service';
 
 export const dynamic = 'force-dynamic';
 
 const PROSPECTIVE_PAGE_SIZE = 1000;
+const TRAINING_RUN_LIMIT = 8;
+
+type TrainingRunRow = {
+  created_at: string;
+  workflow_run_id: number | string;
+  workflow_run_attempt: number | string;
+  git_sha: string | null;
+  model_dir: string;
+  model_version: string;
+  lookback_days: number | null;
+  limit_value: number | null;
+  test_ratio: number | null;
+  min_examples: number | null;
+  requested_probability_strategy: string | null;
+  selected_probability_strategy: string | null;
+  calibration_enabled: boolean | null;
+  calibration_method: string | null;
+  draw_calibration_method: string | null;
+  games_seen: number | null;
+  games_used: number | null;
+  examples_built: number | null;
+  unique_snapshot_dates_used: number | null;
+  winner_accuracy: number | null;
+  draw_recall: number | null;
+  predicted_draw_rate: number | null;
+  log_loss: number | null;
+  margin_mae: number | null;
+  exact_score_accuracy: number | null;
+  calibrated_log_loss: number | null;
+  calibrated_draw_recall: number | null;
+  calibrated_brier_score: number | null;
+};
+
+function isMissingTable(error: unknown, tableName: string): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (message.includes('could not find the table') || message.includes('schema cache')) && message.includes(tableName.toLowerCase());
+}
 
 async function fetchAllProspectiveRows(): Promise<ProspectiveSnapshotRow[]> {
   const supabase = createServiceSupabase();
@@ -83,13 +121,64 @@ async function fetchPitCoverage() {
   };
 }
 
+async function fetchTrainingRuns(): Promise<TrainingRunSummary[]> {
+  const supabase = createServiceSupabase();
+  try {
+    const { data, error } = await supabase
+      .from('model_training_runs')
+      .select(
+        'created_at, workflow_run_id, workflow_run_attempt, git_sha, model_dir, model_version, lookback_days, limit_value, test_ratio, min_examples, requested_probability_strategy, selected_probability_strategy, calibration_enabled, calibration_method, draw_calibration_method, games_seen, games_used, examples_built, unique_snapshot_dates_used, winner_accuracy, draw_recall, predicted_draw_rate, log_loss, margin_mae, exact_score_accuracy, calibrated_log_loss, calibrated_draw_recall, calibrated_brier_score'
+      )
+      .order('workflow_run_id', { ascending: false })
+      .limit(TRAINING_RUN_LIMIT);
+
+    if (error) throw error;
+
+    return ((data ?? []) as TrainingRunRow[]).map((row) => ({
+      createdAt: row.created_at,
+      workflowRunId: Number(row.workflow_run_id),
+      workflowRunAttempt: Number(row.workflow_run_attempt),
+      gitSha: row.git_sha,
+      modelDir: row.model_dir,
+      modelVersion: row.model_version,
+      lookbackDays: row.lookback_days,
+      limitValue: row.limit_value,
+      testRatio: row.test_ratio,
+      minExamples: row.min_examples,
+      requestedProbabilityStrategy: row.requested_probability_strategy,
+      selectedProbabilityStrategy: row.selected_probability_strategy,
+      calibrationEnabled: Boolean(row.calibration_enabled),
+      calibrationMethod: row.calibration_method,
+      drawCalibrationMethod: row.draw_calibration_method,
+      gamesSeen: row.games_seen,
+      gamesUsed: row.games_used,
+      examplesBuilt: row.examples_built,
+      uniqueSnapshotDatesUsed: row.unique_snapshot_dates_used,
+      winnerAccuracy: row.winner_accuracy,
+      drawRecall: row.draw_recall,
+      predictedDrawRate: row.predicted_draw_rate,
+      logLoss: row.log_loss,
+      marginMae: row.margin_mae,
+      exactScoreAccuracy: row.exact_score_accuracy,
+      calibratedLogLoss: row.calibrated_log_loss,
+      calibratedDrawRecall: row.calibrated_draw_recall,
+      calibratedBrierScore: row.calibrated_brier_score,
+    }));
+  } catch (error) {
+    if (isMissingTable(error, 'model_training_runs')) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 export async function GET() {
   const auth = await requireAdmin();
   if (auth.error) return auth.error;
 
   try {
-    const [rows, pitCoverage] = await Promise.all([fetchAllProspectiveRows(), fetchPitCoverage()]);
-    const snapshot = buildMissionControlSnapshot(rows, pitCoverage);
+    const [rows, pitCoverage, trainingRuns] = await Promise.all([fetchAllProspectiveRows(), fetchPitCoverage(), fetchTrainingRuns()]);
+    const snapshot = buildMissionControlSnapshot(rows, pitCoverage, trainingRuns);
     return NextResponse.json(snapshot);
   } catch (error) {
     console.error('Mission control snapshot error:', error);

--- a/frontend/components/mission-control/ModelSnapshotDashboard.tsx
+++ b/frontend/components/mission-control/ModelSnapshotDashboard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Info, Trophy, Target, Clock3, Database, GitCompareArrows } from 'lucide-react';
+import { ArrowUpRight, Clock3, Database, FlaskConical, GitCompareArrows, History, Info, Target, Trophy, TrendingUp, type LucideIcon } from 'lucide-react';
 import { useMissionControlSnapshot } from '@/hooks/useMissionControl';
-import type { MissionControlSnapshot, ModelPerformanceSummary, ModelVersionSummary } from '@/types/mission-control';
+import type { MissionControlSnapshot, ModelPerformanceSummary, ModelVersionSummary, TrainingRunSummary } from '@/types/mission-control';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -35,11 +35,35 @@ function formatShortDate(value: string | null | undefined): string {
   }).format(new Date(`${value}T00:00:00Z`));
 }
 
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return 'N/A';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
 function formatPercentPointDelta(value: number | null): string {
   if (value == null || Number.isNaN(value)) return 'N/A';
   const points = value * 100;
   const sign = points > 0 ? '+' : '';
   return `${sign}${points.toFixed(2)} pts`;
+}
+
+function formatDeltaMagnitude(value: number, digits = 2): string {
+  return `${Math.abs(value * 100).toFixed(digits)} pts`;
+}
+
+function formatStrategy(value: string | null | undefined): string {
+  if (!value) return 'N/A';
+  return value.replace(/_/g, ' ');
+}
+
+function githubRunUrl(runId: number): string {
+  return `https://github.com/dallasheidt14/PitchRank/actions/runs/${runId}`;
 }
 
 function SectionSkeleton() {
@@ -84,7 +108,7 @@ function MetricTile({
   tooltip: string;
   value: string;
   subtitle?: string;
-  icon: typeof Trophy;
+  icon: LucideIcon;
 }) {
   return (
     <Card variant="flat" className="border-white/10 bg-white/5">
@@ -104,6 +128,37 @@ function MetricTile({
       </CardContent>
     </Card>
   );
+}
+
+function trainingChangeSummary(current: TrainingRunSummary, previous: TrainingRunSummary | null): string {
+  if (!previous) {
+    return 'No earlier recorded training run yet. This is the baseline holdout snapshot for the new training tracker.';
+  }
+
+  const parts: string[] = [];
+  if (current.winnerAccuracy != null && previous.winnerAccuracy != null) {
+    const delta = current.winnerAccuracy - previous.winnerAccuracy;
+    parts.push(`winner accuracy ${delta >= 0 ? 'up' : 'down'} ${formatDeltaMagnitude(delta)}`);
+  }
+  if (current.drawRecall != null && previous.drawRecall != null) {
+    const delta = current.drawRecall - previous.drawRecall;
+    parts.push(`draw recall ${delta >= 0 ? 'up' : 'down'} ${formatDeltaMagnitude(delta)}`);
+  }
+  if (current.logLoss != null && previous.logLoss != null) {
+    const delta = current.logLoss - previous.logLoss;
+    parts.push(`log loss ${delta <= 0 ? 'down' : 'up'} ${Math.abs(delta).toFixed(3)}`);
+  }
+  if (current.gamesUsed != null && previous.gamesUsed != null) {
+    const delta = current.gamesUsed - previous.gamesUsed;
+    const sign = delta > 0 ? '+' : '';
+    parts.push(`games used ${sign}${delta.toLocaleString()}`);
+  }
+
+  if (!parts.length) {
+    return 'No comparable metrics were available from the previous recorded training run.';
+  }
+
+  return `Versus the previous recorded run: ${parts.join(', ')}.`;
 }
 
 function winnerSummaryText(heuristic: ModelPerformanceSummary, offline: ModelPerformanceSummary): string {
@@ -135,6 +190,8 @@ function drawSummaryText(heuristic: ModelPerformanceSummary, offline: ModelPerfo
 }
 
 function QuickReadCard({ data }: { data: MissionControlSnapshot }) {
+  const latestTrainingRun = data.trainingRuns[0] ?? null;
+
   return (
     <Card variant="flat" className="border-white/10 bg-white/5">
       <CardHeader className="border-b border-white/10">
@@ -150,6 +207,14 @@ function QuickReadCard({ data }: { data: MissionControlSnapshot }) {
         </p>
         <p>{winnerSummaryText(data.heuristic, data.offline)}</p>
         <p>{drawSummaryText(data.heuristic, data.offline)}</p>
+        {latestTrainingRun ? (
+          <p>
+            The latest offline training run was recorded on <strong>{formatDateTime(latestTrainingRun.createdAt)}</strong> and
+            used <strong>{formatNumber(latestTrainingRun.gamesUsed)}</strong> leakage-safe games, with holdout winner accuracy of{' '}
+            <strong>{formatPercent(latestTrainingRun.winnerAccuracy)}</strong> and log loss of{' '}
+            <strong>{formatDecimal(latestTrainingRun.logLoss)}</strong>.
+          </p>
+        ) : null}
         <p>
           There are <strong>{formatNumber(data.pipeline.pendingResult)}</strong> frozen fixtures still waiting on final scores and{' '}
           <strong>{formatNumber(data.pipeline.pendingResolution)}</strong> fixtures that still need cleaner team matching before
@@ -157,6 +222,223 @@ function QuickReadCard({ data }: { data: MissionControlSnapshot }) {
         </p>
       </CardContent>
     </Card>
+  );
+}
+
+function LatestTrainingCard({
+  runs,
+  currentOfflineVersion,
+}: {
+  runs: TrainingRunSummary[];
+  currentOfflineVersion: string | null;
+}) {
+  const latest = runs[0] ?? null;
+  const previous = runs[1] ?? null;
+
+  if (!latest) {
+    return (
+      <Card variant="flat" className="border-white/10 bg-white/5">
+        <CardHeader className="border-b border-white/10">
+          <CardTitle className="text-white">Latest Offline Training Run</CardTitle>
+          <CardDescription className="text-gray-400">
+            Holdout results from the training workflow will appear here once a run is recorded
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-6 text-sm text-gray-400">No recorded training runs yet.</CardContent>
+      </Card>
+    );
+  }
+
+  const isCurrentBenchmark = currentOfflineVersion != null && latest.modelVersion === currentOfflineVersion;
+
+  return (
+    <Card variant="flat" className="border-white/10 bg-white/5">
+      <CardHeader className="border-b border-white/10">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <CardTitle className="text-white">Latest Offline Training Run</CardTitle>
+            <CardDescription className="text-gray-400">
+              Offline holdout metrics from the training workflow. Use this to spot retrain improvement before the model has enough
+              prospective games to judge live.
+            </CardDescription>
+          </div>
+          <a
+            href={githubRunUrl(latest.workflowRunId)}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-emerald-200 transition hover:text-white"
+          >
+            Open run #{latest.workflowRunId}
+            <ArrowUpRight className="h-4 w-4" />
+          </a>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-6">
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline" className="border-white/20 text-gray-200">
+            {latest.modelVersion}
+          </Badge>
+          <Badge variant="outline" className="border-white/20 text-gray-200">
+            strategy: {formatStrategy(latest.selectedProbabilityStrategy ?? latest.requestedProbabilityStrategy)}
+          </Badge>
+          <Badge
+            variant="outline"
+            className={isCurrentBenchmark ? 'border-emerald-400/30 text-emerald-200' : 'border-amber-400/30 text-amber-200'}
+          >
+            {isCurrentBenchmark ? 'current prospective benchmark' : 'newer than current benchmark'}
+          </Badge>
+          <Badge variant="outline" className="border-white/20 text-gray-200">
+            calibration: {latest.calibrationEnabled ? `${latest.calibrationMethod ?? 'on'}` : 'off'}
+          </Badge>
+        </div>
+
+        <p className="text-sm text-gray-300">{trainingChangeSummary(latest, previous)}</p>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <MetricTile
+            title="Games used"
+            tooltip="Historical matches that had valid point-in-time snapshots and were actually used to train and test this run."
+            value={formatNumber(latest.gamesUsed)}
+            subtitle={`${formatNumber(latest.examplesBuilt)} mirrored examples built`}
+            icon={Database}
+          />
+          <MetricTile
+            title="Winner accuracy"
+            tooltip="Offline holdout accuracy on picking the correct winner or draw outcome for this specific training run."
+            value={formatPercent(latest.winnerAccuracy)}
+            subtitle={`Requested ${formatStrategy(latest.requestedProbabilityStrategy)}`}
+            icon={Trophy}
+          />
+          <MetricTile
+            title="Draw recall"
+            tooltip="Out of the holdout games that truly ended in a draw, how often this training run called draw."
+            value={formatPercent(latest.drawRecall)}
+            subtitle={`Predicted draw rate ${formatPercent(latest.predictedDrawRate)}`}
+            icon={Target}
+          />
+          <MetricTile
+            title="Log loss"
+            tooltip="Offline holdout probability-quality score for this run. Lower is better."
+            value={formatDecimal(latest.logLoss)}
+            subtitle={
+              latest.calibratedLogLoss != null
+                ? `Calibrated ${formatDecimal(latest.calibratedLogLoss)}`
+                : `Exact score ${formatPercent(latest.exactScoreAccuracy)}`
+            }
+            icon={TrendingUp}
+          />
+          <MetricTile
+            title="Margin MAE"
+            tooltip="Average offline holdout error in expected goal margin. Lower is better."
+            value={formatDecimal(latest.marginMae)}
+            subtitle={`Lookback ${formatNumber(latest.lookbackDays)} days`}
+            icon={FlaskConical}
+          />
+          <MetricTile
+            title="Snapshot dates used"
+            tooltip="How many distinct point-in-time snapshot dates were actually used in this training run."
+            value={formatNumber(latest.uniqueSnapshotDatesUsed)}
+            subtitle={`Recorded ${formatDateTime(latest.createdAt)}`}
+            icon={History}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrainingHistoryTable({
+  runs,
+  currentOfflineVersion,
+}: {
+  runs: TrainingRunSummary[];
+  currentOfflineVersion: string | null;
+}) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/5">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-white/10 hover:bg-white/5">
+            <TableHead className="text-gray-400">
+              <InfoLabel
+                label="Run"
+                tooltip="GitHub Actions training run that produced this offline model summary."
+              />
+            </TableHead>
+            <TableHead className="text-gray-400">
+              <InfoLabel
+                label="Model version"
+                tooltip="Version string that can later become the offline benchmark in the prospective pipeline."
+              />
+            </TableHead>
+            <TableHead className="text-right text-gray-400">
+              <InfoLabel label="Games used" tooltip="Leakage-safe historical matches used by that training run." />
+            </TableHead>
+            <TableHead className="text-right text-gray-400">
+              <InfoLabel label="Winner acc." tooltip="Offline holdout winner accuracy for that run." />
+            </TableHead>
+            <TableHead className="text-right text-gray-400">
+              <InfoLabel label="Draw recall" tooltip="Offline holdout draw recall for that run." />
+            </TableHead>
+            <TableHead className="text-right text-gray-400">
+              <InfoLabel label="Log loss" tooltip="Offline holdout probability-quality score. Lower is better." />
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {runs.map((run) => {
+            const isCurrentBenchmark = currentOfflineVersion != null && run.modelVersion === currentOfflineVersion;
+            return (
+              <TableRow key={run.workflowRunId} className="border-white/10 hover:bg-white/5">
+                <TableCell className="text-white">
+                  <div className="space-y-1">
+                    <a
+                      href={githubRunUrl(run.workflowRunId)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 text-white transition hover:text-emerald-200"
+                    >
+                      #{run.workflowRunId}
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                    </a>
+                    <div className="text-xs text-gray-500">{formatDateTime(run.createdAt)}</div>
+                  </div>
+                </TableCell>
+                <TableCell className="max-w-[360px] truncate text-white" title={run.modelVersion}>
+                  <div className="flex items-center gap-2">
+                    <span>{run.modelVersion}</span>
+                    {isCurrentBenchmark ? (
+                      <Badge variant="outline" className="border-emerald-400/30 text-emerald-200">
+                        benchmark
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500">
+                    {formatStrategy(run.selectedProbabilityStrategy ?? run.requestedProbabilityStrategy)}
+                  </div>
+                </TableCell>
+                <TableCell className="text-right text-gray-300">{formatNumber(run.gamesUsed)}</TableCell>
+                <TableCell className="text-right text-gray-300">{formatPercent(run.winnerAccuracy)}</TableCell>
+                <TableCell className="text-right text-gray-300">{formatPercent(run.drawRecall)}</TableCell>
+                <TableCell className="text-right text-gray-300">
+                  <div>{formatDecimal(run.logLoss)}</div>
+                  {run.calibratedLogLoss != null ? (
+                    <div className="text-xs text-gray-500">cal {formatDecimal(run.calibratedLogLoss)}</div>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+          {runs.length === 0 ? (
+            <TableRow className="border-white/10">
+              <TableCell colSpan={6} className="text-center text-gray-500">
+                No recorded training runs yet
+              </TableCell>
+            </TableRow>
+          ) : null}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
@@ -257,11 +539,11 @@ function ComparisonTable({
 function StatusTable({ snapshot }: { snapshot: MissionControlSnapshot }) {
   const rows = [
     {
-      label: 'Ready to compare',
+      label: 'Settled rows across all versions',
       tooltip:
-        'Fixtures where we matched the final result back to the frozen predictions. These rows actively count toward the accuracy numbers above.',
+        'Fixtures where we matched the final result back to frozen predictions. This includes older model versions, so it can be larger than the current apples-to-apples comparison sample above.',
       value: formatNumber(snapshot.pipeline.settled),
-      meaning: 'Final score found and both predictions can be judged.',
+      meaning: 'Final score found and at least one version pairing can be judged.',
     },
     {
       label: 'Waiting on final score',
@@ -534,7 +816,7 @@ export function ModelSnapshotDashboard() {
             <CardHeader className="border-b border-white/10">
               <CardTitle className="text-white">Pipeline Status</CardTitle>
               <CardDescription className="text-gray-400">
-                Where the prospective evaluation pipeline is currently getting stuck or moving cleanly
+                Operational counts for the prospective evaluation pipeline, including older model versions
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4 pt-6">
@@ -608,6 +890,33 @@ export function ModelSnapshotDashboard() {
           </Card>
         </div>
 
+        <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
+          <LatestTrainingCard runs={data.trainingRuns} currentOfflineVersion={data.currentOfflineVersion} />
+
+          <Card variant="flat" className="border-white/10 bg-white/5">
+            <CardHeader className="border-b border-white/10">
+              <CardTitle className="text-white">Training vs Live Results</CardTitle>
+              <CardDescription className="text-gray-400">
+                Why both sections matter and how to interpret them together
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-6 text-sm text-gray-300">
+              <div>
+                <p className="font-medium text-white">Training run metrics</p>
+                <p>Offline holdout numbers from the training workflow. Useful for seeing whether a retrain got better before enough live games finish.</p>
+              </div>
+              <div>
+                <p className="font-medium text-white">Prospective comparison</p>
+                <p>Frozen pregame predictions judged against real final scores. This is the real scoreboard for deciding whether to swap models live.</p>
+              </div>
+              <div>
+                <p className="font-medium text-white">Best decision rule</p>
+                <p>If a new training run looks better here, freeze it into future fixtures and wait for the prospective section to confirm the gain on real games.</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
         <Card variant="flat" className="border-white/10 bg-white/5">
           <CardHeader className="border-b border-white/10">
             <CardTitle className="text-white">Offline Version Benchmarks</CardTitle>
@@ -617,6 +926,18 @@ export function ModelSnapshotDashboard() {
           </CardHeader>
           <CardContent className="pt-6">
             <VersionTable versions={data.offlineVersions} currentVersion={data.currentOfflineVersion} />
+          </CardContent>
+        </Card>
+
+        <Card variant="flat" className="border-white/10 bg-white/5">
+          <CardHeader className="border-b border-white/10">
+            <CardTitle className="text-white">Recent Training Runs</CardTitle>
+            <CardDescription className="text-gray-400">
+              Latest recorded offline training runs so you can see whether retrains are trending in the right direction
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6">
+            <TrainingHistoryTable runs={data.trainingRuns} currentOfflineVersion={data.currentOfflineVersion} />
           </CardContent>
         </Card>
       </div>

--- a/frontend/lib/mission-control/modelSnapshot.test.ts
+++ b/frontend/lib/mission-control/modelSnapshot.test.ts
@@ -125,5 +125,6 @@ describe('buildMissionControlSnapshot', () => {
     expect(snapshot.offline.drawRecall).toBe(1);
     expect(snapshot.headToHead.fixturesWithBothPredictions).toBe(2);
     expect(snapshot.headToHead.winnerDisagreementRate).toBe(0.5);
+    expect(snapshot.trainingRuns).toEqual([]);
   });
 });

--- a/frontend/lib/mission-control/modelSnapshot.ts
+++ b/frontend/lib/mission-control/modelSnapshot.ts
@@ -5,6 +5,7 @@ import type {
   ModelPerformanceSummary,
   ModelVersionSummary,
   PipelineSummary,
+  TrainingRunSummary,
 } from '@/types/mission-control';
 
 const EPSILON = 1e-15;
@@ -364,7 +365,8 @@ function buildPipelineSummary(rows: ProspectiveSnapshotRow[]): PipelineSummary {
 
 export function buildMissionControlSnapshot(
   rows: ProspectiveSnapshotRow[],
-  pitCoverage: MissionControlSnapshot['pitCoverage']
+  pitCoverage: MissionControlSnapshot['pitCoverage'],
+  trainingRuns: TrainingRunSummary[] = []
 ): MissionControlSnapshot {
   const heuristicVersions = buildVersionSummaries(rows, 'heuristic');
   const offlineVersions = buildVersionSummaries(rows, 'offline');
@@ -387,5 +389,6 @@ export function buildMissionControlSnapshot(
     offlineVersions,
     pipeline: buildPipelineSummary(rows),
     pitCoverage,
+    trainingRuns,
   };
 }

--- a/frontend/types/mission-control.ts
+++ b/frontend/types/mission-control.ts
@@ -48,6 +48,37 @@ export interface PitCoverageSummary {
   last365TrainableGames: number | null;
 }
 
+export interface TrainingRunSummary {
+  createdAt: string;
+  workflowRunId: number;
+  workflowRunAttempt: number;
+  gitSha: string | null;
+  modelDir: string;
+  modelVersion: string;
+  lookbackDays: number | null;
+  limitValue: number | null;
+  testRatio: number | null;
+  minExamples: number | null;
+  requestedProbabilityStrategy: string | null;
+  selectedProbabilityStrategy: string | null;
+  calibrationEnabled: boolean;
+  calibrationMethod: string | null;
+  drawCalibrationMethod: string | null;
+  gamesSeen: number | null;
+  gamesUsed: number | null;
+  examplesBuilt: number | null;
+  uniqueSnapshotDatesUsed: number | null;
+  winnerAccuracy: number | null;
+  drawRecall: number | null;
+  predictedDrawRate: number | null;
+  logLoss: number | null;
+  marginMae: number | null;
+  exactScoreAccuracy: number | null;
+  calibratedLogLoss: number | null;
+  calibratedDrawRecall: number | null;
+  calibratedBrierScore: number | null;
+}
+
 export interface MissionControlSnapshot {
   generatedAt: string;
   currentHeuristicVersion: string | null;
@@ -59,4 +90,5 @@ export interface MissionControlSnapshot {
   offlineVersions: ModelVersionSummary[];
   pipeline: PipelineSummary;
   pitCoverage: PitCoverageSummary;
+  trainingRuns: TrainingRunSummary[];
 }

--- a/scripts/record_point_in_time_training_run.py
+++ b/scripts/record_point_in_time_training_run.py
@@ -1,0 +1,170 @@
+"""
+Persist point-in-time training workflow summaries into Supabase for Mission Control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from supabase import Client, create_client  # noqa: E402
+
+
+def _supabase_client() -> Client:
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY/SUPABASE_SERVICE_KEY")
+    return create_client(supabase_url, supabase_key)
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _derive_model_version(workflow_run_id: int, training_metrics: Dict[str, Any], requested_strategy: str) -> str:
+    selected_strategy = str(
+        training_metrics.get("probability_strategy")
+        or training_metrics.get("requested_probability_strategy")
+        or requested_strategy
+        or "unknown"
+    ).strip()
+    return f"pitm_{workflow_run_id}_{selected_strategy}"
+
+
+def build_training_run_record(
+    *,
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+    git_sha: Optional[str],
+    model_dir: Path,
+    lookback_days: Optional[int],
+    limit_value: Optional[int],
+    test_ratio: Optional[float],
+    min_examples: Optional[int],
+    requested_probability_strategy: str,
+    calibration_enabled: bool,
+    calibration_method: Optional[str],
+    draw_calibration_method: Optional[str],
+) -> Dict[str, Any]:
+    dataset_summary = _load_json(model_dir / "dataset_summary.json")
+    training_metrics = _load_json(model_dir / "training_metrics.json")
+    calibration_summary = _load_json(model_dir / "point_in_time_model_calibration_summary.json")
+
+    if not training_metrics:
+        raise FileNotFoundError(f"training_metrics.json not found in {model_dir}")
+
+    after_metrics = calibration_summary.get("after_metrics") if isinstance(calibration_summary, dict) else {}
+    after_metrics = after_metrics if isinstance(after_metrics, dict) else {}
+
+    return {
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+        "git_sha": git_sha,
+        "model_dir": str(model_dir),
+        "model_version": _derive_model_version(workflow_run_id, training_metrics, requested_probability_strategy),
+        "lookback_days": lookback_days,
+        "limit_value": limit_value,
+        "test_ratio": test_ratio,
+        "min_examples": min_examples,
+        "requested_probability_strategy": requested_probability_strategy,
+        "selected_probability_strategy": training_metrics.get("probability_strategy"),
+        "calibration_enabled": calibration_enabled,
+        "calibration_method": calibration_method if calibration_enabled else None,
+        "draw_calibration_method": draw_calibration_method if calibration_enabled else None,
+        "dataset_summary": dataset_summary,
+        "training_metrics": training_metrics,
+        "calibration_summary": calibration_summary or None,
+        "games_seen": _as_int(dataset_summary.get("games_seen")),
+        "games_used": _as_int(dataset_summary.get("games_used")),
+        "examples_built": _as_int(dataset_summary.get("examples_built")),
+        "unique_snapshot_dates_used": _as_int(dataset_summary.get("unique_snapshot_dates_used")),
+        "winner_accuracy": _as_float(training_metrics.get("winner_accuracy")),
+        "draw_recall": _as_float(training_metrics.get("draw_recall")),
+        "predicted_draw_rate": _as_float(training_metrics.get("predicted_draw_rate")),
+        "log_loss": _as_float(training_metrics.get("log_loss")),
+        "margin_mae": _as_float(training_metrics.get("margin_mae")),
+        "exact_score_accuracy": _as_float(training_metrics.get("exact_score_accuracy")),
+        "calibrated_log_loss": _as_float(after_metrics.get("log_loss")),
+        "calibrated_draw_recall": _as_float(after_metrics.get("draw_recall")),
+        "calibrated_brier_score": _as_float(after_metrics.get("brier_score")),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Record a point-in-time model training run in Supabase")
+    parser.add_argument("--workflow-run-id", type=int, required=True)
+    parser.add_argument("--workflow-run-attempt", type=int, required=True)
+    parser.add_argument("--git-sha", default=None)
+    parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--lookback-days", type=int, default=None)
+    parser.add_argument(
+        "--limit",
+        type=lambda value: None if str(value).lower() == "none" else int(value),
+        default=None,
+        help='Maximum number of games fetched during training (use "None" for no limit)',
+    )
+    parser.add_argument("--test-ratio", type=float, default=None)
+    parser.add_argument("--min-examples", type=int, default=None)
+    parser.add_argument("--requested-probability-strategy", required=True)
+    parser.add_argument("--calibration-enabled", action="store_true")
+    parser.add_argument("--calibration-method", default=None)
+    parser.add_argument("--draw-calibration-method", default=None)
+    args = parser.parse_args()
+
+    record = build_training_run_record(
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_attempt=args.workflow_run_attempt,
+        git_sha=args.git_sha,
+        model_dir=Path(args.model_dir),
+        lookback_days=args.lookback_days,
+        limit_value=args.limit,
+        test_ratio=args.test_ratio,
+        min_examples=args.min_examples,
+        requested_probability_strategy=args.requested_probability_strategy,
+        calibration_enabled=args.calibration_enabled,
+        calibration_method=args.calibration_method,
+        draw_calibration_method=args.draw_calibration_method,
+    )
+
+    _supabase_client().table("model_training_runs").upsert(record, on_conflict="workflow_run_id").execute()
+    print(json.dumps({"workflow_run_id": args.workflow_run_id, "model_version": record["model_version"]}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260414000000_create_model_training_runs.sql
+++ b/supabase/migrations/20260414000000_create_model_training_runs.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS model_training_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    workflow_run_id BIGINT NOT NULL UNIQUE,
+    workflow_run_attempt INTEGER NOT NULL DEFAULT 1,
+    git_sha TEXT NULL,
+
+    model_dir TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+
+    lookback_days INTEGER NULL,
+    limit_value INTEGER NULL,
+    test_ratio DOUBLE PRECISION NULL,
+    min_examples INTEGER NULL,
+    requested_probability_strategy TEXT NULL,
+    selected_probability_strategy TEXT NULL,
+
+    calibration_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    calibration_method TEXT NULL,
+    draw_calibration_method TEXT NULL,
+
+    dataset_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+    training_metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+    calibration_summary JSONB NULL,
+
+    games_seen INTEGER NULL,
+    games_used INTEGER NULL,
+    examples_built INTEGER NULL,
+    unique_snapshot_dates_used INTEGER NULL,
+
+    winner_accuracy DOUBLE PRECISION NULL,
+    draw_recall DOUBLE PRECISION NULL,
+    predicted_draw_rate DOUBLE PRECISION NULL,
+    log_loss DOUBLE PRECISION NULL,
+    margin_mae DOUBLE PRECISION NULL,
+    exact_score_accuracy DOUBLE PRECISION NULL,
+
+    calibrated_log_loss DOUBLE PRECISION NULL,
+    calibrated_draw_recall DOUBLE PRECISION NULL,
+    calibrated_brier_score DOUBLE PRECISION NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_training_runs_created_at
+    ON model_training_runs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_model_training_runs_model_version
+    ON model_training_runs (model_version);
+
+CREATE OR REPLACE FUNCTION update_model_training_runs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_model_training_runs_updated_at
+    ON model_training_runs;
+
+CREATE TRIGGER update_model_training_runs_updated_at
+    BEFORE UPDATE ON model_training_runs
+    FOR EACH ROW EXECUTE FUNCTION update_model_training_runs_updated_at();
+
+ALTER TABLE model_training_runs ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE model_training_runs IS
+    'Recorded summaries from Train Point-In-Time Match Model workflow runs for Mission Control.';

--- a/tests/unit/test_record_point_in_time_training_run.py
+++ b/tests/unit/test_record_point_in_time_training_run.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+from scripts.record_point_in_time_training_run import build_training_run_record
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_build_training_run_record_extracts_training_and_calibration_metrics(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "dataset_summary.json",
+        {
+            "games_seen": 1000,
+            "games_used": 600,
+            "examples_built": 1200,
+            "unique_snapshot_dates_used": 24,
+        },
+    )
+    _write_json(
+        tmp_path / "training_metrics.json",
+        {
+            "requested_probability_strategy": "hybrid",
+            "probability_strategy": "hybrid",
+            "winner_accuracy": 0.61,
+            "draw_recall": 0.12,
+            "predicted_draw_rate": 0.1,
+            "log_loss": 0.91,
+            "margin_mae": 2.15,
+            "exact_score_accuracy": 0.07,
+        },
+    )
+    _write_json(
+        tmp_path / "point_in_time_model_calibration_summary.json",
+        {
+            "method": "temperature",
+            "draw_method": "none",
+            "after_metrics": {
+                "log_loss": 0.89,
+                "draw_recall": 0.11,
+                "brier_score": 0.52,
+            },
+        },
+    )
+
+    record = build_training_run_record(
+        workflow_run_id=24414774665,
+        workflow_run_attempt=1,
+        git_sha="abcdef123456",
+        model_dir=tmp_path,
+        lookback_days=267,
+        limit_value=None,
+        test_ratio=0.2,
+        min_examples=100,
+        requested_probability_strategy="hybrid",
+        calibration_enabled=True,
+        calibration_method="temperature",
+        draw_calibration_method="none",
+    )
+
+    assert record["model_version"] == "pitm_24414774665_hybrid"
+    assert record["games_used"] == 600
+    assert record["winner_accuracy"] == 0.61
+    assert record["calibrated_log_loss"] == 0.89
+    assert record["calibration_enabled"] is True


### PR DESCRIPTION
## Summary
- record point-in-time training workflow summaries into Supabase for Mission Control
- show the latest offline training run and recent training history on /mission-control
- clarify that settled pipeline counts span all model versions and backfill recent training runs into the new table

## Validation
- python -m pytest C:\\PitchRank_prepare_worktree\\tests\\unit\\test_record_point_in_time_training_run.py
- python -m py_compile C:\\PitchRank_prepare_worktree\\scripts\\record_point_in_time_training_run.py
- npm.cmd run lint -- app/api/mission-control/model-snapshot/route.ts components/mission-control/ModelSnapshotDashboard.tsx lib/mission-control/modelSnapshot.ts lib/mission-control/modelSnapshot.test.ts types/mission-control.ts
- npm.cmd run typecheck
- npm.cmd run test -- lib/mission-control/modelSnapshot.test.ts