### PR TITLE
fix(analytics): include today in trailing-window presets and keep empty GA4 rows

### DIFF
--- a/frontend/lib/internal-analytics/__tests__/dates.test.ts
+++ b/frontend/lib/internal-analytics/__tests__/dates.test.ts
@@ -14,14 +14,14 @@ describe('resolveDateRange', () => {
     expect(r).toEqual({ start: '2026-04-14', end: '2026-04-14', preset: 'today' });
   });
 
-  it("resolves 'last_7_days' as the prior 7 days ending yesterday", () => {
+  it("resolves 'last_7_days' as the 7 days ending today (inclusive)", () => {
     const r = resolveDateRange('last_7_days', 'America/Phoenix');
-    expect(r).toEqual({ start: '2026-04-07', end: '2026-04-13', preset: 'last_7_days' });
+    expect(r).toEqual({ start: '2026-04-08', end: '2026-04-14', preset: 'last_7_days' });
   });
 
-  it("resolves 'last_28_days' as the prior 28 days ending yesterday", () => {
+  it("resolves 'last_28_days' as the 28 days ending today (inclusive)", () => {
     const r = resolveDateRange('last_28_days', 'America/Phoenix');
-    expect(r).toEqual({ start: '2026-03-17', end: '2026-04-13', preset: 'last_28_days' });
+    expect(r).toEqual({ start: '2026-03-18', end: '2026-04-14', preset: 'last_28_days' });
   });
 
   it("resolves 'mtd' from the 1st through today", () => {

--- a/frontend/lib/internal-analytics/chat/tools.ts
+++ b/frontend/lib/internal-analytics/chat/tools.ts
@@ -130,6 +130,7 @@ export function buildTools(ctx: ToolContext) {
                   ? [{ metric: { metricName: args.order_by.metric }, desc: args.order_by.desc }]
                   : undefined,
                 limit: String(args.limit),
+                keepEmptyRows: args.dimensions?.includes('date') ? true : undefined,
               },
             });
             return { source: 'ga4', rows: ga4RowsToObjects(res.data as never), date_range: range };

--- a/frontend/lib/internal-analytics/dates.ts
+++ b/frontend/lib/internal-analytics/dates.ts
@@ -27,15 +27,14 @@ export function resolveDateRange(input: DateRangePreset | DateRange, timeZone: s
   if (typeof input === 'object') return { start: input.start, end: input.end };
 
   const today = todayInPropertyTz(timeZone);
-  const yesterday = addDaysISO(today, -1);
 
   switch (input) {
     case 'today':
       return { start: today, end: today, preset: 'today' };
     case 'last_7_days':
-      return { start: addDaysISO(yesterday, -6), end: yesterday, preset: 'last_7_days' };
+      return { start: addDaysISO(today, -6), end: today, preset: 'last_7_days' };
     case 'last_28_days':
-      return { start: addDaysISO(yesterday, -27), end: yesterday, preset: 'last_28_days' };
+      return { start: addDaysISO(today, -27), end: today, preset: 'last_28_days' };
     case 'mtd':
       return { start: startOfMonthISO(today), end: today, preset: 'mtd' };
   }

--- a/frontend/lib/internal-analytics/queries/ga4-overview.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-overview.ts
@@ -34,6 +34,7 @@ async function fetchOverviewRaw(range: DateRange): Promise<unknown> {
         dimensions: [{ name: 'date' }],
         metrics: [{ name: 'sessions' }, { name: 'activeUsers' }, { name: 'screenPageViews' }],
         orderBys: [{ dimension: { dimensionName: 'date' } }],
+        keepEmptyRows: true,
       },
     });
     return res.data;

--- a/frontend/lib/internal-analytics/queries/ga4-upgrade-views.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-upgrade-views.ts
@@ -37,6 +37,7 @@ async function fetchRaw(range: DateRange) {
             filter: { fieldName: 'pagePath', stringFilter: { matchType: 'EXACT', value: '/upgrade' } },
           },
           orderBys: [{ dimension: { dimensionName: 'date' } }],
+          keepEmptyRows: true,
         },
       }),
       client.properties.runReport({
@@ -46,6 +47,7 @@ async function fetchRaw(range: DateRange) {
           dimensions: [{ name: 'date' }],
           metrics: [{ name: 'sessions' }],
           orderBys: [{ dimension: { dimensionName: 'date' } }],
+          keepEmptyRows: true,
         },
       }),
     ]);


### PR DESCRIPTION
## Summary
- `last_7_days` and `last_28_days` presets now end at **today** instead of yesterday, so live traffic (including the upgrade funnel) shows up immediately on the internal analytics dashboard. `detectFreshness` already flags today as partial, so the UI continues to warn about in-flight data.
- GA4 reports that use the `date` dimension now pass `keepEmptyRows: true` (overview, upgrade-views, and the chat `query_ga4` tool when a date dimension is requested), so zero-metric days no longer drop out of the time-series and leave gaps in charts.
- `last_28_days` fix is bundled because it was inconsistent with the `last_7_days` fix (users hitting either preset would see different trailing-window semantics otherwise).

## Files
- `frontend/lib/internal-analytics/dates.ts` — preset resolution
- `frontend/lib/internal-analytics/__tests__/dates.test.ts` — updated expectations for both presets
- `frontend/lib/internal-analytics/queries/ga4-overview.ts` — `keepEmptyRows: true`
- `frontend/lib/internal-analytics/queries/ga4-upgrade-views.ts` — `keepEmptyRows: true` on both reports
- `frontend/lib/internal-analytics/chat/tools.ts` — `keepEmptyRows` conditional on `date` dimension in `query_ga4`

## Test plan
- [x] `npx vitest run lib/internal-analytics` — 34/34 pass
- [x] `npx tsc --noEmit` — clean for analytics files
- [ ] Manual: load `/analytics` with `last_7_days` preset and confirm today's upgrade funnel row is present
- [ ] Manual: load `/analytics` with `last_28_days` preset and confirm end date shows today
- [ ] Manual: confirm GA4 time-series charts have no missing dates in range

🤖 Generated with [Claude Code](https://claude.com/claude-code)