### PR TITLE
Remove Glicko-2 references from PA pillar guide

### DIFF
--- a/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
@@ -96,9 +96,9 @@ PitchRank is different. We track:
 
 We exclude futsal games — they're a different sport with different rosters, and including them pollutes outdoor rankings.
 
-### The Glicko-2 Algorithm, Explained Simply
+### The Rating Algorithm, Explained Simply
 
-PitchRank uses a Glicko-2 rating engine. Here's how PA team rankings get calculated, without the math:
+PitchRank uses a game-by-game rating engine. Here's how PA team rankings get calculated, without the math:
 
 1. **Every team has a rating** — a numeric skill estimate that starts neutral and moves as games are played
 2. **Game results shift ratings** — wins push a team's rating up, losses push it down, and draws move both teams toward each other
@@ -313,4 +313,4 @@ Because rankings aren't bragging rights. They're how you make better decisions a
 
 ---
 
-**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game Glicko-2 math. No politics, no favoritism, no self-reported records — just results. Check your Pennsylvania team at [PitchRank.io](https://pitchrank.io).
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game math. No politics, no favoritism, no self-reported records — just results. Check your Pennsylvania team at [PitchRank.io](https://pitchrank.io).


### PR DESCRIPTION
## Summary
- Pillar mentioned "Glicko-2" by name in 3 places. Replaces with "rating algorithm" / "game-by-game rating engine" to keep the explainer accessible and avoid naming the specific algorithm.
- Same treatment already applied to the PA U10 Boys spoke on PR #629.

## Note on internal links
- H3 subsection anchor changed: \`#the-glicko-2-algorithm-explained-simply\` → \`#the-rating-algorithm-explained-simply\`
- The spoke post links to the parent H2 (\`#how-pennsylvania-soccer-rankings-actually-work\`), which is unchanged — no broken internal links.

## Test plan
- [ ] Preview deploy: verify pillar still renders
- [ ] Spot-check the "Rating Algorithm, Explained Simply" section for readability
- [ ] No other content links to the old fragment anchor (grepped — none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)