### PR TITLE
perf: apply safe PageSpeed audit fixes

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -133,6 +133,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        {/* Preconnect to Supabase for faster API requests */}
+        <link rel="preconnect" href="https://pfkrhmprwxtghtpinrot.supabase.co" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://pfkrhmprwxtghtpinrot.supabase.co" />
+
         {/* Structured Data for SEO */}
         <StructuredData />
 

--- a/frontend/components/GlobalSearch.tsx
+++ b/frontend/components/GlobalSearch.tsx
@@ -201,9 +201,11 @@ export function GlobalSearch() {
           }}
           onKeyDown={handleKeyDown}
           className="pl-8 sm:pl-10 pr-8 sm:pr-10 w-full text-sm h-10 sm:h-11"
+          role="combobox"
           aria-label="Search for teams"
           aria-autocomplete="list"
           aria-expanded={isOpen && searchResults.length > 0}
+          aria-controls="global-search-results"
         />
         {searchQuery && (
           <button
@@ -231,10 +233,12 @@ export function GlobalSearch() {
                 No teams found matching &quot;{searchQuery}&quot;
               </div>
             ) : (
-              <div className="space-y-1" ref={listRef}>
+              <div id="global-search-results" role="listbox" className="space-y-1" ref={listRef}>
                 {searchResults.map((team, index) => (
                   <button
                     key={team.team_id_master}
+                    role="option"
+                    aria-selected={index === selectedIndex}
                     onClick={() => handleSelect(team)}
                     className={`w-full text-left p-3 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary min-h-[44px] ${
                       index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'

--- a/frontend/components/HowWeRank.tsx
+++ b/frontend/components/HowWeRank.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { Scale, Layers, TrendingUp, Shield, ChevronRight } from 'lucide-react';
@@ -50,9 +50,9 @@ export function HowWeRank() {
     <Card className="overflow-hidden border-0 shadow-lg">
       <CardHeader className="bg-gradient-to-r from-primary to-[oklch(0.28_0.08_165)] text-primary-foreground relative overflow-hidden">
         <div className="absolute right-0 top-0 w-2 h-full bg-accent -skew-x-12" aria-hidden="true" />
-        <CardTitle className="text-2xl sm:text-3xl font-display font-bold uppercase tracking-wide">
+        <h2 className="text-2xl sm:text-3xl font-display font-bold uppercase tracking-wide leading-none">
           Why Our Rankings Are Different
-        </CardTitle>
+        </h2>
         <p className="text-primary-foreground/80 text-sm sm:text-base">Built to be accurate, not gameable</p>
       </CardHeader>
       <CardContent className="p-4 sm:p-6">

--- a/frontend/components/RecentMovers.tsx
+++ b/frontend/components/RecentMovers.tsx
@@ -163,7 +163,7 @@ export function RecentMovers({
                       </div>
                       <div
                         className={`flex items-center gap-1.5 text-sm font-bold px-2 py-1 rounded ${
-                          isImprovement ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'
+                          isImprovement ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
                         }`}
                         aria-label={`${isImprovement ? 'Improved' : 'Declined'} by ${Math.abs(rankChange)} ranks`}
                       >

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,5 +88,14 @@
   },
   "overrides": {
     "vite": ">=8.0.5"
-  }
+  },
+  "browserslist": [
+    "chrome >= 93",
+    "firefox >= 93",
+    "edge >= 93",
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
+    "opera >= 79",
+    "not dead"
+  ]
 }


### PR DESCRIPTION
## Summary

Safe, zero-functional-risk batch from the PageSpeed audit.

- **Supabase preconnect + dns-prefetch** in `app/layout.tsx` — ~320ms LCP savings
- **Modern browserslist** in `package.json` (Chrome/FF/Edge >=93, Safari/iOS >=15.4) — drops ~14 KiB of legacy polyfills (`Array.at/flat/flatMap`, `Object.fromEntries/hasOwn`, `String.trim*`)
- **ARIA combobox** on `GlobalSearch` — adds `role=combobox` + `aria-controls`, and `role=listbox`/`role=option`/`aria-selected` on results so `aria-expanded` is valid
- **Heading hierarchy** in `HowWeRank` — replace `CardTitle` div with `<h2>` so the methodology h3s sit under a proper h2 (previously jumped h1 → h3)
- **Contrast** in `RecentMovers` — rank-change badges go from `text-green-600`/`text-red-600` to `800` variants for WCAG AA

## Test plan

- [x] `tsc --noEmit` — clean
- [x] ESLint on all 5 files — clean
- [x] Local dev: preconnect in head, h1 → h2 → h3 order, search `aria-expanded` toggles on open, 8 `role=option` children with `aria-selected` on highlighted row, badges render `bg-green-100 text-green-800`
- [x] Console clean (TTFB 145ms, LCP 516ms, CLS 0.001 in dev)
- [ ] Vercel preview LCP/bundle size check after build

## Notes

Browserslist drops Safari <15.4 (March 2022) and Chrome <93 (Aug 2021). If analytics show non-trivial traffic from older browsers, loosen targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)