### PR TITLE
Add PA U10 Boys soccer rankings spoke post

### DIFF
--- a/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
+++ b/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
@@ -24,9 +24,9 @@ Quick context before the table: **Black Conshy '16 B (FC DELCO)** holds the #1 s
 
 ## Top 25 PA U10 Boys Teams
 
-Sorted by PowerScore, highest first. This is a snapshot — rankings update weekly as new results come in.
+Ordered by PitchRank's Glicko-2 cohort rank — the same ordering used on the [PA U10 Boys rankings page](/rankings/pa/u10/male). PowerScore is shown alongside as a 0–1 readability score; because it's a smoothed display metric, a slightly higher PowerScore doesn't always outrank a team above it (strength-of-schedule and rating uncertainty are what decide the order — more on that below). This is a snapshot; rankings update weekly.
 
-| PA # | Team | Club | PowerScore | Record |
+| PA Rank | Team | Club | PowerScore | Record |
 |---|---|---|---|---|
 | 1 | Black Conshy '16 B | FC DELCO | 0.945 | 22-1-7 |
 | 2 | Pittsburgh Riverhounds 2016 PRE ECNL | Pittsburgh Riverhounds | 0.936 | 13-3-1 |
@@ -70,11 +70,11 @@ See the full cohort — all 371 PA U10 boys teams — on the [PA U10 Boys rankin
 
 This is the question every U10 parent asks when they see the table: **How is a 25-0-5 team ranked #9 instead of #1?**
 
-West-Mont United S.A's 2016 Blue has an undefeated record. FC DELCO's #1 team has seven draws and a loss. Yet FC DELCO ranks higher.
+West-Mont United S.A's 2016 Blue has an undefeated record and a PowerScore (0.943) that is almost identical to FC DELCO's #1 team. Yet FC DELCO ranks higher — and so does every other team between them.
 
-The answer is **strength of schedule**. PitchRank's [Glicko-2 engine](/blog/pennsylvania-youth-soccer-rankings-guide#how-pennsylvania-soccer-rankings-actually-work) doesn't just count wins — it weights each result by the quality of the opponent. FC DELCO's schedule included repeated matchups against other top-5 PA teams, MLS Next opponents, and nationally-ranked out-of-state clubs. West-Mont's schedule, while dominant, didn't include the same density of elite opponents.
+The answer is **strength of schedule plus rating confidence**. PitchRank's [Glicko-2 engine](/blog/pennsylvania-youth-soccer-rankings-guide#how-pennsylvania-soccer-rankings-actually-work) doesn't just count wins — it weights each result by the quality of the opponent and the engine's confidence in both ratings. FC DELCO and the other teams above West-Mont played denser schedules against other top-5 PA teams, MLS Next opponents, and nationally-ranked out-of-state clubs. That gave the engine more signal. West-Mont's schedule, while dominant, had fewer matchups against opponents the engine was already confident about — so the same PowerScore carries more uncertainty, and the final rank sits lower.
 
-That doesn't mean West-Mont isn't a genuinely strong team — a 0.943 PowerScore is elite. It just means the data supports FC DELCO slightly more confidently.
+That doesn't mean West-Mont isn't a genuinely strong team — a 0.943 PowerScore is elite. It just means the data currently supports the teams ranked above them slightly more confidently.
 
 For U10 parents, the lesson: **a team's record tells you less than its opponents' records**. When evaluating whether a team is playing at the right level, look at who they play — not just whether they win.
 

--- a/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
+++ b/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
@@ -24,7 +24,7 @@ Quick context before the table: **Black Conshy '16 B (FC DELCO)** holds the #1 s
 
 ## Top 25 PA U10 Boys Teams
 
-Ordered by PitchRank's Glicko-2 cohort rank — the same ordering used on the [PA U10 Boys rankings page](/rankings/pa/u10/male). PowerScore is shown alongside as a 0–1 readability score; because it's a smoothed display metric, a slightly higher PowerScore doesn't always outrank a team above it (strength-of-schedule and rating uncertainty are what decide the order — more on that below). This is a snapshot; rankings update weekly.
+Ordered by PitchRank's cohort rank — the same ordering used on the [PA U10 Boys rankings page](/rankings/pa/u10/male). PowerScore is shown alongside as a 0–1 readability score; because it's a smoothed display metric, a slightly higher PowerScore doesn't always outrank a team above it (strength-of-schedule and rating uncertainty are what decide the order — more on that below). This is a snapshot; rankings update weekly.
 
 | PA Rank | Team | Club | PowerScore | Record |
 |---|---|---|---|---|
@@ -62,7 +62,7 @@ See the full cohort — all 371 PA U10 boys teams — on the [PA U10 Boys rankin
 
 **Philadelphia Union's SWAG Academy 2016** is the MLS academy representative at U10, sitting at #3. That's the pipeline feeding into the Union's later MLS Next squads.
 
-**Western PA has one team in the top 5** — Pittsburgh Riverhounds 2016 PRE ECNL at #2. Their PowerScore is nearly identical to the #1 team despite a much shorter game log (17 games vs. 30). That's Glicko-2 doing its job — more uncertainty early, but results against strong opponents pull the rating up fast.
+**Western PA has one team in the top 5** — Pittsburgh Riverhounds 2016 PRE ECNL at #2. Their PowerScore is nearly identical to the #1 team despite a much shorter game log (17 games vs. 30). That's the rating engine doing its job — more uncertainty early, but results against strong opponents pull the rating up fast.
 
 **Central PA** shows up through CASA 2016 Premier (#12, Capital Area SA) and FC Bucks 2016 United (#4, Council Rock United from Bucks County).
 
@@ -72,7 +72,7 @@ This is the question every U10 parent asks when they see the table: **How is a 2
 
 West-Mont United S.A's 2016 Blue has an undefeated record and a PowerScore (0.943) that is almost identical to FC DELCO's #1 team. Yet FC DELCO ranks higher — and so does every other team between them.
 
-The answer is **strength of schedule plus rating confidence**. PitchRank's [Glicko-2 engine](/blog/pennsylvania-youth-soccer-rankings-guide#how-pennsylvania-soccer-rankings-actually-work) doesn't just count wins — it weights each result by the quality of the opponent and the engine's confidence in both ratings. FC DELCO and the other teams above West-Mont played denser schedules against other top-5 PA teams, MLS Next opponents, and nationally-ranked out-of-state clubs. That gave the engine more signal. West-Mont's schedule, while dominant, had fewer matchups against opponents the engine was already confident about — so the same PowerScore carries more uncertainty, and the final rank sits lower.
+The answer is **strength of schedule plus rating confidence**. PitchRank's [rating engine](/blog/pennsylvania-youth-soccer-rankings-guide#how-pennsylvania-soccer-rankings-actually-work) doesn't just count wins — it weights each result by the quality of the opponent and the engine's confidence in both ratings. FC DELCO and the other teams above West-Mont played denser schedules against other top-5 PA teams, MLS Next opponents, and nationally-ranked out-of-state clubs. That gave the engine more signal. West-Mont's schedule, while dominant, had fewer matchups against opponents the engine was already confident about — so the same PowerScore carries more uncertainty, and the final rank sits lower.
 
 That doesn't mean West-Mont isn't a genuinely strong team — a 0.943 PowerScore is elite. It just means the data currently supports the teams ranked above them slightly more confidently.
 
@@ -108,4 +108,4 @@ Yes — and many of the top U10 teams do play up for tougher competition. PitchR
 
 **Want the bigger picture?** This post is part of the [Pennsylvania Youth Soccer Rankings Guide](/blog/pennsylvania-youth-soccer-rankings-guide) — covers EDP, EPYSA, MLS Next, college recruiting, and how rankings work across every PA age group.
 
-**Check your team:** [PitchRank.io](https://pitchrank.io) — transparent, game-by-game Glicko-2 rankings for all 50 states.
+**Check your team:** [PitchRank.io](https://pitchrank.io) — transparent, game-by-game rankings for all 50 states.

--- a/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
+++ b/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
@@ -1,0 +1,111 @@
+---
+title: "PA U10 Boys Soccer Rankings 2026: Top 25 Teams in Pennsylvania"
+slug: 'pa-u10-boys-soccer-rankings'
+excerpt: "The top 25 U10 boys soccer teams in Pennsylvania, ranked by PowerScore. FC DELCO, Philadelphia Union SWAG, Pittsburgh Riverhounds — see where your team stands."
+author: 'PitchRank Team'
+date: '2026-04-15'
+readingTime: '6 min read'
+tags: ['Pennsylvania', 'U10', 'Boys Soccer', 'Rankings', 'FC DELCO', 'Philadelphia Union']
+keywords:
+  [
+    'pa u10 boys soccer rankings',
+    'pennsylvania u10 boys soccer rankings',
+    'pa u10 soccer rankings',
+    'u10 boys soccer rankings pennsylvania',
+    'best u10 soccer teams in pa',
+  ]
+---
+
+# PA U10 Boys Soccer Rankings 2026: Top 25 Teams in Pennsylvania
+
+Pennsylvania has **371 active U10 boys soccer teams** in our database. Here are the top 25 — the top 6.7% of the state — ranked by PowerScore using game-by-game results across EDP, EPYSA, MLS Next, PRE-ECNL, friendlies, and showcases.
+
+Quick context before the table: **Black Conshy '16 B (FC DELCO)** holds the #1 spot in Pennsylvania *and* the #1 spot in the entire U10 Male national cohort on PitchRank. Strength of schedule matters as much as win-loss — which is why the only undefeated team in the top 25 (West-Mont United, 25-0-5) sits at #9, not #1. More on that below.
+
+## Top 25 PA U10 Boys Teams
+
+Sorted by PowerScore, highest first. This is a snapshot — rankings update weekly as new results come in.
+
+| PA # | Team | Club | PowerScore | Record |
+|---|---|---|---|---|
+| 1 | Black Conshy '16 B | FC DELCO | 0.945 | 22-1-7 |
+| 2 | Pittsburgh Riverhounds 2016 PRE ECNL | Pittsburgh Riverhounds | 0.936 | 13-3-1 |
+| 3 | SWAG Academy 2016 | Philadelphia Union | 0.928 | 19-6-5 |
+| 4 | FC Bucks 2016 United | Council Rock United | 0.906 | 21-6-3 |
+| 5 | NEU 2016 Raptors | Northeast United | 0.877 | 19-6-5 |
+| 6 | 2016 Black | Philadelphia Ukrainian Nationals | 0.872 | 15-11-4 |
+| 7 | Philadelphia SC Surf 2016 Azzurri | Philadelphia SC | 0.846 | 17-9-4 |
+| 8 | 2016 Black | Lehigh Valley United | 0.827 | 13-12-5 |
+| 9 | 2016 Blue | West-Mont United S.A | 0.943 | 25-0-5 |
+| 10 | Black Dtown '16 B | FC DELCO | 0.922 | 17-7-6 |
+| 11 | FC Philly | Tournament Team | 0.876 | 21-4-5 |
+| 12 | CASA 2016 Premier | Capital Area SA | 0.819 | 18-4-3 |
+| 13 | FCE 2016 PRE ECNL | FC Europa | 0.778 | 15-11-4 |
+| 14 | Wolves Black 2016 | Upper Dublin SC | 0.765 | 21-5-4 |
+| 15 | White Conshy '16 B | FC DELCO | 0.923 | 24-3-3 |
+| 16 | VE Union 2016 | Vereinigung Erzgebirge SC | 0.802 | 16-9-5 |
+| 17 | Delaware FC 2016 | Delaware Football Club | 0.737 | 10-6-1 |
+| 18 | Celtic SC 2016 | Celtic SC | 0.727 | 14-9-1 |
+| 19 | Sporting PA 2016 Black | Sporting Athletic Club PA | 0.678 | 6-8-4 |
+| 20 | Sporting PA 2016 Red | Sporting Athletic Club PA | 0.724 | 13-8-3 |
+| 21 | Elite 2016 | Penn Fusion Soccer Academy | 0.714 | 12-16-2 |
+| 22 | Triboro SC Fusion2 | Triboro Soccer Club | 0.720 | 15-7-8 |
+| 23 | 2016 APEX | Montgomery United SC | 0.649 | 19-9-2 |
+| 24 | Dynamo United 2016A | Dynamo United | 0.625 | 9-3-4 |
+| 25 | 2016 Rush | PA Rush | 0.665 | 12-9-9 |
+
+See the full cohort — all 371 PA U10 boys teams — on the [PA U10 Boys rankings page](/rankings/pa/u10/male).
+
+## Who Dominates the PA U10 Boys Scene
+
+**FC DELCO has three teams in the top 25** — more than any other club. Black Conshy '16 B (#1), Black Dtown '16 B (#10), and White Conshy '16 B (#15). That depth is what separates the state's top clubs from their competitors: not just one strong team, but a pyramid of competitive squads at the same age.
+
+**Philadelphia Union's SWAG Academy 2016** is the MLS academy representative at U10, sitting at #3. That's the pipeline feeding into the Union's later MLS Next squads.
+
+**Western PA has one team in the top 5** — Pittsburgh Riverhounds 2016 PRE ECNL at #2. Their PowerScore is nearly identical to the #1 team despite a much shorter game log (17 games vs. 30). That's Glicko-2 doing its job — more uncertainty early, but results against strong opponents pull the rating up fast.
+
+**Central PA** shows up through CASA 2016 Premier (#12, Capital Area SA) and FC Bucks 2016 United (#4, Council Rock United from Bucks County).
+
+## Why the Undefeated Team Isn't #1
+
+This is the question every U10 parent asks when they see the table: **How is a 25-0-5 team ranked #9 instead of #1?**
+
+West-Mont United S.A's 2016 Blue has an undefeated record. FC DELCO's #1 team has seven draws and a loss. Yet FC DELCO ranks higher.
+
+The answer is **strength of schedule**. PitchRank's [Glicko-2 engine](/blog/pennsylvania-youth-soccer-rankings-guide#how-pennsylvania-soccer-rankings-actually-work) doesn't just count wins — it weights each result by the quality of the opponent. FC DELCO's schedule included repeated matchups against other top-5 PA teams, MLS Next opponents, and nationally-ranked out-of-state clubs. West-Mont's schedule, while dominant, didn't include the same density of elite opponents.
+
+That doesn't mean West-Mont isn't a genuinely strong team — a 0.943 PowerScore is elite. It just means the data supports FC DELCO slightly more confidently.
+
+For U10 parents, the lesson: **a team's record tells you less than its opponents' records**. When evaluating whether a team is playing at the right level, look at who they play — not just whether they win.
+
+## How to Use These Rankings
+
+If your son plays U10 boys soccer in PA, here's how to put this list to work:
+
+1. **Find your team** — either in the table above or at the [full PA U10 Boys rankings page](/rankings/pa/u10/male)
+2. **Compare against teams you play regularly** — are they ranked meaningfully higher or lower than you? Consistent losses to lower-ranked teams or consistent wins over higher-ranked teams are the interesting signals
+3. **Look at opponent mix, not just record** — a team with a .500 record against top-20 PA opposition is more developmentally valuable than a team with a .900 record against the bottom 100
+4. **Reality-check club claims** — if a club tells you their U10 is "top tier," the bar for that is a PowerScore of 0.70 or higher. Only **48 PA U10 boys teams** (12.9%) clear that threshold. Being "top tier" at U10 in Pennsylvania is genuinely rare.
+
+## FAQ
+
+### How many U10 boys soccer teams are there in Pennsylvania?
+PitchRank is currently tracking **371 active PA U10 boys teams** across EDP, EPYSA, MLS Next, PRE-ECNL, and local leagues. The cohort changes season-to-season as teams reclassify ages.
+
+### What's a good PowerScore for a U10 team?
+On the 0-1 PowerScore scale used throughout PA rankings: 0.85+ is elite, 0.70-0.84 is top tier, 0.50-0.69 is solid competitive, below that is developing or recreational. Only 20 PA U10 boys teams (5.4%) crack the 0.80 mark.
+
+### How often do PA U10 boys rankings update?
+Weekly during the active season as new game results flow in. Expect larger shifts in fall and spring — fewer during the winter indoor/futsal stretch (futsal games are excluded from rankings).
+
+### Why is my son's team not in the top 25?
+The top 25 is the top ~7% of the PA cohort. If your team isn't on this list, it doesn't mean they're not competitive — it means they're below a PowerScore of roughly 0.62. Check the [full PA U10 rankings](/rankings/pa/u10/male) to see exactly where they sit and who they'd need to start beating to climb.
+
+### Can U10 teams play up into U11 rankings?
+Yes — and many of the top U10 teams do play up for tougher competition. PitchRank tracks games at the team's registered age group, so a U10 team playing U11 opponents gets credit for the strength of those U11 opponents. This is actually why some U10 teams have surprisingly high PowerScores.
+
+---
+
+**Want the bigger picture?** This post is part of the [Pennsylvania Youth Soccer Rankings Guide](/blog/pennsylvania-youth-soccer-rankings-guide) — covers EDP, EPYSA, MLS Next, college recruiting, and how rankings work across every PA age group.
+
+**Check your team:** [PitchRank.io](https://pitchrank.io) — transparent, game-by-game Glicko-2 rankings for all 50 states.


### PR DESCRIPTION
## Summary
- First spoke in the PA topical cluster. Anchors on \`/rankings/pa/u10/male\` — currently the best-performing PA page (19.67% CTR, pos 4.80 per GSC).
- Features live top-25 PA U10 boys table with real PowerScore data from rankings_full (371 total teams in cohort).
- Uses the "why is the undefeated team ranked #9" question to teach strength-of-schedule — a GEO-friendly explainer that links back to the pillar.

## Keyword targets
- Primary: \`pa u10 boys soccer rankings\`
- Secondary: \`pennsylvania u10 boys soccer rankings\`, \`u10 boys soccer rankings pennsylvania\`, \`best u10 soccer teams in pa\`

## Test plan
- [ ] Preview deploy renders at \`/blog/pa-u10-boys-soccer-rankings\`
- [ ] Internal links resolve: \`/rankings/pa/u10/male\`, pillar post fragment link
- [ ] Table renders cleanly on mobile
- [ ] Post-merge: GSC indexing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)