### PR TITLE
perf(layout): split QueryClientProvider out of root to free anon-route LCP

### DIFF
--- a/frontend/app/(internal)/analytics/layout.tsx
+++ b/frontend/app/(internal)/analytics/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createServerSupabase } from '@/lib/supabase/server';
 import type { ReactNode } from 'react';
+import { DataProviders } from '@/app/data-providers';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -17,8 +18,10 @@ export default async function AnalyticsLayout({ children }: { children: ReactNod
   if (!profile || profile.plan !== 'admin') redirect('/');
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-6">{children}</div>
-    </div>
+    <DataProviders>
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-6">{children}</div>
+      </div>
+    </DataProviders>
   );
 }

--- a/frontend/app/compare/layout.tsx
+++ b/frontend/app/compare/layout.tsx
@@ -1,0 +1,5 @@
+import { DataProviders } from '@/app/data-providers';
+
+export default function CompareLayout({ children }: { children: React.ReactNode }) {
+  return <DataProviders>{children}</DataProviders>;
+}

--- a/frontend/app/data-providers.tsx
+++ b/frontend/app/data-providers.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { isNetworkError } from '@/lib/errors';
+
+export function DataProviders({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          // Optimized for rankings data that updates infrequently (weekly/daily)
+          // Increased from 1 minute to 5 minutes to reduce unnecessary refetches
+          staleTime: 5 * 60 * 1000, // 5 minutes (rankings update weekly)
+
+          // Garbage collection time - how long unused cache is kept
+          gcTime: 10 * 60 * 1000, // 10 minutes (increased from default 5 min)
+
+          refetchOnWindowFocus: false,
+
+          // Only refetch on mount if data is stale (default behavior when staleTime is set)
+          // refetchOnMount defaults to true, which respects staleTime
+
+          // Automatic request deduplication in React Query v5 based on query keys
+
+          // Retry all errors at least once to handle transient Supabase issues
+          // Network errors get more retries since they're typically recoverable
+          retry: (failureCount, error) => {
+            if (isNetworkError(error)) return failureCount < 3;
+            return failureCount < 1;
+          },
+
+          // Exponential backoff for retries
+          retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+        },
+      },
+    });
+
+    return client;
+  });
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/frontend/app/infographics/layout.tsx
+++ b/frontend/app/infographics/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { BASE_URL } from '@/lib/constants';
+import { DataProviders } from '@/app/data-providers';
 
 export const metadata: Metadata = {
   title: 'Social Media Infographics',
@@ -23,5 +24,5 @@ export const metadata: Metadata = {
 };
 
 export default function InfographicsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return <DataProviders>{children}</DataProviders>;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Oswald, DM_Sans, JetBrains_Mono } from 'next/font/google';
 import './globals.css';
-import { Providers } from './providers';
+import { SiteProviders } from './providers';
 import { Navigation } from '@/components/Navigation';
 import { Toaster } from '@/components/ui/Toaster';
 import { StructuredData } from '@/components/StructuredData';
