### PR TITLE
Add programmatic SEO content modules to all ranking pages

### DIFF
--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -5,6 +5,8 @@ import { api } from '@/lib/api';
 import { formatPowerScore } from '@/lib/utils';
 import BreadcrumbSchema from '@/components/BreadcrumbSchema';
 import { safeJsonLd } from '@/lib/schema-utils';
+import { computeCohortModules } from '@/lib/cohort-seo';
+import { CohortSEOContent } from '@/components/CohortSEOContent';
 
 // Revalidate every hour for ISR caching
 export const revalidate = 3600;
@@ -110,27 +112,17 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
   // This ensures fresh data fetching on client-side navigation between different rankings pages
   const routeKey = `${region}-${ageGroup}-${gender}`;
 
-  // Server-side fetch top 25 teams so the initial HTML has real content for Googlebot.
-  // Rendered as a static section below the interactive table — does not interfere with client-side loading.
+  // Server-side fetch all teams for SEO content modules + top-25 sr-only list.
+  // ISR caches for 1 hour so this runs at most once/hour/page.
   const genderForAPI = (gender === 'male' ? 'M' : gender === 'female' ? 'F' : null) as 'M' | 'F' | null;
   const regionForAPI = region.toLowerCase() === 'national' ? null : region;
-  let topTeams: Array<{
-    team_id_master: string;
-    team_name: string;
-    club_name: string | null;
-    power_score_final: number;
-  }> = [];
+  let allTeams: Awaited<ReturnType<typeof api.getRankings>> = [];
   try {
-    const data = await api.getRankings(regionForAPI, ageGroup, genderForAPI, { limit: 25 });
-    topTeams = data.map((t) => ({
-      team_id_master: t.team_id_master,
-      team_name: t.team_name,
-      club_name: t.club_name,
-      power_score_final: t.power_score_final,
-    }));
+    allTeams = await api.getRankings(regionForAPI, ageGroup, genderForAPI, { limit: 2000 });
   } catch (e) {
-    console.warn(`[ISR] Failed to fetch top teams for ${region}/${ageGroup}/${gender}:`, e);
+    console.warn(`[ISR] Failed to fetch teams for ${region}/${ageGroup}/${gender}:`, e);
   }
+  const topTeams = allTeams.slice(0, 25);
 
   // Prepare structured data for SEO
   const formattedAgeGroup = formatAgeGroup(ageGroup);
@@ -152,6 +144,12 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
   };
 
   const jsonLd = safeJsonLd(structuredData);
+
+  // Compute programmatic SEO content modules from the full team set
+  const cohortData =
+    allTeams.length > 0
+      ? computeCohortModules(allTeams, locationText, formattedAgeGroup, formattedGender, isNational, safeRegion)
+      : null;
 
   // Build breadcrumb trail
   const breadcrumbItems = [
@@ -178,6 +176,9 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
             : `${locationText} ${formattedAgeGroup} ${formattedGender} youth soccer rankings, updated weekly from real game results. See where ${locationText} clubs stand by PowerScore — a 0-to-1 rating built from strength of schedule, game outcomes, and opponent quality. Rankings update every Monday.`}
         </p>
       </section>
