### PR TITLE
Fix gender mismatch, mover links, FAQ placement in SEO modules

### DIFF
--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -6,7 +6,7 @@ import { formatPowerScore } from '@/lib/utils';
 import BreadcrumbSchema from '@/components/BreadcrumbSchema';
 import { safeJsonLd } from '@/lib/schema-utils';
 import { computeCohortModules } from '@/lib/cohort-seo';
-import { CohortSEOContent } from '@/components/CohortSEOContent';
+import { CohortSEOContent, CohortFAQ } from '@/components/CohortSEOContent';
 
 // Revalidate every hour for ISR caching
 export const revalidate = 3600;
@@ -148,7 +148,7 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
   // Compute programmatic SEO content modules from the full team set
   const cohortData =
     allTeams.length > 0
-      ? computeCohortModules(allTeams, locationText, formattedAgeGroup, formattedGender, isNational, safeRegion)
+      ? computeCohortModules(allTeams, locationText, formattedAgeGroup, formattedGender, isNational, safeRegion, gender)
       : null;
 
   // Build breadcrumb trail
@@ -198,6 +198,9 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
       )}
 
       <RankingsPageContent key={routeKey} region={region} ageGroup={ageGroup} gender={gender} />
+
+      {/* FAQ below the interactive table — JSON-LD tells Google it exists regardless of position */}
+      {cohortData && <CohortFAQ data={cohortData} />}
     </>
   );
 }

