### PR TITLE
feat(analytics): add upgrade funnel, most wanted teams, upgrade sources tiles

### DIFF
--- a/frontend/app/(internal)/analytics/components/DashboardGrid.tsx
+++ b/frontend/app/(internal)/analytics/components/DashboardGrid.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_PRESET, REACT_QUERY_STALE_MS, REACT_QUERY_GC_MS } from '@/lib/i
 import type { DateRangePreset } from '@/lib/internal-analytics/types';
 import { DateRangePicker } from './DateRangePicker';
 import { Button } from '@/components/ui/button';
+import { UpgradeFunnelTile } from './tiles/UpgradeFunnelTile';
 import { TrafficOverviewTile } from './tiles/TrafficOverviewTile';
 import { TopPagesTile } from './tiles/TopPagesTile';
 import { UpgradeViewsTile } from './tiles/UpgradeViewsTile';
@@ -13,6 +14,8 @@ import { SearchPerformanceTile } from './tiles/SearchPerformanceTile';
 import { TrafficSourcesTile } from './tiles/TrafficSourcesTile';
 import { TopQueriesTile } from './tiles/TopQueriesTile';
 import { LandingPagesTile } from './tiles/LandingPagesTile';
+import { MostWantedTeamsTile } from './tiles/MostWantedTeamsTile';
+import { UpgradeSourcesTile } from './tiles/UpgradeSourcesTile';
 import { ChatSidebar } from './chat/ChatSidebar';
 
 export function DashboardGrid() {
@@ -44,6 +47,7 @@ export function DashboardGrid() {
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
           <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UpgradeFunnelTile range={range} />
             <TrafficOverviewTile range={range} />
             <UpgradeViewsTile range={range} />
             <TopPagesTile range={range} />
@@ -51,6 +55,8 @@ export function DashboardGrid() {
             <SearchPerformanceTile range={range} />
             <TopQueriesTile range={range} />
             <LandingPagesTile range={range} />
+            <MostWantedTeamsTile range={range} />
+            <UpgradeSourcesTile range={range} />
           </div>
           <div className="lg:col-span-1">
             <ChatSidebar range={range} />

--- a/frontend/app/(internal)/analytics/components/tiles/MostWantedTeamsTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/MostWantedTeamsTile.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { TileShell, type TileState } from './TileShell';
+import type { DateRangePreset } from '@/lib/internal-analytics/types';
+
+type Row = {
+  team_id: string;
+  team_name?: string;
+  paywall_impressions: number;
+};
+
+type Resp = {
+  rows: Row[];
+  row_count: number;
+  totals: { paywall_impressions: number };
+  warnings?: string[];
+};
+
+export function MostWantedTeamsTile({ range }: { range: DateRangePreset }) {
+  const q = useQuery({
+    queryKey: ['ga4_most_wanted_teams', range],
+    queryFn: async (): Promise<Resp> => {
+      const r = await fetch(`/api/internal/analytics/ga4/most-wanted-teams?range=${range}&limit=10`);
+      if (!r.ok) throw new Error((await r.json()).error?.message ?? 'Request failed');
+      return r.json();
+    },
+  });
+
+  let state: TileState = { status: 'loading' };
+  if (q.isError)
+    state = { status: 'error', message: (q.error as Error).message, retry: () => q.refetch() };
+  else if (q.data && q.data.row_count === 0) state = { status: 'empty' };
+  else if (q.data) state = { status: 'success' };
+
+  return (
+    <TileShell
+      title="Most Wanted Teams"
+      description="Teams non-premium users try to access most"
+      state={state}
+    >
+      {q.data && (
+        <>
+          {q.data.warnings && q.data.warnings.length > 0 && (
+            <p className="text-xs text-amber-600 mb-2">{q.data.warnings[0]}</p>
+          )}
+          <table className="w-full text-sm">
+            <thead className="text-left text-muted-foreground">
+              <tr>
+                <th>Team</th>
+                <th className="text-right">Impressions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {q.data.rows.map((r, i) => (
+                <tr key={`${r.team_id}-${i}`} className="border-t">
+                  <td className="py-1 truncate max-w-[180px]" title={r.team_id}>
+                    {r.team_name ?? r.team_id}
+                  </td>
+                  <td className="text-right">{r.paywall_impressions.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </TileShell>
+  );
+}

--- a/frontend/app/(internal)/analytics/components/tiles/UpgradeFunnelTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/UpgradeFunnelTile.tsx
@@ -1,0 +1,83 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { TileShell, type TileState } from './TileShell';
+import type { DateRangePreset } from '@/lib/internal-analytics/types';
+
+type FunnelRow = {
+  step: string;
+  label: string;
+  count: number;
+  pct_of_top: number;
+};
+
+type Derived = {
+  conversion_rate: number;
+  cart_abandonment: number;
+};
+
+type Resp = {
+  rows: FunnelRow[];
+  row_count: number;
+  derived: Derived;
+  warnings?: string[];
+};
+
+export function UpgradeFunnelTile({ range }: { range: DateRangePreset }) {
+  const q = useQuery({
+    queryKey: ['ga4_upgrade_funnel', range],
+    queryFn: async (): Promise<Resp> => {
+      const r = await fetch(`/api/internal/analytics/ga4/upgrade-funnel?range=${range}`);
+      if (!r.ok) throw new Error((await r.json()).error?.message ?? 'Request failed');
+      return r.json();
+    },
+  });
+
+  let state: TileState = { status: 'loading' };
+  if (q.isError)
+    state = { status: 'error', message: (q.error as Error).message, retry: () => q.refetch() };
+  else if (q.data && q.data.row_count === 0) state = { status: 'empty' };
+  else if (q.data) state = { status: 'success' };
+
+  const fmtPct = (v: number) => `${(v * 100).toFixed(1)}%`;
+
+  return (
+    <TileShell
+      title="Upgrade Funnel"
+      description="4-step conversion from page view to subscription"
+      state={state}
+    >
+      {q.data && (
+        <div className="space-y-3">
+          {q.data.rows.map((row) => (
+            <div key={row.step}>
+              <div className="flex justify-between text-sm mb-1">
+                <span className="text-muted-foreground">{row.label}</span>
+                <span className="font-medium tabular-nums">{row.count.toLocaleString()}</span>
+              </div>
+              <div className="h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${Math.max(row.pct_of_top * 100, row.count > 0 ? 2 : 0)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+          <div className="pt-2 border-t flex gap-4 text-xs text-muted-foreground">
+            <span>
+              Conversion:{' '}
+              <span className="text-foreground font-medium">
+                {fmtPct(q.data.derived.conversion_rate)}
+              </span>
+            </span>
+            <span>
+              Cart abandonment:{' '}
+              <span className="text-foreground font-medium">
+                {fmtPct(q.data.derived.cart_abandonment)}
+              </span>
+            </span>
+          </div>
+        </div>
+      )}
+    </TileShell>
+  );
+}

--- a/frontend/app/(internal)/analytics/components/tiles/UpgradeSourcesTile.tsx
+++ b/frontend/app/(internal)/analytics/components/tiles/UpgradeSourcesTile.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+import { TileShell, type TileState } from './TileShell';
+import type { DateRangePreset } from '@/lib/internal-analytics/types';
+
+type Row = {
+  source: string;
+  views: number;
+  subscriptions: number;
+  conversion_rate: number;
+};
+
+type Resp = {
+  rows: Row[];
+  row_count: number;
+  totals: { views: number; subscriptions: number };
+  derived: { conversion_rate: number };
+  warnings?: string[];
+};
+
+export function UpgradeSourcesTile({ range }: { range: DateRangePreset }) {
+  const q = useQuery({
+    queryKey: ['ga4_upgrade_sources', range],
+    queryFn: async (): Promise<Resp> => {
+      const r = await fetch(`/api/internal/analytics/ga4/upgrade-sources?range=${range}&limit=10`);
+      if (!r.ok) throw new Error((await r.json()).error?.message ?? 'Request failed');
+      return r.json();
+    },
+  });
+
+  let state: TileState = { status: 'loading' };
+  if (q.isError)
+    state = { status: 'error', message: (q.error as Error).message, retry: () => q.refetch() };
+  else if (q.data && q.data.row_count === 0) state = { status: 'empty' };
+  else if (q.data) state = { status: 'success' };
+
+  const fmtPct = (v: number) => `${(v * 100).toFixed(1)}%`;
+
+  return (
+    <TileShell
+      title="Upgrade Sources"
+      description="Where upgrade views and subscriptions come from"
+      state={state}
+    >
+      {q.data && (
+        <>
+          {q.data.warnings && q.data.warnings.length > 0 && (
+            <p className="text-xs text-amber-600 mb-2">{q.data.warnings[0]}</p>
+          )}
+          <table className="w-full text-sm">
+            <thead className="text-left text-muted-foreground">
+              <tr>
+                <th>Source</th>
+                <th className="text-right">Views</th>
+                <th className="text-right">Subs</th>
+                <th className="text-right">Conv.</th>
+              </tr>
+            </thead>
+            <tbody>
+              {q.data.rows.map((r, i) => (
+                <tr key={`${r.source}-${i}`} className="border-t">
+                  <td className="py-1 truncate max-w-[140px]" title={r.source}>
+                    {r.source}
+                  </td>
+                  <td className="text-right">{r.views.toLocaleString()}</td>
+                  <td className="text-right">{r.subscriptions.toLocaleString()}</td>
+                  <td className="text-right">{fmtPct(r.conversion_rate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </TileShell>
+  );
+}

--- a/frontend/app/api/internal/analytics/ga4/most-wanted-teams/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/most-wanted-teams/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { runReport } from '@/lib/internal-analytics/report-registry';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const auth = await requireAdmin();
+  if (auth.error) return auth.error;
+  const url = new URL(req.url);
+  const range = url.searchParams.get('range') ?? 'last_7_days';
+  const limit = Number(url.searchParams.get('limit') ?? 10);
+  try {
+    const data = await runReport('ga4_most_wanted_teams', { date_range: range, limit });
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
+    throw e;
+  }
+}

--- a/frontend/app/api/internal/analytics/ga4/upgrade-funnel/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/upgrade-funnel/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { runReport } from '@/lib/internal-analytics/report-registry';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const auth = await requireAdmin();
+  if (auth.error) return auth.error;
+  const url = new URL(req.url);
+  const range = url.searchParams.get('range') ?? 'last_7_days';
+  try {
+    const data = await runReport('ga4_upgrade_funnel', { date_range: range });
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
+    throw e;
+  }
+}

--- a/frontend/app/api/internal/analytics/ga4/upgrade-sources/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/upgrade-sources/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { runReport } from '@/lib/internal-analytics/report-registry';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const auth = await requireAdmin();
+  if (auth.error) return auth.error;
+  const url = new URL(req.url);
+  const range = url.searchParams.get('range') ?? 'last_7_days';
+  const limit = Number(url.searchParams.get('limit') ?? 10);
+  try {
+    const data = await runReport('ga4_upgrade_sources', { date_range: range, limit });
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
+    throw e;
+  }
+}

--- a/frontend/lib/internal-analytics/queries/ga4-most-wanted-teams.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-most-wanted-teams.ts
@@ -1,0 +1,163 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { getAnalyticsDataClient } from '@/lib/google-auth';
+import {
+  GA4_PROPERTY_ID,
+  CACHE_TTL_SECONDS,
+  DEFAULT_ROW_LIMIT,
+  MAX_ROW_LIMIT,
+} from '../constants';
+import type { DateRange, TileResponse } from '../types';
+import { resolveDateRange, detectFreshness, rangeDays } from '../dates';
+import { coalesce, sortedKeys } from './_coalesce';
+import { toTaxonomyError, TaxonomyAwareError } from './_error';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export type Ga4MostWantedTeamsParams = {
+  dateRange: DateRange;
+  limit?: number;
+  forceFresh?: boolean;
+  timezone?: string;
+};
+
+export type Ga4MostWantedTeamsRow = {
+  team_id: string;
+  team_name?: string;
+  paywall_impressions: number;
+};
+
+async function fetchRaw(range: DateRange, limit: number) {
+  try {
+    const client = getAnalyticsDataClient();
+    const res = await client.properties.runReport({
+      property: `properties/${GA4_PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: range.start, endDate: range.end }],
+        dimensions: [{ name: 'customEvent:team_id' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            stringFilter: { matchType: 'EXACT', value: 'paywall_impression' },
+          },
+        },
+        orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+        limit: String(limit),
+      },
+    });
+    return res.data;
+  } catch (e) {
+    // 400 typically means customEvent:team_id dimension not configured
+    const err = e as { code?: number; status?: number };
+    if (err?.code === 400 || err?.status === 400) {
+      return { rows: null, __dimensionNotConfigured: true } as never;
+    }
+    throw new TaxonomyAwareError(toTaxonomyError(e));
+  }
+}
+
+async function runOnce(
+  params: Ga4MostWantedTeamsParams,
+): Promise<TileResponse<Ga4MostWantedTeamsRow>> {
+  const tz = params.timezone ?? 'America/Phoenix';
+  const range = resolveDateRange(params.dateRange, tz);
+  const limit = Math.min(params.limit ?? DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT);
+
+  const raw = await fetchRaw(range, limit) as never as {
+    rows?: Array<{ dimensionValues?: Array<{ value?: string }>; metricValues?: Array<{ value?: string }> }>;
+    __dimensionNotConfigured?: boolean;
+  };
+  const fresh = detectFreshness('ga4', range, tz);
+
+  if (raw.__dimensionNotConfigured) {
+    return {
+      report: 'ga4_most_wanted_teams',
+      source: 'ga4',
+      date_range: range,
+      timezone: tz,
+      rows: [],
+      row_count: 0,
+      totals: {},
+      derived: {},
+      truncated: false,
+      data_freshness: fresh.freshness,
+      warnings: [
+        ...(fresh.warnings ?? []),
+        'customEvent:team_id dimension not configured in GA4 — register it under Admin > Custom definitions',
+      ],
+      generated_at: new Date().toISOString(),
+      debug: { cost: { estimated_units: 0, range_days: rangeDays(range), metric_count: 1, dimension_count: 1, limit } },
+    };
+  }
+
+  const rawRows = raw.rows ?? [];
+  const teamIds = rawRows
+    .map((r) => r.dimensionValues?.[0]?.value)
+    .filter((id): id is string => Boolean(id) && id !== '(not set)');
+
+  // Resolve team names from Supabase
+  const nameMap: Record<string, string> = {};
+  if (teamIds.length > 0) {
+    try {
+      const supabase = await createServerSupabase();
+      const { data } = await supabase
+        .from('teams')
+        .select('id, name')
+        .in('id', teamIds);
+      for (const t of data ?? []) {
+        nameMap[String(t.id)] = t.name as string;
+      }
+    } catch {
+      // name resolution is best-effort; continue without names
+    }
+  }
+
+  const rows: Ga4MostWantedTeamsRow[] = rawRows.map((r) => {
+    const team_id = r.dimensionValues?.[0]?.value ?? '(not set)';
+    return {
+      team_id,
+      team_name: nameMap[team_id],
+      paywall_impressions: Number(r.metricValues?.[0]?.value ?? 0),
+    };
+  });
+
+  const totalImpressions = rows.reduce((s, r) => s + r.paywall_impressions, 0);
+
+  return {
+    report: 'ga4_most_wanted_teams',
+    source: 'ga4',
+    date_range: range,
+    timezone: tz,
+    rows,
+    row_count: rows.length,
+    totals: { paywall_impressions: totalImpressions },
+    derived: {},
+    truncated: rows.length >= limit,
+    truncation_reason: rows.length >= limit ? 'limit_reached' : undefined,
+    data_freshness: fresh.freshness,
+    warnings: fresh.warnings,
+    generated_at: new Date().toISOString(),
+    debug: {
+      cost: {
+        estimated_units: rangeDays(range) * 1,
+        range_days: rangeDays(range),
+        metric_count: 1,
+        dimension_count: 1,
+        limit,
+      },
+    },
+  };
+}
+
+export function getGa4MostWantedTeams(
+  params: Ga4MostWantedTeamsParams,
+): Promise<TileResponse<Ga4MostWantedTeamsRow>> {
+  const cacheArgs = { ...params, forceFresh: undefined };
+  const key = `ga4_most_wanted_teams:${sortedKeys(cacheArgs)}`;
+  const run = () => coalesce(key, () => runOnce(params));
+  if (params.forceFresh) return run();
+  return unstable_cache(run, ['ga4_most_wanted_teams', sortedKeys(cacheArgs)], {
+    revalidate: CACHE_TTL_SECONDS,
+    tags: ['analytics:ga4', 'analytics:ga4_most_wanted_teams'],
+  })();
+}

--- a/frontend/lib/internal-analytics/queries/ga4-upgrade-funnel.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-upgrade-funnel.ts
@@ -1,0 +1,130 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { getAnalyticsDataClient } from '@/lib/google-auth';
+import {
+  GA4_PROPERTY_ID,
+  CACHE_TTL_SECONDS,
+} from '../constants';
+import type { DateRange, TileResponse } from '../types';
+import { resolveDateRange, detectFreshness, rangeDays } from '../dates';
+import { coalesce, sortedKeys } from './_coalesce';
+import { toTaxonomyError, TaxonomyAwareError } from './_error';
+
+export type Ga4UpgradeFunnelParams = {
+  dateRange: DateRange;
+  forceFresh?: boolean;
+  timezone?: string;
+};
+
+export type Ga4UpgradeFunnelRow = {
+  step: string;
+  label: string;
+  count: number;
+  pct_of_top: number;
+};
+
+const FUNNEL_EVENTS = [
+  { step: 'upgrade_page_viewed', label: 'Viewed' },
+  { step: 'plan_selected', label: 'Plan selected' },
+  { step: 'checkout_initiated', label: 'Checkout started' },
+  { step: 'subscription_completed', label: 'Subscribed' },
+] as const;
+
+async function fetchRaw(range: DateRange) {
+  try {
+    const client = getAnalyticsDataClient();
+    const res = await client.properties.runReport({
+      property: `properties/${GA4_PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: range.start, endDate: range.end }],
+        dimensions: [{ name: 'eventName' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            inListFilter: {
+              values: FUNNEL_EVENTS.map((e) => e.step),
+            },
+          },
+        },
+      },
+    });
+    return res.data;
+  } catch (e) {
+    throw new TaxonomyAwareError(toTaxonomyError(e));
+  }
+}
+
+async function runOnce(
+  params: Ga4UpgradeFunnelParams,
+): Promise<TileResponse<Ga4UpgradeFunnelRow>> {
+  const tz = params.timezone ?? 'America/Phoenix';
+  const range = resolveDateRange(params.dateRange, tz);
+
+  const raw = await fetchRaw(range);
+  const countMap: Record<string, number> = {};
+  for (const row of raw.rows ?? []) {
+    const eventName = row.dimensionValues?.[0]?.value ?? '';
+    const count = Number(row.metricValues?.[0]?.value ?? 0);
+    countMap[eventName] = count;
+  }
+
+  const viewed = countMap['upgrade_page_viewed'] ?? 0;
+  const completed = countMap['subscription_completed'] ?? 0;
+  const checkout = countMap['checkout_initiated'] ?? 0;
+
+  const rows: Ga4UpgradeFunnelRow[] = FUNNEL_EVENTS.map(({ step, label }) => {
+    const count = countMap[step] ?? 0;
+    return {
+      step,
+      label,
+      count,
+      pct_of_top: viewed > 0 ? count / viewed : 0,
+    };
+  });
+
+  const fresh = detectFreshness('ga4', range, tz);
+
+  return {
+    report: 'ga4_upgrade_funnel',
+    source: 'ga4',
+    date_range: range,
+    timezone: tz,
+    rows,
+    row_count: rows.length,
+    totals: {
+      upgrade_page_viewed: viewed,
+      subscription_completed: completed,
+    },
+    derived: {
+      conversion_rate: viewed > 0 ? completed / viewed : 0,
+      cart_abandonment: checkout > 0 ? 1 - completed / checkout : 0,
+    },
+    truncated: false,
+    data_freshness: fresh.freshness,
+    warnings: fresh.warnings,
+    generated_at: new Date().toISOString(),
+    debug: {
+      cost: {
+        estimated_units: rangeDays(range) * 1,
+        range_days: rangeDays(range),
+        metric_count: 1,
+        dimension_count: 1,
+        limit: FUNNEL_EVENTS.length,
+      },
+    },
+  };
+}
+
+export function getGa4UpgradeFunnel(
+  params: Ga4UpgradeFunnelParams,
+): Promise<TileResponse<Ga4UpgradeFunnelRow>> {
+  const cacheArgs = { ...params, forceFresh: undefined };
+  const key = `ga4_upgrade_funnel:${sortedKeys(cacheArgs)}`;
+  const run = () => coalesce(key, () => runOnce(params));
+  if (params.forceFresh) return run();
+  return unstable_cache(run, ['ga4_upgrade_funnel', sortedKeys(cacheArgs)], {
+    revalidate: CACHE_TTL_SECONDS,
+    tags: ['analytics:ga4', 'analytics:ga4_upgrade_funnel'],
+  })();
+}

--- a/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
@@ -1,0 +1,157 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { getAnalyticsDataClient } from '@/lib/google-auth';
+import {
+  GA4_PROPERTY_ID,
+  CACHE_TTL_SECONDS,
+  DEFAULT_ROW_LIMIT,
+  MAX_ROW_LIMIT,
+} from '../constants';
+import type { DateRange, TileResponse } from '../types';
+import { resolveDateRange, detectFreshness, rangeDays } from '../dates';
+import { coalesce, sortedKeys } from './_coalesce';
+import { toTaxonomyError, TaxonomyAwareError } from './_error';
+
+export type Ga4UpgradeSourcesParams = {
+  dateRange: DateRange;
+  limit?: number;
+  forceFresh?: boolean;
+  timezone?: string;
+};
+
+export type Ga4UpgradeSourcesRow = {
+  source: string;
+  views: number;
+  subscriptions: number;
+  conversion_rate: number;
+};
+
+async function fetchRaw(range: DateRange, limit: number) {
+  try {
+    const client = getAnalyticsDataClient();
+    const res = await client.properties.runReport({
+      property: `properties/${GA4_PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: range.start, endDate: range.end }],
+        dimensions: [{ name: 'customEvent:source' }, { name: 'eventName' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            inListFilter: {
+              values: ['upgrade_page_viewed', 'subscription_completed'],
+            },
+          },
+        },
+        orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+        limit: String(limit * 2), // 2 event types per source
+      },
+    });
+    return res.data;
+  } catch (e) {
+    const err = e as { code?: number; status?: number };
+    if (err?.code === 400 || err?.status === 400) {
+      return { rows: null, __dimensionNotConfigured: true } as never;
+    }
+    throw new TaxonomyAwareError(toTaxonomyError(e));
+  }
+}
+
+async function runOnce(
+  params: Ga4UpgradeSourcesParams,
+): Promise<TileResponse<Ga4UpgradeSourcesRow>> {
+  const tz = params.timezone ?? 'America/Phoenix';
+  const range = resolveDateRange(params.dateRange, tz);
+  const limit = Math.min(params.limit ?? DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT);
+
+  const raw = await fetchRaw(range, limit) as never as {
+    rows?: Array<{ dimensionValues?: Array<{ value?: string }>; metricValues?: Array<{ value?: string }> }>;
+    __dimensionNotConfigured?: boolean;
+  };
+  const fresh = detectFreshness('ga4', range, tz);
+
+  if (raw.__dimensionNotConfigured) {
+    return {
+      report: 'ga4_upgrade_sources',
+      source: 'ga4',
+      date_range: range,
+      timezone: tz,
+      rows: [],
+      row_count: 0,
+      totals: {},
+      derived: {},
+      truncated: false,
+      data_freshness: fresh.freshness,
+      warnings: [
+        ...(fresh.warnings ?? []),
+        'customEvent:source dimension not configured in GA4 — register it under Admin > Custom definitions',
+      ],
+      generated_at: new Date().toISOString(),
+      debug: { cost: { estimated_units: 0, range_days: rangeDays(range), metric_count: 1, dimension_count: 2, limit } },
+    };
+  }
+
+  // Pivot: source -> { views, subscriptions }
+  const pivot: Record<string, { views: number; subscriptions: number }> = {};
+  for (const row of raw.rows ?? []) {
+    const source = row.dimensionValues?.[0]?.value ?? '(not set)';
+    const eventName = row.dimensionValues?.[1]?.value ?? '';
+    const count = Number(row.metricValues?.[0]?.value ?? 0);
+    if (!pivot[source]) pivot[source] = { views: 0, subscriptions: 0 };
+    if (eventName === 'upgrade_page_viewed') pivot[source].views += count;
+    else if (eventName === 'subscription_completed') pivot[source].subscriptions += count;
+  }
+
+  const rows: Ga4UpgradeSourcesRow[] = Object.entries(pivot)
+    .map(([source, { views, subscriptions }]) => ({
+      source,
+      views,
+      subscriptions,
+      conversion_rate: views > 0 ? subscriptions / views : 0,
+    }))
+    .sort((a, b) => b.views - a.views)
+    .slice(0, limit);
+
+  const totalViews = rows.reduce((s, r) => s + r.views, 0);
+  const totalSubs = rows.reduce((s, r) => s + r.subscriptions, 0);
+
+  return {
+    report: 'ga4_upgrade_sources',
+    source: 'ga4',
+    date_range: range,
+    timezone: tz,
+    rows,
+    row_count: rows.length,
+    totals: { views: totalViews, subscriptions: totalSubs },
+    derived: {
+      conversion_rate: totalViews > 0 ? totalSubs / totalViews : 0,
+    },
+    truncated: rows.length >= limit,
+    truncation_reason: rows.length >= limit ? 'limit_reached' : undefined,
+    data_freshness: fresh.freshness,
+    warnings: fresh.warnings,
+    generated_at: new Date().toISOString(),
+    debug: {
+      cost: {
+        estimated_units: rangeDays(range) * 2,
+        range_days: rangeDays(range),
+        metric_count: 1,
+        dimension_count: 2,
+        limit,
+      },
+    },
+  };
+}
+
+export function getGa4UpgradeSources(
+  params: Ga4UpgradeSourcesParams,
+): Promise<TileResponse<Ga4UpgradeSourcesRow>> {
+  const cacheArgs = { ...params, forceFresh: undefined };
+  const key = `ga4_upgrade_sources:${sortedKeys(cacheArgs)}`;
+  const run = () => coalesce(key, () => runOnce(params));
+  if (params.forceFresh) return run();
+  return unstable_cache(run, ['ga4_upgrade_sources', sortedKeys(cacheArgs)], {
+    revalidate: CACHE_TTL_SECONDS,
+    tags: ['analytics:ga4', 'analytics:ga4_upgrade_sources'],
+  })();
+}

--- a/frontend/lib/internal-analytics/report-registry.ts
+++ b/frontend/lib/internal-analytics/report-registry.ts
@@ -7,6 +7,9 @@ import { getGa4Overview } from './queries/ga4-overview';
 import { getGa4TopPages, type Ga4TopPagesParams } from './queries/ga4-top-pages';
 import { getGa4TrafficSources } from './queries/ga4-traffic-sources';
 import { getGa4UpgradeViews, type Ga4UpgradeViewsParams } from './queries/ga4-upgrade-views';
+import { getGa4UpgradeFunnel } from './queries/ga4-upgrade-funnel';
+import { getGa4MostWantedTeams } from './queries/ga4-most-wanted-teams';
+import { getGa4UpgradeSources } from './queries/ga4-upgrade-sources';
 import { getGscPerformance, type GscPerformanceParams } from './queries/gsc-performance';
 import { getGscTopQueries, type GscTopQueriesParams } from './queries/gsc-top-queries';
 import { getGscLandingPages, type GscLandingPagesParams } from './queries/gsc-landing-pages';
@@ -71,6 +74,27 @@ export const REPORTS = {
       } as Ga4UpgradeViewsParams),
     summaryRequired: ['totals', 'conversion_rate'],
     derivedMetrics: ['conversion_rate'],
+  },
+  ga4_upgrade_funnel: {
+    source: 'ga4',
+    description: 'Upgrade funnel event counts across 4 steps (viewed -> planned -> checkout -> subscribed).',
+    paramsSchema: z.object({ ...Common }),
+    handler: (p: any) => getGa4UpgradeFunnel({ dateRange: p.date_range, forceFresh: p.forceFresh }),
+    summaryRequired: ['totals', 'conversion_rate'],
+  },
+  ga4_most_wanted_teams: {
+    source: 'ga4',
+    description: 'Teams that non-premium users most frequently try to access (paywall impressions by team_id).',
+    paramsSchema: z.object({ ...Common, limit: z.number().int().min(1).max(MAX_ROW_LIMIT).optional() }),
+    handler: (p: any) => getGa4MostWantedTeams({ dateRange: p.date_range, limit: p.limit, forceFresh: p.forceFresh }),
+    summaryRequired: ['totals'],
+  },
+  ga4_upgrade_sources: {
+    source: 'ga4',
+    description: 'Where upgrade page views and subscriptions come from (breakdown by source event parameter).',
+    paramsSchema: z.object({ ...Common, limit: z.number().int().min(1).max(MAX_ROW_LIMIT).optional() }),
+    handler: (p: any) => getGa4UpgradeSources({ dateRange: p.date_range, limit: p.limit, forceFresh: p.forceFresh }),
+    summaryRequired: ['totals', 'conversion_rate'],
   },
   gsc_performance: {
     source: 'gsc',


### PR DESCRIPTION
## Summary

- **Tile A — Upgrade Funnel**: 4-step funnel (Viewed → Plan selected → Checkout started → Subscribed) queried from GA4 `eventName` dimension. Returns per-step counts, `pct_of_top` bars, and derived `conversion_rate` + `cart_abandonment`.
- **Tile B — Most Wanted Teams**: GA4 `paywall_impression` events grouped by `customEvent:team_id`, team names resolved via Supabase `teams` table. Handles unconfigured custom dimension with actionable warning.
- **Tile C — Upgrade Sources**: Single GA4 query on `customEvent:source` × `eventName` pivoted in JS to rows of `{ source, views, subscriptions, conversion_rate }`. Same 400-guard with warning.

## Files changed (11)
- `frontend/lib/internal-analytics/queries/ga4-upgrade-funnel.ts` (new)
- `frontend/lib/internal-analytics/queries/ga4-most-wanted-teams.ts` (new)
- `frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts` (new)
- `frontend/app/api/internal/analytics/ga4/upgrade-funnel/route.ts` (new)
- `frontend/app/api/internal/analytics/ga4/most-wanted-teams/route.ts` (new)
- `frontend/app/api/internal/analytics/ga4/upgrade-sources/route.ts` (new)
- `frontend/app/(internal)/analytics/components/tiles/UpgradeFunnelTile.tsx` (new)
- `frontend/app/(internal)/analytics/components/tiles/MostWantedTeamsTile.tsx` (new)
- `frontend/app/(internal)/analytics/components/tiles/UpgradeSourcesTile.tsx` (new)
- `frontend/lib/internal-analytics/report-registry.ts` (modified — 3 new entries)
- `frontend/app/(internal)/analytics/components/DashboardGrid.tsx` (modified — UpgradeFunnelTile first, MostWantedTeamsTile + UpgradeSourcesTile appended)

## Test plan
- [ ] Dashboard loads without TS errors (`tsc --noEmit`)
- [ ] UpgradeFunnelTile renders 4 bars; conversion_rate and cart_abandonment display correctly
- [ ] MostWantedTeamsTile shows amber warning if `customEvent:team_id` not configured in GA4
- [ ] UpgradeSourcesTile shows amber warning if `customEvent:source` not configured in GA4
- [ ] All 3 API routes return 401 for non-admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)