### PR TITLE
perf(layout): drop unused font weights to speed up mobile LCP

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,10 +11,11 @@ import { WebVitalsReporter } from '@/components/WebVitalsReporter';
 import { BASE_URL_WWW } from '@/lib/constants';
 
 // Athletic Editorial Typography
+// Oswald: display font for headings — only 600/700 are used in the codebase
 const oswald = Oswald({
   variable: '--font-oswald',
   subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
+  weight: ['600', '700'],
   fallback: ['system-ui', 'sans-serif'],
   display: 'swap',
 });
@@ -27,10 +28,11 @@ const dmSans = DM_Sans({
   display: 'swap',
 });
 
+// JetBrains Mono: used for stat numbers — 400 is not used in the codebase
 const jetbrainsMono = JetBrains_Mono({
   variable: '--font-jetbrains-mono',
   subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
+  weight: ['500', '600', '700'],
   fallback: ['ui-monospace', 'monospace'],
   display: 'swap',
 });


### PR DESCRIPTION
## Summary

- Oswald: 4 weights → 2 (`['600', '700']`). Only `font-bold` (700, 97 uses) and `font-semibold` (600, 63 uses) appear with `font-display` across the codebase — 0 uses of `font-medium/normal/light` with `font-display` (verified by grep).
- JetBrains Mono: 4 weights → 3 (`['500', '600', '700']`). `font-mono` never pairs with `font-normal` (0 uses of `font-mono font-normal`).
- DM Sans: unchanged — all 4 weights are used across 658 font-weight occurrences on body text.

## Why

PSI mobile LCP on `/rankings/*` is **6.1–7.0s** against Google's 2.5s "good" threshold, and mobile is 64% of current clicks. The PSI `lcp-breakdown-insight` audit identifies the LCP element as the page H1 (Oswald 700) with this breakdown on `/rankings/md` mobile:

| Subpart | Duration |
|---|--:|
| TTFB | 1.74s |
| Font load gap | ~2.6s |
| Element render delay | 2.35s |
| **Total LCP** | **6.7s** |

Dropping the unused weights cuts the Oswald woff2 glyph payload by ~50% and the JetBrains Mono payload by ~25%, which should shorten the font-load gap. This is the cheapest, lowest-risk fix in the tiered Week 4 LCP plan.

## Expected outcome

Mobile LCP: 6.1–7.0s → ~4.5s (directional). Re-run PSI on the same 5 pages after merge to confirm.

## Test plan

- [ ] Vercel preview deploy shows the site rendering correctly — verify headings (Oswald), body (DM Sans), stat numbers (JetBrains Mono) all look right on `/`, `/rankings/md`, a blog post, and the methodology page
- [ ] PSI re-run on mobile for `/`, `/rankings/md`, `/rankings/ny/u14/male`, `/rankings/co`, `/blog/california-youth-soccer-rankings-guide` — record new mobile LCP per page
- [ ] Compare before/after LCP in `.turbo/seo-week4/pagespeed-audit.md`

## Follow-ups (not in this PR)

- Tier 2: identify + remove the 50 KiB chunk `0s6glhvz~ywoj.js` that's 80% unused; migrate GA to `@next/third-parties`
- Tier 3: migrate `HomeStats`/`RecentMovers` from `'use client'` to RSC with client islands

🤖 Generated with [Claude Code](https://claude.com/claude-code)