### PR TITLE
perf(scrape): shard + bulk RPCs + 429 retry for scrape-games workflow

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -28,7 +28,7 @@ on:
         type: string
         default: ''
       concurrency:
-        description: 'Number of concurrent scrapes'
+        description: 'Number of concurrent scrapes (manual override; default is computed adaptively per shard)'
         required: false
         type: string
         default: '30'
@@ -43,28 +43,106 @@ on:
         type: boolean
         default: false
 
-# Prevent overlapping scrape runs — the Monday 6:00 AM run must finish
-# before the 11:15 AM run starts. Without this, both runs write to the
-# same games/team_alias_map tables simultaneously, causing duplicate
-# inserts and stale alias cache reads.
+# Workflow-level concurrency: serialize SEPARATE workflow RUNS (the Mon 06:00 UTC
+# cron must finish before the Mon 11:15 UTC cron starts). Without this, the two
+# runs write to `games` and `team_alias_map` simultaneously, causing duplicate
+# inserts and stale alias-cache reads.
+#
+# DO NOT add a job-level `concurrency:` key inside `scrape-and-import` — doing so
+# would serialize the 5 matrix shards and kill the parallel-speedup the plan
+# relies on.
 concurrency:
   group: game-scraping
-  cancel-in-progress: false  # Queue the second run, don't cancel the first
+  cancel-in-progress: false  # Queue the second cron run; do not cancel the first
 
 jobs:
-  scrape-and-import:
+  prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 360  # 6 hour timeout (GitHub max) for large scrapes
-
+    # Hard ceiling. Sized to accommodate the maintain step's 25-min worst case
+    # plus ~5 min of checkout/install/gate overhead.
+    timeout-minutes: 30
+    outputs:
+      should_shard: ${{ steps.gate.outputs.should_shard }}
+      shard_count:  ${{ steps.gate.outputs.shard_count }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-          cache: 'pip'  # Cache pip dependencies for faster subsequent runs
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          mkdir -p logs data/raw data/cache
+
+      - name: Compute shard gate
+        id: gate
+        # User-controlled workflow_dispatch inputs flow via env: vars (never
+        # interpolated directly into the shell body) so the shell, not the
+        # GitHub Actions parser, handles quoting. Regex validates the value
+        # before any numeric comparison.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LIMIT_TEAMS: ${{ inputs.limit_teams }}
+        run: |
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            echo "should_shard=true" >> "$GITHUB_OUTPUT"
+            echo "shard_count=5"      >> "$GITHUB_OUTPUT"
+          elif [[ "$LIMIT_TEAMS" =~ ^[0-9]+$ ]] && [ "$LIMIT_TEAMS" -ge 5000 ]; then
+            echo "should_shard=true" >> "$GITHUB_OUTPUT"
+            echo "shard_count=5"      >> "$GITHUB_OUTPUT"
+          else
+            # Small or no-arg manual run: only shard 0 executes. The RPC's hash
+            # filter collapses to a no-op when p_shard_count <= 1.
+            echo "should_shard=false" >> "$GITHUB_OUTPUT"
+            echo "shard_count=1"      >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Maintain GotSport direct ID aliases
+        # Best-effort Tier 1 import-matching optimization; NOT a scraping
+        # correctness requirement. continue-on-error prevents a transient
+        # Supabase blip from cascading through `needs: prepare` and skipping
+        # all 5 scrape shards.
+        #
+        # Step-level timeout-minutes (25) prevents the whole prepare JOB from
+        # being cancelled when the per-row UPDATE loop hits its worst case
+        # (~5K aliases × ~300ms ≈ 25 min). The job-level timeout is 30 min.
+        # The checkout/install/gate steps above MUST NOT use continue-on-error
+        # — they produce outputs every downstream shard depends on.
+        continue-on-error: true
+        timeout-minutes: 25
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: python scripts/maintain_gotsport_direct_id_aliases.py
+
+  scrape-and-import:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 120  # Reduced from 360. Each shard does ~1/5 the work.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4]
+    # Shard 0 always runs (covers the small-run case). Shards 1-4 only when sharding.
+    if: ${{ matrix.shard == 0 || needs.prepare.outputs.should_shard == 'true' }}
+    # Job-level env: consistent for all steps. DO NOT put SCRAPE_SHARD_COUNT on
+    # any step-level env block — step-level env overrides job-level env, which
+    # would silently freeze SCRAPE_SHARD_COUNT to a stale literal.
+    env:
+      SCRAPE_SHARD_INDEX: ${{ matrix.shard }}
+      SCRAPE_SHARD_COUNT: ${{ needs.prepare.outputs.shard_count }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -74,71 +152,86 @@ jobs:
 
       - name: Build scrape command
         id: build-command
+        # Reads SCRAPE_SHARD_COUNT from job env (= needs.prepare.outputs.shard_count).
+        # Computes per-shard --limit-teams and adaptive --concurrency.
+        #
+        # User-controlled workflow_dispatch inputs are passed via env: vars
+        # (never interpolated directly into the shell body) so the shell
+        # handles quoting. Numeric inputs are regex-validated before any
+        # arithmetic / comparison.
+        #
+        # Per-shard integer division may lose 1–4 teams when inputs.limit_teams
+        # is not divisible by 5 (e.g. 5001/5=1000 → total 5000). Acceptable at
+        # scraping scale.
+        env:
+          EVENT_NAME:        ${{ github.event_name }}
+          LIMIT_TEAMS:       ${{ inputs.limit_teams }}
+          NULL_TEAMS_ONLY:   ${{ inputs.null_teams_only }}
+          SINCE_DATE:        ${{ inputs.since_date }}
+          INCLUDE_RECENT:    ${{ inputs.include_recent }}
+          CONCURRENCY_INPUT: ${{ inputs.concurrency }}
         run: |
           CMD="python scripts/scrape_games.py --provider gotsport --auto-import"
 
-          # Add limit-teams if specified, or use 25000 for scheduled runs
-          if [ -n "${{ inputs.limit_teams }}" ]; then
-            CMD="$CMD --limit-teams ${{ inputs.limit_teams }}"
-            echo "Limiting to ${{ inputs.limit_teams }} teams"
-          elif [ "${{ github.event_name }}" == "schedule" ]; then
-            CMD="$CMD --limit-teams 25000"
-            echo "Scheduled run: Limiting to 25000 teams"
+          LIMIT_FLAG=""
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # Scheduled: 25000 teams total / 5 shards = 5000 per shard
+            LIMIT_FLAG="--limit-teams 5000"
+          elif [[ "$LIMIT_TEAMS" =~ ^[0-9]+$ ]] && [ "$LIMIT_TEAMS" -ge 5000 ]; then
+            LIMIT_FLAG="--limit-teams $(( LIMIT_TEAMS / 5 ))"
+          elif [[ "$LIMIT_TEAMS" =~ ^[0-9]+$ ]]; then
+            # Small manual run: SCRAPE_SHARD_COUNT=1, hash filter is a no-op,
+            # shard 0 runs the full unsharded amount.
+            LIMIT_FLAG="--limit-teams $LIMIT_TEAMS"
           fi
+          # If LIMIT_FLAG is empty, the CLI omits --limit-teams and falls
+          # through to incremental mode (7-day stale filter) — matches the
+          # prior workflow's semantics for manual dispatch with no inputs.
+          CMD="$CMD $LIMIT_FLAG"
 
-          # Add null-teams-only if specified
-          if [ "${{ inputs.null_teams_only }}" == "true" ]; then
+          if [ "$NULL_TEAMS_ONLY" = "true" ]; then
             CMD="$CMD --null-teams-only"
-            echo "Scraping only NULL teams (bootstrap mode)"
           fi
 
-          # Add since-date if specified
-          if [ -n "${{ inputs.since_date }}" ]; then
-            CMD="$CMD --since-date ${{ inputs.since_date }}"
-            echo "Using since_date: ${{ inputs.since_date }}"
+          # YYYY-MM-DD only — guards against shell-meta in the date input.
+          if [[ "$SINCE_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            CMD="$CMD --since-date $SINCE_DATE"
           fi
 
-          # Add include-recent if specified (override 7-day filter)
-          if [ "${{ inputs.include_recent }}" == "true" ]; then
+          if [ "$INCLUDE_RECENT" = "true" ]; then
             CMD="$CMD --include-recent"
-            echo "Including teams scraped within last 7 days"
           fi
 
-          # Add concurrency (default to 30 for scheduled runs where inputs aren't available)
-          CONCURRENCY="${{ inputs.concurrency }}"
-          if [ -z "$CONCURRENCY" ]; then
-            CONCURRENCY="30"
+          # Adaptive concurrency: 50 single-shard, 20 per shard when sharded
+          # (20 × 5 = 100 aggregate in-flight, matches gotsport.py pool_maxsize).
+          # Manual concurrency input wins if explicitly set AND we're not sharding.
+          if [ "$SCRAPE_SHARD_COUNT" = "1" ]; then
+            CONCURRENCY=50
+          else
+            CONCURRENCY=20
+          fi
+          if [[ "$CONCURRENCY_INPUT" =~ ^[0-9]+$ ]] && [ "$SCRAPE_SHARD_COUNT" = "1" ]; then
+            CONCURRENCY="$CONCURRENCY_INPUT"
           fi
           CMD="$CMD --concurrency $CONCURRENCY"
 
-          echo "Command: $CMD"
-          echo "command=$CMD" >> $GITHUB_OUTPUT
+          echo "Shard ${SCRAPE_SHARD_INDEX}/${SCRAPE_SHARD_COUNT}: $CMD"
+          echo "command=$CMD" >> "$GITHUB_OUTPUT"
 
-      - name: Maintain GotSport direct ID aliases
+      - name: Run scrape + auto-import
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL:              ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY:      ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          export PYTHONPATH="${PYTHONPATH}:${PWD}"
-          python scripts/maintain_gotsport_direct_id_aliases.py
-
-      - name: Run Scrape and Import
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          PYTHONPATH: ${{ github.workspace }}
-        run: |
-          export PYTHONPATH="${PYTHONPATH}:${PWD}"
-          ${{ steps.build-command.outputs.command }}
+          NEXT_PUBLIC_SUPABASE_URL:  ${{ secrets.SUPABASE_URL }}
+          PYTHONPATH:                ${{ github.workspace }}
+        run: ${{ steps.build-command.outputs.command }}
 
       - name: Upload scraped data
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: scraped-games-${{ github.run_number }}
+          name: scraped-games-${{ github.run_number }}-shard-${{ matrix.shard }}
           path: data/raw/scraped_games_*.jsonl
           retention-days: 7
           if-no-files-found: ignore
@@ -147,9 +240,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: scrape-logs-${{ github.run_number }}
-          path: |
-            logs/*.log
+          name: scrape-logs-${{ github.run_number }}-shard-${{ matrix.shard }}
+          path: logs/*.log
           retention-days: 30
           if-no-files-found: ignore
 
@@ -157,14 +249,14 @@ jobs:
         if: always()
         run: |
           echo "===================="
-          echo "Scrape workflow completed"
+          echo "Scrape shard ${SCRAPE_SHARD_INDEX}/${SCRAPE_SHARD_COUNT} completed"
           echo "===================="
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            echo "Teams limit: 25000 (scheduled run)"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Teams limit: 5000 per shard × 5 shards = 25000 (scheduled run)"
           else
-            echo "Teams limit: ${{ inputs.limit_teams || 'All eligible' }}"
+            echo "Teams limit input: ${{ inputs.limit_teams || 'empty (incremental mode)' }}"
           fi
           echo "Null teams only: ${{ inputs.null_teams_only }}"
           echo "Include recent (override 7-day filter): ${{ inputs.include_recent }}"
-          echo "Concurrency: ${{ inputs.concurrency }}"
+          echo "Concurrency input: ${{ inputs.concurrency }}"
           echo "Check artifacts for scraped data and logs"

--- a/scripts/scrape_games.py
+++ b/scripts/scrape_games.py
@@ -24,6 +24,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
+from src.etl.bulk_ops import bulk_update_last_scraped_at, call_rpc_with_fallback
 from src.scrapers.gotsport import GotSportScraper, TeamNotFoundError
 from supabase import create_client
 
@@ -57,59 +58,15 @@ def _is_placeholder_unknown_team(team: Dict) -> bool:
     return team_name.lower() == f"unknown_{provider_team_id}".lower()
 
 
-def _bulk_fetch_scrape_dates(supabase, provider_id: str, team_ids: List[str]) -> Dict[str, Optional[datetime]]:
-    """OPTIMIZATION: Bulk fetch all last_scraped_at dates in one query"""
-    if not team_ids:
-        return {}
-
-    # Initialize all teams to None
-    scrape_dates = {team_id: None for team_id in team_ids}
-
-    # Fetch from teams table (last_scraped_at column) - more efficient than team_scrape_log
-    # Reduced batch size to avoid URL length limits (UUIDs are ~36 chars each)
-    batch_size = 100
-
-    for i in range(0, len(team_ids), batch_size):
-        batch_ids = team_ids[i : i + batch_size]
-        try:
-            # Get last_scraped_at directly from teams table
-            result = (
-                supabase.table("teams")
-                .select("team_id_master, last_scraped_at")
-                .in_("team_id_master", batch_ids)
-                .eq("provider_id", provider_id)
-                .execute()
-            )
-
-            # Update scrape dates
-            for team in result.data or []:
-                team_id = team["team_id_master"]
-                last_scraped = team.get("last_scraped_at")
-                if last_scraped:
-                    try:
-                        scrape_dates[team_id] = datetime.fromisoformat(last_scraped.replace("Z", "+00:00"))
-                    except (ValueError, TypeError):
-                        scrape_dates[team_id] = None
-                else:
-                    scrape_dates[team_id] = None
-        except Exception as e:
-            logger.warning(f"Error bulk fetching scrape dates: {e}")
-            # Already initialized to None, so no action needed
-
-    return scrape_dates
-
-
 def _bulk_log_team_scrapes(supabase, provider_id: str, scrape_logs: List[Dict[str, Any]]):
     """OPTIMIZATION: Batch log team scrapes instead of individual calls"""
     if not scrape_logs:
         return
 
-    now = datetime.now()
-    now_iso = now.isoformat()
+    now_iso = datetime.now().isoformat()
 
-    # Prepare batch updates for teams table and log entries
-    log_entries = []
-    team_ids_to_update = []
+    log_entries: List[Dict[str, Any]] = []
+    update_payload: List[Dict[str, Any]] = []
 
     for scrape_log in scrape_logs:
         team_id_master = scrape_log["team_id_master"]
@@ -126,35 +83,71 @@ def _bulk_log_team_scrapes(supabase, provider_id: str, scrape_logs: List[Dict[st
             }
         )
         if scrape_log.get("update_last_scraped_at", True):
-            team_ids_to_update.append(team_id_master)
+            update_payload.append({"team_id_master": team_id_master, "last_scraped_at": now_iso})
 
-    # Batch insert scrape logs first
-    batch_size = 500  # Larger batches for inserts
+    # Batch insert scrape logs.
+    log_insert_batch_size = 500
     inserted_count = 0
-    for i in range(0, len(log_entries), batch_size):
-        batch = log_entries[i : i + batch_size]
+    for i in range(0, len(log_entries), log_insert_batch_size):
+        batch = log_entries[i : i + log_insert_batch_size]
         try:
             supabase.table("team_scrape_log").insert(batch).execute()
             inserted_count += len(batch)
         except Exception as e:
-            logger.warning(f"Error batch inserting scrape logs (batch {i // batch_size + 1}): {e}")
+            logger.warning(f"Error batch inserting scrape logs (batch {i // log_insert_batch_size + 1}): {e}")
 
-    # Batch update teams.last_scraped_at (one update per team, but batched for efficiency)
-    # Supabase doesn't support bulk UPDATE with different values easily, so we update individually but in batches
-    batch_size = 100
-    updated_count = 0
-    for i in range(0, len(team_ids_to_update), batch_size):
-        batch = team_ids_to_update[i : i + batch_size]
-        for team_id_master in batch:
-            try:
-                supabase.table("teams").update({"last_scraped_at": now_iso}).eq(
-                    "team_id_master", team_id_master
-                ).execute()
-                updated_count += 1
-            except Exception as e:
-                logger.warning(f"Error updating last_scraped_at for team {team_id_master}: {e}")
+    updated_count = bulk_update_last_scraped_at(supabase, update_payload)
 
     logger.info(f"Bulk logged {inserted_count} scrape logs and updated {updated_count} team timestamps")
+
+
+def _legacy_paginated_team_fetch(
+    supabase,
+    provider_id: str,
+    limit_teams: Optional[int],
+    null_teams_only: bool,
+    include_recent: bool,
+) -> List[Dict]:
+    """Fallback path for the `get_teams_to_scrape_limited` RPC.
+
+    Preserves the pre-RPC paginated `.range()` loop verbatim for each of the
+    three legacy branches. Only invoked when the RPC returns SQLSTATE 42883
+    ("function does not exist"), i.e. the migration has not been applied yet.
+    """
+    teams: List[Dict] = []
+    page_size = 1000
+    offset = 0
+
+    while True:
+        query = supabase.table("teams").select("*").eq("provider_id", provider_id)
+        if null_teams_only:
+            query = query.is_("last_scraped_at", "null")
+        # `include_recent` and the default `limit_teams` branch both fetch all
+        # provider teams; priority ordering is applied in Python below.
+        teams_result = query.range(offset, offset + page_size - 1).execute()
+
+        if not teams_result.data:
+            break
+
+        teams.extend(teams_result.data)
+
+        if len(teams_result.data) < page_size:
+            break
+
+        offset += page_size
+
+    if not null_teams_only and not include_recent:
+        # Steady-state / limit_teams path: sort by priority
+        #   1. NULL last_scraped_at first (never scraped)
+        #   2. Then oldest last_scraped_at ascending
+        teams.sort(
+            key=lambda t: (
+                0 if t.get("last_scraped_at") is None else 1,
+                t.get("last_scraped_at") or "",
+            )
+        )
+
+    return teams
 
 
 async def _scrape_team_concurrent(
@@ -293,111 +286,47 @@ async def scrape_games(
     scraper = GotSportScraper(supabase, provider)
     provider_id = scraper._get_provider_id()
 
-    # Get teams to scrape
+    # Get teams to scrape via get_teams_to_scrape_limited RPC (SQL-side filter,
+    # priority order, and shard-by-hash). The three legacy modes (null_teams_only,
+    # include_recent, limit_teams) collapse into a single call.
+    shard_index = int(os.getenv("SCRAPE_SHARD_INDEX", "0"))
+    shard_count = int(os.getenv("SCRAPE_SHARD_COUNT", "1"))
+    rpc_params = {
+        "p_provider_id": provider_id,
+        "p_limit": limit_teams if limit_teams else None,
+        "p_shard_index": shard_index,
+        "p_shard_count": shard_count,
+        "p_include_recent": bool(include_recent),
+        "p_null_only": bool(null_teams_only),
+    }
+
     if null_teams_only:
-        # Get teams with NULL last_scraped_at (with pagination to handle >1000 teams)
-        console.print("[cyan]Fetching teams with NULL last_scraped_at (paginated)...[/cyan]")
-        teams = []
-        page_size = 1000
-        offset = 0
-
-        while True:
-            teams_result = (
-                supabase.table("teams")
-                .select("*")
-                .eq("provider_id", provider_id)
-                .is_("last_scraped_at", "null")
-                .range(offset, offset + page_size - 1)
-                .execute()
-            )
-
-            if not teams_result.data:
-                break
-
-            teams.extend(teams_result.data)
-
-            if len(teams_result.data) < page_size:
-                break
-
-            offset += page_size
-            console.print(f"  Fetched {len(teams)} teams so far...")
-
-        console.print(f"[cyan]Found {len(teams)} teams with NULL last_scraped_at[/cyan]")
+        console.print("[cyan]Fetching teams with NULL last_scraped_at (RPC)...[/cyan]")
     elif include_recent:
-        # Include ALL teams (override 7-day filter) - useful for manual re-scrapes
-        console.print("[cyan]Fetching ALL teams (including recently scraped)...[/cyan]")
-        teams = []
-        page_size = 1000
-        offset = 0
-
-        while True:
-            teams_result = (
-                supabase.table("teams")
-                .select("*")
-                .eq("provider_id", provider_id)
-                .range(offset, offset + page_size - 1)
-                .execute()
-            )
-
-            if not teams_result.data:
-                break
-
-            teams.extend(teams_result.data)
-
-            if len(teams_result.data) < page_size:
-                break
-
-            offset += page_size
-            console.print(f"  Fetched {len(teams)} teams so far...")
-
-        console.print(f"[cyan]Found {len(teams)} total teams (all teams mode)[/cyan]")
-        console.print("[dim]Each team will use its cached last_scraped_at for incremental updates[/dim]")
+        console.print("[cyan]Fetching ALL teams (including recently scraped) (RPC)...[/cyan]")
     elif limit_teams:
-        # User specified a team limit — fetch ALL teams sorted by priority:
-        #   1. Never scraped (NULL last_scraped_at) first
-        #   2. Then oldest last_scraped_at ascending
-        # This ensures the limit slices off the most-recently-scraped teams,
-        # giving priority to teams that need it most.
-        console.print(f"[cyan]Fetching ALL teams (sorted by scrape priority for limit={limit_teams})...[/cyan]")
-        teams = []
-        page_size = 1000
-        offset = 0
-
-        while True:
-            teams_result = (
-                supabase.table("teams")
-                .select("*")
-                .eq("provider_id", provider_id)
-                .range(offset, offset + page_size - 1)
-                .execute()
-            )
-
-            if not teams_result.data:
-                break
-
-            teams.extend(teams_result.data)
-
-            if len(teams_result.data) < page_size:
-                break
-
-            offset += page_size
-            console.print(f"  Fetched {len(teams)} teams so far...")
-
-        # Sort: NULL last_scraped_at first (never scraped), then oldest first
-        teams.sort(
-            key=lambda t: (
-                0 if t.get("last_scraped_at") is None else 1,
-                t.get("last_scraped_at") or "",
-            )
-        )
-
-        null_count = sum(1 for t in teams if t.get("last_scraped_at") is None)
-        console.print(f"[cyan]Found {len(teams)} total teams ({null_count} never scraped, sorted by priority)[/cyan]")
-        console.print(f"[dim]Will scrape up to {limit_teams} teams, prioritizing never-scraped and oldest[/dim]")
+        console.print(f"[cyan]Fetching top {limit_teams} teams by scrape priority (RPC)...[/cyan]")
     else:
-        # Steady-state incremental mode: scrape teams not scraped in last 7 days
-        teams = scraper._get_teams_to_scrape()
-        console.print("[cyan]Incremental mode: Scraping teams not updated in last 7 days[/cyan]")
+        console.print("[cyan]Incremental mode: Scraping teams not updated in last 7 days (RPC)...[/cyan]")
+
+    if shard_count > 1:
+        console.print(f"[dim]Shard {shard_index} of {shard_count} (hash-partitioned by team_id_master)[/dim]")
+
+    teams = (
+        call_rpc_with_fallback(
+            supabase,
+            "get_teams_to_scrape_limited",
+            rpc_params,
+            fallback=lambda: _legacy_paginated_team_fetch(
+                supabase, provider_id, limit_teams, null_teams_only, include_recent
+            ),
+            log_msg="PERF REGRESSION: Falling back to paginated team fetch: %s",
+        )
+        or []
+    )
+
+    console.print(f"[cyan]Found {len(teams)} teams[/cyan]")
+    if not null_teams_only:
         console.print("[dim]Each team will use its cached last_scraped_at for incremental updates[/dim]")
 
     # Filter out U8/U9 and U20+ teams (PitchRank supports U10-U19)
@@ -445,8 +374,7 @@ async def scrape_games(
         console.print(f"[cyan]Limiting to {limit_teams} teams[/cyan]")
 
     console.print(
-        f"[bold cyan]Scraping games for {len(teams)} teams "
-        f"(of {total_eligible} eligible after filtering)[/bold cyan]"
+        f"[bold cyan]Scraping games for {len(teams)} teams (of {total_eligible} eligible after filtering)[/bold cyan]"
     )
     console.print(f"[cyan]Concurrency: {concurrency} teams at once[/cyan]")
     if since_date:
@@ -456,11 +384,22 @@ async def scrape_games(
     else:
         console.print()
 
-    # OPTIMIZATION 1: Bulk fetch all scrape dates
-    console.print("[dim]Fetching scrape dates for all teams...[/dim]")
-    team_ids = [t.get("team_id_master") for t in teams if t.get("team_id_master")]
-    scrape_dates_cache = _bulk_fetch_scrape_dates(supabase, provider_id, team_ids)
-    console.print(f"[green]✓[/green] Loaded scrape dates for {len(scrape_dates_cache)} teams\n")
+    # The team fetch already returned `last_scraped_at` on every row, so the
+    # scrape-date cache is built in-memory — no extra round-trips.
+    scrape_dates_cache: Dict[str, Optional[datetime]] = {}
+    for t in teams:
+        tid = t.get("team_id_master")
+        if not tid:
+            continue
+        last_scraped = t.get("last_scraped_at")
+        if last_scraped:
+            try:
+                scrape_dates_cache[tid] = datetime.fromisoformat(last_scraped.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                scrape_dates_cache[tid] = None
+        else:
+            scrape_dates_cache[tid] = None
+    console.print(f"[green]✓[/green] Scrape-date cache built for {len(scrape_dates_cache)} teams\n")
 
     # Set up output file for incremental saving
     if not output_file:

--- a/src/etl/bulk_ops.py
+++ b/src/etl/bulk_ops.py
@@ -1,0 +1,119 @@
+"""Shared bulk-update helpers for Supabase RPC calls.
+
+Centralizes the chunked `bulk_update_last_scraped_at` RPC pattern used by
+`scripts/scrape_games.py` and `src/etl/enhanced_pipeline.py`. Callers supply an
+optional fallback for the "RPC function does not exist yet" case (SQLSTATE
+42883), which happens when the migration hasn't been applied.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from postgrest.exceptions import APIError
+
+logger = logging.getLogger(__name__)
+
+BULK_UPDATE_RPC = "bulk_update_last_scraped_at"
+BULK_UPDATE_CHUNK_SIZE = 2000
+BULK_UPDATE_MIN_CHUNK = 125
+PG_UNDEFINED_FUNCTION = "42883"
+# postgrest-py uses an int for the HTTP status on non-JSON bodies and a
+# string for PostgREST JSON error codes — accept both for 413.
+HTTP_PAYLOAD_TOO_LARGE_CODES = (413, "413")
+
+
+def call_rpc_with_fallback(
+    supabase,
+    fn_name: str,
+    params: Dict[str, Any],
+    *,
+    fallback: Callable[[], Any],
+    log_msg: str = "PERF REGRESSION: RPC missing: %s",
+) -> Any:
+    """Call a Supabase RPC, fall back to a Python path if the function is missing.
+
+    Triggers `fallback()` only for SQLSTATE 42883 ("function does not exist"),
+    which is the expected signal during rolling deploys where the Python code
+    is live but the migration has not yet applied. Any other APIError re-raises.
+
+    Returns `res.data` from the RPC on success, or `fallback()`'s return on 42883.
+    `log_msg` must contain a single `%s` placeholder for the error.
+    """
+    try:
+        res = supabase.rpc(fn_name, params).execute()
+        return res.data
+    except APIError as err:
+        if getattr(err, "code", None) == PG_UNDEFINED_FUNCTION:
+            logger.error(log_msg, err)
+            return fallback()
+        raise
+
+
+def bulk_update_last_scraped_at(
+    supabase,
+    updates: List[Dict[str, Any]],
+    *,
+    chunk_size: int = BULK_UPDATE_CHUNK_SIZE,
+    on_missing_function: Optional[Callable[[], int]] = None,
+    missing_function_log: str = "PERF REGRESSION: bulk_update_last_scraped_at RPC missing: %s",
+) -> int:
+    """Call `bulk_update_last_scraped_at` in chunks, halving on HTTP 413.
+
+    Returns total rows actually updated (may be < len(updates) if some
+    team_id_master values have no matching teams row — logged as a warning).
+
+    If the RPC is missing (SQLSTATE 42883) and `on_missing_function` is
+    provided, it is invoked and its return value is returned as the count.
+    Without a fallback, 42883 re-raises.
+    """
+    if not updates:
+        return 0
+
+    total_updated = 0
+    i = 0
+    size = chunk_size
+    while i < len(updates):
+        chunk = updates[i : i + size]
+        try:
+            res = supabase.rpc(BULK_UPDATE_RPC, {"updates": chunk}).execute()
+            returned = res.data if isinstance(res.data, int) else len(chunk)
+            total_updated += returned
+            if returned < len(chunk):
+                logger.warning(
+                    "bulk_update_last_scraped_at: %d of %d rows updated",
+                    returned,
+                    len(chunk),
+                )
+            i += len(chunk)
+            size = chunk_size
+        except APIError as err:
+            code = getattr(err, "code", None)
+            msg = str(err)
+            if code == PG_UNDEFINED_FUNCTION:
+                if on_missing_function is not None:
+                    logger.error(missing_function_log, err)
+                    return on_missing_function()
+                raise
+            if (code in HTTP_PAYLOAD_TOO_LARGE_CODES or "413" in msg) and size > BULK_UPDATE_MIN_CHUNK:
+                new_size = max(size // 2, BULK_UPDATE_MIN_CHUNK)
+                logger.warning(
+                    "bulk_update_last_scraped_at: 413 on chunk size %d, halving to %d",
+                    size,
+                    new_size,
+                )
+                size = new_size
+                continue
+            logger.warning(
+                "Error bulk updating last_scraped_at (chunk %d-%d): %s",
+                i,
+                i + len(chunk),
+                err,
+            )
+            # Advance by the chunk we actually attempted, not the pre-shrink
+            # `size`, so a non-413 error mid-halving doesn't skip rows.
+            i += len(chunk)
+            size = chunk_size
+
+    return total_updated

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -1,6 +1,7 @@
 """Enhanced ETL Pipeline with metrics tracking and bulk operations"""
 
 import logging
+import os
 import random
 import sys
 import time
@@ -15,6 +16,7 @@ if _project_root not in sys.path:
     sys.path.append(_project_root)
 
 from config.settings import BUILD_ID, MATCHING_CONFIG, SUPABASE_KEY, SUPABASE_URL  # noqa: E402
+from src.etl.bulk_ops import bulk_update_last_scraped_at, call_rpc_with_fallback  # noqa: E402
 from src.models.game_matcher import GameHistoryMatcher  # noqa: E402
 from src.utils.enhanced_validators import EnhancedDataValidator, parse_game_date  # noqa: E402
 from supabase import Client, create_client  # noqa: E402
@@ -156,32 +158,27 @@ class EnhancedETLPipeline:
                 f"Check credentials and network before retrying."
             ) from e
 
-        # Preload alias map cache (paginated to load ALL approved aliases)
+        # Preload alias map cache via RPC (one round-trip) with paginated fallback.
         self.alias_cache = {}
         try:
-            all_alias_data = []
-            page_size = 1000
-            offset = 0
-            while True:
-                alias_result = (
-                    self.supabase.table("team_alias_map")
-                    .select("provider_team_id, team_id_master, match_method, review_status")
-                    .eq("provider_id", self.provider_id)
-                    .eq("review_status", "approved")
-                    .range(offset, offset + page_size - 1)
-                    .execute()
+            # Stagger concurrent matrix shards so 5 parallel workflow shards don't
+            # hammer PostgREST with simultaneous ~13 MB alias-map responses.
+            shard_idx = int(os.getenv("SCRAPE_SHARD_INDEX", "0"))
+            if shard_idx > 0:
+                time.sleep(shard_idx * 2)
+
+            all_alias_data = (
+                call_rpc_with_fallback(
+                    self.supabase,
+                    "get_approved_aliases",
+                    {"p_provider_id": self.provider_id},
+                    fallback=self._paginated_alias_preload,
+                    log_msg="PERF REGRESSION: Falling back to paginated alias preload: %s",
                 )
-
-                if not alias_result.data:
-                    break
-                all_alias_data.extend(alias_result.data)
-                if len(alias_result.data) < page_size:
-                    break
-                offset += page_size
-
-            logger.info(
-                f"Fetched {len(all_alias_data)} approved aliases from database ({offset // page_size + 1} pages)"
+                or []
             )
+
+            logger.info(f"Fetched {len(all_alias_data)} approved aliases from database")
 
             for alias in all_alias_data:
                 raw_team_id = str(alias["provider_team_id"])
@@ -2210,26 +2207,19 @@ class EnhancedETLPipeline:
                 logger.debug("No valid scraped_at timestamps found in imported games")
                 return
 
-            # Update teams.last_scraped_at in batches
-            batch_size = 100
-            updated_count = 0
+            payload = [
+                {"team_id_master": team_id, "last_scraped_at": scraped_at.isoformat()}
+                for team_id, scraped_at in team_scrape_dates.items()
+            ]
 
-            team_ids = list(team_scrape_dates.keys())
-            for i in range(0, len(team_ids), batch_size):
-                batch_ids = team_ids[i : i + batch_size]
-
-                for team_id in batch_ids:
-                    scraped_at = team_scrape_dates[team_id]
-                    scraped_at_iso = scraped_at.isoformat()
-
-                    try:
-                        # Update last_scraped_at for this team
-                        self.supabase.table("teams").update({"last_scraped_at": scraped_at_iso}).eq(
-                            "team_id_master", team_id
-                        ).eq("provider_id", self.provider_id).execute()
-                        updated_count += 1
-                    except Exception as e:
-                        logger.warning(f"Error updating last_scraped_at for team {team_id}: {e}")
+            updated_count = bulk_update_last_scraped_at(
+                self.supabase,
+                payload,
+                on_missing_function=lambda: self._legacy_update_team_scrape_dates_per_team(team_scrape_dates),
+                missing_function_log=(
+                    "PERF REGRESSION: Falling back to per-team UPDATE in _update_team_scrape_dates: %s"
+                ),
+            )
 
             if updated_count > 0:
                 logger.info(f"Updated last_scraped_at for {updated_count} teams based on imported games")
@@ -2237,6 +2227,60 @@ class EnhancedETLPipeline:
         except Exception as e:
             logger.warning(f"Error updating team scrape dates: {e}")
             # Don't fail the import if this step fails
+
+    def _paginated_alias_preload(self) -> List[Dict[str, Any]]:
+        """Paginated team_alias_map fallback for `get_approved_aliases` RPC.
+
+        Triggered only on SQLSTATE 42883 during rolling deploys. Returns rows
+        with the same shape the RPC produces, so the downstream cache-population
+        loop is branch-agnostic.
+        """
+        rows: List[Dict[str, Any]] = []
+        page_size = 1000
+        offset = 0
+        while True:
+            fallback_result = (
+                self.supabase.table("team_alias_map")
+                .select("provider_team_id, team_id_master, match_method, review_status")
+                .eq("provider_id", self.provider_id)
+                .eq("review_status", "approved")
+                .range(offset, offset + page_size - 1)
+                .execute()
+            )
+            if not fallback_result.data:
+                break
+            rows.extend(fallback_result.data)
+            if len(fallback_result.data) < page_size:
+                break
+            offset += page_size
+        return rows
+
+    def _legacy_update_team_scrape_dates_per_team(self, team_scrape_dates: Dict[str, datetime]) -> int:
+        """Paginated per-team UPDATE fallback for _update_team_scrape_dates.
+
+        Preserves the pre-RPC behavior verbatim. Invoked when
+        `bulk_update_last_scraped_at` returns SQLSTATE 42883.
+        """
+        batch_size = 100
+        updated_count = 0
+
+        team_ids = list(team_scrape_dates.keys())
+        for i in range(0, len(team_ids), batch_size):
+            batch_ids = team_ids[i : i + batch_size]
+
+            for team_id in batch_ids:
+                scraped_at = team_scrape_dates[team_id]
+                scraped_at_iso = scraped_at.isoformat()
+
+                try:
+                    self.supabase.table("teams").update({"last_scraped_at": scraped_at_iso}).eq(
+                        "team_id_master", team_id
+                    ).eq("provider_id", self.provider_id).execute()
+                    updated_count += 1
+                except Exception as e:
+                    logger.warning(f"Error updating last_scraped_at for team {team_id}: {e}")
+
+        return updated_count
 
     async def _process_team_matching_stats(self):
         """Process team matching statistics from alias map"""

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -85,14 +85,17 @@ class GotSportScraper(BaseScraper):
             verify_ssl = certifi.where()
             logger.debug(f"Using certifi certificates: {verify_ssl}")
 
-        # Configure HTTPAdapter with larger connection pool and SSL improvements
+        # Configure HTTPAdapter with larger connection pool and SSL improvements.
+        # 429 is in status_forcelist so urllib3 transparently retries rate-limit
+        # responses. backoff_factor=1.0 → waits of 1s, 2s, 4s between the 3 tries.
         adapter = HTTPAdapter(
             pool_connections=100,  # number of connection pools
             pool_maxsize=100,  # total concurrent connections
             max_retries=Retry(
                 total=3,
-                backoff_factor=0.3,
-                status_forcelist=[500, 502, 503, 504],  # Retry on server errors
+                backoff_factor=1.0,
+                status_forcelist=[429, 500, 502, 503, 504],  # Retry on rate limit + server errors
+                respect_retry_after_header=True,  # Honor Retry-After from GotSport
                 # Retry on SSL errors (will be caught and retried)
                 allowed_methods=["GET", "HEAD"],
             ),
@@ -180,6 +183,19 @@ class GotSportScraper(BaseScraper):
                 else:
                     response = self.session.get(api_url, params=params, timeout=self.timeout)
 
+                # Surface transparent urllib3 retries. response.raw.retries may be
+                # None on responses that never triggered the retry machinery.
+                retries_obj = getattr(response.raw, "retries", None)
+                history = getattr(retries_obj, "history", ()) or ()
+                n429 = sum(1 for h in history if getattr(h, "status", None) == 429)
+                if n429:
+                    logger.warning(
+                        "gotsport 429 retries: team=%s count=%d url=%s",
+                        normalized_team_id,
+                        n429,
+                        api_url,
+                    )
+
                 response.raise_for_status()
                 data = response.json()
 
@@ -214,7 +230,7 @@ class GotSportScraper(BaseScraper):
                                 if since_date_obj is not None and game_date < since_date_obj:
                                     logger.debug(
                                         f"Reached date cutoff at {game_date}, "
-                        f"stopping parse for team {normalized_team_id}"
+                                        f"stopping parse for team {normalized_team_id}"
                                     )
                                     break
                             except (ValueError, TypeError):
@@ -279,6 +295,24 @@ class GotSportScraper(BaseScraper):
                     else:
                         logger.error(f"SSL error failed after {self.max_retries} attempts: {e}")
                         raise
+
+            except requests.exceptions.RetryError as e:
+                # urllib3 exhausted its per-call retry budget (total=3) on 429
+                # or 5xx. Emit the verification-grep marker here, then fall
+                # through to the outer retry loop to preserve the pre-change
+                # behavior (where the generic RequestException handler did the
+                # same thing). Must precede the RequestException handler below
+                # because RetryError is a RequestException subclass.
+                logger.error(
+                    "gotsport 429 retry-exhausted: team=%s url=%s err=%s",
+                    normalized_team_id,
+                    api_url,
+                    e,
+                )
+                if attempt < self.max_retries - 1:
+                    time.sleep(self.retry_delay)
+                    continue
+                raise
 
             except requests.exceptions.RequestException as e:
                 if attempt < self.max_retries - 1:

--- a/supabase/migrations/20260422000000_add_bulk_update_last_scraped_at.sql
+++ b/supabase/migrations/20260422000000_add_bulk_update_last_scraped_at.sql
@@ -1,0 +1,50 @@
+-- Bulk update teams.last_scraped_at from a JSONB payload.
+--
+-- Replaces per-row UPDATE loops in scripts/scrape_games.py::_bulk_log_team_scrapes
+-- and src/etl/enhanced_pipeline.py::_update_team_scrape_dates. A single RPC call
+-- with ~2,000 rows replaces ~2,000 sequential REST round-trips.
+--
+-- Payload shape: [{"team_id_master": "<uuid>", "last_scraped_at": "<iso8601>"}, ...]
+--
+-- Behavioral contract:
+--   * Empty or null `updates` returns 0 immediately.
+--   * Duplicate team_id_master keys in payload: last value wins (UPDATE...FROM picks
+--     one arbitrarily). Acceptable — callers produce unique keys by construction.
+--   * team_id_master values with no matching row in `teams`: silently skipped.
+--     Returned rowcount reflects ACTUAL updates, not input length. Callers must
+--     treat `rowcount < len(payload)` as a warning, not an error.
+--   * Malformed timestamp strings: cast error raised loudly. Do not mask.
+--
+-- service_role-only RPC; no GRANT needed. Additive — does not modify existing
+-- objects.
+
+create or replace function public.bulk_update_last_scraped_at(updates jsonb)
+returns int
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  affected int;
+begin
+  if updates is null or jsonb_array_length(updates) = 0 then
+    return 0;
+  end if;
+
+  update public.teams t
+     set last_scraped_at = u.last_scraped_at
+    from jsonb_to_recordset(updates) as u(
+      team_id_master uuid,
+      last_scraped_at timestamptz
+    )
+   where t.team_id_master = u.team_id_master;
+
+  get diagnostics affected = row_count;
+  return affected;
+end;
+$$;
+
+comment on function public.bulk_update_last_scraped_at(jsonb) is
+'Bulk update teams.last_scraped_at from a JSONB array of {team_id_master, last_scraped_at}.
+Returns the number of rows actually updated (may be less than input length if a
+team_id_master has no matching row).';

--- a/supabase/migrations/20260422000001_add_get_approved_aliases.sql
+++ b/supabase/migrations/20260422000001_add_get_approved_aliases.sql
@@ -1,0 +1,44 @@
+-- Return all approved aliases for a provider in a single RPC call.
+--
+-- Replaces the paginated .range() loop in
+-- src/etl/enhanced_pipeline.py::EnhancedETLPipeline._ensure_initialized, which
+-- currently issues ~84 paginated GETs at 1000 rows each per pipeline init for
+-- the GotSport provider.
+--
+-- service_role-only RPC; no GRANT needed. Additive — does not modify existing
+-- alias tables or functions.
+
+create or replace function public.get_approved_aliases(p_provider_id uuid)
+returns table (
+  provider_team_id text,
+  team_id_master   uuid,
+  match_method     text,
+  review_status    text
+)
+language sql
+stable
+security invoker
+set search_path = public, pg_temp
+as $$
+  -- review_status is surfaced as a constant column so callers that cache it
+  -- see the same row shape whether they hit the RPC or the legacy paginated
+  -- .range() fallback (which projects review_status from the table).
+  select
+    m.provider_team_id,
+    m.team_id_master,
+    m.match_method,
+    'approved'::text as review_status
+  from public.team_alias_map m
+  where m.provider_id = p_provider_id
+    and m.review_status = 'approved';
+$$;
+
+comment on function public.get_approved_aliases(uuid) is
+'Return all approved (provider_team_id, team_id_master, match_method) rows for
+the given provider in one call. Replaces paginated alias preload.';
+
+-- Covering partial index — serves the RPC in a single index-only scan.
+create index if not exists team_alias_map_provider_approved_idx
+  on public.team_alias_map (provider_id)
+  include (provider_team_id, team_id_master, match_method)
+  where review_status = 'approved';

--- a/supabase/migrations/20260422000002_add_get_teams_to_scrape_limited.sql
+++ b/supabase/migrations/20260422000002_add_get_teams_to_scrape_limited.sql
@@ -1,0 +1,75 @@
+-- Ordered, filtered, shard-aware team fetch for scrape-games.
+--
+-- Replaces the 130K-team paginated fetch + Python-side sort in
+-- scripts/scrape_games.py:297-396. Pushes filtering (age_group, birth_year,
+-- placeholder unknown) and priority ordering (NULLS FIRST, then oldest) into
+-- Postgres, and adds deterministic hash sharding for parallel workflow shards.
+--
+-- THIS MIGRATION IS PURELY ADDITIVE. The existing
+-- `get_teams_to_scrape(p_provider_id)` function used by src/scrapers/base.py
+-- is NOT modified or dropped.
+--
+-- Note: hashtext() is deterministic within a Postgres major version. If the PG
+-- major version changes, shards reshuffle — acceptable, one-time rescrape of
+-- some teams.
+--
+-- service_role-only RPC; no GRANT needed.
+
+create or replace function public.get_teams_to_scrape_limited(
+  p_provider_id    uuid,
+  p_limit          int     default null,   -- null = no limit
+  p_shard_index    int     default 0,      -- 0-based
+  p_shard_count    int     default 1,      -- 1 = no sharding (hash filter is a no-op)
+  p_include_recent boolean default false,  -- bypass 7-day staleness filter
+  p_null_only      boolean default false   -- only last_scraped_at IS NULL
+)
+returns setof public.teams
+language sql
+stable
+security invoker
+set search_path = public, pg_temp
+as $$
+  with current_year as (
+    select extract(year from now())::int as yr
+  )
+  select t.*
+  from public.teams t, current_year c
+  where t.provider_id = p_provider_id
+
+    -- Hash sharding: mutation-safe, independent of last_scraped_at.
+    and (p_shard_count <= 1 or (hashtext(t.team_id_master::text) % p_shard_count) = p_shard_index)
+
+    -- Staleness / null / include-recent gating.
+    and (p_include_recent
+         or t.last_scraped_at is null
+         or t.last_scraped_at < now() - interval '7 days')
+    and (not p_null_only or t.last_scraped_at is null)
+
+    -- Age-group filter (PitchRank supports U10–U19 only).
+    and (t.age_group is null
+         or upper(trim(t.age_group)) not in ('U8','U-8','U9','U-9'))
+
+    -- Birth-year exclusion — dynamic per current year.
+    -- Mirrors the Python post-filter in scripts/scrape_games.py:
+    --   young end: U7 (yr-7), U8 (yr-8), U9 (yr-9)
+    --   old end:   U20 (yr-20), U21 (yr-21)
+    -- Five values — must match the Python list exactly.
+    and (t.birth_year is null
+         or t.birth_year not in (c.yr - 21, c.yr - 20, c.yr - 9, c.yr - 8, c.yr - 7))
+
+    -- Placeholder unknown filter.
+    and not (t.team_name = 'unknown_' || t.provider_team_id)
+
+  order by t.last_scraped_at asc nulls first
+  limit coalesce(p_limit, 2147483647);
+$$;
+
+comment on function public.get_teams_to_scrape_limited(uuid, int, int, int, boolean, boolean) is
+'Ordered, filtered, shard-aware team fetch for scrape-games. Priority: NULL
+last_scraped_at first, then oldest. Hash shards by team_id_master for
+mutation-safe parallel workflow shards.';
+
+-- Composite index: provider_id + priority order (NULLS FIRST).
+-- Serves the primary WHERE + ORDER BY path for the RPC.
+create index if not exists teams_provider_scrape_priority_idx
+  on public.teams (provider_id, last_scraped_at asc nulls first);

--- a/tests/unit/test_bulk_ops.py
+++ b/tests/unit/test_bulk_ops.py
@@ -1,0 +1,198 @@
+"""Unit tests for `src.etl.bulk_ops`."""
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+from postgrest.exceptions import APIError
+
+from src.etl.bulk_ops import (
+    BULK_UPDATE_CHUNK_SIZE,
+    BULK_UPDATE_MIN_CHUNK,
+    bulk_update_last_scraped_at,
+    call_rpc_with_fallback,
+)
+
+
+def _api_error(*, code=None, message="boom") -> APIError:
+    """Construct an APIError the same way postgrest-py does internally."""
+    return APIError({"code": code, "message": message, "hint": None, "details": None})
+
+
+class StubRpc:
+    def __init__(self, supabase, fn_name, params):
+        self.supabase = supabase
+        self.fn_name = fn_name
+        self.params = params
+
+    def execute(self):
+        self.supabase.calls.append((self.fn_name, self.params))
+        reaction = self.supabase._next_reaction()
+        if callable(reaction):
+            return reaction(self.params)
+        return reaction
+
+
+class StubSupabase:
+    """Scriptable stub for `supabase.rpc(fn, params).execute()`."""
+
+    def __init__(self, reactions: Optional[List[Any]] = None):
+        self.calls: List[tuple] = []
+        # Each reaction is either:
+        #   * a SimpleNamespace/dict returned from execute()
+        #   * an Exception instance (raised when consumed)
+        #   * a callable(params) -> SimpleNamespace
+        self._reactions: List[Any] = list(reactions or [])
+
+    def _next_reaction(self):
+        if not self._reactions:
+            return SimpleNamespace(data=None)
+        reaction = self._reactions.pop(0)
+        if isinstance(reaction, Exception):
+            raise reaction
+        return reaction
+
+    def rpc(self, fn_name: str, params: Dict[str, Any]):
+        return StubRpc(self, fn_name, params)
+
+
+# ---------- bulk_update_last_scraped_at ----------
+
+
+def test_empty_payload_short_circuits_without_calling_supabase():
+    sb = StubSupabase()
+    assert bulk_update_last_scraped_at(sb, []) == 0
+    assert sb.calls == []
+
+
+def test_single_chunk_happy_path_returns_rpc_rowcount():
+    sb = StubSupabase([SimpleNamespace(data=10)])
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(10)]
+    assert bulk_update_last_scraped_at(sb, payload) == 10
+    assert len(sb.calls) == 1
+    assert sb.calls[0][0] == "bulk_update_last_scraped_at"
+    assert len(sb.calls[0][1]["updates"]) == 10
+
+
+def test_multiple_chunks_sum_returned_counts():
+    # chunk_size=10 → 2 calls of 10 and 5
+    sb = StubSupabase([SimpleNamespace(data=10), SimpleNamespace(data=5)])
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(15)]
+    total = bulk_update_last_scraped_at(sb, payload, chunk_size=10)
+    assert total == 15
+    assert [len(call[1]["updates"]) for call in sb.calls] == [10, 5]
+
+
+def test_partial_rowcount_warns_but_still_accumulates(caplog):
+    sb = StubSupabase([SimpleNamespace(data=8)])  # RPC says 8 of 10 rows matched
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(10)]
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="src.etl.bulk_ops")
+    assert bulk_update_last_scraped_at(sb, payload) == 8
+    assert any("8 of 10 rows updated" in rec.message for rec in caplog.records)
+
+
+def test_42883_without_fallback_reraises():
+    sb = StubSupabase([_api_error(code="42883")])
+    payload = [{"team_id_master": "t0", "last_scraped_at": "2026-04-22T00:00:00"}]
+    with pytest.raises(APIError) as excinfo:
+        bulk_update_last_scraped_at(sb, payload)
+    assert getattr(excinfo.value, "code", None) == "42883"
+
+
+def test_42883_with_fallback_invokes_fallback_and_returns_its_count():
+    sb = StubSupabase([_api_error(code="42883")])
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(3)]
+    fallback_invocations = []
+
+    def fallback():
+        fallback_invocations.append(True)
+        return 42
+
+    total = bulk_update_last_scraped_at(sb, payload, on_missing_function=fallback)
+    assert total == 42
+    assert len(fallback_invocations) == 1
+    # Only one RPC attempt — the helper gives up immediately on 42883 because
+    # all subsequent chunks would also fail.
+    assert len(sb.calls) == 1
+
+
+def test_413_halves_chunk_and_retries():
+    # First call (size=200) raises 413. `max(200 // 2, 125) = 125`, so the
+    # retry chunk is 125, then size resets to chunk_size=200 on success, so
+    # the remaining 75 rows ship as one final chunk.
+    sb = StubSupabase(
+        [
+            _api_error(code=413, message="payload too large 413"),
+            SimpleNamespace(data=125),
+            SimpleNamespace(data=75),
+        ]
+    )
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(200)]
+    total = bulk_update_last_scraped_at(sb, payload, chunk_size=200)
+    assert total == 200
+    assert [len(c[1]["updates"]) for c in sb.calls] == [200, 125, 75]
+
+
+def test_413_halving_floors_at_min_chunk():
+    assert BULK_UPDATE_MIN_CHUNK == 125
+    # A non-halvable 413 on a sub-floor chunk must not loop forever.
+    # Size starts at 125, a 413 at that size bypasses halving (size > floor check).
+    sb = StubSupabase([_api_error(code=413, message="413 still too big")])
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(125)]
+    # Even with a 413, the helper advances past the chunk (it does not infinite-loop)
+    # because size > BULK_UPDATE_MIN_CHUNK is False at floor.
+    total = bulk_update_last_scraped_at(sb, payload, chunk_size=125)
+    # The chunk is skipped with a warning; returned count is 0.
+    assert total == 0
+    assert len(sb.calls) == 1
+
+
+def test_non_413_api_error_skips_chunk_and_continues():
+    sb = StubSupabase(
+        [
+            _api_error(code="23505", message="unique violation"),  # chunk 1 fails
+            SimpleNamespace(data=5),  # chunk 2 succeeds
+        ]
+    )
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(10)]
+    total = bulk_update_last_scraped_at(sb, payload, chunk_size=5)
+    assert total == 5
+    assert len(sb.calls) == 2
+
+
+def test_non_int_response_data_falls_back_to_chunk_length():
+    # PostgREST REST may return `null` or a list for some shapes; the helper
+    # treats non-int responses as "count == chunk length".
+    sb = StubSupabase([SimpleNamespace(data=None)])
+    payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(4)]
+    assert bulk_update_last_scraped_at(sb, payload) == 4
+
+
+# ---------- call_rpc_with_fallback ----------
+
+
+def test_call_rpc_with_fallback_happy_path_returns_data():
+    sb = StubSupabase([SimpleNamespace(data=[{"id": 1}, {"id": 2}])])
+    result = call_rpc_with_fallback(
+        sb, "get_foo", {"p_id": 1}, fallback=lambda: pytest.fail("fallback should not fire")
+    )
+    assert result == [{"id": 1}, {"id": 2}]
+
+
+def test_call_rpc_with_fallback_on_42883_invokes_fallback():
+    sb = StubSupabase([_api_error(code="42883")])
+    result = call_rpc_with_fallback(sb, "get_foo", {}, fallback=lambda: [{"fallback": True}])
+    assert result == [{"fallback": True}]
+
+
+def test_call_rpc_with_fallback_reraises_non_42883():
+    sb = StubSupabase([_api_error(code="42P01", message="relation does not exist")])
+    with pytest.raises(APIError):
+        call_rpc_with_fallback(sb, "get_foo", {}, fallback=lambda: pytest.fail("should not fire"))
+
+
+def test_bulk_update_chunk_size_constant_is_2000():
+    # Guards against accidental renames / tuning of the performance contract.
+    assert BULK_UPDATE_CHUNK_SIZE == 2000

--- a/tests/unit/test_scrape_games.py
+++ b/tests/unit/test_scrape_games.py
@@ -39,13 +39,30 @@ class FakeQuery:
         return SimpleNamespace(data=[])
 
 
+class FakeRpc:
+    def __init__(self, supabase, fn_name, params):
+        self.supabase = supabase
+        self.fn_name = fn_name
+        self.params = params
+
+    def execute(self):
+        self.supabase.rpc_calls.append((self.fn_name, self.params))
+        updates = self.params.get("updates") if isinstance(self.params, dict) else None
+        count = len(updates) if updates else 0
+        return SimpleNamespace(data=count)
+
+
 class FakeSupabase:
     def __init__(self):
         self.insert_calls = []
         self.update_calls = []
+        self.rpc_calls = []
 
     def table(self, table_name):
         return FakeQuery(self, table_name)
+
+    def rpc(self, fn_name, params):
+        return FakeRpc(self, fn_name, params)
 
 
 class FakeProgress:
@@ -99,11 +116,14 @@ def test_bulk_log_team_scrapes_records_error_status_and_selective_updates():
     assert table_name == "team_scrape_log"
     assert [row["status"] for row in inserted_rows] == ["success", "error"]
 
-    assert len(supabase.update_calls) == 1
-    update_table, payload, filters = supabase.update_calls[0]
-    assert update_table == "teams"
-    assert payload.keys() == {"last_scraped_at"}
-    assert filters == [("team_id_master", "team-1")]
+    # last_scraped_at is now updated via bulk RPC; only teams with
+    # update_last_scraped_at=True should appear in the payload.
+    assert supabase.update_calls == []
+    assert len(supabase.rpc_calls) == 1
+    fn_name, params = supabase.rpc_calls[0]
+    assert fn_name == "bulk_update_last_scraped_at"
+    assert [u["team_id_master"] for u in params["updates"]] == ["team-1"]
+    assert set(params["updates"][0].keys()) == {"team_id_master", "last_scraped_at"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Scrape-games workflow was brushing the 6h GHA ceiling on 25K-team scheduled runs and dragging through ~2h on 5K manual runs. This PR targets the four serializable bottlenecks diagnostics identified.

- **Three additive Supabase migrations:**
  - \`bulk_update_last_scraped_at(updates jsonb)\` replaces per-row UPDATE loops (one in \`scrape_games.py\`, one in \`enhanced_pipeline.py\`) with a single JSONB-array RPC. Chunked at 2,000 rows with adaptive 413 halving.
  - \`get_approved_aliases(p_provider_id uuid)\` replaces the 84-page paginated alias preload with one RPC call. Includes a covering partial index.
  - \`get_teams_to_scrape_limited(...)\` replaces the 130K-team fetch and Python-side priority sort with a single SQL call. Adds hash-sharding by \`team_id_master\` for deterministic disjoint shards, plus a composite priority index.
- **Workflow restructured** into a two-stage job graph: one \`prepare\` job (alias maintenance + shard gate) followed by a 5-shard \`scrape-and-import\` matrix. Workflow-level \`concurrency\` still serializes the two Monday crons. Shell injection via \`\${{ inputs.* }}\` in arithmetic expansion fixed by hoisting inputs to step-level \`env:\`.
- **GotSport 429 retries:** added \`429\` to \`status_forcelist\`, raised \`backoff_factor\` to \`1.0\`, set \`respect_retry_after_header=True\`, and surfaced retry counts + exhaustion markers for log-based verification.
- **Shared \`src/etl/bulk_ops.py\` helper** consolidates the RPC-with-fallback pattern behind \`bulk_update_last_scraped_at()\` and \`call_rpc_with_fallback()\` with typed constants for HTTP / SQLSTATE codes.

All RPCs ship with SQLSTATE-42883 fallback paths, so rolling deploys (Python live, migration not yet applied) stay green and log \`PERF REGRESSION:\` markers.

## Targets

- 5K manual run under 1h (was ~2h)
- 25K scheduled run under 2.5h (was 4-5h)

## Flow

\`\`\`mermaid
flowchart LR
  Trigger[schedule or workflow_dispatch] --> Prepare
  Prepare[prepare: gate + alias maintenance]
  Prepare -- should_shard=true --> S0[shard 0]
  Prepare -- should_shard=true --> S1[shard 1]
  Prepare -- should_shard=true --> S2[shard 2]
  Prepare -- should_shard=true --> S3[shard 3]
  Prepare -- should_shard=true --> S4[shard 4]
  Prepare -- should_shard=false --> S0only[shard 0 only]
\`\`\`

## Test plan

- [ ] \`supabase db push\` applies all three migrations; verify signatures via \`psql \df\`
- [ ] \`EXPLAIN ANALYZE\` on \`get_teams_to_scrape_limited\` uses \`teams_provider_scrape_priority_idx\` and completes in < 1s
- [ ] 5-shard disjointness: sum of 5 shards equals unsharded total, no duplicates
- [ ] Manual 5K run: 5 shards complete, wall time under 1h, \`grep PERF REGRESSION logs/*.log\` is empty
- [ ] Manual 25K run: shards within ~20% of each other, total under 2.5h
- [ ] Cron serialization: Mon 06:00 UTC run \`completedAt\` precedes Mon 11:15 UTC run \`startedAt\`
- [ ] \`grep 'gotsport 429 retry-exhausted' logs/*.log\` returns 0
- [ ] Temporarily rename one new RPC; verify fallback path fires one \`PERF REGRESSION:\` line and run completes
- [ ] Rename back; subsequent runs show no \`PERF REGRESSION:\` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)