### PR TITLE
Fix PIT training pre-build stall

### DIFF
--- a/.github/workflows/train-point-in-time-match-model.yml
+++ b/.github/workflows/train-point-in-time-match-model.yml
@@ -138,6 +138,7 @@ jobs:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PYTHONUNBUFFERED: "1"
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas>=2.0.0
 numpy>=1.24.0
 supabase>=2.0.0
 python-dotenv>=1.0.0
+psycopg2-binary>=2.9.9
 
 # Data processing
 pyarrow>=14.0.0

--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import httpx
 import numpy as np
 import pandas as pd
 from dotenv import load_dotenv
@@ -55,6 +56,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 DIRECT_DB_BATCH_SIZE = 5000
+REST_SNAPSHOT_BATCH_SIZE = 250
+REST_SNAPSHOT_CONCURRENCY = 8
 
 
 def _database_url() -> Optional[str]:
@@ -215,6 +218,83 @@ def _fetch_team_names_via_db(team_ids: List[str]) -> Dict[str, str]:
     return team_names
 
 
+def _supabase_rest_credentials() -> Tuple[Optional[str], Optional[str]]:
+    return (
+        os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL"),
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY"),
+    )
+
+
+async def _fetch_prediction_feature_snapshots_via_rest(
+    team_ids: List[str],
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    supabase_url, supabase_key = _supabase_rest_credentials()
+    if not supabase_url or not supabase_key:
+        raise RuntimeError("Supabase REST credentials are unavailable for concurrent snapshot fetch")
+
+    logger.info(
+        "Fetching prediction feature snapshots for %s teams between %s and %s via concurrent Supabase REST...",
+        f"{len(team_ids):,}",
+        start_date,
+        end_date,
+    )
+
+    fields = (
+        "snapshot_date,team_id,age_group,gender,status,rank_in_cohort_final,"
+        "power_score_final,sos_norm,offense_norm,defense_norm,glicko_rating,glicko_rd,"
+        "glicko_volatility,wins,losses,draws,games_played,win_percentage,exp_margin,"
+        "exp_win_rate,exp_goals_for,exp_goals_against"
+    )
+    endpoint = f"{supabase_url.rstrip('/')}/rest/v1/prediction_feature_history"
+    headers = {
+        "apikey": supabase_key,
+        "Authorization": f"Bearer {supabase_key}",
+    }
+    semaphore = asyncio.Semaphore(REST_SNAPSHOT_CONCURRENCY)
+    rows: List[dict] = []
+    rows_fetched = 0
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=30.0)) as client:
+        async def fetch_batch(index: int, batch: List[str]) -> List[dict]:
+            params = [
+                ("select", fields),
+                ("team_id", f"in.({','.join(batch)})"),
+                ("snapshot_date", f"gte.{start_date}"),
+                ("snapshot_date", f"lte.{end_date}"),
+            ]
+            async with semaphore:
+                response = await client.get(endpoint, params=params, headers=headers)
+                response.raise_for_status()
+                return response.json()
+
+        tasks = [
+            fetch_batch(index, team_ids[index : index + REST_SNAPSHOT_BATCH_SIZE])
+            for index in range(0, len(team_ids), REST_SNAPSHOT_BATCH_SIZE)
+        ]
+
+        for completed_index, task in enumerate(asyncio.as_completed(tasks), start=1):
+            batch_rows = await task
+            if batch_rows:
+                rows.extend(batch_rows)
+                rows_fetched += len(batch_rows)
+            if completed_index % 10 == 0 or completed_index == len(tasks):
+                teams_processed = min(completed_index * REST_SNAPSHOT_BATCH_SIZE, len(team_ids))
+                logger.info(
+                    "  Concurrent REST snapshot fetch: completed %s/%s batches (%s/%s team ids, %s rows)",
+                    f"{completed_index:,}",
+                    f"{len(tasks):,}",
+                    f"{teams_processed:,}",
+                    f"{len(team_ids):,}",
+                    f"{rows_fetched:,}",
+                )
+
+    snapshots_df = pd.DataFrame(rows)
+    logger.info("Fetched %s prediction snapshots via concurrent Supabase REST", f"{len(snapshots_df):,}")
+    return snapshots_df
+
+
 async def fetch_historical_games(
     supabase: Client,
     lookback_days: int = 365,
@@ -231,11 +311,14 @@ async def fetch_historical_games(
         test_slice: Optional tuple (state, age_group) for testing (e.g., ('AZ', 'u12'))
     """
     if _can_use_direct_db():
-        return _fetch_historical_games_via_db(
-            lookback_days=lookback_days,
-            limit=limit,
-            test_slice=test_slice,
-        )
+        try:
+            return _fetch_historical_games_via_db(
+                lookback_days=lookback_days,
+                limit=limit,
+                test_slice=test_slice,
+            )
+        except Exception as error:
+            logger.warning("Direct Postgres historical-game fetch failed, falling back to Supabase REST: %s", error)
 
     cutoff_date = (datetime.now() - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
 
@@ -388,6 +471,15 @@ async def fetch_prediction_feature_snapshots(
             )
         except Exception as error:
             logger.warning("Direct Postgres snapshot fetch failed, falling back to Supabase REST: %s", error)
+
+    try:
+        return await _fetch_prediction_feature_snapshots_via_rest(
+            team_ids=team_ids,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except Exception as error:
+        logger.warning("Concurrent Supabase REST snapshot fetch failed, falling back to serial client: %s", error)
 
     logger.info(
         "Fetching prediction feature snapshots for %s teams between %s and %s...",

--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import os
 import sys
+from contextlib import closing
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -25,6 +26,14 @@ import numpy as np
 import pandas as pd
 from dotenv import load_dotenv
 from tqdm import tqdm
+
+try:
+    import psycopg2  # type: ignore
+
+    HAS_PSYCOPG2 = True
+except ImportError:  # pragma: no cover - exercised only when psycopg2 is unavailable
+    psycopg2 = None
+    HAS_PSYCOPG2 = False
 
 # Load environment variables
 env_local = Path(".env.local")
@@ -45,6 +54,166 @@ from supabase import Client, create_client  # noqa: E402
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+DIRECT_DB_BATCH_SIZE = 5000
+
+
+def _database_url() -> Optional[str]:
+    return os.getenv("DATABASE_URL")
+
+
+def _can_use_direct_db() -> bool:
+    return bool(_database_url()) and HAS_PSYCOPG2
+
+
+def _open_direct_db_connection():
+    database_url = _database_url()
+    if not database_url or not HAS_PSYCOPG2:
+        raise RuntimeError("DATABASE_URL or psycopg2 is unavailable")
+    return psycopg2.connect(database_url)
+
+
+def _fetch_historical_games_via_db(
+    lookback_days: int,
+    limit: Optional[int] = None,
+    test_slice: Optional[Tuple[str, str]] = None,
+) -> pd.DataFrame:
+    cutoff_date = (datetime.now() - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
+    logger.info("Fetching historical games from %s via direct Postgres...", cutoff_date)
+
+    params: List[object] = [cutoff_date]
+    joins = ""
+    filters = ""
+
+    if test_slice:
+        state_code, age_group = test_slice
+        joins = """
+        JOIN teams home_team ON home_team.team_id_master = g.home_team_master_id
+        JOIN teams away_team ON away_team.team_id_master = g.away_team_master_id
+        """
+        filters = """
+          AND home_team.state_code = %s
+          AND away_team.state_code = %s
+          AND home_team.age_group ILIKE %s
+          AND away_team.age_group ILIKE %s
+        """
+        params.extend([state_code, state_code, f"%{age_group}%", f"%{age_group}%"])
+
+    limit_clause = ""
+    if limit:
+        limit_clause = "LIMIT %s"
+        params.append(int(limit))
+
+    sql = f"""
+        SELECT
+            g.id,
+            g.game_date,
+            g.home_team_master_id,
+            g.away_team_master_id,
+            g.home_score,
+            g.away_score
+        FROM games g
+        {joins}
+        WHERE g.home_team_master_id IS NOT NULL
+          AND g.away_team_master_id IS NOT NULL
+          AND g.home_score IS NOT NULL
+          AND g.away_score IS NOT NULL
+          AND g.game_date >= %s
+          {filters}
+        ORDER BY g.game_date ASC
+        {limit_clause}
+    """
+
+    with closing(_open_direct_db_connection()) as conn:
+        games_df = pd.read_sql_query(sql, conn, params=params)
+
+    logger.info("Fetched %s games total via direct Postgres", f"{len(games_df):,}")
+    return games_df
+
+
+def _fetch_prediction_feature_snapshots_via_db(
+    team_ids: List[str],
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    logger.info(
+        "Fetching prediction feature snapshots for %s teams between %s and %s via direct Postgres...",
+        f"{len(team_ids):,}",
+        start_date,
+        end_date,
+    )
+
+    sql = """
+        SELECT
+            snapshot_date,
+            team_id,
+            age_group,
+            gender,
+            status,
+            rank_in_cohort_final,
+            power_score_final,
+            sos_norm,
+            offense_norm,
+            defense_norm,
+            glicko_rating,
+            glicko_rd,
+            glicko_volatility,
+            wins,
+            losses,
+            draws,
+            games_played,
+            win_percentage,
+            exp_margin,
+            exp_win_rate,
+            exp_goals_for,
+            exp_goals_against
+        FROM prediction_feature_history
+        WHERE snapshot_date >= %s
+          AND snapshot_date <= %s
+          AND team_id = ANY(%s::uuid[])
+    """
+
+    frames: List[pd.DataFrame] = []
+    rows_fetched = 0
+
+    with closing(_open_direct_db_connection()) as conn:
+        for index in range(0, len(team_ids), DIRECT_DB_BATCH_SIZE):
+            batch = team_ids[index : index + DIRECT_DB_BATCH_SIZE]
+            frame = pd.read_sql_query(sql, conn, params=[start_date, end_date, batch])
+            if not frame.empty:
+                frames.append(frame)
+                rows_fetched += len(frame)
+            logger.info(
+                "  Direct Postgres snapshot batch %s-%s complete (%s team ids, %s rows so far)",
+                f"{index:,}",
+                f"{min(index + len(batch), len(team_ids)):,}",
+                f"{len(batch):,}",
+                f"{rows_fetched:,}",
+            )
+
+    snapshots_df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    logger.info("Fetched %s prediction snapshots via direct Postgres", f"{len(snapshots_df):,}")
+    return snapshots_df
+
+
+def _fetch_team_names_via_db(team_ids: List[str]) -> Dict[str, str]:
+    logger.info("Fetching team names for %s teams via direct Postgres...", f"{len(team_ids):,}")
+    sql = """
+        SELECT team_id_master, team_name
+        FROM teams
+        WHERE team_id_master = ANY(%s::uuid[])
+    """
+
+    team_names: Dict[str, str] = {}
+    with closing(_open_direct_db_connection()) as conn:
+        for index in range(0, len(team_ids), DIRECT_DB_BATCH_SIZE):
+            batch = team_ids[index : index + DIRECT_DB_BATCH_SIZE]
+            frame = pd.read_sql_query(sql, conn, params=[batch])
+            for _, row in frame.iterrows():
+                if row.get("team_id_master") and row.get("team_name"):
+                    team_names[str(row["team_id_master"])] = str(row["team_name"])
+    logger.info("Fetched canonical names for %s teams via direct Postgres", f"{len(team_names):,}")
+    return team_names
+
 
 async def fetch_historical_games(
     supabase: Client,
@@ -61,6 +230,13 @@ async def fetch_historical_games(
         limit: Maximum number of games to fetch (None = all)
         test_slice: Optional tuple (state, age_group) for testing (e.g., ('AZ', 'u12'))
     """
+    if _can_use_direct_db():
+        return _fetch_historical_games_via_db(
+            lookback_days=lookback_days,
+            limit=limit,
+            test_slice=test_slice,
+        )
+
     cutoff_date = (datetime.now() - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
 
     logger.info(f"Fetching historical games from {cutoff_date}...")
@@ -202,6 +378,16 @@ async def fetch_prediction_feature_snapshots(
     """
     if not team_ids:
         return pd.DataFrame()
+
+    if _can_use_direct_db():
+        try:
+            return _fetch_prediction_feature_snapshots_via_db(
+                team_ids=team_ids,
+                start_date=start_date,
+                end_date=end_date,
+            )
+        except Exception as error:
+            logger.warning("Direct Postgres snapshot fetch failed, falling back to Supabase REST: %s", error)
 
     logger.info(
         "Fetching prediction feature snapshots for %s teams between %s and %s...",
@@ -427,6 +613,12 @@ async def fetch_team_game_histories(
 
 async def fetch_team_names(supabase: Client, team_ids: List[str]) -> Dict[str, str]:
     """Fetch canonical team names for predictor age fallback and reporting."""
+    if _can_use_direct_db():
+        try:
+            return _fetch_team_names_via_db(team_ids)
+        except Exception as error:
+            logger.warning("Direct Postgres team-name fetch failed, falling back to Supabase REST: %s", error)
+
     logger.info(f"Fetching team names for {len(team_ids):,} teams...")
 
     team_names: Dict[str, str] = {}

--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -56,7 +56,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 DIRECT_DB_BATCH_SIZE = 5000
-REST_SNAPSHOT_BATCH_SIZE = 250
+# Keep REST batches at 100 team ids so each request stays below PostgREST's default 1,000-row cap.
+REST_SNAPSHOT_BATCH_SIZE = 100
 REST_SNAPSHOT_CONCURRENCY = 8
 
 

--- a/scripts/train_point_in_time_match_model.py
+++ b/scripts/train_point_in_time_match_model.py
@@ -31,7 +31,6 @@ from scripts.backtest_predictor import (  # noqa: E402
     build_snapshot_index,
     fetch_historical_games,
     fetch_prediction_feature_snapshots,
-    fetch_team_names,
 )
 from src.predictions.point_in_time_match_model import (  # noqa: E402
     DatasetBuildResult,
@@ -106,6 +105,11 @@ async def main():
         action="store_true",
         help="Persist the built training frame to CSV for inspection",
     )
+    parser.add_argument(
+        "--include-team-names",
+        action="store_true",
+        help="Fetch canonical team names for dataset/reporting output (slower; disabled by default in CI)",
+    )
     args = parser.parse_args()
 
     supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
@@ -141,7 +145,17 @@ async def main():
         sys.exit(1)
 
     snapshot_index = build_snapshot_index(snapshots_df)
-    team_names = await fetch_team_names(supabase, team_ids)
+    team_names = {}
+    if args.include_team_names:
+        from scripts.backtest_predictor import fetch_team_names  # noqa: E402
+
+        team_names = await fetch_team_names(supabase, team_ids)
+    else:
+        logger.info(
+            "Skipping canonical team-name fetch for %s teams during training; names are metadata-only and not "
+            "required for model fitting.",
+            f"{len(team_ids):,}",
+        )
 
     logger.info(
         "Building point-in-time dataset from %s games, %s snapshots, and %s teams",
@@ -154,6 +168,7 @@ async def main():
         snapshot_index=snapshot_index,
         team_names=team_names,
         include_mirrored_examples=True,
+        progress_log_every=5000,
     )
 
     model_dir = Path(args.model_dir)

--- a/src/predictions/point_in_time_match_model.py
+++ b/src/predictions/point_in_time_match_model.py
@@ -948,6 +948,7 @@ def build_point_in_time_dataset(
     snapshot_index: Dict[str, List[dict]],
     team_names: Optional[Dict[str, str]] = None,
     include_mirrored_examples: bool = True,
+    progress_log_every: int = 0,
 ) -> DatasetBuildResult:
     """
     Build a leakage-safe training frame from point-in-time snapshots.
@@ -1004,7 +1005,9 @@ def build_point_in_time_dataset(
             actual_score_b=score_b,
         )
 
-    for _, game_row in games_df.iterrows():
+    total_games = len(games_df)
+
+    for index, (_, game_row) in enumerate(games_df.iterrows(), start=1):
         if pd.isna(game_row.get("home_team_master_id")) or pd.isna(game_row.get("away_team_master_id")):
             continue
         if pd.isna(game_row.get("home_score")) or pd.isna(game_row.get("away_score")):
@@ -1064,6 +1067,16 @@ def build_point_in_time_dataset(
         )
         per_team_history[home_id].append(predictor_game)
         per_team_history[away_id].append(predictor_game)
+
+        if progress_log_every and index % progress_log_every == 0:
+            logger.info(
+                "Dataset build progress: processed %s/%s games, used=%s, skipped_missing_snapshot=%s, examples=%s",
+                f"{index:,}",
+                f"{total_games:,}",
+                f"{games_used:,}",
+                f"{skipped_missing_snapshot:,}",
+                f"{len(rows):,}",
+            )
 
     dataset = pd.DataFrame(rows)
     if not dataset.empty:

--- a/tests/unit/test_backtest_predictor.py
+++ b/tests/unit/test_backtest_predictor.py
@@ -1,6 +1,9 @@
 import asyncio
 
-from scripts.backtest_predictor import fetch_historical_games
+import pandas as pd
+
+import scripts.backtest_predictor as backtest_predictor
+from scripts.backtest_predictor import fetch_historical_games, fetch_prediction_feature_snapshots
 
 
 class _FakeResponse:
@@ -53,7 +56,13 @@ class _FakeSupabase:
         return query
 
 
+class _FakeConnection:
+    def close(self):
+        return None
+
+
 def test_fetch_historical_games_rebuilds_query_each_batch():
+    backtest_predictor._database_url.cache_clear() if hasattr(backtest_predictor._database_url, "cache_clear") else None
     batches = [
         [
             {
@@ -78,8 +87,106 @@ def test_fetch_historical_games_rebuilds_query_each_batch():
         ],
     ]
     supabase = _FakeSupabase(batches)
+    # Force the legacy Supabase path for this regression test even if DATABASE_URL is set locally.
+    import os
 
-    games_df = asyncio.run(fetch_historical_games(supabase, lookback_days=30))
+    original_database_url = os.environ.pop("DATABASE_URL", None)
+
+    try:
+        games_df = asyncio.run(fetch_historical_games(supabase, lookback_days=30))
+    finally:
+        if original_database_url is not None:
+            os.environ["DATABASE_URL"] = original_database_url
 
     assert len(games_df) == 1001
     assert [query._range_calls for query in supabase.queries] == [[(0, 999)], [(1000, 1999)]]
+
+
+def test_fetch_historical_games_prefers_direct_database_url(monkeypatch):
+    calls = []
+
+    def fake_connect(_database_url):
+        return _FakeConnection()
+
+    def fake_read_sql_query(sql, conn, params=None):
+        calls.append((sql, conn, params))
+        return pd.DataFrame(
+            [
+                {
+                    "id": "game-1",
+                    "game_date": "2026-04-01",
+                    "home_team_master_id": "home-1",
+                    "away_team_master_id": "away-1",
+                    "home_score": 2,
+                    "away_score": 1,
+                }
+            ]
+        )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example")
+    monkeypatch.setattr(backtest_predictor, "HAS_PSYCOPG2", True)
+    monkeypatch.setattr(backtest_predictor, "psycopg2", type("Psycopg", (), {"connect": staticmethod(fake_connect)}))
+    monkeypatch.setattr(backtest_predictor.pd, "read_sql_query", fake_read_sql_query)
+
+    games_df = asyncio.run(fetch_historical_games(None, lookback_days=30, limit=10))
+
+    assert len(games_df) == 1
+    assert len(calls) == 1
+    assert "FROM games g" in calls[0][0]
+    assert calls[0][2][-1] == 10
+
+
+def test_fetch_prediction_feature_snapshots_prefers_direct_database_url(monkeypatch):
+    calls = []
+
+    def fake_connect(_database_url):
+        return _FakeConnection()
+
+    def fake_read_sql_query(sql, conn, params=None):
+        calls.append((sql, conn, params))
+        return pd.DataFrame(
+            [
+                {
+                    "snapshot_date": "2026-04-01",
+                    "team_id": params[2][0],
+                    "age_group": "u12",
+                    "gender": "boys",
+                    "status": "active",
+                    "rank_in_cohort_final": 10,
+                    "power_score_final": 0.7,
+                    "sos_norm": 0.6,
+                    "offense_norm": 0.55,
+                    "defense_norm": 0.52,
+                    "glicko_rating": 1500,
+                    "glicko_rd": 120,
+                    "glicko_volatility": 0.06,
+                    "wins": 10,
+                    "losses": 2,
+                    "draws": 1,
+                    "games_played": 13,
+                    "win_percentage": 0.77,
+                    "exp_margin": 1.1,
+                    "exp_win_rate": 0.69,
+                    "exp_goals_for": 2.3,
+                    "exp_goals_against": 1.0,
+                }
+            ]
+        )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example")
+    monkeypatch.setattr(backtest_predictor, "HAS_PSYCOPG2", True)
+    monkeypatch.setattr(backtest_predictor, "psycopg2", type("Psycopg", (), {"connect": staticmethod(fake_connect)}))
+    monkeypatch.setattr(backtest_predictor.pd, "read_sql_query", fake_read_sql_query)
+
+    snapshots_df = asyncio.run(
+        fetch_prediction_feature_snapshots(
+            None,
+            team_ids=["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
+            start_date="2026-04-01",
+            end_date="2026-04-10",
+        )
+    )
+
+    assert len(snapshots_df) == 1
+    assert len(calls) == 1
+    assert "FROM prediction_feature_history" in calls[0][0]


### PR DESCRIPTION
## Summary
- skip the metadata-only canonical team-name fetch during PIT training by default
- keep team-name fetching available behind an explicit flag for local inspection
- add periodic dataset-build progress logs so long training runs stay observable

## Why
The latest failing PIT training run never reached dataset build or model fitting. It stalled during the canonical team-name fetch over ~102k teams, which is not required for training.

## Validation
- python -m pytest tests/unit/test_point_in_time_match_model.py
- python -m py_compile scripts/train_point_in_time_match_model.py src/predictions/point_in_time_match_model.py

## Probe run
- https://github.com/dallasheidt14/PitchRank/actions/runs/24422253407