### PR TITLE
Add two-way cross-linking between ranking pages and blog posts

### DIFF
--- a/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
+++ b/frontend/app/rankings/[region]/[ageGroup]/[gender]/page.tsx
@@ -5,7 +5,7 @@ import { api } from '@/lib/api';
 import { formatPowerScore } from '@/lib/utils';
 import BreadcrumbSchema from '@/components/BreadcrumbSchema';
 import { safeJsonLd } from '@/lib/schema-utils';
-import { computeCohortModules } from '@/lib/cohort-seo';
+import { computeCohortModules, getRelatedGuide } from '@/lib/cohort-seo';
 import { CohortSEOContent, CohortFAQ } from '@/components/CohortSEOContent';
 
 // Revalidate every hour for ISR caching
@@ -179,6 +179,24 @@ export default async function RankingsPage({ params }: RankingsPageProps) {
 
       {/* Programmatic SEO content modules — visible, unique per page */}
       {cohortData && <CohortSEOContent data={cohortData} />}
+
+      {/* Related Guide — links ranking page to matching state pillar blog */}
+      {(() => {
+        const guide = !isNational ? getRelatedGuide(region) : null;
+        return guide ? (
+          <section className="container mx-auto px-4 pb-4">
+            <p className="text-sm text-muted-foreground">
+              Read our complete guide:{' '}
+              <a
+                href={`/blog/${guide.slug}`}
+                className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+              >
+                {guide.title} &rarr;
+              </a>
+            </p>
+          </section>
+        ) : null;
+      })()}
 
       {/* Top teams in DOM for Googlebot but visually hidden — the interactive table shows the same data */}
       {topTeams.length > 0 && (

--- a/frontend/content/blog-posts.tsx
+++ b/frontend/content/blog-posts.tsx
@@ -1812,6 +1812,42 @@ export const blogPosts: BlogPost[] = [
           </div>
         </section>
 
+        {/* Browse Rankings by Age Group */}
+        <section>
+          <h2 className="text-2xl font-display font-bold mb-4">Browse California Rankings by Age Group</h2>
+          <p className="text-muted-foreground leading-relaxed mb-4">
+            Find your team&apos;s age group and gender to see the latest California rankings:
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-2 pr-4 font-semibold">Age Group</th>
+                  <th className="text-left py-2 pr-4 font-semibold">Boys</th>
+                  <th className="text-left py-2 font-semibold">Girls</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'] as const).map((ag) => (
+                  <tr key={ag} className="border-b border-border/40">
+                    <td className="py-2 pr-4 font-medium">{ag.toUpperCase()}</td>
+                    <td className="py-2 pr-4">
+                      <Link href={`/rankings/ca/${ag}/male`} className="text-primary underline underline-offset-2">
+                        California {ag.toUpperCase()} Boys
+                      </Link>
+                    </td>
+                    <td className="py-2">
+                      <Link href={`/rankings/ca/${ag}/female`} className="text-primary underline underline-offset-2">
+                        California {ag.toUpperCase()} Girls
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
         {/* CTA */}
         <section className="p-6 rounded-lg bg-primary/10 border border-primary/20">
           <h2 className="text-2xl font-display font-bold mb-4">Find Your California Team&apos;s Ranking</h2>
@@ -2467,6 +2503,42 @@ export const blogPosts: BlogPost[] = [
                 ensure your team gets credit.
               </p>
             </div>
+          </div>
+        </section>
+
+        {/* Browse Rankings by Age Group */}
+        <section>
+          <h2 className="text-2xl font-display font-bold mb-4">Browse Texas Rankings by Age Group</h2>
+          <p className="text-muted-foreground leading-relaxed mb-4">
+            Find your team&apos;s age group and gender to see the latest Texas rankings:
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-2 pr-4 font-semibold">Age Group</th>
+                  <th className="text-left py-2 pr-4 font-semibold">Boys</th>
+                  <th className="text-left py-2 font-semibold">Girls</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(['u10', 'u11', 'u12', 'u13', 'u14', 'u15', 'u16', 'u17', 'u19'] as const).map((ag) => (
+                  <tr key={ag} className="border-b border-border/40">
+                    <td className="py-2 pr-4 font-medium">{ag.toUpperCase()}</td>
+                    <td className="py-2 pr-4">
+                      <Link href={`/rankings/tx/${ag}/male`} className="text-primary underline underline-offset-2">
+                        Texas {ag.toUpperCase()} Boys
+                      </Link>
+                    </td>
+                    <td className="py-2">
+                      <Link href={`/rankings/tx/${ag}/female`} className="text-primary underline underline-offset-2">
+                        Texas {ag.toUpperCase()} Girls
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </section>
 

--- a/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
@@ -292,6 +292,22 @@ Top clubs track rankings internally. They schedule games specifically to improve
 
 This is good for parents — it creates accountability and transparency.
 
+## Browse Arizona Rankings by Age Group
+
+Find your team's age group and gender to see the latest Arizona rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [Arizona U10 Boys](/rankings/az/u10/male) | [Arizona U10 Girls](/rankings/az/u10/female) |
+| U11 | [Arizona U11 Boys](/rankings/az/u11/male) | [Arizona U11 Girls](/rankings/az/u11/female) |
+| U12 | [Arizona U12 Boys](/rankings/az/u12/male) | [Arizona U12 Girls](/rankings/az/u12/female) |
+| U13 | [Arizona U13 Boys](/rankings/az/u13/male) | [Arizona U13 Girls](/rankings/az/u13/female) |
+| U14 | [Arizona U14 Boys](/rankings/az/u14/male) | [Arizona U14 Girls](/rankings/az/u14/female) |
+| U15 | [Arizona U15 Boys](/rankings/az/u15/male) | [Arizona U15 Girls](/rankings/az/u15/female) |
+| U16 | [Arizona U16 Boys](/rankings/az/u16/male) | [Arizona U16 Girls](/rankings/az/u16/female) |
+| U17 | [Arizona U17 Boys](/rankings/az/u17/male) | [Arizona U17 Girls](/rankings/az/u17/female) |
+| U19 | [Arizona U19 Boys](/rankings/az/u19/male) | [Arizona U19 Girls](/rankings/az/u19/female) |
+
 ## Take Action: Check Your Arizona Team's Ranking
 
 Ready to see where your team stands?

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -211,6 +211,22 @@ College coaches prioritize:
 
 **Colorado's advantage:** Strong in-state college programs (Denver, Air Force, Colorado College, Colorado School of Mines) plus proximity to schools across the Mountain West. Use rankings to identify which Colorado clubs consistently place players in college.
 
+## Browse Colorado Rankings by Age Group
+
+Find your team's age group and gender to see the latest Colorado rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [Colorado U10 Boys](/rankings/co/u10/male) | [Colorado U10 Girls](/rankings/co/u10/female) |
+| U11 | [Colorado U11 Boys](/rankings/co/u11/male) | [Colorado U11 Girls](/rankings/co/u11/female) |
+| U12 | [Colorado U12 Boys](/rankings/co/u12/male) | [Colorado U12 Girls](/rankings/co/u12/female) |
+| U13 | [Colorado U13 Boys](/rankings/co/u13/male) | [Colorado U13 Girls](/rankings/co/u13/female) |
+| U14 | [Colorado U14 Boys](/rankings/co/u14/male) | [Colorado U14 Girls](/rankings/co/u14/female) |
+| U15 | [Colorado U15 Boys](/rankings/co/u15/male) | [Colorado U15 Girls](/rankings/co/u15/female) |
+| U16 | [Colorado U16 Boys](/rankings/co/u16/male) | [Colorado U16 Girls](/rankings/co/u16/female) |
+| U17 | [Colorado U17 Boys](/rankings/co/u17/male) | [Colorado U17 Girls](/rankings/co/u17/female) |
+| U19 | [Colorado U19 Boys](/rankings/co/u19/male) | [Colorado U19 Girls](/rankings/co/u19/female) |
+
 ## Take Action: Check Your Colorado Team's Ranking
 
 1. Visit **[PitchRank.io](https://pitchrank.io)**

--- a/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
@@ -225,6 +225,22 @@ Look at teams you regularly play against. Are they ranked higher or lower? This 
 
 Rankings shift as new games are played. Check weekly to see how wins, losses, and tournament results move your team's ranking.
 
+## Browse Florida Rankings by Age Group
+
+Find your team's age group and gender to see the latest Florida rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [Florida U10 Boys](/rankings/fl/u10/male) | [Florida U10 Girls](/rankings/fl/u10/female) |
+| U11 | [Florida U11 Boys](/rankings/fl/u11/male) | [Florida U11 Girls](/rankings/fl/u11/female) |
+| U12 | [Florida U12 Boys](/rankings/fl/u12/male) | [Florida U12 Girls](/rankings/fl/u12/female) |
+| U13 | [Florida U13 Boys](/rankings/fl/u13/male) | [Florida U13 Girls](/rankings/fl/u13/female) |
+| U14 | [Florida U14 Boys](/rankings/fl/u14/male) | [Florida U14 Girls](/rankings/fl/u14/female) |
+| U15 | [Florida U15 Boys](/rankings/fl/u15/male) | [Florida U15 Girls](/rankings/fl/u15/female) |
+| U16 | [Florida U16 Boys](/rankings/fl/u16/male) | [Florida U16 Girls](/rankings/fl/u16/female) |
+| U17 | [Florida U17 Boys](/rankings/fl/u17/male) | [Florida U17 Girls](/rankings/fl/u17/female) |
+| U19 | [Florida U19 Boys](/rankings/fl/u19/male) | [Florida U19 Girls](/rankings/fl/u19/female) |
+
 ## Frequently Asked Questions
 
 ### How are youth soccer teams ranked in Florida?

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -194,6 +194,22 @@ College coaches prioritize:
 
 **Michigan's advantage:** Proximity to Big Ten, MAC, and GLIAC schools means access to top college programs. Use rankings to identify which Michigan clubs consistently place players in college.
 
+## Browse Michigan Rankings by Age Group
+
+Find your team's age group and gender to see the latest Michigan rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [Michigan U10 Boys](/rankings/mi/u10/male) | [Michigan U10 Girls](/rankings/mi/u10/female) |
+| U11 | [Michigan U11 Boys](/rankings/mi/u11/male) | [Michigan U11 Girls](/rankings/mi/u11/female) |
+| U12 | [Michigan U12 Boys](/rankings/mi/u12/male) | [Michigan U12 Girls](/rankings/mi/u12/female) |
+| U13 | [Michigan U13 Boys](/rankings/mi/u13/male) | [Michigan U13 Girls](/rankings/mi/u13/female) |
+| U14 | [Michigan U14 Boys](/rankings/mi/u14/male) | [Michigan U14 Girls](/rankings/mi/u14/female) |
+| U15 | [Michigan U15 Boys](/rankings/mi/u15/male) | [Michigan U15 Girls](/rankings/mi/u15/female) |
+| U16 | [Michigan U16 Boys](/rankings/mi/u16/male) | [Michigan U16 Girls](/rankings/mi/u16/female) |
+| U17 | [Michigan U17 Boys](/rankings/mi/u17/male) | [Michigan U17 Girls](/rankings/mi/u17/female) |
+| U19 | [Michigan U19 Boys](/rankings/mi/u19/male) | [Michigan U19 Girls](/rankings/mi/u19/female) |
+
 ## Take Action: Check Your Michigan Team's Ranking
 
 1. Visit **[PitchRank.io](https://pitchrank.io)**

--- a/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
@@ -220,6 +220,22 @@ Rankings shift constantly. Check weekly to see how wins and losses affect your t
 
 > **Ready to check?** [See all New Jersey youth soccer rankings](/rankings/nj)
 
+## Browse New Jersey Rankings by Age Group
+
+Find your team's age group and gender to see the latest New Jersey rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [New Jersey U10 Boys](/rankings/nj/u10/male) | [New Jersey U10 Girls](/rankings/nj/u10/female) |
+| U11 | [New Jersey U11 Boys](/rankings/nj/u11/male) | [New Jersey U11 Girls](/rankings/nj/u11/female) |
+| U12 | [New Jersey U12 Boys](/rankings/nj/u12/male) | [New Jersey U12 Girls](/rankings/nj/u12/female) |
+| U13 | [New Jersey U13 Boys](/rankings/nj/u13/male) | [New Jersey U13 Girls](/rankings/nj/u13/female) |
+| U14 | [New Jersey U14 Boys](/rankings/nj/u14/male) | [New Jersey U14 Girls](/rankings/nj/u14/female) |
+| U15 | [New Jersey U15 Boys](/rankings/nj/u15/male) | [New Jersey U15 Girls](/rankings/nj/u15/female) |
+| U16 | [New Jersey U16 Boys](/rankings/nj/u16/male) | [New Jersey U16 Girls](/rankings/nj/u16/female) |
+| U17 | [New Jersey U17 Boys](/rankings/nj/u17/male) | [New Jersey U17 Girls](/rankings/nj/u17/female) |
+| U19 | [New Jersey U19 Boys](/rankings/nj/u19/male) | [New Jersey U19 Girls](/rankings/nj/u19/female) |
+
 ## Frequently Asked Questions
 
 ### How are youth soccer teams ranked in New Jersey?

--- a/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
@@ -249,6 +249,22 @@ Rankings shift as new games are played. Check weekly to see how wins, losses, an
 
 > **Ready to check?** [See all North Carolina youth soccer rankings](/rankings/nc)
 
+## Browse North Carolina Rankings by Age Group
+
+Find your team's age group and gender to see the latest North Carolina rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [North Carolina U10 Boys](/rankings/nc/u10/male) | [North Carolina U10 Girls](/rankings/nc/u10/female) |
+| U11 | [North Carolina U11 Boys](/rankings/nc/u11/male) | [North Carolina U11 Girls](/rankings/nc/u11/female) |
+| U12 | [North Carolina U12 Boys](/rankings/nc/u12/male) | [North Carolina U12 Girls](/rankings/nc/u12/female) |
+| U13 | [North Carolina U13 Boys](/rankings/nc/u13/male) | [North Carolina U13 Girls](/rankings/nc/u13/female) |
+| U14 | [North Carolina U14 Boys](/rankings/nc/u14/male) | [North Carolina U14 Girls](/rankings/nc/u14/female) |
+| U15 | [North Carolina U15 Boys](/rankings/nc/u15/male) | [North Carolina U15 Girls](/rankings/nc/u15/female) |
+| U16 | [North Carolina U16 Boys](/rankings/nc/u16/male) | [North Carolina U16 Girls](/rankings/nc/u16/female) |
+| U17 | [North Carolina U17 Boys](/rankings/nc/u17/male) | [North Carolina U17 Girls](/rankings/nc/u17/female) |
+| U19 | [North Carolina U19 Boys](/rankings/nc/u19/male) | [North Carolina U19 Girls](/rankings/nc/u19/female) |
+
 ## Frequently Asked Questions
 
 ### How are youth soccer teams ranked in North Carolina?

--- a/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
@@ -297,6 +297,22 @@ PowerScores refresh after each weekly data pull. Expect rankings to shift every 
 
 No. Our engine penalizes teams that avoid strong competition via strength-of-schedule weighting. A team that wins every game against weak opponents will not overtake a team with more losses but a far harder schedule. You cannot fake SOS.
 
+## Browse Pennsylvania Rankings by Age Group
+
+Find your team's age group and gender to see the latest Pennsylvania rankings:
+
+| Age Group | Boys | Girls |
+|-----------|------|-------|
+| U10 | [Pennsylvania U10 Boys](/rankings/pa/u10/male) | [Pennsylvania U10 Girls](/rankings/pa/u10/female) |
+| U11 | [Pennsylvania U11 Boys](/rankings/pa/u11/male) | [Pennsylvania U11 Girls](/rankings/pa/u11/female) |
+| U12 | [Pennsylvania U12 Boys](/rankings/pa/u12/male) | [Pennsylvania U12 Girls](/rankings/pa/u12/female) |
+| U13 | [Pennsylvania U13 Boys](/rankings/pa/u13/male) | [Pennsylvania U13 Girls](/rankings/pa/u13/female) |
+| U14 | [Pennsylvania U14 Boys](/rankings/pa/u14/male) | [Pennsylvania U14 Girls](/rankings/pa/u14/female) |
+| U15 | [Pennsylvania U15 Boys](/rankings/pa/u15/male) | [Pennsylvania U15 Girls](/rankings/pa/u15/female) |
+| U16 | [Pennsylvania U16 Boys](/rankings/pa/u16/male) | [Pennsylvania U16 Girls](/rankings/pa/u16/female) |
+| U17 | [Pennsylvania U17 Boys](/rankings/pa/u17/male) | [Pennsylvania U17 Girls](/rankings/pa/u17/female) |
+| U19 | [Pennsylvania U19 Boys](/rankings/pa/u19/male) | [Pennsylvania U19 Girls](/rankings/pa/u19/female) |
+
 ## Take Action: Check Your Pennsylvania Team's Ranking
 
 Ready to see where your team actually stands among PA's 5,357 teams?

--- a/frontend/lib/cohort-seo.ts
+++ b/frontend/lib/cohort-seo.ts
@@ -32,7 +32,7 @@ export function computeCohortModules(
   genderDisplay: string,
   isNational: boolean,
   region: string,
-  genderSlug: string,
+  genderSlug: string
 ): CohortModuleData {
   const totalTeams = teams.length;
   const positioningHook = getPositioningHook(totalTeams);
@@ -103,6 +103,26 @@ export function computeCohortModules(
     region,
     genderSlug,
   };
+}
+
+/**
+ * States that have a pillar blog post.
+ * Returns the blog slug and display title, or null if no pillar exists.
+ */
+const STATE_PILLAR_SLUGS: Record<string, { slug: string; title: string }> = {
+  az: { slug: 'arizona-youth-soccer-rankings-guide', title: 'Arizona Youth Soccer Rankings Guide' },
+  ca: { slug: 'california-youth-soccer-rankings-guide', title: 'California Youth Soccer Rankings Guide' },
+  co: { slug: 'colorado-youth-soccer-rankings-guide', title: 'Colorado Youth Soccer Rankings Guide' },
+  fl: { slug: 'florida-youth-soccer-rankings-guide', title: 'Florida Youth Soccer Rankings Guide' },
+  mi: { slug: 'michigan-youth-soccer-rankings-guide', title: 'Michigan Youth Soccer Rankings Guide' },
+  nj: { slug: 'new-jersey-youth-soccer-rankings-guide', title: 'New Jersey Youth Soccer Rankings Guide' },
+  nc: { slug: 'north-carolina-youth-soccer-rankings-guide', title: 'North Carolina Youth Soccer Rankings Guide' },
+  pa: { slug: 'pennsylvania-youth-soccer-rankings-guide', title: 'Pennsylvania Youth Soccer Rankings Guide' },
+  tx: { slug: 'texas-youth-soccer-rankings-guide', title: 'Texas Youth Soccer Rankings Guide' },
+};
+
+export function getRelatedGuide(stateCode: string): { slug: string; title: string } | null {
+  return STATE_PILLAR_SLUGS[stateCode.toLowerCase()] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Ranking → Blog**: Add "Related Guide" link on ranking pages for the 9 states with pillar blog posts (AZ, CA, CO, FL, MI, NJ, NC, PA, TX). Renders between the SEO content card and the table.
- **Blog → Rankings**: Add "Browse Rankings by Age Group" section to all 9 state pillar blogs with a table of links to `/rankings/{state}/{age}/{gender}` (9 age groups x 2 genders = 18 links per post, 162 new internal links total)
- Covers 7 MDX posts + 2 programmatic TSX posts (CA, TX)

Completes Week 3 cross-linking from the SEO roadmap. Builds on #639 (blog FAQ JSON-LD).

## Test plan
- [ ] Visit a PA ranking page (e.g., /rankings/pa/u12/male) — verify "Read our complete guide: Pennsylvania Youth Soccer Rankings Guide →" link appears
- [ ] Visit a state without a pillar (e.g., /rankings/oh/u12/male) — verify no guide link renders
- [ ] Visit /rankings/national/u12/male — verify no guide link (national has no pillar)
- [ ] Open the PA pillar blog — verify the "Browse Rankings by Age Group" table renders with working links
- [ ] Click a link in the table (e.g., PA U12 Boys) — verify it navigates to the correct ranking page

🤖 Generated with [Claude Code](https://claude.com/claude-code)