### PR TITLE
feat(ingest): add PlayMetrics scraper and matcher provider

### DIFF
--- a/.github/workflows/playmetrics-scrape-import.yml
+++ b/.github/workflows/playmetrics-scrape-import.yml
@@ -1,0 +1,150 @@
+name: PlayMetrics League Scrape and Import
+
+on:
+  schedule:
+    # Run every Sunday at 11:30 PM Mountain Time
+    # MST (UTC-7): 11:30 PM MST Sunday = 6:30 AM UTC Monday
+    # MDT (UTC-6): 11:30 PM MDT Sunday = 5:30 AM UTC Monday
+    # Using 6:30 AM UTC means: MST = 11:30 PM Sunday, MDT = 12:30 AM Monday
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      league_url:
+        description: 'PlayMetrics league URL (default: SECL & State League Fall 2025)'
+        required: false
+        type: string
+        default: 'https://playmetricssports.com/g/leagues/1014-1514-8ccd4dbb/league_view.html'
+      dry_run:
+        description: 'Scrape only (skip import step)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  scrape-and-import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    env:
+      DEFAULT_LEAGUE_URL: 'https://playmetricssports.com/g/leagues/1014-1514-8ccd4dbb/league_view.html'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create data directories
+        run: |
+          mkdir -p data/raw/playmetrics
+          mkdir -p logs
+
+      - name: Resolve league URL
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            LEAGUE_URL="${DEFAULT_LEAGUE_URL}"
+            echo "Scheduled run: Using default league URL"
+          else
+            LEAGUE_URL="${{ inputs.league_url }}"
+            echo "Manual run: Using provided league URL"
+          fi
+          echo "league_url=$LEAGUE_URL" >> "$GITHUB_OUTPUT"
+          echo "League: $LEAGUE_URL"
+
+      - name: Scrape PlayMetrics League
+        env:
+          # Scraper only POSTs to the PlayMetrics public API and writes a local
+          # CSV — no Supabase access, so no service key is exposed here.
+          PYTHONPATH: ${{ github.workspace }}
+          LEAGUE_URL: ${{ steps.resolve.outputs.league_url }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          echo "Scraping PlayMetrics league: $LEAGUE_URL"
+          python scripts/scrape_playmetrics_league.py \
+            --league-url "$LEAGUE_URL" \
+            --output-dir data/raw/playmetrics \
+            2>&1 | tee logs/playmetrics_scrape.log
+
+      - name: Find scraped CSV file
+        id: find_csv
+        run: |
+          CSV_FILE=$(ls -t data/raw/playmetrics/playmetrics_*.csv 2>/dev/null | head -n 1)
+          if [ -z "$CSV_FILE" ]; then
+            echo "Error: Could not find scraped CSV file"
+            exit 1
+          fi
+          echo "Found CSV file: $CSV_FILE"
+          echo "csv_file=$CSV_FILE" >> "$GITHUB_OUTPUT"
+
+          LINE_COUNT=$(wc -l < "$CSV_FILE")
+          GAME_COUNT=$((LINE_COUNT - 1))
+          echo "game_count=$GAME_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$GAME_COUNT" -le 0 ]; then
+            echo "⚠️  CSV has 0 game records (headers only) — skipping import step"
+            echo "has_games=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ CSV has $GAME_COUNT game records"
+            echo "has_games=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import Games
+        if: ${{ steps.find_csv.outputs.has_games == 'true' && (github.event_name == 'schedule' || inputs.dry_run == false) }}
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          CSV_FILE="${{ steps.find_csv.outputs.csv_file }}"
+          echo "Importing games from: $CSV_FILE"
+          python scripts/import_games_enhanced.py "$CSV_FILE" playmetrics --stream --concurrency 8 --checkpoint \
+            2>&1 | tee logs/playmetrics_import.log
+
+      - name: Upload scraped data
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playmetrics-csv-${{ github.run_number }}
+          path: data/raw/playmetrics/playmetrics_*.csv
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playmetrics-logs-${{ github.run_number }}
+          path: logs/playmetrics_*.log
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Report results
+        if: always()
+        run: |
+          {
+            echo "## PlayMetrics Scrape Summary"
+            echo ""
+            echo "- **League URL:** ${{ steps.resolve.outputs.league_url }}"
+            echo "- **Trigger:** ${{ github.event_name }}"
+            echo "- **Games found:** ${{ steps.find_csv.outputs.game_count || '0' }}"
+            if [ "${{ steps.find_csv.outputs.has_games }}" == "false" ]; then
+              echo "- **Import:** Skipped (no games to import)"
+            elif [ "${{ github.event_name }}" == "schedule" ] || [ "${{ inputs.dry_run }}" == "false" ]; then
+              echo "- **Import:** Completed"
+            else
+              echo "- **Import:** Skipped (dry run)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/scrape_playmetrics_league.py
+++ b/scripts/scrape_playmetrics_league.py
@@ -1,0 +1,662 @@
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
+
+import requests
+
+# Add parent directory to path for imports
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.utils.team_utils import calculate_age_group_from_birth_year, extract_birth_year_from_name  # noqa: E402
+
+API_BASE = "https://api.gb.playmetrics.com/external/lss"
+OUTPUT_DIR = "data/raw/playmetrics"
+
+# Global scrape identifiers (set in main())
+SCRAPE_TS = None
+SCRAPE_RUN_ID = None
+
+# governing_body_id → 2-letter state code.
+# Add entries here as PlayMetrics leagues are onboarded.
+GB_STATE_MAP: Dict[int, str] = {
+    1014: "WI",
+}
+
+# state_code → full state name (for the `state` CSV column).
+STATE_CODE_TO_NAME: Dict[str, str] = {
+    "WI": "Wisconsin",
+}
+
+# state_code → IANA timezone for local-date conversion of ``start_datetime``
+# (which is UTC). Without this, a 9pm CT kickoff rolls past midnight UTC and
+# the naive [:10] slice returns the wrong calendar date.
+STATE_CODE_TO_TIMEZONE: Dict[str, str] = {
+    "WI": "America/Chicago",
+}
+
+# Canonical 27-column CSV (matches scripts/scrape_tgs_event.py REQUIRED_COLUMNS),
+# plus `division_name` appended as column 28. The importer reads `division_name`
+# into `games.division_name` when present.
+REQUIRED_COLUMNS = [
+    "provider",
+    "scrape_run_id",
+    "event_id",
+    "event_name",
+    "schedule_id",
+    "age_year",
+    "age_group",
+    "gender",
+    "team_id",
+    "team_id_source",
+    "team_name",
+    "club_name",
+    "opponent_id",
+    "opponent_id_source",
+    "opponent_name",
+    "opponent_club_name",
+    "state",
+    "state_code",
+    "game_date",
+    "game_time",
+    "home_away",
+    "goals_for",
+    "goals_against",
+    "result",
+    "venue",
+    "source_url",
+    "scraped_at",
+    "division_name",
+]
+
+# -----------------------------
+# CONFIG LOADER
+# -----------------------------
+
+
+def _parse_league_url(url: str) -> Optional[Tuple[int, int, str]]:
+    """Parse a PlayMetrics league URL into (governing_body_id, league_id, key).
+
+    Expected shape:
+        https://playmetricssports.com/g/leagues/{gb}-{league}-{key}/league_view.html
+    """
+    m = re.search(r"/leagues/(\d+)-(\d+)-([0-9a-fA-F]+)/", url)
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), m.group(3)
+
+
+def resolve_config():
+    """Load configuration with precedence: CLI > ENV > Defaults"""
+    parser = argparse.ArgumentParser(description="PlayMetrics League Scraper")
+
+    parser.add_argument("--league-url", type=str, help="Full league URL (alternative to explicit IDs)")
+    parser.add_argument("--governing-body-id", type=int, help="Governing body ID (e.g. 1014 for WI)")
+    parser.add_argument("--league-id", type=int, help="League ID")
+    parser.add_argument("--key", type=str, help="League key token")
+    parser.add_argument("--output-dir", type=str, help="Output directory")
+    parser.add_argument("--dry-run", action="store_true", help="Validate without writing output")
+
+    args = parser.parse_args()
+
+    # Resolve league identity: CLI --league-url > CLI explicit IDs > ENV --league-url
+    league_url = args.league_url or os.getenv("PLAYMETRICS_LEAGUE_URL")
+    gb_id = args.governing_body_id
+    league_id = args.league_id
+    key = args.key
+
+    if league_url and not (gb_id and league_id and key):
+        parsed = _parse_league_url(league_url)
+        if not parsed:
+            print(f"❌ Could not parse league URL: {league_url}")
+            sys.exit(1)
+        gb_id, league_id, key = parsed
+
+    if not (gb_id and league_id and key):
+        print("❌ Must provide --league-url OR all three of --governing-body-id/--league-id/--key")
+        sys.exit(1)
+
+    if gb_id not in GB_STATE_MAP:
+        raise ValueError(
+            f"Unknown PlayMetrics governing_body_id {gb_id}. "
+            f"Add an entry to GB_STATE_MAP in scripts/scrape_playmetrics_league.py."
+        )
+
+    output_dir = args.output_dir or os.getenv("PLAYMETRICS_OUTPUT_DIR", OUTPUT_DIR)
+    delay_sec = float(os.getenv("PLAYMETRICS_DELAY_SEC", "0.3"))
+
+    return {
+        "governing_body_id": gb_id,
+        "league_id": league_id,
+        "key": key,
+        "output_dir": output_dir,
+        "dry_run": args.dry_run,
+        "delay_sec": delay_sec,
+    }
+
+
+# -----------------------------
+# HELPER FUNCTIONS
+# -----------------------------
+
+
+def compute_result(goals_for: Optional[int], goals_against: Optional[int]) -> str:
+    """Compute result from a team's perspective: W / L / D / U"""
+    if goals_for is None or goals_against is None:
+        return "U"
+    if goals_for > goals_against:
+        return "W"
+    if goals_for < goals_against:
+        return "L"
+    return "D"
+
+
+def map_min_age_to_age_group(min_age: Optional[int]) -> Optional[str]:
+    """Map PlayMetrics division.min_age to PitchRank age_group.
+
+    PitchRank slots dual-age divisions to the younger cohort; U18 merges into U19
+    (config/settings.py:86-96 _BIRTH_YEARS skips 18). This is a *fallback* only —
+    ``derive_team_age_group`` is preferred because PlayMetrics reports min_age
+    as the play-up gate (e.g. ``min_age=10`` on an "11U A" division that admits
+    10-year-olds), which would incorrectly bucket an 11U team into u10.
+    """
+    if min_age is None:
+        return None
+    try:
+        age = int(min_age)
+    except (ValueError, TypeError):
+        return None
+    if 10 <= age <= 17:
+        return f"u{age}"
+    if age in (18, 19):
+        return "u19"
+    return None
+
+
+# "U11", "u-11", "11U", "11u" — PitchRank tracks u10-u17 and u19 (u18 merges into u19).
+_TEAM_U_AGE_RE = re.compile(r"\b(?:[Uu]-?(\d{1,2})|(\d{1,2})[Uu])\b")
+
+
+def derive_team_age_group(team_name: str, fallback_age_group: Optional[str]) -> Optional[str]:
+    """Derive age_group from the team's own name; fall back to the division value.
+
+    Priority:
+      1. 4-digit birth year (``2015`` → u11 for season 2025).
+      2. ``U11`` / ``11U`` token.
+      3. Division-level ``min_age`` mapping (``fallback_age_group``).
+
+    u18 is always remapped to u19 to match PitchRank's age cohorts.
+    """
+    if team_name:
+        birth_year = extract_birth_year_from_name(team_name)
+        if birth_year:
+            ag = calculate_age_group_from_birth_year(birth_year)
+            if ag:
+                ag = ag.lower()
+                return "u19" if ag == "u18" else ag
+
+        m = _TEAM_U_AGE_RE.search(team_name)
+        if m:
+            num = int(m.group(1) or m.group(2))
+            if 10 <= num <= 17:
+                return f"u{num}"
+            if num in (18, 19):
+                return "u19"
+    return fallback_age_group
+
+
+def parse_int_or_none(v) -> Optional[int]:
+    """Parse a game score. Only whole integers in 0..50 are accepted; else None.
+
+    Filters malformed scores (``"2.5"``, ``"-1"``, ``"999"``) at scrape time so
+    they don't surface as bogus W/L/D rows. Matches the importer's validation
+    window (``src/utils/enhanced_validators.py``: 0..50).
+    """
+    if v is None or isinstance(v, bool):
+        return None
+    if isinstance(v, int):
+        return v if 0 <= v <= 50 else None
+    s = str(v).strip()
+    if not s or s.lower() in ("none", "null"):
+        return None
+    try:
+        f = float(s)
+    except (ValueError, TypeError):
+        return None
+    if not f.is_integer():
+        return None
+    i = int(f)
+    return i if 0 <= i <= 50 else None
+
+
+def parse_utc_to_local_date(iso_utc: str, state_code: str) -> str:
+    """Convert a UTC ISO timestamp to ``YYYY-MM-DD`` in the state's local zone.
+
+    Falls back to a UTC slice if the timestamp is unparseable or the state has
+    no tz mapping — the calendar-date error for unmapped states is no worse
+    than what we had before this helper existed.
+    """
+    if not iso_utc:
+        return ""
+    tz_name = STATE_CODE_TO_TIMEZONE.get(state_code)
+    if not tz_name:
+        return iso_utc[:10]
+    try:
+        dt_iso = iso_utc.rstrip("Z")
+        dt = datetime.fromisoformat(dt_iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(ZoneInfo(tz_name)).strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return iso_utc[:10]
+
+
+# -----------------------------
+# API FUNCTIONS
+# -----------------------------
+
+
+def _post(endpoint: str, body: Dict, retries: int = 3, timeout: int = 30) -> Dict:
+    """POST to a PlayMetrics LSS endpoint with exponential-backoff retry.
+
+    Raises ``RuntimeError`` on exhausted retries so the workflow aborts loudly
+    instead of silently emitting an incomplete CSV (a transient 5xx dropping a
+    whole division is worse than failing the run and retrying next cycle).
+    """
+    url = f"{API_BASE}/{endpoint}"
+    headers = {"content-type": "text/plain;charset=UTF-8"}
+    payload = json.dumps(body)
+    last_error: Optional[str] = None
+
+    for attempt in range(retries):
+        try:
+            r = requests.post(url, data=payload, headers=headers, timeout=timeout)
+            if r.status_code == 200:
+                return r.json()
+            last_error = f"HTTP {r.status_code}"
+            print(f"  ⚠️ {last_error} for {endpoint} (attempt {attempt + 1}/{retries})")
+        except requests.RequestException as e:
+            last_error = str(e)
+            print(f"  ⚠️ Request error for {endpoint} (attempt {attempt + 1}/{retries}): {e}")
+        if attempt < retries - 1:
+            time.sleep(1 * (attempt + 1))
+    raise RuntimeError(f"PlayMetrics API call failed after {retries} attempts: {endpoint} ({last_error})")
+
+
+def get_league(gb_id: int, league_id: int, key: str) -> Dict:
+    """Fetch league metadata (name, dates, divisions)."""
+    body = {"governing_body_id": gb_id, "league_id": league_id, "key": key}
+    return _post("league", body)
+
+
+def get_division(gb_id: int, league_id: int, key: str, division_id: int) -> Dict:
+    """Fetch a single division (teams, schedule, sport_configuration, standings)."""
+    body = {
+        "governing_body_id": gb_id,
+        "league_id": league_id,
+        "key": key,
+        "division_id": division_id,
+    }
+    return _post("division", body)
+
+
+# -----------------------------
+# NORMALIZATION
+# -----------------------------
+
+
+def _build_source_url(gb_id: int, league_id: int, key: str, division_id: int) -> str:
+    return (
+        f"https://playmetricssports.com/g/leagues/{gb_id}-{league_id}-{key}/divisions/{division_id}/division_view.html"
+    )
+
+
+def _build_venue(field: Optional[Dict]) -> str:
+    """Join field.name + field.address into a single venue string."""
+    if not field:
+        return ""
+    name = str(field.get("name") or "").strip()
+    address = str(field.get("address") or "").strip()
+    return f"{name} {address}".strip()
+
+
+def normalize_game(
+    game: Dict,
+    team_lookup: Dict[str, Dict],
+    division: Dict,
+    league_name: str,
+    gb_id: int,
+    league_id: int,
+    key: str,
+    age_group: str,
+    gender: str,
+    state_code: str,
+) -> Optional[List[Dict]]:
+    """Map a PlayMetrics schedule game to canonical CSV rows (home + away perspective).
+
+    Returns a 2-element list (home row, away row) or None if the game should be skipped.
+    The ``status != "Played"`` and orphan-team-id gates live in the caller
+    (``scrape_division``) so it can increment per-reason counters; this helper
+    only handles normalization once those gates have passed.
+    """
+    home_key = str(game.get("home_team_id"))
+    away_key = str(game.get("away_team_id"))
+    home_entry = team_lookup[home_key]
+    away_entry = team_lookup[away_key]
+
+    home_score = parse_int_or_none(game.get("home_team_score"))
+    away_score = parse_int_or_none(game.get("away_team_score"))
+
+    start_dt_raw = str(game.get("start_datetime") or "").strip()
+    game_date = parse_utc_to_local_date(start_dt_raw, state_code)
+    game_time = str(game.get("time") or "").strip()
+
+    division_id = division.get("id")
+    division_name = str(division.get("name") or "").strip()
+    source_url = _build_source_url(gb_id, league_id, key, division_id) if division_id is not None else ""
+    venue = _build_venue(game.get("field"))
+    state_name = STATE_CODE_TO_NAME.get(state_code, "")
+
+    home_team_name = home_entry.get("team_name", "")
+    away_team_name = away_entry.get("team_name", "")
+    home_age_group = derive_team_age_group(home_team_name, age_group)
+    away_age_group = derive_team_age_group(away_team_name, age_group)
+
+    base = {
+        "provider": "playmetrics",
+        "scrape_run_id": SCRAPE_RUN_ID,
+        "event_id": "",
+        "event_name": league_name,
+        "schedule_id": str(game.get("id") or ""),
+        "age_year": "",
+        "gender": gender,
+        "state": state_name,
+        "state_code": state_code,
+        "game_date": game_date,
+        "game_time": game_time,
+        "venue": venue,
+        "source_url": source_url,
+        "scraped_at": SCRAPE_TS,
+        "division_name": division_name,
+    }
+
+    home_row = {
+        **base,
+        "age_group": home_age_group,
+        "team_id": home_key,
+        "team_id_source": home_key,
+        "team_name": home_team_name,
+        "club_name": home_entry.get("club_name", ""),
+        "opponent_id": away_key,
+        "opponent_id_source": away_key,
+        "opponent_name": away_team_name,
+        "opponent_club_name": away_entry.get("club_name", ""),
+        "home_away": "H",
+        "goals_for": home_score if home_score is not None else "",
+        "goals_against": away_score if away_score is not None else "",
+        "result": compute_result(home_score, away_score),
+    }
+    away_row = {
+        **base,
+        "age_group": away_age_group,
+        "team_id": away_key,
+        "team_id_source": away_key,
+        "team_name": away_team_name,
+        "club_name": away_entry.get("club_name", ""),
+        "opponent_id": home_key,
+        "opponent_id_source": home_key,
+        "opponent_name": home_team_name,
+        "opponent_club_name": home_entry.get("club_name", ""),
+        "home_away": "A",
+        "goals_for": away_score if away_score is not None else "",
+        "goals_against": home_score if home_score is not None else "",
+        "result": compute_result(away_score, home_score),
+    }
+    return [home_row, away_row]
+
+
+# -----------------------------
+# SCRAPER CORE
+# -----------------------------
+
+
+def scrape_division(
+    division: Dict,
+    league_name: str,
+    config: Dict,
+) -> Tuple[List[Dict], Dict[str, int]]:
+    """Scrape a single division.
+
+    Returns ``(records, counts)``. ``counts["futsal"]`` is ``1`` when the
+    division was skipped as futsal, ``0`` otherwise; the caller uses it to
+    bump the league-level ``futsal_dropped`` tally.
+    """
+    counts = {
+        "games_emitted": 0,
+        "skipped_non_played": 0,
+        "skipped_forfeit": 0,
+        "skipped_other_status": 0,
+        "skipped_orphan": 0,
+        "futsal": 0,
+    }
+
+    division_id = division.get("id")
+    division_name = str(division.get("name") or "").strip()
+    if division_id is None:
+        print(f"  ⚠️ Division missing id: {division_name}")
+        return [], counts
+
+    age_group = map_min_age_to_age_group(division.get("min_age"))
+    if not age_group:
+        print(f"  ⏭️  {division_name}: skipping (min_age={division.get('min_age')} not in tracked range)")
+        return [], counts
+
+    gender_raw = str(division.get("gender") or "").strip().upper()
+    gender = "Male" if gender_raw == "M" else "Female"
+
+    gb_id = config["governing_body_id"]
+    league_id = config["league_id"]
+    key = config["key"]
+    state_code = GB_STATE_MAP[gb_id]
+
+    div_data = get_division(gb_id, league_id, key, division_id)
+
+    sport_config = div_data.get("sport_configuration")
+    sport_name = ""
+    if isinstance(sport_config, dict):
+        sport_name = str(sport_config.get("name") or "").strip()
+    if not sport_name:
+        print(f"  ⚠️ {division_name}: sport_configuration missing or unnamed (not skipped)")
+    elif "futsal" in sport_name.lower():
+        print(f"  ⏭️  {division_name}: skipping (futsal)")
+        counts["futsal"] = 1
+        return [], counts
+
+    teams = div_data.get("teams") or []
+    schedule = div_data.get("schedule") or []
+
+    team_lookup: Dict[str, Dict] = {}
+    for entry in teams:
+        team = entry.get("team") or {}
+        club = entry.get("club") or {}
+        team_id = team.get("id")
+        if team_id is None:
+            continue
+        team_lookup[str(team_id)] = {
+            "team_name": str(team.get("name") or "").strip(),
+            "club_id": club.get("id"),
+            "club_name": str(club.get("name") or "").strip(),
+        }
+
+    records: List[Dict] = []
+    for game in schedule:
+        status = str(game.get("status") or "").strip()
+        if status != "Played":
+            counts["skipped_non_played"] += 1
+            if status.lower() == "forfeit":
+                counts["skipped_forfeit"] += 1
+            else:
+                counts["skipped_other_status"] += 1
+            continue
+
+        home_id = game.get("home_team_id")
+        away_id = game.get("away_team_id")
+        if home_id is None or away_id is None or str(home_id) not in team_lookup or str(away_id) not in team_lookup:
+            counts["skipped_orphan"] += 1
+            print(f"  ⚠️ {division_name}: orphan game id={game.get('id')} home={home_id} away={away_id}")
+            continue
+
+        rows = normalize_game(
+            game,
+            team_lookup,
+            division,
+            league_name,
+            gb_id,
+            league_id,
+            key,
+            age_group,
+            gender,
+            state_code,
+        )
+        if rows:
+            records.extend(rows)
+            counts["games_emitted"] += 1
+
+    print(
+        f"  ✅ {division_name} ({age_group}, {gender}): {counts['games_emitted']} games "
+        f"({counts['skipped_non_played']} non-played, {counts['skipped_orphan']} orphan)"
+    )
+    return records, counts
+
+
+def scrape_league(config: Dict) -> Tuple[List[Dict], Dict]:
+    """Scrape a full PlayMetrics league. Returns (records, summary)."""
+    gb_id = config["governing_body_id"]
+    league_id = config["league_id"]
+    key = config["key"]
+
+    summary = {
+        "league_name": "",
+        "division_total": 0,
+        "division_processed": 0,
+        "futsal_dropped": 0,
+        "games_emitted": 0,
+        "skipped_non_played": 0,
+        "skipped_forfeit": 0,
+        "skipped_other_status": 0,
+        "skipped_orphan": 0,
+    }
+
+    league_data = get_league(gb_id, league_id, key)
+    league_name = str(league_data.get("name") or f"League {league_id}").strip()
+    divisions = league_data.get("divisions") or []
+    summary["league_name"] = league_name
+    summary["division_total"] = len(divisions)
+
+    print(f"\n📌 LEAGUE: {league_name}")
+    print(f"  Divisions: {len(divisions)}")
+
+    all_records: List[Dict] = []
+    for division in divisions:
+        records, counts = scrape_division(division, league_name, config)
+        # Pace regardless of outcome — futsal-classified divisions still issued
+        # an API call, so they should be subject to the same rate-limit window.
+        time.sleep(config["delay_sec"])
+        if counts["futsal"]:
+            summary["futsal_dropped"] += 1
+            continue
+        all_records.extend(records)
+        summary["division_processed"] += 1
+        summary["games_emitted"] += counts["games_emitted"]
+        summary["skipped_non_played"] += counts["skipped_non_played"]
+        summary["skipped_forfeit"] += counts["skipped_forfeit"]
+        summary["skipped_other_status"] += counts["skipped_other_status"]
+        summary["skipped_orphan"] += counts["skipped_orphan"]
+
+    return all_records, summary
+
+
+# -----------------------------
+# VALIDATION + OUTPUT
+# -----------------------------
+
+
+def validate_records(records: List[Dict]) -> None:
+    """Validate all records have required columns"""
+    if not records:
+        return
+    for i, r in enumerate(records):
+        missing = [col for col in REQUIRED_COLUMNS if col not in r]
+        if missing:
+            raise ValueError(f"Record {i} missing columns: {missing}")
+
+
+def write_output(records: List[Dict], config: Dict) -> Path:
+    """Write records to CSV. Always writes header, even on 0 records."""
+    output_dir = Path(config["output_dir"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = SCRAPE_TS.replace(":", "-").replace(".", "-")
+    fname = f"playmetrics_{config['governing_body_id']}_{config['league_id']}_{config['key']}_{timestamp}.csv"
+    path = output_dir / fname
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=REQUIRED_COLUMNS)
+        writer.writeheader()
+        writer.writerows(records)
+
+    print(f"\n✅ OUTPUT: {path}")
+    return path
+
+
+# -----------------------------
+# ENTRYPOINT
+# -----------------------------
+
+
+def main():
+    global SCRAPE_TS, SCRAPE_RUN_ID
+
+    SCRAPE_TS = datetime.now(timezone.utc).isoformat()
+    SCRAPE_RUN_ID = f"{SCRAPE_TS}_{uuid.uuid4().hex[:6]}"
+
+    config = resolve_config()
+
+    print("🚀 PlayMetrics League Scraper")
+    print(f"🏛️  Governing body: {config['governing_body_id']} ({GB_STATE_MAP[config['governing_body_id']]})")
+    print(f"🆔 League: {config['league_id']}-{config['key']}")
+    print(f"🆔 Scrape run ID: {SCRAPE_RUN_ID}")
+
+    scrape_start = time.time()
+    records, summary = scrape_league(config)
+    scrape_duration = time.time() - scrape_start
+
+    if records:
+        validate_records(records)
+
+    if not config["dry_run"]:
+        write_output(records, config)
+        if not records:
+            print("⚠️  No games scraped — empty CSV written (headers only)")
+    else:
+        print(f"\n🔍 DRY RUN — {len(records)} rows validated (not written)")
+
+    print(
+        f"\n📊 Scraped {summary['games_emitted']} games across {summary['division_processed']} divisions; "
+        f"{summary['skipped_non_played']} non-played games dropped "
+        f"({summary['skipped_forfeit']} forfeits, {summary['skipped_other_status']} other statuses); "
+        f"{summary['futsal_dropped']} futsal divisions skipped."
+    )
+    print(f"⏱️  Total time: {scrape_duration:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -240,6 +240,13 @@ class EnhancedETLPipeline:
             self.matcher = AffinityWAGameMatcher(
                 self.supabase, provider_id=self.provider_id, alias_cache=self.alias_cache
             )
+        elif self.provider_code.lower() == "playmetrics":
+            from src.models.playmetrics_matcher import PlayMetricsGameMatcher
+
+            logger.info("Using PlayMetricsGameMatcher (WI-scoped fuzzy + auto-create)")
+            self.matcher = PlayMetricsGameMatcher(
+                self.supabase, provider_id=self.provider_id, alias_cache=self.alias_cache
+            )
         else:
             logger.info(f"Using standard GameHistoryMatcher for provider: {self.provider_code}")
             self.matcher = GameHistoryMatcher(self.supabase, provider_id=self.provider_id, alias_cache=self.alias_cache)
@@ -592,7 +599,7 @@ class EnhancedETLPipeline:
                     if legacy_existing:
                         logger.info(
                             f"[Pipeline] Modular11: Found {len(legacy_existing)} games "
-                        f"with LEGACY UIDs in DB (these are NOT new games)"
+                            f"with LEGACY UIDs in DB (these are NOT new games)"
                         )
 
                 # For Modular11, check game_uid first (it includes age_group and division)
@@ -617,7 +624,7 @@ class EnhancedETLPipeline:
                     if existing_composite_keys:
                         logger.info(
                             f"[Pipeline] Found {len(existing_composite_keys)} duplicate games "
-                        f"by composite key (already in DB)"
+                            f"by composite key (already in DB)"
                         )
                         # Capture duplicates before filtering for backfill
                         m11_composite_dupes = [
@@ -633,7 +640,7 @@ class EnhancedETLPipeline:
                         self.metrics.duplicates_found += len(existing_composite_keys)
                         logger.info(
                             f"[Pipeline] Filtered to {len(games_with_existing_uid)} games "
-                        f"after composite key duplicate check"
+                            f"after composite key duplicate check"
                         )
                         # Backfill missing master IDs on Modular11 composite-key duplicates
                         bf = await self._backfill_duplicate_team_links(m11_composite_dupes)
@@ -799,7 +806,7 @@ class EnhancedETLPipeline:
                                 game["game_uid"] = modified_game_uid
                                 logger.info(
                                     f"[Pipeline] Modified game_uid for conflict (age only): "
-                    f"{game_uid} -> {modified_game_uid}"
+                                    f"{game_uid} -> {modified_game_uid}"
                                 )
                                 games_to_insert.append(game)
                             else:

--- a/src/models/playmetrics_matcher.py
+++ b/src/models/playmetrics_matcher.py
@@ -1,0 +1,381 @@
+"""
+PlayMetrics-specific game matcher for Wisconsin youth soccer leagues.
+
+Hybrid design:
+- Structure mirrors ``TGSGameMatcher`` — JSON-API, integer provider_team_id
+  unique per team, so ``_match_by_provider_id`` skips the age-group gate.
+- State scoping mirrors ``AffinityWAGameMatcher`` — candidates are narrowed to
+  WI in ``_fuzzy_match_team`` and autocreated teams get ``state_code="WI"``.
+- Inline autocreate: after base ``_match_team`` exhausts alias / direct_id /
+  fuzzy paths without matching, a fresh team row is created so no game is
+  dropped.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from config.settings import MATCHING_CONFIG
+from src.models.game_matcher import GameHistoryMatcher
+from src.utils.club_normalizer import are_same_club
+from src.utils.team_name_utils import extract_distinctions
+
+logger = logging.getLogger(__name__)
+
+STATE_CODE = "WI"
+
+# state_code → full state name (mirrors the scraper's mapping; keep in sync
+# with ``scripts/scrape_playmetrics_league.py`` when new states are added).
+STATE_CODE_TO_NAME: Dict[str, str] = {
+    "WI": "Wisconsin",
+}
+
+
+class PlayMetricsGameMatcher(GameHistoryMatcher):
+    """PlayMetrics matcher: WI-scoped fuzzy + autocreate fallback.
+
+    Keeps base thresholds (fuzzy=0.75, auto_approve=0.90, review=0.75) so the
+    review-queue routing in the base class continues to behave the same way.
+    """
+
+    def __init__(self, supabase, provider_id=None, alias_cache=None):
+        super().__init__(supabase, provider_id=provider_id, alias_cache=alias_cache)
+        self.default_state_code = STATE_CODE
+        # Per-(state, age_group, gender) candidate cache for _fuzzy_match_team.
+        # Without it, each unmatched team in a batch re-issues the same
+        # ~200-500-row query for its bucket — dozens to thousands of identical
+        # RTTs per import. Populated on first miss; kept fresh via `append`
+        # inside ``_create_new_playmetrics_team``. Keyed by state so multi-state
+        # support (next-GB onboarding) is a drop-in.
+        self._candidate_cache: Dict = {}
+
+    @staticmethod
+    def _normalize_gender(gender: Optional[str]) -> Optional[str]:
+        """Canonicalize gender to ``"Male"`` or ``"Female"`` for DB + cache keys."""
+        if not gender:
+            return None
+        return "Male" if gender.upper() in ("M", "MALE", "BOYS", "B") else "Female"
+
+    def _match_by_provider_id(
+        self, provider_id: str, provider_team_id: str, age_group: Optional[str] = None, gender: Optional[str] = None
+    ) -> Optional[Dict]:
+        """Skip age_group validation: PlayMetrics teams[].team.id is unique per team.
+
+        Mirror of ``TGSGameMatcher._match_by_provider_id`` — same rationale:
+        using a stable provider-native ID, so a match is authoritative regardless
+        of whether the current game's age_group differs (e.g. playing up).
+        """
+        if not provider_team_id:
+            return None
+
+        team_id_str = str(provider_team_id).strip()
+
+        # Check cache first (if available); cache already has semicolon-split IDs expanded.
+        if self.alias_cache and team_id_str in self.alias_cache:
+            cached = self.alias_cache[team_id_str]
+            return {
+                "team_id_master": cached["team_id_master"],
+                "review_status": cached.get("review_status", "approved"),
+                "match_method": cached.get("match_method"),
+            }
+
+        # Tier 1: Direct ID match — exact
+        try:
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("match_method", "direct_id")
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                return result.data[0]
+        except Exception as e:
+            logger.debug(f"[PlayMetrics] No exact direct_id match: {e}")
+
+        # Tier 2: Semicolon-separated alias (merged teams)
+        try:
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method, provider_team_id")
+                .eq("provider_id", provider_id)
+                .eq("review_status", "approved")
+                .like("provider_team_id", f"%{team_id_str}%")
+                .execute()
+            )
+            if result.data:
+                for alias in result.data:
+                    alias_ids = [i.strip() for i in str(alias["provider_team_id"]).split(";")]
+                    if team_id_str in alias_ids:
+                        return {
+                            "team_id_master": alias["team_id_master"],
+                            "review_status": alias.get("review_status", "approved"),
+                            "match_method": alias.get("match_method"),
+                        }
+        except Exception as e:
+            logger.debug(f"[PlayMetrics] No semicolon-alias match: {e}")
+
+        # Tier 3: Any approved alias — exact
+        try:
+            result = (
+                self.db.table("team_alias_map")
+                .select("team_id_master, review_status, match_method")
+                .eq("provider_id", provider_id)
+                .eq("provider_team_id", team_id_str)
+                .eq("review_status", "approved")
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                return result.data[0]
+        except Exception as e:
+            logger.debug(f"[PlayMetrics] No alias map match: {e}")
+        return None
+
+    def _fuzzy_match_team(
+        self, team_name: str, age_group: str, gender: str, club_name: Optional[str] = None
+    ) -> Optional[Dict]:
+        """WI-scoped fuzzy matching with Python-side club gate.
+
+        SQL narrows candidates to ``state_code/age_group/gender`` only — no SQL
+        ``.ilike("club_name", ...)`` prefix filter because that drops legitimate
+        candidates whose club_name differs by prefix (e.g. ``"Bavarian United"``
+        vs ``"Bavarian Soccer Club"`` normalize to the same canonical club).
+        Within the candidate set, ``are_same_club`` enforces the club gate, then
+        distinction-based rejection prevents within-club variant collisions
+        (Red ≠ Blue, ECNL ≠ ECRL), and finally base ``_calculate_match_score``
+        assigns the weighted score.
+        """
+        try:
+            age_group_normalized = age_group.lower() if age_group else age_group
+            gender_normalized = self._normalize_gender(gender)
+            club_threshold = MATCHING_CONFIG.get("affinity_club_similarity_threshold", 0.9)
+
+            candidates = self._get_candidates(STATE_CODE, age_group_normalized, gender_normalized)
+            if not candidates:
+                return None
+
+            provider_distinctions = extract_distinctions(team_name)
+            provider_team = {
+                "team_name": team_name,
+                "club_name": club_name,
+                "age_group": age_group,
+                "state_code": STATE_CODE,
+            }
+
+            best_match = None
+            best_score = 0.0
+
+            for team in candidates:
+                candidate_club = team.get("club_name")
+
+                # Stage 1: canonical same-club gate.
+                if club_name and candidate_club:
+                    if not are_same_club(club_name, candidate_club, threshold=club_threshold):
+                        continue
+
+                # Stage 2: distinction-based hard rejection (Red ≠ Blue, ECNL ≠ ECRL, etc.).
+                # Distinctions are memoized on the cached row so repeated matcher calls
+                # within one import don't re-run the regex-heavy extractor.
+                cand_distinctions = team.get("_distinctions")
+                if cand_distinctions is None:
+                    cand_distinctions = extract_distinctions(team.get("team_name", ""))
+                    team["_distinctions"] = cand_distinctions
+                if provider_distinctions["colors"] != cand_distinctions["colors"]:
+                    continue
+                if provider_distinctions["directions"] != cand_distinctions["directions"]:
+                    continue
+                if provider_distinctions["programs"] != cand_distinctions["programs"]:
+                    continue
+                if provider_distinctions["team_number"] != cand_distinctions["team_number"]:
+                    continue
+                if provider_distinctions["location_codes"] != cand_distinctions["location_codes"]:
+                    continue
+                if provider_distinctions["squad_words"] != cand_distinctions["squad_words"]:
+                    continue
+                cand_coach = cand_distinctions.get("coach_name")
+                if (
+                    provider_distinctions.get("coach_name")
+                    and cand_coach
+                    and provider_distinctions["coach_name"] != cand_coach
+                ):
+                    continue
+
+                cand_name = team.get("team_name", "")
+                candidate = {
+                    "team_name": cand_name,
+                    "club_name": candidate_club,
+                    "age_group": team.get("age_group"),
+                    "state_code": team.get("state_code"),
+                }
+                score = self._calculate_match_score(provider_team, candidate)
+
+                if score >= self.fuzzy_threshold and score > best_score:
+                    best_score = score
+                    best_match = {
+                        "team_id": team["team_id_master"],
+                        "team_name": cand_name,
+                        "confidence": round(score, 3),
+                    }
+
+            return best_match
+        except Exception as e:
+            logger.error(f"[PlayMetrics] Fuzzy match error: {e}")
+            return None
+
+    def _get_candidates(
+        self,
+        state_code: str,
+        age_group_normalized: Optional[str],
+        gender_normalized: Optional[str],
+    ) -> list:
+        """Return the candidate set for (state, age_group, gender), fetching on first miss."""
+        key = (state_code, age_group_normalized, gender_normalized)
+        cached = self._candidate_cache.get(key)
+        if cached is not None:
+            return cached
+        result = (
+            self.db.table("teams")
+            .select("team_id_master, team_name, club_name, age_group, gender, state_code")
+            .eq("age_group", age_group_normalized)
+            .eq("gender", gender_normalized)
+            .eq("state_code", state_code)
+            .execute()
+        )
+        data = list(result.data) if result and result.data else []
+        self._candidate_cache[key] = data
+        return data
+
+    def _match_team(
+        self,
+        provider_id: str,
+        provider_team_id: Optional[str],
+        team_name: Optional[str],
+        age_group: Optional[str],
+        gender: Optional[str],
+        club_name: Optional[str] = None,
+    ) -> Dict:
+        """Try base matching (alias / direct_id / fuzzy). On miss, autocreate a new team."""
+        base_result = super()._match_team(provider_id, provider_team_id, team_name, age_group, gender, club_name)
+
+        if base_result.get("matched"):
+            return base_result
+
+        if team_name and age_group and gender:
+            logger.info(f"[PlayMetrics] No match for '{team_name}' ({age_group}, {gender}), creating new team")
+            try:
+                new_team_id = self._create_new_playmetrics_team(
+                    team_name=team_name,
+                    club_name=club_name,
+                    age_group=age_group,
+                    gender=gender,
+                    provider_id=provider_id,
+                    provider_team_id=provider_team_id,
+                )
+                match_method = "direct_id" if provider_team_id else "import"
+                self._create_alias(
+                    provider_id=provider_id,
+                    provider_team_id=provider_team_id,
+                    team_name=team_name,
+                    team_id_master=new_team_id,
+                    match_method=match_method,
+                    confidence=1.0,
+                    age_group=age_group,
+                    gender=gender,
+                    review_status="approved",
+                )
+                logger.info(f"[PlayMetrics] Created: {team_name} ({age_group}, {gender}) -> {new_team_id}")
+                return {
+                    "matched": True,
+                    "team_id": new_team_id,
+                    "method": match_method,
+                    "confidence": 1.0,
+                    "created": True,
+                }
+            except Exception as e:
+                logger.error(f"[PlayMetrics] Error creating team for {team_name}: {e}")
+
+        return base_result
+
+    def _create_new_playmetrics_team(
+        self,
+        team_name: str,
+        club_name: Optional[str],
+        age_group: str,
+        gender: str,
+        provider_id: Optional[str],
+        provider_team_id: Optional[str] = None,
+    ) -> str:
+        """Create a new row in ``teams`` for a PlayMetrics team. WI-only for now.
+
+        Handles the concurrent-autocreate race: two games in the same batch for
+        a brand-new team can both reach this method, so we retry the lookup on
+        the ``UNIQUE(provider_id, provider_team_id)`` constraint violation.
+        """
+        if not provider_team_id:
+            import hashlib
+
+            # MD5 for deterministic ID generation (not security).
+            provider_team_id = hashlib.md5(f"{team_name}_{age_group}_{gender}".encode()).hexdigest()[:16]
+
+        if provider_id:
+            try:
+                existing = (
+                    self.db.table("teams")
+                    .select("team_id_master")
+                    .eq("provider_id", provider_id)
+                    .eq("provider_team_id", provider_team_id)
+                    .single()
+                    .execute()
+                )
+                if existing.data:
+                    return existing.data["team_id_master"]
+            except Exception:
+                pass
+
+        team_id_master = str(uuid.uuid4())
+        age_group_normalized = age_group.lower() if age_group else age_group
+        gender_normalized = self._normalize_gender(gender)
+
+        team_data = {
+            "team_id_master": team_id_master,
+            "team_name": team_name,
+            "club_name": club_name or team_name,
+            "age_group": age_group_normalized,
+            "gender": gender_normalized,
+            "state_code": STATE_CODE,
+            "state": STATE_CODE_TO_NAME.get(STATE_CODE),
+            "provider_id": provider_id,
+            "provider_team_id": provider_team_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        try:
+            self.db.table("teams").insert(team_data).execute()
+            # Keep the fuzzy-match candidate cache fresh so later rows in the same
+            # batch can match against the team we just created.
+            key = (STATE_CODE, age_group_normalized, gender_normalized)
+            if key in self._candidate_cache:
+                self._candidate_cache[key].append({**team_data, "_distinctions": None})
+            return team_id_master
+        except Exception as e:
+            err = str(e).lower()
+            if "duplicate key" in err or "23505" in err:
+                logger.debug(f"[PlayMetrics] Duplicate key on insert, looking up existing team: {e}")
+                if provider_id and provider_team_id:
+                    existing = (
+                        self.db.table("teams")
+                        .select("team_id_master")
+                        .eq("provider_id", provider_id)
+                        .eq("provider_team_id", provider_team_id)
+                        .single()
+                        .execute()
+                    )
+                    if existing.data:
+                        return existing.data["team_id_master"]
+            logger.error(f"[PlayMetrics] Error creating new team: {e}")
+            raise

--- a/tests/unit/test_scrape_playmetrics.py
+++ b/tests/unit/test_scrape_playmetrics.py
@@ -1,0 +1,159 @@
+"""Unit tests for pure helpers in scripts/scrape_playmetrics_league.py.
+
+Scope is limited to the novel, branch-heavy pure functions that encode domain
+rules:
+
+- ``derive_team_age_group`` — three-tier age resolution (birth year / U-token /
+  division fallback) with the u18→u19 merge
+- ``map_min_age_to_age_group`` — the fallback itself
+- ``parse_int_or_none`` — score validation (0..50 whole integers only)
+- ``parse_utc_to_local_date`` — state-local calendar-date conversion
+- ``_parse_league_url`` — URL slug decomposition
+
+The matcher and HTTP/CSV plumbing are covered by the end-to-end scrape+validate
+verification in the implementation plan, not by unit tests (matches the
+TGS/Affinity-WA convention).
+"""
+
+import pytest
+
+from scripts.scrape_playmetrics_league import (
+    _parse_league_url,
+    derive_team_age_group,
+    map_min_age_to_age_group,
+    parse_int_or_none,
+    parse_utc_to_local_date,
+)
+
+
+class TestDeriveTeamAgeGroup:
+    """Team-name-first age_group derivation with division fallback."""
+
+    @pytest.mark.parametrize(
+        "name, fallback, expected",
+        [
+            # Birth-year parse beats division fallback
+            ("11uB Croatian Eagles Red- 2015", "u10", "u11"),
+            ("North Shore United 2015 Boys Blue Pre-Club Premier", "u10", "u11"),
+            ("2014 ACE BLACK", "u11", "u12"),
+            ("2016 Boys Red", "u10", "u10"),
+            # Birth year 2007 → u19 (not u18) — PitchRank merges u18 into u19
+            ("Neenah SC 2007 Girls 19U Red Premier", "u19", "u19"),
+            # Birth year 2008 → u18 → remapped to u19
+            ("Mukwonago 2008 Girls Blue", "u19", "u19"),
+            # U-token parse when no birth year
+            ("U11 Boys White", "u10", "u11"),
+            ("Forward Madison FC Select U11 Boys", "u10", "u11"),
+            ("Mukwonago U18 Girls Blue", "u19", "u19"),
+            # Fallback when neither signal present
+            ("High School Girls Borts II", "u19", "u19"),
+            ("North Shore United High School Girls State Level", "u19", "u19"),
+            ("ACE Team Name", "u12", "u12"),
+            # Birth-year wins when both signals appear
+            ("Rush 11U (2015) Wisconsin", "u10", "u11"),
+            # Empty/None team name falls straight through
+            ("", "u13", "u13"),
+        ],
+    )
+    def test_derivation(self, name, fallback, expected):
+        assert derive_team_age_group(name, fallback) == expected
+
+    def test_unmapped_birth_year_falls_back(self):
+        # 2004 is outside ``calculate_age_group_from_birth_year``'s range for
+        # season 2025 → falls through to the U-token / fallback path.
+        assert derive_team_age_group("FC 2004 Boys", "u16") == "u16"
+
+
+class TestMapMinAgeToAgeGroup:
+    @pytest.mark.parametrize(
+        "age, expected",
+        [
+            (10, "u10"),
+            (11, "u11"),
+            (15, "u15"),
+            (17, "u17"),
+            (18, "u19"),  # u18 merges into u19
+            (19, "u19"),
+        ],
+    )
+    def test_valid_range(self, age, expected):
+        assert map_min_age_to_age_group(age) == expected
+
+    @pytest.mark.parametrize("age", [None, 0, 9, 20, 99, "not-an-int"])
+    def test_invalid_or_out_of_range(self, age):
+        assert map_min_age_to_age_group(age) is None
+
+
+class TestParseIntOrNone:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (0, 0),
+            (3, 3),
+            (50, 50),
+            ("0", 0),
+            ("7", 7),
+            ("50", 50),
+            ("3.0", 3),  # whole-valued float accepted
+        ],
+    )
+    def test_valid_scores(self, value, expected):
+        assert parse_int_or_none(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            " ",
+            "None",
+            "null",
+            "NONE",
+            "NULL",
+            True,
+            False,  # bool rejected (bool is int subclass)
+            "2.5",
+            "-1",
+            -1,
+            51,
+            999,
+            "999",
+            "abc",
+            "3 goals",
+        ],
+    )
+    def test_rejected(self, value):
+        assert parse_int_or_none(value) is None
+
+
+class TestParseUtcToLocalDate:
+    def test_wi_evening_rolls_back_a_day(self):
+        # 9:00 PM CT on Sep 6 2025 == 02:00Z on Sep 7 2025 (CDT = UTC-5)
+        assert parse_utc_to_local_date("2025-09-07T02:00:00", "WI") == "2025-09-06"
+
+    def test_wi_afternoon_same_day(self):
+        # 2:30 PM CT on Sep 6 2025 == 19:30Z on Sep 6 2025
+        assert parse_utc_to_local_date("2025-09-06T19:30:00", "WI") == "2025-09-06"
+
+    def test_handles_trailing_z(self):
+        assert parse_utc_to_local_date("2025-09-06T19:30:00Z", "WI") == "2025-09-06"
+
+    def test_unmapped_state_falls_back_to_utc_slice(self):
+        assert parse_utc_to_local_date("2025-09-07T02:00:00", "ZZ") == "2025-09-07"
+
+    def test_empty_input(self):
+        assert parse_utc_to_local_date("", "WI") == ""
+
+    def test_unparseable_falls_back_to_slice(self):
+        # 10-char slice of the unparseable string, not a conversion
+        assert parse_utc_to_local_date("not-a-date-2025", "WI") == "not-a-date"
+
+
+class TestParseLeagueUrl:
+    def test_canonical_url(self):
+        url = "https://playmetricssports.com/g/leagues/1014-1514-8ccd4dbb/league_view.html"
+        assert _parse_league_url(url) == (1014, 1514, "8ccd4dbb")
+
+    def test_malformed_url_returns_none(self):
+        assert _parse_league_url("https://example.com/nope") is None
+        assert _parse_league_url("") is None


### PR DESCRIPTION
## Summary

Adds a fifth ingestion provider. Scraper hits the public PlayMetrics LSS JSON API. Matcher autocreates WI teams inline with state-scoped fuzzy matching. Weekly GitHub Action mirrors the TGS workflow. First target league is SECL & State League Fall 2025.

## Notable decisions

- **age_group from team name, not min_age.** PlayMetrics sets `min_age=10` on "11U A/SL" divisions because 10-year-olds can play up. Literal mapping put every 11U team into u10. The scraper parses birth year (`2015` → u11) or `U11`/`11U` token from `team_name` first; `min_age` is only a fallback.
- **UTC → local tz for game_date.** A 9pm Central kickoff is next-day UTC. Convert via `America/Chicago` (per-state map) before slicing.
- **Strict score validation.** `parse_int_or_none` only accepts 0..50 integers.
- **Loud on API failure.** `_post` raises after 3 retries. Better to fail the workflow than silently ship a CSV missing divisions.
- **Candidate cache in matcher.** Keyed by `(state, age_group, gender)`. Cuts per-import Supabase RTTs from hundreds to ~16.

## Verification

- Live SECL scrape: 72 divisions, 2,130 games, 0 futsal, 39 non-played dropped
- Validator-only import: 4,260 / 4,260 rows pass
- 59 new unit tests for pure scraper helpers (`tests/unit/test_scrape_playmetrics.py`)

## One-time setup

```sql
INSERT INTO providers (code, name, base_url)
VALUES ('playmetrics', 'PlayMetrics', 'https://playmetricssports.com')
ON CONFLICT (code) DO NOTHING;
```

## Test plan

- [ ] Run the `INSERT INTO providers ...` above against production Supabase
- [ ] Trigger `.github/workflows/playmetrics-scrape-import.yml` manually with the default SECL URL
- [ ] Spot-check `games` count for provider and verify a team's `age_group` matches its birth year

## Follow-ups

`.turbo/improvements.md` has a new entry: autocreate-on-miss is now triplicated across TGS, Affinity WA, and PlayMetrics matchers, and HTTP retry helpers have drifted between scrapers. Good consolidation PR before a fourth provider.