### PR TITLE
fix(scrape): use dynamic matrix so prod workflow parses; add run-name

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -1,4 +1,13 @@
 name: Scrape Games
+# Run title shown in the Actions list. Cleaner than the default (latest commit subject).
+run-name: >-
+  Scrape Games · ${{
+    github.event_name == 'schedule' && '25000 (scheduled)' ||
+    (inputs.limit_teams != '' && format('{0} teams', inputs.limit_teams)) ||
+    (inputs.null_teams_only == true && 'NULL bootstrap') ||
+    (inputs.include_recent == true && 'include recent') ||
+    'incremental'
+  }}
 
 on:
   schedule:
@@ -64,6 +73,13 @@ jobs:
     outputs:
       should_shard: ${{ steps.gate.outputs.should_shard }}
       shard_count:  ${{ steps.gate.outputs.shard_count }}
+      # JSON array of shard indices to actually run. [0] for small runs, [0..4]
+      # when sharding. The scrape-and-import matrix consumes this via fromJSON(),
+      # so only the shards we want get matrix-instantiated. This replaces an
+      # earlier job-level `if: matrix.shard == 0 || ...` gate, which GitHub
+      # rejected at parse time because `matrix` context isn't available at the
+      # job level.
+      shards:       ${{ steps.gate.outputs.shards }}
     steps:
       - uses: actions/checkout@v5
 
@@ -89,16 +105,19 @@ jobs:
           LIMIT_TEAMS: ${{ inputs.limit_teams }}
         run: |
           if [ "$EVENT_NAME" = "schedule" ]; then
-            echo "should_shard=true" >> "$GITHUB_OUTPUT"
-            echo "shard_count=5"      >> "$GITHUB_OUTPUT"
+            echo "should_shard=true"        >> "$GITHUB_OUTPUT"
+            echo "shard_count=5"            >> "$GITHUB_OUTPUT"
+            echo "shards=[0,1,2,3,4]"       >> "$GITHUB_OUTPUT"
           elif [[ "$LIMIT_TEAMS" =~ ^[0-9]+$ ]] && [ "$LIMIT_TEAMS" -ge 5000 ]; then
-            echo "should_shard=true" >> "$GITHUB_OUTPUT"
-            echo "shard_count=5"      >> "$GITHUB_OUTPUT"
+            echo "should_shard=true"        >> "$GITHUB_OUTPUT"
+            echo "shard_count=5"            >> "$GITHUB_OUTPUT"
+            echo "shards=[0,1,2,3,4]"       >> "$GITHUB_OUTPUT"
           else
             # Small or no-arg manual run: only shard 0 executes. The RPC's hash
             # filter collapses to a no-op when p_shard_count <= 1.
-            echo "should_shard=false" >> "$GITHUB_OUTPUT"
-            echo "shard_count=1"      >> "$GITHUB_OUTPUT"
+            echo "should_shard=false"       >> "$GITHUB_OUTPUT"
+            echo "shard_count=1"            >> "$GITHUB_OUTPUT"
+            echo "shards=[0]"               >> "$GITHUB_OUTPUT"
           fi
 
       - name: Maintain GotSport direct ID aliases
@@ -126,10 +145,13 @@ jobs:
     timeout-minutes: 120  # Reduced from 360. Each shard does ~1/5 the work.
     strategy:
       fail-fast: false
+      # Dynamic matrix: the prepare job emits `shards` as a JSON array. Small
+      # runs get [0] (single-shard, hash filter no-op); scheduled / >=5000-team
+      # manual runs get [0,1,2,3,4]. The earlier approach (fixed [0..4] matrix
+      # + job-level `if: matrix.shard == 0 || ...`) is invalid GHA syntax:
+      # `matrix` context is not available at job-level `if:`.
       matrix:
-        shard: [0, 1, 2, 3, 4]
-    # Shard 0 always runs (covers the small-run case). Shards 1-4 only when sharding.
-    if: ${{ matrix.shard == 0 || needs.prepare.outputs.should_shard == 'true' }}
+        shard: ${{ fromJSON(needs.prepare.outputs.shards) }}
     # Job-level env: consistent for all steps. DO NOT put SCRAPE_SHARD_COUNT on
     # any step-level env block — step-level env overrides job-level env, which
     # would silently freeze SCRAPE_SHARD_COUNT to a stale literal.


### PR DESCRIPTION
## Summary

Hotfix for PR #651. The original workflow used a job-level \`if: matrix.shard == 0 || ...\` gate, which GitHub rejects at parse time:

> \`Unrecognized named-value: 'matrix'. Located at position 1 within expression: matrix.shard == 0 || needs.prepare.outputs.should_shard == 'true'\`

\`matrix\` context is not available at job-level \`if:\` (only at step-level). The whole workflow fails to parse, so both manual dispatch and scheduled runs are blocked.

## Fix

Switch to a **dynamic matrix**. The \`prepare\` job emits \`shards\` as a JSON array, and \`strategy.matrix.shard\` consumes it via \`fromJSON()\`:

- Small / no-arg manual runs → \`shards=[0]\` → only shard 0 instantiated
- Schedule or \`limit_teams>=5000\` → \`shards=[0,1,2,3,4]\` → all 5 instantiated

No job-level \`if:\` needed. Idiomatic GHA pattern for conditional matrix dimensions. UI also stays clean (no skipped/gray shard entries for small runs).

Also bundles a **\`run-name:\`** so the Actions list shows meaningful titles like \`Scrape Games · 5000 teams\` or \`Scrape Games · 25000 (scheduled)\` instead of the squash-merge commit subject.

## Test plan

- [ ] \`gh workflow run scrape-games.yml -f limit_teams=200\` queues successfully (parse passes)
- [ ] Small run spawns only shard 0 in the Actions UI
- [ ] \`gh workflow run scrape-games.yml -f limit_teams=5000\` spawns all 5 shards
- [ ] Run-name appears as \`Scrape Games · 200 teams\` / \`Scrape Games · 5000 teams\` / \`Scrape Games · incremental\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)