--- a/frontend/components/CohortSEOContent.tsx
+++ b/frontend/components/CohortSEOContent.tsx
@@ -13,7 +13,8 @@ function formatDate(iso: string): string {
 
 /**
  * Server-rendered SEO content modules for ranking pages.
- * Renders between the H1/intro and the interactive table.
+ * Renders between the H1/intro and the interactive table (modules 1-3 + freshness).
+ * FAQ renders separately below the table via CohortFAQ.
  */
 export function CohortSEOContent({ data }: CohortSEOContentProps) {
   const {
@@ -28,17 +29,115 @@ export function CohortSEOContent({ data }: CohortSEOContentProps) {
     ageGroupDisplay,
     genderLabel,
     isNational,
-    region,
   } = data;
 
-  const faqItems = buildCohortFAQ(data);
   const scope = isNational ? 'nationally' : `in ${locationText}`;
   const hasMovers = risers.length > 0 || fallers.length > 0;
-  const pageUrl = isNational
-    ? `/rankings/national/${data.ageGroupDisplay.toLowerCase()}/${data.genderDisplay.toLowerCase()}`
-    : `/rankings/${region}/${data.ageGroupDisplay.toLowerCase()}/${data.genderDisplay.toLowerCase()}`;
 
-  // FAQPage JSON-LD
+  return (
+    <section className="container mx-auto px-4 pb-6 space-y-6">
+      {/* Module 1: Group Summary */}
+      <div>
+        <h2 className="font-display text-lg font-semibold mb-1">
+          {locationText} {ageGroupDisplay} {genderLabel === 'boys' ? 'Boys' : 'Girls'} at a Glance
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          The {isNational ? 'national' : locationText} {ageGroupDisplay} {genderLabel} group is{' '}
+          <strong>{positioningHook}</strong>, with <strong>{totalTeams.toLocaleString()} active teams</strong>{' '}
+          competing {scope} across all tracked leagues.
+        </p>
+      </div>
+
+      {/* Module 2: Top Clubs */}
+      {topClubs.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2">Top Clubs by Team Count</h3>
+          <div className="overflow-x-auto">
+            <table className="text-sm w-full max-w-md">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="pb-1 pr-4 font-medium text-muted-foreground">Club</th>
+                  <th className="pb-1 font-medium text-muted-foreground">Teams</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topClubs.map((club) => (
+                  <tr key={club.name} className="border-b border-border/50">
+                    <td className="py-1 pr-4">{club.name}</td>
+                    <td className="py-1">{club.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Module 3: Biggest Movers This Week */}
+      {hasMovers && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2">Biggest Movers This Week</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+            {risers.length > 0 && (
+              <div>
+                <p className="font-medium text-green-600 dark:text-green-400 mb-1">Rising</p>
+                <ul className="space-y-0.5">
+                  {risers.map((t) => (
+                    <li key={t.teamId}>
+                      <a
+                        href={`/teams/${t.teamId}`}
+                        className="underline decoration-1 underline-offset-2 hover:decoration-2"
+                      >
+                        {t.teamName}
+                      </a>
+                      {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
+                      <span className="text-green-600 dark:text-green-400"> &mdash; up {t.change} spots</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {fallers.length > 0 && (
+              <div>
+                <p className="font-medium text-red-500 dark:text-red-400 mb-1">Falling</p>
+                <ul className="space-y-0.5">
+                  {fallers.map((t) => (
+                    <li key={t.teamId}>
+                      <a
+                        href={`/teams/${t.teamId}`}
+                        className="underline decoration-1 underline-offset-2 hover:decoration-2"
+                      >
+                        {t.teamName}
+                      </a>
+                      {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
+                      <span className="text-red-500 dark:text-red-400">
+                        {' '}&mdash; down {Math.abs(t.change)} spots
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Module 5: Freshness Signal */}
+      <p className="text-xs text-muted-foreground">
+        {lastCalculated && <>Rankings last calculated {formatDate(lastCalculated)}. </>}
+        {lastGameDate && <>Most recent game in this group: {formatDate(lastGameDate)}.</>}
+      </p>
+    </section>
+  );
+}
+
+/**
+ * FAQ section rendered below the interactive rankings table.
+ * Includes FAQPage JSON-LD for Google/AI citation eligibility.
+ */
+export function CohortFAQ({ data }: CohortSEOContentProps) {
+  const faqItems = buildCohortFAQ(data);
+
   const faqJsonLd = safeJsonLd({
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
@@ -55,104 +154,16 @@ export function CohortSEOContent({ data }: CohortSEOContentProps) {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: faqJsonLd }} />
-
-      <section className="container mx-auto px-4 pb-6 space-y-6">
-        {/* Module 1: Cohort Summary */}
-        <div>
-          <h2 className="font-display text-lg font-semibold mb-1">
-            {locationText} {ageGroupDisplay} {genderLabel === 'boys' ? 'Boys' : 'Girls'} at a Glance
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            The {isNational ? 'national' : locationText} {ageGroupDisplay} {genderLabel} group is{' '}
-            <strong>{positioningHook}</strong>, with <strong>{totalTeams.toLocaleString()} active teams</strong>{' '}
-            competing {scope} across all tracked leagues.
-          </p>
-        </div>
-
-        {/* Module 2: Top Clubs */}
-        {topClubs.length > 0 && (
-          <div>
-            <h3 className="text-sm font-semibold mb-2">Top Clubs by Team Count</h3>
-            <div className="overflow-x-auto">
-              <table className="text-sm w-full max-w-md">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="pb-1 pr-4 font-medium text-muted-foreground">Club</th>
-                    <th className="pb-1 font-medium text-muted-foreground">Teams</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {topClubs.map((club) => (
-                    <tr key={club.name} className="border-b border-border/50">
-                      <td className="py-1 pr-4">{club.name}</td>
-                      <td className="py-1">{club.count}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+      <section className="container mx-auto px-4 py-6">
+        <h3 className="text-sm font-semibold mb-2">FAQ</h3>
+        <dl className="space-y-3 text-sm">
+          {faqItems.map((item) => (
+            <div key={item.question}>
+              <dt className="font-medium">{item.question}</dt>
+              <dd className="text-muted-foreground mt-0.5">{item.answer}</dd>
             </div>
-          </div>
-        )}
-
-        {/* Module 3: Biggest Movers This Week */}
-        {hasMovers && (
-          <div>
-            <h3 className="text-sm font-semibold mb-2">Biggest Movers This Week</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-              {risers.length > 0 && (
-                <div>
-                  <p className="font-medium text-green-600 dark:text-green-400 mb-1">Rising</p>
-                  <ul className="space-y-0.5">
-                    {risers.map((t) => (
-                      <li key={t.teamId}>
-                        <a href={`${pageUrl}?highlight=${t.teamId}`} className="hover:underline">
-                          {t.teamName}
-                        </a>
-                        {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
-                        <span className="text-green-600 dark:text-green-400"> &mdash; up {t.change} spots</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {fallers.length > 0 && (
-                <div>
-                  <p className="font-medium text-red-500 dark:text-red-400 mb-1">Falling</p>
-                  <ul className="space-y-0.5">
-                    {fallers.map((t) => (
-                      <li key={t.teamId}>
-                        <a href={`${pageUrl}?highlight=${t.teamId}`} className="hover:underline">
-                          {t.teamName}
-                        </a>
-                        {t.clubName && <span className="text-muted-foreground"> ({t.clubName})</span>}
-                        <span className="text-red-500 dark:text-red-400"> &mdash; down {Math.abs(t.change)} spots</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Module 4: FAQ */}
-        <div>
-          <h3 className="text-sm font-semibold mb-2">FAQ</h3>
-          <dl className="space-y-3 text-sm">
-            {faqItems.map((item) => (
-              <div key={item.question}>
-                <dt className="font-medium">{item.question}</dt>
-                <dd className="text-muted-foreground mt-0.5">{item.answer}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-
-        {/* Module 5: Freshness Signal */}
-        <p className="text-xs text-muted-foreground">
-          {lastCalculated && <>Rankings last calculated {formatDate(lastCalculated)}. </>}
-          {lastGameDate && <>Most recent game in this group: {formatDate(lastGameDate)}.</>}
-        </p>
+          ))}
+        </dl>
       </section>
     </>
   );

--- a/frontend/lib/cohort-seo.ts
+++ b/frontend/lib/cohort-seo.ts
@@ -14,6 +14,8 @@ export interface CohortModuleData {
   genderLabel: string;
   isNational: boolean;
   region: string;
+  /** Raw URL-safe gender param ('male' or 'female') for link construction */
+  genderSlug: string;
 }
 
 function getPositioningHook(count: number): string {
@@ -29,7 +31,8 @@ export function computeCohortModules(
   ageGroupDisplay: string,
   genderDisplay: string,
   isNational: boolean,
-  region: string
+  region: string,
+  genderSlug: string,
 ): CohortModuleData {
   const totalTeams = teams.length;
   const positioningHook = getPositioningHook(totalTeams);
@@ -81,7 +84,8 @@ export function computeCohortModules(
   }
 
   const lastCalculated = teams[0]?.last_calculated ?? null;
-  const genderLabel = genderDisplay === 'Male' ? 'boys' : 'girls';
+  // formatGender returns "Boys"/"Girls", not "Male"/"Female"
+  const genderLabel = genderDisplay === 'Boys' || genderDisplay === 'Male' ? 'boys' : 'girls';
 
   return {
     totalTeams,
@@ -97,6 +101,7 @@ export function computeCohortModules(
     genderLabel,
     isNational,
     region,
+    genderSlug,
   };
 }
 


### PR DESCRIPTION
## Bugs fixed
- **Gender mismatch**: "Girls" showed on Boys pages. Root cause: `formatGender()` returns "Boys"/"Girls" not "Male"/"Female", but `genderLabel` comparison assumed "Male".
- **Broken mover links**: URLs used `genderDisplay.toLowerCase()` → "boys" instead of "male". Also linked to same-page `?highlight=` which broke filters. Now links to `/teams/{id}`.
- **Movers not visually clickable**: Added persistent underline styling.

## UX improvement
- FAQ moved below the interactive table (was above). JSON-LD still tells Google it exists. Split into `CohortSEOContent` (above table) + `CohortFAQ` (below table).

## Test plan
- [ ] `/rankings/ar/u12/male` — should say "Boys" not "Girls" throughout
- [ ] `/rankings/pa/u13/female` — should say "Girls" correctly
- [ ] Mover team names are visually underlined and link to `/teams/{id}`
- [ ] FAQ renders below the rankings table, not above

🤖 Generated with [Claude Code](https://claude.com/claude-code)