+
+      {/* Programmatic SEO content modules — visible, unique per page */}
+      {cohortData && <CohortSEOContent data={cohortData} />}
 
       {/* Top teams in DOM for Googlebot but visually hidden — the interactive table shows the same data */}
       {topTeams.length > 0 && (

--- a/frontend/components/CohortSEOContent.tsx
+++ b/frontend/components/CohortSEOContent.tsx
@@ -1,0 +1,159 @@
+import type { CohortModuleData } from '@/lib/cohort-seo';
+import { buildCohortFAQ } from '@/lib/cohort-seo';
+import { safeJsonLd } from '@/lib/schema-utils';
+
+interface CohortSEOContentProps {
+  data: CohortModuleData;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+/**
+ * Server-rendered SEO content modules for ranking pages.
+ * Renders between the H1/intro and the interactive table.
+ */
+export function CohortSEOContent({ data }: CohortSEOContentProps) {
+  const {
+    totalTeams,
+    positioningHook,
+    topClubs,
+    risers,
+    fallers,
+    lastGameDate,
+    lastCalculated,
+    locationText,
+    ageGroupDisplay,
+    genderLabel,
+    isNational,
+    region,
+  } = data;
+
+  const faqItems = buildCohortFAQ(data);
+  const scope = isNational ? 'nationally' : `in ${locationText}`;
+  const hasMovers = risers.length > 0 || fallers.length > 0;
+  const pageUrl = isNational
+    ? `/rankings/national/${data.ageGroupDisplay.toLowerCase()}/${data.genderDisplay.toLowerCase()}`
+    : `/rankings/${region}/${data.ageGroupDisplay.toLowerCase()}/${data.genderDisplay.toLowerCase()}`;
+
+  // FAQPage JSON-LD
+  const faqJsonLd = safeJsonLd({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  });
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: faqJsonLd }} />
+
+      <section className="container mx-auto px-4 pb-6 space-y-6">
+        {/* Module 1: Cohort Summary */}
+        <div>
+          <h2 className="font-display text-lg font-semibold mb-1">
+            {locationText} {ageGroupDisplay} {genderLabel === 'boys' ? 'Boys' : 'Girls'} at a Glance
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            The {isNational ? 'national' : locationText} {ageGroupDisplay} {genderLabel} group is{' '}
+            <strong>{positioningHook}</strong>, with <strong>{totalTeams.toLocaleString()} active teams</strong>{' '}
+            competing {scope} across all tracked leagues.
+          </p>
+        </div>
+
+        {/* Module 2: Top Clubs */}
+        {topClubs.length > 0 && (
+          <div>
+            <h3 className="text-sm font-semibold mb-2">Top Clubs by Team Count</h3>
+            <div className="overflow-x-auto">
+              <table className="text-sm w-full max-w-md">
+                <thead>
+                  <tr className="border-b text-left">
+                    <th className="pb-1 pr-4 font-medium text-muted-foreground">Club</th>
+                    <th className="pb-1 font-medium text-muted-foreground">Teams</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topClubs.map((club) => (
+                    <tr key={club.name} className="border-b border-border/50">
+                      <td className="py-1 pr-4">{club.name}</td>
+                      <td className="py-1">{club.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Module 3: Biggest Movers This Week */}
+        {hasMovers && (
+          <div>
+            <h3 className="text-sm font-semibold mb-2">Biggest Movers This Week</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+              {risers.length > 0 && (
+                <div>
+                  <p className="font-medium text-green-600 dark:text-green-400 mb-1">Rising</p>
+                  <ul className="space-y-0.5">
+                    {risers.map((t) => (
+                      <li key={t.teamId}>
+                        <a href={`${pageUrl}?highlight=${t.teamId}`} className="hover:underline">
+                          {t.teamName}
+                        </a>
+                        {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
+                        <span className="text-green-600 dark:text-green-400"> &mdash; up {t.change} spots</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {fallers.length > 0 && (
+                <div>
+                  <p className="font-medium text-red-500 dark:text-red-400 mb-1">Falling</p>
+                  <ul className="space-y-0.5">
+                    {fallers.map((t) => (
+                      <li key={t.teamId}>
+                        <a href={`${pageUrl}?highlight=${t.teamId}`} className="hover:underline">
+                          {t.teamName}
+                        </a>
+                        {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
+                        <span className="text-red-500 dark:text-red-400"> &mdash; down {Math.abs(t.change)} spots</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Module 4: FAQ */}
+        <div>
+          <h3 className="text-sm font-semibold mb-2">FAQ</h3>
+          <dl className="space-y-3 text-sm">
+            {faqItems.map((item) => (
+              <div key={item.question}>
+                <dt className="font-medium">{item.question}</dt>
+                <dd className="text-muted-foreground mt-0.5">{item.answer}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        {/* Module 5: Freshness Signal */}
+        <p className="text-xs text-muted-foreground">
+          {lastCalculated && <>Rankings last calculated {formatDate(lastCalculated)}. </>}
+          {lastGameDate && <>Most recent game in this group: {formatDate(lastGameDate)}.</>}
+        </p>
+      </section>
+    </>
+  );
+}

--- a/frontend/lib/cohort-seo.ts
+++ b/frontend/lib/cohort-seo.ts
@@ -1,0 +1,125 @@
+import type { RankingRow } from '@/types/RankingRow';
+
+export interface CohortModuleData {
+  totalTeams: number;
+  positioningHook: string;
+  topClubs: Array<{ name: string; count: number }>;
+  risers: Array<{ teamId: string; teamName: string; clubName: string | null; change: number }>;
+  fallers: Array<{ teamId: string; teamName: string; clubName: string | null; change: number }>;
+  lastGameDate: string | null;
+  lastCalculated: string | null;
+  locationText: string;
+  ageGroupDisplay: string;
+  genderDisplay: string;
+  genderLabel: string;
+  isNational: boolean;
+  region: string;
+}
+
+function getPositioningHook(count: number): string {
+  if (count >= 500) return 'one of the deepest groups in the country';
+  if (count >= 200) return 'a strong competitive group';
+  if (count >= 50) return 'a growing group';
+  return 'an emerging group';
+}
+
+export function computeCohortModules(
+  teams: RankingRow[],
+  locationText: string,
+  ageGroupDisplay: string,
+  genderDisplay: string,
+  isNational: boolean,
+  region: string
+): CohortModuleData {
+  const totalTeams = teams.length;
+  const positioningHook = getPositioningHook(totalTeams);
+
+  // Top clubs by team count in this cohort
+  const clubCounts = new Map<string, number>();
+  for (const team of teams) {
+    if (team.club_name) {
+      clubCounts.set(team.club_name, (clubCounts.get(team.club_name) ?? 0) + 1);
+    }
+  }
+  const topClubs = [...clubCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name, count]) => ({ name, count }));
+
+  // Biggest movers — use state rank change for state pages, national for national
+  const rankChangeField = isNational ? 'rank_change_7d' : 'rank_change_state_7d';
+  const activeTeams = teams.filter((t) => t.status === 'Active' && (t.total_games_played ?? 0) >= 8);
+
+  const risers = activeTeams
+    .filter((t) => (t[rankChangeField] ?? 0) > 0)
+    .sort((a, b) => (b[rankChangeField] ?? 0) - (a[rankChangeField] ?? 0))
+    .slice(0, 3)
+    .map((t) => ({
+      teamId: t.team_id_master,
+      teamName: t.team_name,
+      clubName: t.club_name,
+      change: t[rankChangeField]!,
+    }));
+
+  const fallers = activeTeams
+    .filter((t) => (t[rankChangeField] ?? 0) < 0)
+    .sort((a, b) => (a[rankChangeField] ?? 0) - (b[rankChangeField] ?? 0))
+    .slice(0, 3)
+    .map((t) => ({
+      teamId: t.team_id_master,
+      teamName: t.team_name,
+      clubName: t.club_name,
+      change: t[rankChangeField]!,
+    }));
+
+  // Most recent game date across all teams in cohort
+  let lastGameDate: string | null = null;
+  for (const team of teams) {
+    if (team.last_game && (!lastGameDate || team.last_game > lastGameDate)) {
+      lastGameDate = team.last_game;
+    }
+  }
+
+  const lastCalculated = teams[0]?.last_calculated ?? null;
+  const genderLabel = genderDisplay === 'Male' ? 'boys' : 'girls';
+
+  return {
+    totalTeams,
+    positioningHook,
+    topClubs,
+    risers,
+    fallers,
+    lastGameDate,
+    lastCalculated,
+    locationText,
+    ageGroupDisplay,
+    genderDisplay,
+    genderLabel,
+    isNational,
+    region,
+  };
+}
+
+/**
+ * Build FAQ items for this cohort's ranking page.
+ */
+export function buildCohortFAQ(data: CohortModuleData): Array<{ question: string; answer: string }> {
+  const { totalTeams, locationText, ageGroupDisplay, genderLabel, isNational } = data;
+  const scope = isNational ? 'nationally' : `in ${locationText}`;
+
+  return [
+    {
+      question: `How many ${ageGroupDisplay} ${genderLabel} soccer teams are there ${scope}?`,
+      answer: `PitchRank tracks ${totalTeams.toLocaleString()} active ${ageGroupDisplay} ${genderLabel} teams ${scope} across all competitive leagues.`,
+    },
+    {
+      question: `How often do ${isNational ? 'national' : locationText} ${ageGroupDisplay} ${genderLabel} rankings update?`,
+      answer: 'Weekly every Monday as new game results come in. Rankings stabilize after 8\u201310 games.',
+    },
+    {
+      question: `Which leagues are tracked for ${isNational ? 'national' : locationText} ${ageGroupDisplay} ${genderLabel} rankings?`,
+      answer:
+        'EDP, ECNL, MLS Next, NPL, US Youth Soccer state leagues, showcases, and friendlies \u2014 every competitive game we can find.',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Every `/rankings/{state}/{age}/{gender}` page now gets 5 server-rendered content modules below the H1/intro:
  1. **Cohort summary** with positioning hook ("one of the deepest groups in the country" / "a growing group")
  2. **Top clubs table** (top 5 by team count in this group)
  3. **Biggest movers this week** (top 3 risers/fallers from `rank_change_state_7d`, clickable links with `?highlight=` param)
  4. **FAQ** with `FAQPage` JSON-LD (team count, update cadence, leagues tracked)
  5. **Freshness signal** (last calculated + last game dates)

- Data fetch increased from top 25 to full cohort (limit 2000) — ISR caches 1hr so cost is unchanged
- All content is unique per page (different team counts, clubs, movers, FAQ answers)
- Zero backend changes — uses existing `get_state_rankings` / `get_national_rankings` RPCs
- Typechecks clean

## New files
- `frontend/lib/cohort-seo.ts` — pure utility computing module data from `RankingRow[]`
- `frontend/components/CohortSEOContent.tsx` — server component rendering all 5 modules

## SEO roadmap context
Week 1 deliverable from the 20-week SEO roadmap (`docs/superpowers/specs/2026-04-16-seo-roadmap-design.md`). This enriches 1,200+ ranking pages with unique content — the highest-ROI SEO lever.

## Test plan
- [ ] Preview deploy: check `/rankings/pa/u13/male` — modules render with real PA U13 data
- [ ] Check `/rankings/national/u12/female` — national variant uses `rank_change_7d` not state
- [ ] Check a small cohort (e.g., `/rankings/wy/u19/male`) — positioning hook says "an emerging group"
- [ ] Verify FAQPage JSON-LD in page source (search for `FAQPage`)
- [ ] Movers show green/red styling with team names
- [ ] Mobile rendering: table and movers grid stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)