### PR TITLE
Paginate PIT snapshot REST fallback

### DIFF
--- a/scripts/backtest_predictor.py
+++ b/scripts/backtest_predictor.py
@@ -56,9 +56,10 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 DIRECT_DB_BATCH_SIZE = 5000
-# Keep REST batches at 100 team ids so each request stays below PostgREST's default 1,000-row cap.
-REST_SNAPSHOT_BATCH_SIZE = 100
+# Batch team ids, then paginate within each batch so we don't truncate at the PostgREST row cap.
+REST_SNAPSHOT_BATCH_SIZE = 250
 REST_SNAPSHOT_CONCURRENCY = 8
+REST_PAGE_SIZE = 1000
 
 
 def _database_url() -> Optional[str]:
@@ -259,16 +260,33 @@ async def _fetch_prediction_feature_snapshots_via_rest(
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=30.0)) as client:
         async def fetch_batch(index: int, batch: List[str]) -> List[dict]:
-            params = [
-                ("select", fields),
-                ("team_id", f"in.({','.join(batch)})"),
-                ("snapshot_date", f"gte.{start_date}"),
-                ("snapshot_date", f"lte.{end_date}"),
-            ]
-            async with semaphore:
-                response = await client.get(endpoint, params=params, headers=headers)
-                response.raise_for_status()
-                return response.json()
+            batch_rows: List[dict] = []
+            offset = 0
+
+            while True:
+                params = [
+                    ("select", fields),
+                    ("team_id", f"in.({','.join(batch)})"),
+                    ("snapshot_date", f"gte.{start_date}"),
+                    ("snapshot_date", f"lte.{end_date}"),
+                    ("order", "team_id.asc,snapshot_date.asc"),
+                    ("limit", str(REST_PAGE_SIZE)),
+                    ("offset", str(offset)),
+                ]
+                async with semaphore:
+                    response = await client.get(endpoint, params=params, headers=headers)
+                    response.raise_for_status()
+                    page_rows = response.json()
+
+                if not page_rows:
+                    break
+
+                batch_rows.extend(page_rows)
+                if len(page_rows) < REST_PAGE_SIZE:
+                    break
+                offset += REST_PAGE_SIZE
+
+            return batch_rows
 
         tasks = [
             fetch_batch(index, team_ids[index : index + REST_SNAPSHOT_BATCH_SIZE])

--- a/tests/unit/test_backtest_predictor.py
+++ b/tests/unit/test_backtest_predictor.py
@@ -61,6 +61,39 @@ class _FakeConnection:
         return None
 
 
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, pages):
+        self._pages = pages
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, endpoint, params=None, headers=None):
+        params_dict = {}
+        for key, value in params or []:
+            params_dict.setdefault(key, []).append(value)
+        offset = int(params_dict["offset"][0])
+        limit = int(params_dict["limit"][0])
+        self.calls.append((endpoint, params_dict, headers))
+        page = self._pages.get((offset, limit), [])
+        return _FakeHttpResponse(page)
+
+
 def test_fetch_historical_games_rebuilds_query_each_batch():
     backtest_predictor._database_url.cache_clear() if hasattr(backtest_predictor._database_url, "cache_clear") else None
     batches = [
@@ -190,3 +223,39 @@ def test_fetch_prediction_feature_snapshots_prefers_direct_database_url(monkeypa
     assert len(snapshots_df) == 1
     assert len(calls) == 1
     assert "FROM prediction_feature_history" in calls[0][0]
+
+
+def test_fetch_prediction_feature_snapshots_rest_path_paginates(monkeypatch):
+    client = _FakeAsyncClient(
+        {
+            (0, 2): [
+                {"snapshot_date": "2026-04-01", "team_id": "team-1"},
+                {"snapshot_date": "2026-04-02", "team_id": "team-1"},
+            ],
+            (2, 2): [
+                {"snapshot_date": "2026-04-03", "team_id": "team-2"},
+            ],
+        }
+    )
+
+    monkeypatch.setattr(backtest_predictor, "REST_SNAPSHOT_BATCH_SIZE", 2)
+    monkeypatch.setattr(backtest_predictor, "REST_PAGE_SIZE", 2)
+    monkeypatch.setattr(backtest_predictor, "REST_SNAPSHOT_CONCURRENCY", 1)
+    monkeypatch.setattr(backtest_predictor, "_supabase_rest_credentials", lambda: ("https://example.supabase.co", "key"))
+    monkeypatch.setattr(backtest_predictor.httpx, "AsyncClient", lambda *args, **kwargs: client)
+
+    snapshots_df = asyncio.run(
+        backtest_predictor._fetch_prediction_feature_snapshots_via_rest(
+            team_ids=["team-1", "team-2"],
+            start_date="2026-04-01",
+            end_date="2026-04-10",
+        )
+    )
+
+    assert len(snapshots_df) == 3
+    assert len(client.calls) == 2
+    first_params = client.calls[0][1]
+    second_params = client.calls[1][1]
+    assert first_params["limit"] == ["2"]
+    assert first_params["offset"] == ["0"]
+    assert second_params["offset"] == ["2"]


### PR DESCRIPTION
## Summary
- paginate the prediction_feature_history REST fallback so PostgREST row caps do not truncate snapshot batches
- increase the REST team batch size now that pagination is explicit
- add a regression test that proves multiple pages are fetched for one batch

## Why
The training workflow was succeeding after the CI/runtime fix, but it only used ~38k games because the REST fallback was silently truncating each snapshot batch at 1,000 rows. That made the trainer think most teams had no usable as-of snapshots.

## Validation
- python -m pytest tests/unit/test_backtest_predictor.py tests/unit/test_point_in_time_match_model.py
- live-data spot check: expected 8,903 snapshot rows from the DB and fetched 8,903 via the paginated REST path for the same 250-team sample