### PR TITLE
feat(analytics): traffic sources tile + shrink search perf + dedupe top pages

### DIFF
--- a/frontend/app/(internal)/analytics/components/DashboardGrid.tsx
+++ b/frontend/app/(internal)/analytics/components/DashboardGrid.tsx
@@ -10,6 +10,7 @@ import { TrafficOverviewTile } from './tiles/TrafficOverviewTile';
 import { TopPagesTile } from './tiles/TopPagesTile';
 import { UpgradeViewsTile } from './tiles/UpgradeViewsTile';
 import { SearchPerformanceTile } from './tiles/SearchPerformanceTile';
+import { TrafficSourcesTile } from './tiles/TrafficSourcesTile';
 import { TopQueriesTile } from './tiles/TopQueriesTile';
 import { LandingPagesTile } from './tiles/LandingPagesTile';
 import { ChatSidebar } from './chat/ChatSidebar';
@@ -46,6 +47,7 @@ export function DashboardGrid() {
             <TrafficOverviewTile range={range} />
             <UpgradeViewsTile range={range} />
             <TopPagesTile range={range} />
+            <TrafficSourcesTile range={range} />
             <SearchPerformanceTile range={range} />
             <TopQueriesTile range={range} />
             <LandingPagesTile range={range} />

--- a/frontend/app/(internal)/analytics/components/tiles/SearchPerformanceTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/SearchPerformanceTile.tsx
@@ -31,25 +31,25 @@ export function SearchPerformanceTile({ range }: { range: DateRangePreset }) {
     <TileShell title="Search Performance" description="Clicks · impressions · CTR · position" state={state}>
       {q.data && (
         <div className="space-y-3">
-          <div className="grid grid-cols-4 gap-2 text-sm">
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
             <div>
-              <div className="text-muted-foreground">Clicks</div>
-              <div className="text-lg font-semibold">{q.data.totals.clicks.toLocaleString()}</div>
+              <span className="text-muted-foreground">Clicks </span>
+              <span className="font-semibold">{q.data.totals.clicks.toLocaleString()}</span>
             </div>
             <div>
-              <div className="text-muted-foreground">Impressions</div>
-              <div className="text-lg font-semibold">{q.data.totals.impressions.toLocaleString()}</div>
+              <span className="text-muted-foreground">Impr. </span>
+              <span className="font-semibold">{q.data.totals.impressions.toLocaleString()}</span>
             </div>
             <div>
-              <div className="text-muted-foreground">CTR</div>
-              <div className="text-lg font-semibold">{(q.data.totals.ctr * 100).toFixed(2)}%</div>
+              <span className="text-muted-foreground">CTR </span>
+              <span className="font-semibold">{(q.data.totals.ctr * 100).toFixed(2)}%</span>
             </div>
             <div>
-              <div className="text-muted-foreground">Pos.</div>
-              <div className="text-lg font-semibold">{q.data.totals.position.toFixed(1)}</div>
+              <span className="text-muted-foreground">Pos. </span>
+              <span className="font-semibold">{q.data.totals.position.toFixed(1)}</span>
             </div>
           </div>
-          <div className="h-32">
+          <div className="h-20">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={q.data.rows}>
                 <XAxis dataKey="date" hide />

--- a/frontend/app/(internal)/analytics/components/tiles/TopPagesTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/TopPagesTile.tsx
@@ -5,7 +5,6 @@ import type { DateRangePreset } from '@/lib/internal-analytics/types';
 
 type Row = {
   pagePath: string;
-  pageTitle: string;
   screenPageViews: number;
   activeUsers: number;
   engagementRate: number;

--- a/frontend/app/(internal)/analytics/components/tiles/TrafficSourcesTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/TrafficSourcesTile.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { TileShell, type TileState } from './TileShell';
+import type { DateRangePreset } from '@/lib/internal-analytics/types';
+
+type Row = {
+  source: string;
+  medium: string;
+  sessions: number;
+  activeUsers: number;
+  engagementRate: number;
+};
+type Resp = { rows: Row[]; row_count: number };
+
+export function TrafficSourcesTile({ range }: { range: DateRangePreset }) {
+  const q = useQuery({
+    queryKey: ['ga4_traffic_sources', range],
+    queryFn: async (): Promise<Resp> => {
+      const r = await fetch(`/api/internal/analytics/ga4/traffic-sources?range=${range}&limit=10`);
+      if (!r.ok) throw new Error((await r.json()).error?.message ?? 'Request failed');
+      return r.json();
+    },
+  });
+
+  let state: TileState = { status: 'loading' };
+  if (q.isError)
+    state = { status: 'error', message: (q.error as Error).message, retry: () => q.refetch() };
+  else if (q.data && q.data.row_count === 0) state = { status: 'empty' };
+  else if (q.data) state = { status: 'success' };
+
+  return (
+    <TileShell title="Traffic Sources" description="Where your visitors come from" state={state}>
+      {q.data && (
+        <table className="w-full text-sm">
+          <thead className="text-left text-muted-foreground">
+            <tr>
+              <th>Source / Medium</th>
+              <th className="text-right">Sessions</th>
+              <th className="text-right">Users</th>
+            </tr>
+          </thead>
+          <tbody>
+            {q.data.rows.map((r, i) => (
+              <tr key={`${r.source}-${r.medium}-${i}`} className="border-t">
+                <td
+                  className="py-1 truncate max-w-[180px]"
+                  title={`${r.source} / ${r.medium}`}
+                >
+                  {r.source} / {r.medium}
+                </td>
+                <td className="text-right">{r.sessions.toLocaleString()}</td>
+                <td className="text-right">{r.activeUsers.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </TileShell>
+  );
+}

--- a/frontend/app/api/internal/analytics/ga4/traffic-sources/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/traffic-sources/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { runReport } from '@/lib/internal-analytics/report-registry';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const auth = await requireAdmin();
+  if (auth.error) return auth.error;
+  const url = new URL(req.url);
+  const range = url.searchParams.get('range') ?? 'last_7_days';
+  const limit = Number(url.searchParams.get('limit') ?? 10);
+  try {
+    const data = await runReport('ga4_traffic_sources', { date_range: range, limit });
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
+    throw e;
+  }
+}

--- a/frontend/lib/internal-analytics/queries/ga4-top-pages.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-top-pages.ts
@@ -1,8 +1,12 @@
-// frontend/lib/internal-analytics/queries/ga4-top-pages.ts
 import 'server-only';
 import { unstable_cache } from 'next/cache';
 import { getAnalyticsDataClient } from '@/lib/google-auth';
-import { GA4_PROPERTY_ID, CACHE_TTL_SECONDS, DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT } from '../constants';
+import {
+  GA4_PROPERTY_ID,
+  CACHE_TTL_SECONDS,
+  DEFAULT_ROW_LIMIT,
+  MAX_ROW_LIMIT,
+} from '../constants';
 import type { DateRange, TileResponse } from '../types';
 import { resolveDateRange, detectFreshness, rangeDays } from '../dates';
 import { ga4RowsToObjects } from '../transforms/ga4';
@@ -18,7 +22,6 @@ export type Ga4TopPagesParams = {
 
 export type Ga4TopPagesRow = {
   pagePath: string;
-  pageTitle: string;
   screenPageViews: number;
   activeUsers: number;
   engagementRate: number;
@@ -31,8 +34,12 @@ async function fetchRaw(range: DateRange, limit: number) {
       property: `properties/${GA4_PROPERTY_ID}`,
       requestBody: {
         dateRanges: [{ startDate: range.start, endDate: range.end }],
-        dimensions: [{ name: 'pagePath' }, { name: 'pageTitle' }],
-        metrics: [{ name: 'screenPageViews' }, { name: 'activeUsers' }, { name: 'engagementRate' }],
+        dimensions: [{ name: 'pagePath' }],
+        metrics: [
+          { name: 'screenPageViews' },
+          { name: 'activeUsers' },
+          { name: 'engagementRate' },
+        ],
         orderBys: [{ metric: { metricName: 'screenPageViews' }, desc: true }],
         limit: String(limit),
       },
@@ -51,7 +58,6 @@ async function runOnce(params: Ga4TopPagesParams): Promise<TileResponse<Ga4TopPa
   const raw = await fetchRaw(range, limit);
   const rows = ga4RowsToObjects(raw as never).map((r) => ({
     pagePath: String(r.pagePath ?? ''),
-    pageTitle: String(r.pageTitle ?? ''),
     screenPageViews: Number(r.screenPageViews ?? 0),
     activeUsers: Number(r.activeUsers ?? 0),
     engagementRate: Number(r.engagementRate ?? 0),
@@ -61,7 +67,7 @@ async function runOnce(params: Ga4TopPagesParams): Promise<TileResponse<Ga4TopPa
       screenPageViews: acc.screenPageViews + r.screenPageViews,
       activeUsers: acc.activeUsers + r.activeUsers,
     }),
-    { screenPageViews: 0, activeUsers: 0 }
+    { screenPageViews: 0, activeUsers: 0 },
   );
   const fresh = detectFreshness('ga4', range, tz);
 
@@ -84,7 +90,7 @@ async function runOnce(params: Ga4TopPagesParams): Promise<TileResponse<Ga4TopPa
         estimated_units: rangeDays(range) * 2,
         range_days: rangeDays(range),
         metric_count: 3,
-        dimension_count: 2,
+        dimension_count: 1,
         limit,
       },
     },

--- a/frontend/lib/internal-analytics/queries/ga4-traffic-sources.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-traffic-sources.ts
@@ -1,0 +1,115 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { getAnalyticsDataClient } from '@/lib/google-auth';
+import {
+  GA4_PROPERTY_ID,
+  CACHE_TTL_SECONDS,
+  DEFAULT_ROW_LIMIT,
+  MAX_ROW_LIMIT,
+} from '../constants';
+import type { DateRange, TileResponse } from '../types';
+import { resolveDateRange, detectFreshness, rangeDays } from '../dates';
+import { ga4RowsToObjects } from '../transforms/ga4';
+import { coalesce, sortedKeys } from './_coalesce';
+import { toTaxonomyError, TaxonomyAwareError } from './_error';
+
+export type Ga4TrafficSourcesParams = {
+  dateRange: DateRange;
+  limit?: number;
+  forceFresh?: boolean;
+  timezone?: string;
+};
+
+export type Ga4TrafficSourcesRow = {
+  source: string;
+  medium: string;
+  sessions: number;
+  activeUsers: number;
+  engagementRate: number;
+};
+
+async function fetchRaw(range: DateRange, limit: number) {
+  try {
+    const client = getAnalyticsDataClient();
+    const res = await client.properties.runReport({
+      property: `properties/${GA4_PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: range.start, endDate: range.end }],
+        dimensions: [{ name: 'sessionSource' }, { name: 'sessionMedium' }],
+        metrics: [
+          { name: 'sessions' },
+          { name: 'activeUsers' },
+          { name: 'engagementRate' },
+        ],
+        orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+        limit: String(limit),
+      },
+    });
+    return res.data;
+  } catch (e) {
+    throw new TaxonomyAwareError(toTaxonomyError(e));
+  }
+}
+
+async function runOnce(
+  params: Ga4TrafficSourcesParams,
+): Promise<TileResponse<Ga4TrafficSourcesRow>> {
+  const tz = params.timezone ?? 'America/Phoenix';
+  const range = resolveDateRange(params.dateRange, tz);
+  const limit = Math.min(params.limit ?? DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT);
+
+  const raw = await fetchRaw(range, limit);
+  const rows = ga4RowsToObjects(raw as never).map((r) => ({
+    source: String(r.sessionSource ?? '(unknown)'),
+    medium: String(r.sessionMedium ?? '(none)'),
+    sessions: Number(r.sessions ?? 0),
+    activeUsers: Number(r.activeUsers ?? 0),
+    engagementRate: Number(r.engagementRate ?? 0),
+  }));
+  const totals = rows.reduce(
+    (acc, r) => ({
+      sessions: acc.sessions + r.sessions,
+      activeUsers: acc.activeUsers + r.activeUsers,
+    }),
+    { sessions: 0, activeUsers: 0 },
+  );
+  const fresh = detectFreshness('ga4', range, tz);
+
+  return {
+    report: 'ga4_traffic_sources',
+    source: 'ga4',
+    date_range: range,
+    timezone: tz,
+    rows,
+    row_count: rows.length,
+    totals,
+    derived: {},
+    truncated: rows.length >= limit,
+    truncation_reason: rows.length >= limit ? 'limit_reached' : undefined,
+    data_freshness: fresh.freshness,
+    warnings: fresh.warnings,
+    generated_at: new Date().toISOString(),
+    debug: {
+      cost: {
+        estimated_units: rangeDays(range) * 2,
+        range_days: rangeDays(range),
+        metric_count: 3,
+        dimension_count: 2,
+        limit,
+      },
+    },
+  };
+}
+
+export function getGa4TrafficSources(
+  params: Ga4TrafficSourcesParams,
+): Promise<TileResponse<Ga4TrafficSourcesRow>> {
+  const cacheArgs = { ...params, forceFresh: undefined };
+  const key = `ga4_traffic_sources:${sortedKeys(cacheArgs)}`;
+  const run = () => coalesce(key, () => runOnce(params));
+  if (params.forceFresh) return run();
+  return unstable_cache(run, ['ga4_traffic_sources', sortedKeys(cacheArgs)], {
+    revalidate: CACHE_TTL_SECONDS,
+    tags: ['analytics:ga4', 'analytics:ga4_traffic_sources'],
+  })();
+}

--- a/frontend/lib/internal-analytics/report-registry.ts
+++ b/frontend/lib/internal-analytics/report-registry.ts
@@ -5,6 +5,7 @@ import type { DateRangePreset } from './types';
 import { DATE_RANGE_PRESETS, MAX_ROW_LIMIT } from './constants';
 import { getGa4Overview } from './queries/ga4-overview';
 import { getGa4TopPages, type Ga4TopPagesParams } from './queries/ga4-top-pages';
+import { getGa4TrafficSources } from './queries/ga4-traffic-sources';
 import { getGa4UpgradeViews, type Ga4UpgradeViewsParams } from './queries/ga4-upgrade-views';
 import { getGscPerformance, type GscPerformanceParams } from './queries/gsc-performance';
 import { getGscTopQueries, type GscTopQueriesParams } from './queries/gsc-top-queries';
@@ -49,6 +50,13 @@ export const REPORTS = {
     paramsSchema: z.object({ ...Common, limit: z.number().int().min(1).max(MAX_ROW_LIMIT).optional() }),
     handler: (p: WithLimit) =>
       getGa4TopPages({ dateRange: p.date_range, limit: p.limit, forceFresh: p.forceFresh } as Ga4TopPagesParams),
+    summaryRequired: ['totals'],
+  },
+  ga4_traffic_sources: {
+    source: 'ga4',
+    description: 'Top traffic sources by sessions, with user counts.',
+    paramsSchema: z.object({ ...Common, limit: z.number().int().min(1).max(MAX_ROW_LIMIT).optional() }),
+    handler: (p: any) => getGa4TrafficSources({ dateRange: p.date_range, limit: p.limit, forceFresh: p.forceFresh }),
     summaryRequired: ['totals'],
   },
   ga4_upgrade_views: {


### PR DESCRIPTION
## Summary
- **Change 1 (Top Pages dedupe):** Drop `pageTitle` from GA4 dimensions so `/` only appears once; remove `pageTitle` from `Ga4TopPagesRow` type and `TopPagesTile` Row type
- **Change 2 (Search Performance shrink):** Chart height `h-32` → `h-20`; 4-col metric grid replaced with compact 2×2 inline layout (clicks+impressions / CTR+position)
- **Change 3 (Traffic Sources tile):** New query (`ga4-traffic-sources.ts`), API route (`/api/internal/analytics/ga4/traffic-sources`), `TrafficSourcesTile` component, report-registry entry, and DashboardGrid wiring — placed between TopPagesTile and SearchPerformanceTile

## Layout after merge
```
TrafficOverviewTile  | UpgradeViewsTile
TopPagesTile         | TrafficSourcesTile
SearchPerformanceTile| TopQueriesTile
LandingPagesTile     | (empty)
```

## Test plan
- [ ] `/internal/analytics` loads without error
- [ ] Top Pages shows no duplicate `/` rows
- [ ] Search Performance tile is visually shorter
- [ ] Traffic Sources tile renders with source/medium/sessions/users columns
- [ ] `/api/internal/analytics/ga4/traffic-sources?range=last_7_days` returns `{ rows, row_count, totals }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)