### PR TITLE
Clarify rankings empty-state while new run is in progress

### DIFF
--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -279,7 +279,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     return (
       <Card>
         <CardContent className="pt-6">
-          <div>No teams available.</div>
+          <div>No teams available — new rankings are running, check back shortly.</div>
         </CardContent>
       </Card>
     );


### PR DESCRIPTION
## Summary
Update the rankings empty-state message so users understand a new ranking run is in progress rather than assuming the site is broken.

## Change
`frontend/components/RankingsTable.tsx:282`
- Before: `No teams available.`
- After: `No teams available — new rankings are running, check back shortly.`

## Context
The most recent ranking run completed in 29 min (vs the usual ~2h), which left `rankings_full` sparse and surfaced the bare empty-state text to visitors. This update softens the message while the upstream pipeline issue is investigated separately.

## Test plan
- [ ] Visual check on `/rankings` with an empty cohort (e.g. `/rankings/national/u10/female`) after deploy.