@@ -148,13 +148,13 @@ export default function RootLayout({
       <body
         className={`${oswald.variable} ${dmSans.variable} ${jetbrainsMono.variable} antialiased flex flex-col min-h-screen`}
       >
-        <Providers>
+        <SiteProviders>
           <WebVitalsReporter />
           <Navigation />
           <main className="flex-1 bg-background text-foreground">{children}</main>
           <Footer />
           <Toaster />
-        </Providers>
+        </SiteProviders>
       </body>
     </html>
   );

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
-import { isNetworkError } from '@/lib/errors';
+import { useEffect } from 'react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function SiteProviders({ children }: { children: React.ReactNode }) {
   // Handle unhandled promise rejections
   useEffect(() => {
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
@@ -21,45 +19,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  const [queryClient] = useState(() => {
-    const client = new QueryClient({
-      defaultOptions: {
-        queries: {
-          // Optimized for rankings data that updates infrequently (weekly/daily)
-          // Increased from 1 minute to 5 minutes to reduce unnecessary refetches
-          staleTime: 5 * 60 * 1000, // 5 minutes (rankings update weekly)
-
-          // Garbage collection time - how long unused cache is kept
-          gcTime: 10 * 60 * 1000, // 10 minutes (increased from default 5 min)
-
-          refetchOnWindowFocus: false,
-
-          // Only refetch on mount if data is stale (default behavior when staleTime is set)
-          // refetchOnMount defaults to true, which respects staleTime
-
-          // Automatic request deduplication in React Query v5 based on query keys
-
-          // Retry all errors at least once to handle transient Supabase issues
-          // Network errors get more retries since they're typically recoverable
-          retry: (failureCount, error) => {
-            if (isNetworkError(error)) return failureCount < 3;
-            return failureCount < 1;
-          },
-
-          // Exponential backoff for retries
-          retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
-        },
-      },
-    });
-
-    return client;
-  });
-
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider delayDuration={300} skipDelayDuration={100}>
-        {children}
-      </TooltipProvider>
-    </QueryClientProvider>
+    <TooltipProvider delayDuration={300} skipDelayDuration={100}>
+      {children}
+    </TooltipProvider>
   );
 }

--- a/frontend/app/rankings/layout.tsx
+++ b/frontend/app/rankings/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { BASE_URL } from '@/lib/constants';
+import { DataProviders } from '@/app/data-providers';
 
 /**
  * Layout for rankings pages
@@ -32,5 +33,5 @@ export const metadata: Metadata = {
 };
 
 export default function RankingsLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return <DataProviders>{children}</DataProviders>;
 }

--- a/frontend/app/teams/[id]/layout.tsx
+++ b/frontend/app/teams/[id]/layout.tsx
@@ -1,0 +1,5 @@
+import { DataProviders } from '@/app/data-providers';
+
+export default function TeamLayout({ children }: { children: React.ReactNode }) {
+  return <DataProviders>{children}</DataProviders>;
+}

--- a/frontend/app/watchlist/layout.tsx
+++ b/frontend/app/watchlist/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { DataProviders } from '@/app/data-providers';
 
 export const metadata: Metadata = {
   title: 'Watchlist',
@@ -23,5 +24,5 @@ export const metadata: Metadata = {
 };
 
 export default function WatchlistLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return <DataProviders>{children}</DataProviders>;
 }

--- a/frontend/components/RecentMovers.tsx
+++ b/frontend/components/RecentMovers.tsx
@@ -1,15 +1,90 @@
 'use client';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useRankings, usePrefetchTeam } from '@/lib/hooks';
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { ArrowUp, ArrowDown, TrendingUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ListSkeleton } from '@/components/ui/skeletons';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { normalizeAgeGroup } from '@/lib/utils';
+import type { RankingRow } from '@/types/RankingRow';
 
 type TimeWindow = '7d' | '30d';
+
+/**
+ * Module-level cache for the national rankings used by RecentMovers.
+ *
+ * Replaces a previous react-query usage so the homepage (sitewide entry)
+ * doesn't ship @tanstack/react-query. Cache key is `${age}-${gender}`.
+ */
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes (parity with prior staleTime)
+
+type CacheKey = string;
+const cache = new Map<CacheKey, { data: RankingRow[]; fetchedAt: number }>();
+const inFlight = new Map<CacheKey, Promise<RankingRow[]>>();
+
+async function fetchNationalRankings(ageGroup: string, gender: 'M' | 'F' | 'B' | 'G'): Promise<RankingRow[]> {
+  const BATCH_SIZE = 1000;
+  const allResults: RankingRow[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  const normalizedAge = normalizeAgeGroup(ageGroup);
+
+  while (hasMore) {
+    const params = new URLSearchParams({
+      ...(normalizedAge !== null && { age: String(normalizedAge) }),
+      gender,
+      limit: String(BATCH_SIZE),
+      offset: String(offset),
+    });
+
+    const res = await fetch(`/api/rankings/national?${params.toString()}`);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `National rankings request failed: ${res.status}`);
+    }
+
+    const data: RankingRow[] = await res.json();
+
+    if (!data || data.length === 0) {
+      hasMore = false;
+    } else {
+      allResults.push(...data);
+      if (data.length < BATCH_SIZE) {
+        hasMore = false;
+      } else {
+        offset += BATCH_SIZE;
+      }
+    }
+  }
+
+  return allResults;
+}
+
+function getOrFetchRankings(ageGroup: string, gender: 'M' | 'F' | 'B' | 'G', force: boolean): Promise<RankingRow[]> {
+  const key: CacheKey = `${ageGroup}-${gender}`;
+  const cached = cache.get(key);
+  if (!force && cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return Promise.resolve(cached.data);
+  }
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = fetchNationalRankings(ageGroup, gender)
+    .then((data) => {
+      cache.set(key, { data, fetchedAt: Date.now() });
+      return data;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
 
 interface RecentMoversProps {
   /** Age group to display (e.g., 'u12'). Defaults to 'u12' */
@@ -49,8 +124,57 @@ export function RecentMovers({
     return defaultTimeWindow;
   });
 
-  const { data: rankings, isLoading, isError, error, refetch } = useRankings(null, ageGroup, gender);
-  const prefetchTeam = usePrefetchTeam();
+  // Lazy initializers seed state from the module-level cache on first render.
+  // No setState happens inside the effect's synchronous body; only the async
+  // .then/.catch/.finally callbacks below ever update state.
+  const [rankings, setRankings] = useState<RankingRow[] | undefined>(() => cache.get(`${ageGroup}-${gender}`)?.data);
+  const [isLoading, setIsLoading] = useState<boolean>(() => !cache.get(`${ageGroup}-${gender}`));
+  const [error, setError] = useState<Error | null>(null);
+
+  const runFetch = useCallback(
+    (force: boolean) => {
+      let cancelled = false;
+
+      getOrFetchRankings(ageGroup, gender, force)
+        .then((data) => {
+          if (cancelled) return;
+          setRankings(data);
+          setError(null);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          setError(e instanceof Error ? e : new Error(String(e)));
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setIsLoading(false);
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    },
+    [ageGroup, gender]
+  );
+
+  useEffect(() => {
+    // Lazy initializers above already populated state from cache when fresh.
+    // Skip the fetch if we already have fresh data for this key.
+    const cached = cache.get(`${ageGroup}-${gender}`);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      return;
+    }
+    return runFetch(false);
+  }, [ageGroup, gender, runFetch]);
+
+  const refetch = useCallback(() => {
+    // Event handler — safe to setState synchronously.
+    setIsLoading(true);
+    setError(null);
+    runFetch(true);
+  }, [runFetch]);
+
+  const isError = error !== null;
 
   // Save time window preference to localStorage
   useEffect(() => {
@@ -140,7 +264,6 @@ export function RecentMovers({
                     <Link
                       key={team.team_id_master}
                       href={`/teams/${team.team_id_master}`}
-                      onMouseEnter={() => prefetchTeam(team.team_id_master)}
                       className="flex items-center justify-between p-3 rounded-md hover:bg-secondary/50 border border-transparent hover:border-border transition-all duration-300 group"
                       aria-label={`View ${team.team_name} - moved ${Math.abs(rankChange)} positions ${isImprovement ? 'up' : 'down'}`}
                       tabIndex={0}

--- a/frontend/hooks/useTeamSearch.ts
+++ b/frontend/hooks/useTeamSearch.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState, useCallback } from 'react';
 import { createClientSupabase } from '@/lib/supabase/client';
 import { normalizeAgeGroup } from '@/lib/utils';
 import type { RankingRow } from '@/types/RankingRow';
@@ -9,109 +9,191 @@ import type { RankingRow } from '@/types/RankingRow';
  * Transforms to RankingRow format with default/null values for ranking fields
  *
  * Uses pagination to fetch all teams (handles >1000 teams by fetching in batches)
- * Updated: 2024-11-23
+ *
+ * Module-level cache + in-flight promise dedupe replaces React Query so the
+ * sitewide nav search doesn't pull @tanstack/react-query into the anon bundle.
+ * Cache lives for the lifetime of the page (no GC); refetch() forces a refresh.
  */
-export function useTeamSearch() {
-  return useQuery<RankingRow[]>({
-    queryKey: ['team-search'],
-    queryFn: async () => {
-      const supabase = createClientSupabase();
-      const BATCH_SIZE = 1000; // Supabase default limit
-      const allTeams: RankingRow[] = [];
-      let offset = 0;
-      let hasMore = true;
 
-      // Fetch teams in batches until we've got them all
-      while (hasMore) {
-        const { data, error } = await supabase
-          .from('teams')
-          .select('team_id_master, team_name, club_name, state_code, age_group, gender')
-          .eq('is_deprecated', false) // Filter out deprecated/merged teams
-          .order('team_name', { ascending: true })
-          .range(offset, offset + BATCH_SIZE - 1);
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes (parity with prior staleTime)
 
-        if (error) {
-          console.error('[useTeamSearch] Error fetching teams:', error.message);
-          throw error;
+let cached: { data: RankingRow[]; fetchedAt: number } | null = null;
+let inFlight: Promise<RankingRow[]> | null = null;
+
+async function fetchAllTeams(): Promise<RankingRow[]> {
+  const supabase = createClientSupabase();
+  const BATCH_SIZE = 1000; // Supabase default limit
+  const allTeams: RankingRow[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  // Fetch teams in batches until we've got them all
+  while (hasMore) {
+    const { data, error } = await supabase
+      .from('teams')
+      .select('team_id_master, team_name, club_name, state_code, age_group, gender')
+      .eq('is_deprecated', false) // Filter out deprecated/merged teams
+      .order('team_name', { ascending: true })
+      .range(offset, offset + BATCH_SIZE - 1);
+
+    if (error) {
+      console.error('[useTeamSearch] Error fetching teams:', error.message);
+      throw error;
+    }
+
+    if (!data || data.length === 0) {
+      hasMore = false;
+      break;
+    }
+
+    // Transform batch to RankingRow format
+    const transformedBatch = data.map((team) => {
+      // Convert gender from database format ('Male'|'Female') to API format ('M'|'F')
+      const genderCode = team.gender === 'Male' ? 'M' : team.gender === 'Female' ? 'F' : ('M' as 'M' | 'F' | 'B' | 'G');
+
+      // Create searchable name that combines team name + club name for cross-field matching
+      // This allows "rebels san diego romero" to match team "B2014 Pre-ECNL (Romero)" from club "Rebels San Diego"
+      const searchable_name = (() => {
+        let name = team.team_name;
+
+        // Add club name for combined searches (e.g., "rebels romero")
+        if (team.club_name) {
+          name += ' ' + team.club_name;
         }
 
-        if (!data || data.length === 0) {
-          hasMore = false;
-          break;
+        // Add year variations: "2015" ↔ "15"
+        const fourDigitMatch = team.team_name.match(/20(0[9]|1[0-9]|2[0-9])\b/);
+        if (fourDigitMatch) {
+          name += ' ' + fourDigitMatch[1];
         }
 
-        // Transform batch to RankingRow format
-        const transformedBatch = data.map((team) => {
-          // Convert gender from database format ('Male'|'Female') to API format ('M'|'F')
-          const genderCode =
-            team.gender === 'Male' ? 'M' : team.gender === 'Female' ? 'F' : ('M' as 'M' | 'F' | 'B' | 'G');
-
-          // Create searchable name that combines team name + club name for cross-field matching
-          // This allows "rebels san diego romero" to match team "B2014 Pre-ECNL (Romero)" from club "Rebels San Diego"
-          const searchable_name = (() => {
-            let name = team.team_name;
-
-            // Add club name for combined searches (e.g., "rebels romero")
-            if (team.club_name) {
-              name += ' ' + team.club_name;
-            }
-
-            // Add year variations: "2015" ↔ "15"
-            const fourDigitMatch = team.team_name.match(/20(0[9]|1[0-9]|2[0-9])\b/);
-            if (fourDigitMatch) {
-              name += ' ' + fourDigitMatch[1];
-            }
-
-            const twoDigitMatch = team.team_name.match(/\b(0[9]|1[0-9]|2[0-9])\b(?![\d])/);
-            if (twoDigitMatch && !fourDigitMatch) {
-              name += ' 20' + twoDigitMatch[1];
-            }
-
-            return name;
-          })();
-
-          return {
-            team_id_master: team.team_id_master,
-            team_name: team.team_name,
-            searchable_name,
-            club_name: team.club_name,
-            state: team.state_code, // Map state_code to state
-            age: normalizeAgeGroup(team.age_group) ?? 0, // Convert age_group to integer age
-            gender: genderCode,
-            // Ranking fields (default values for unranked teams)
-            power_score_final: 0,
-            sos_norm: 0,
-            offense_norm: null,
-            defense_norm: null,
-            rank_in_cohort_final: 0,
-            // Record fields (default values)
-            games_played: 0,
-            wins: 0,
-            losses: 0,
-            draws: 0,
-            // Total record fields (required by RankingRow type)
-            total_games_played: 0,
-            total_wins: 0,
-            total_losses: 0,
-            total_draws: 0,
-            win_percentage: null,
-          } as RankingRow;
-        });
-
-        allTeams.push(...transformedBatch);
-
-        // If we got fewer than BATCH_SIZE, we've reached the end
-        if (data.length < BATCH_SIZE) {
-          hasMore = false;
-        } else {
-          offset += BATCH_SIZE;
+        const twoDigitMatch = team.team_name.match(/\b(0[9]|1[0-9]|2[0-9])\b(?![\d])/);
+        if (twoDigitMatch && !fourDigitMatch) {
+          name += ' 20' + twoDigitMatch[1];
         }
-      }
 
-      return allTeams;
-    },
-    staleTime: 10 * 60 * 1000, // 10 minutes - team list doesn't change often
-    gcTime: 60 * 60 * 1000, // Keep in cache for 1 hour
-    throwOnError: false, // Never throw to error boundaries (React 19 compat)
-  });
+        return name;
+      })();
+
+      return {
+        team_id_master: team.team_id_master,
+        team_name: team.team_name,
+        searchable_name,
+        club_name: team.club_name,
+        state: team.state_code, // Map state_code to state
+        age: normalizeAgeGroup(team.age_group) ?? 0, // Convert age_group to integer age
+        gender: genderCode,
+        // Ranking fields (default values for unranked teams)
+        power_score_final: 0,
+        sos_norm: 0,
+        offense_norm: null,
+        defense_norm: null,
+        rank_in_cohort_final: 0,
+        // Record fields (default values)
+        games_played: 0,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        // Total record fields (required by RankingRow type)
+        total_games_played: 0,
+        total_wins: 0,
+        total_losses: 0,
+        total_draws: 0,
+        win_percentage: null,
+      } as RankingRow;
+    });
+
+    allTeams.push(...transformedBatch);
+
+    // If we got fewer than BATCH_SIZE, we've reached the end
+    if (data.length < BATCH_SIZE) {
+      hasMore = false;
+    } else {
+      offset += BATCH_SIZE;
+    }
+  }
+
+  return allTeams;
+}
+
+function getOrFetchTeams(force: boolean): Promise<RankingRow[]> {
+  if (!force && cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return Promise.resolve(cached.data);
+  }
+  if (inFlight) return inFlight;
+
+  inFlight = fetchAllTeams()
+    .then((data) => {
+      cached = { data, fetchedAt: Date.now() };
+      return data;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+export interface UseTeamSearchReturn {
+  data: RankingRow[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useTeamSearch(): UseTeamSearchReturn {
+  // Lazy initializers seed state from the module-level cache on first render.
+  // No setState happens inside the effect's synchronous body; only the async
+  // .then/.catch/.finally callbacks below ever update state.
+  const [data, setData] = useState<RankingRow[] | undefined>(() => cached?.data);
+  const [isLoading, setIsLoading] = useState<boolean>(() => !cached);
+  const [error, setError] = useState<Error | null>(null);
+
+  const runFetch = useCallback((force: boolean) => {
+    let cancelled = false;
+
+    getOrFetchTeams(force)
+      .then((teams) => {
+        if (cancelled) return;
+        setData(teams);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    // Lazy initializers above already populated state from cache when fresh.
+    // Skip the fetch if we already have fresh data.
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      return;
+    }
+    return runFetch(false);
+  }, [runFetch]);
+
+  const refetch = useCallback(() => {
+    // Event handler — safe to setState synchronously.
+    setIsLoading(true);
+    setError(null);
+    runFetch(true);
+  }, [runFetch]);
+
+  return {
+    data,
+    isLoading,
+    isError: error !== null,
+    error,
+    refetch,
+  };
 }


### PR DESCRIPTION
## Summary

- Move `QueryClientProvider` from the sitewide `Providers` wrapper into a new `DataProviders` wrapper that's only mounted on routes that use react-query. Anon routes (`/`, `/blog/*`, `/methodology`, `/login`, `/signup`, `/forgot-password`, etc.) stop shipping `@tanstack/react-query` (~473 KB of blocking JS).
- Refactor the two sitewide consumers off react-query: `useTeamSearch` (sitewide nav search) and `RecentMovers` (homepage). Both now use module-level cache + `useState`/`useEffect` with TTL parity to the prior `staleTime`. `RecentMovers` drops `usePrefetchTeam` in favor of Next.js `<Link>`'s built-in prefetch.
- `DataProviders` is wrapped around children in: `app/rankings/layout.tsx`, `app/teams/[id]/layout.tsx` (new), `app/compare/layout.tsx` (new), `app/watchlist/layout.tsx`, `app/infographics/layout.tsx`, `app/(internal)/analytics/layout.tsx`.

## Why

Bundle math on the post-PR-#644 PSI baseline: total blocking JS on stuck templates is ~128 KB. React Query bundle is ~473 KB unminified and the largest single contributor by a wide margin. Removing it from anon routes is the highest-ROI LCP lever available right now. Expected ~1.5–2.5s LCP improvement on `/`, `/blog/*`, `/methodology`. Combined with PR #644's font fix, this should push at least 3 of the 4 currently-stuck templates into the "good" zone.

## What I verified locally

- `tsc --noEmit` clean.
- `next build` succeeds with exit 0.
- Static-generation status preserved on every target template:
  - `/` → `○ Static`
  - `/blog/[slug]` → `● SSG` (16 paths)
  - `/rankings/[region]` → `● SSG`
  - `/rankings/[region]/[ageGroup]/[gender]` → `● SSG` (196 paths)
  - `/rankings/age/[ageGroup]` → `● SSG`
  - `/methodology`, `/login`, `/signup`, `/forgot-password` → `○ Static`
- Server-side anon page bundles (`.next/server/app/page.js`, `.next/server/app/blog/[slug]/page.js`) contain zero references to `@tanstack/react-query`.
- The Supabase RPC timeout warnings during `next build` are pre-existing (happen on `main` too) — not introduced by this PR.

## Test plan

- [ ] CI build + tests pass.
- [ ] Vercel preview deploy: load `/` and `/blog/youth-soccer-pa-club-rankings` in incognito, DevTools → Network HAR → confirm no chunk containing `@tanstack/react-query` is requested.
- [ ] Vercel preview deploy: load `/rankings/co/u14/boys`, `/teams/[id]` (any), `/watchlist` (signed in) — confirm rankings/team/watchlist pages still render data correctly.
- [ ] Vercel preview deploy: type into the nav search box from any anon page (e.g. `/blog/foo`) — confirm GlobalSearch still finds teams.
- [ ] Vercel preview deploy: load `/` — confirm RecentMovers still shows biggest 7d/30d movers and the 7D/30D toggle works.
- [ ] Compare PSI median-of-3 (mobile) on `/`, `/blog/youth-soccer-pa-club-rankings`, `/rankings/tx/u14/boys` against the Week 4 baseline in `.turbo/seo-week4/pagespeed-audit.md` — expect ≥1.0s LCP improvement on at least 2 of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)