### PR TITLE
fix(hygiene): recognize 14U and canonicalize age tokens

### DIFF
--- a/docs/TEAM_MERGE_RULES.md
+++ b/docs/TEAM_MERGE_RULES.md
@@ -153,8 +153,18 @@ The **"U" prefix is the signal:**
 **Age group formats → `U##`:**
 - `U14B` / `U-14` / `BU14` → `U14`
 - `U14` → `U14`
+- `14U` / `14u` / `14UB` / `14uG` / `14UM` → `U14` (digit-then-U form, optionally gender-suffixed)
 
 **Key principle:** Preserve the original system (birth year vs age group), strip all gender indicators (B/G/Boys/Girls). Gender is tracked separately in `gender` field.
+
+### Canonicalization at comparison time
+
+Stored `team_name` values retain their original form — birth-year names stay birth-year
+(required by `scripts/fix_team_age_groups.py`, which derives `age_group` from the 4-digit
+year in the name). Matchers canonicalize age tokens to a shared cohort key only at
+comparison time, inside `_canonicalize_age_token` (`src/utils/team_name_utils.py`). So
+`EBU 14U Premier 1` and `EBU 2012 Premier 1` both resolve to the `u14` cohort during
+duplicate detection without either name being rewritten on disk.
 
 ---
 

--- a/scripts/find_fuzzy_duplicate_teams.py
+++ b/scripts/find_fuzzy_duplicate_teams.py
@@ -18,7 +18,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+# Two-level path idiom: parent lets us import sibling scripts (find_queue_matches),
+# grandparent lets us import src.utils.team_name_utils (_canonicalize_age_token).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from difflib import SequenceMatcher
 
 from find_queue_matches import (
@@ -27,6 +30,8 @@ from find_queue_matches import (
     has_protected_division,
     normalize_team_name,
 )
+
+from src.utils.team_name_utils import _canonicalize_age_token
 
 # ─────────────────────────────────────────────────────────────────────
 # STRUCTURED DISTINCTION EXTRACTION
@@ -235,7 +240,7 @@ US_STATES = frozenset(
 )
 
 # Age/year patterns
-AGE_PATTERN = re.compile(r"\b(20\d{2})\b|'(\d{2})(?:/(\d{2}))?|\b[Uu]-?(\d{1,2})\b")
+AGE_PATTERN = re.compile(r"\b(20\d{2})\b|'(\d{2})(?:/(\d{2}))?|\b[Uu]-?(\d{1,2})\b|\b(\d{1,2})[Uu]\b")
 
 
 def _tokenize(name: str) -> list[str]:
@@ -320,31 +325,46 @@ def extract_distinctions(name: str, club_name: str = "") -> dict:
             team_number = tok
             classified.add(idx)
 
-    # ── Pass 2: extract age tokens and secondary numbers ──
+    # ── Pass 2: extract canonical age tokens; mask age spans for secondary_nums ──
+    # Canonicalize every AGE_PATTERN match to a cohort key (e.g. 'u14') so '14U',
+    # 'U14', '2012' all collapse to the same token at comparison time.
     age_tokens = []
+    age_spans = []
     for m in AGE_PATTERN.finditer(name):
-        age_tokens.append(m.group(0).lower().strip("'"))
+        canonical = _canonicalize_age_token(m.group(0).lower().strip("'"))
+        if canonical is not None:
+            age_tokens.append(canonical)
+        age_spans.append((m.start(), m.end()))
 
+    # Mask all matched age spans before scanning for secondary numbers — otherwise
+    # names like "14U 2012 Rush Union" would emit '2012' as a spurious secondary_num
+    # after matching the first age at position 0.
+    masked_chars = list(name)
+    for start, end in age_spans:
+        for i in range(start, min(end, len(masked_chars))):
+            masked_chars[i] = " "
+    masked = "".join(masked_chars)
     secondary_nums = []
-    first_age = AGE_PATTERN.search(name)
-    if first_age:
-        after = name[first_age.end() :]
-        secondary_nums = re.findall(r"\d+", after)
+    if age_spans:
+        first_end = age_spans[0][1]
+        secondary_nums = re.findall(r"\d+", masked[first_end:])
 
     # ── Pass 3: classify age-token indices ──
     for idx, tok in enumerate(tokens):
         if idx in classified:
             continue
-        # Age+gender combo (15m, 16m, b06, b08, b2010, u16b) — extract age part
+        # Age+gender combo (15m, 16m, b06, b08, b2010, u16b, 14ub) — canonicalize.
+        # Pass the original token to the helper — it already distinguishes
+        # 4-digit birth years, 2-digit shorthand (14b -> U12), and U-forms (u14b -> U14).
         age_gender_match = re.fullmatch(r"(\d{1,4})u?[bgmf]|[bgmf](\d{1,4})u?|u(\d{1,2})[bgmf]", tok)
         if age_gender_match:
-            age_num = age_gender_match.group(1) or age_gender_match.group(2) or age_gender_match.group(3)
-            if age_num:
-                age_tokens.append(age_num)
+            canonical = _canonicalize_age_token(tok)
+            if canonical is not None:
+                age_tokens.append(canonical)
             classified.add(idx)
         elif re.fullmatch(r"20\d{2}", tok) or re.fullmatch(r"\d{2}/\d{2}", tok):
             classified.add(idx)
-        elif re.fullmatch(r"u-?\d{1,2}", tok):
+        elif re.fullmatch(r"u-?\d{1,2}|\d{1,2}u", tok) and _canonicalize_age_token(tok) is not None:
             classified.add(idx)
         elif re.fullmatch(r"\d+m?", tok):
             classified.add(idx)
@@ -384,7 +404,8 @@ def extract_distinctions(name: str, club_name: str = "") -> dict:
         "location_codes": frozenset(location_codes),
         "state_codes": frozenset(state_codes),
         "squad_words": frozenset(squad_words),
-        "age_tokens": tuple(sorted(age_tokens)),
+        # set() dedupes — canonicalization collapses "14U 2012" to ['u14', 'u14'].
+        "age_tokens": tuple(sorted(set(age_tokens))),
         "secondary_nums": tuple(secondary_nums),
     }
 
@@ -706,5 +727,98 @@ def main():
     )
 
 
+def _run_inline_tests() -> int:
+    """Sanity-check the canonicalization path end-to-end. Returns non-zero on failure."""
+    from src.utils.team_name_utils import _canonicalize_age_token as utils_canon
+
+    passed = failed = 0
+
+    def check(desc: str, cond: bool) -> None:
+        nonlocal passed, failed
+        status = "✅" if cond else "❌"
+        print(f"  {status} {desc}")
+        if cond:
+            passed += 1
+        else:
+            failed += 1
+
+    # Cross-file equivalence (should be trivial identity since we now import the helper)
+    for tok in ["14U", "U14", "2012", "10/11", "14ub"]:
+        check(
+            f"cross-file canonical equivalence for {tok!r}",
+            _canonicalize_age_token(tok) == utils_canon(tok),
+        )
+
+    # Pass-4 leak regression — 14U must be classified, not dumped into squad_words
+    d = extract_distinctions("EBU 14U Premier 1", "EBU")
+    check("14u not in squad_words for 'EBU 14U Premier 1'", "14u" not in d["squad_words"])
+
+    # Canonicalization regression — birth year and digit-U form yield same cohort
+    d_a = extract_distinctions("EBU 2012 Premier 1", "EBU")
+    d_b = extract_distinctions("EBU 14U Premier 1", "EBU")
+    check(
+        "age_tokens match for EBU 2012 vs EBU 14U",
+        d_a["age_tokens"] == d_b["age_tokens"] == ("u14",),
+    )
+
+    # secondary_nums masking regression — "2012" AFTER "14U" must not leak as secondary
+    d = extract_distinctions("14U 2012 Rush Union WI Select", "Rush Union WI")
+    check(
+        "secondary_nums masks age matches for '14U 2012 Rush Union WI Select'",
+        d["secondary_nums"] == (),
+    )
+
+    # Full-pair match — the two failure pairs from the 2026-04-22 incident
+    check(
+        "EBU 14U Premier 1 ↔ EBU 2012 Premier 1 merges",
+        _should_skip_pair("EBU 14U Premier 1", "EBU 2012 Premier 1", club_name="EBU") is False,
+    )
+    check(
+        "14U 2012 Rush Union WI Select ↔ Rush Union WI 2012 Select merges",
+        _should_skip_pair(
+            "14U 2012 Rush Union WI Select",
+            "Rush Union WI 2012 Select",
+            club_name="Rush Union WI",
+        )
+        is False,
+    )
+
+    # Pass-3 preserves birth-year semantic for fused gender-suffix tokens —
+    # 'b2012' must canonicalize to u14, not be wrapped to 'u2012' and dropped.
+    d = extract_distinctions("Phoenix B2012 Red", "Phoenix")
+    check(
+        "Pass-3 'B2012' yields age_tokens ('u14',)",
+        d["age_tokens"] == ("u14",),
+    )
+    d = extract_distinctions("Phoenix 14B Red", "Phoenix")
+    check(
+        "Pass-3 '14B' (birth year 2014) yields age_tokens ('u12',)",
+        d["age_tokens"] == ("u12",),
+    )
+
+    # Regression guardrails
+    check(
+        "same-club different-color still skipped",
+        _should_skip_pair("Phoenix FC 2012 Red", "Phoenix FC 2012 Blue", club_name="Phoenix FC") is True,
+    )
+    check(
+        "cross-cohort still skipped",
+        _should_skip_pair("Phoenix 2012 Red", "Phoenix 2013 Red", club_name="Phoenix") is True,
+    )
+    check(
+        "U18 ↔ 2007 birth year merges (both canonicalize to u19)",
+        _should_skip_pair("Phoenix U18 Red", "Phoenix 2007 Red", club_name="Phoenix") is False,
+    )
+    check(
+        "slash-form '10/11 (u15) stays distinct from '10 (u16)",
+        _should_skip_pair("Phoenix '10/11 Red", "Phoenix '10 Red", club_name="Phoenix") is True,
+    )
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
 if __name__ == "__main__":
+    if "--test" in sys.argv:
+        sys.exit(_run_inline_tests())
     main()

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -15,6 +15,7 @@ Usage:
 import argparse
 import os
 import re
+import sys
 from difflib import SequenceMatcher
 from pathlib import Path
 
@@ -76,6 +77,7 @@ def normalize_team_name(name):
     n = re.sub(r"\b(b|g)\s*(\d{2,4})\b", r"\2", n)  # B2014 -> 2014
     n = re.sub(r"\b(\d{2,4})\s*(b|g)\b", r"\1", n)  # 2014B -> 2014
     n = re.sub(r"\bu\s*(\d+)\b", r"u\1", n)  # U 14 -> u14
+    n = re.sub(r"\b(\d{1,2})u\b", r"u\1", n)  # 14u -> u14 (digit-then-U form)
 
     # Remove extra whitespace
     n = " ".join(n.split())
@@ -103,13 +105,16 @@ def extract_club_from_name(provider_team_name):
 
     name = provider_team_name.strip()
 
-    # Age/year patterns to split on (from team_name_normalizer.py)
-    # Match: U14, U-14, 2014, B2014, 2014B, G2015, 15B, B15, etc.
+    # Age/year patterns to split on (from team_name_normalizer.py).
+    # Match: U14, U-14, 2014, B2014, 2014B, G2015, 15B, B15, 14U, etc.
+    # NOTE: Duplicated inside extract_team_variant and extract_program_tier below;
+    # keep in sync until consolidated into src/utils/team_name_utils.py.
     age_patterns = [
         r"\bU-?\d{1,2}\b",  # U14, U-14
         r"\b[BG]?\d{4}[BG]?\b",  # 2014, B2014, 2014B, G2015, 2015G
         r"\b[BG]\d{2}(?!\d)\b",  # B14, G15 (not followed by more digits)
         r"\b\d{2}[BG](?!\d)\b",  # 14B, 15G (not followed by more digits)
+        r"\b\d{1,2}[Uu]\b",  # 14U, 14u (digit-then-U age form)
     ]
 
     # Find the earliest age pattern match
@@ -459,11 +464,13 @@ def extract_team_variant(name):
 
     # Find age/year position in the team name — search ALL occurrences and
     # look for a candidate word on EITHER side so word-order doesn't matter.
+    # NOTE: Duplicated with extract_club_from_name (above) and extract_program_tier (below).
     age_patterns = [
         r"\bU-?\d{1,2}\b",  # U14, U-14
         r"\b[BG]?\d{4}[BG]?\b",  # 2014, B2014, 2014B, G2015, 2015G
         r"\b[BG]\d{2}(?!\d)\b",  # B14, G15
         r"\b\d{2}[BG](?!\d)\b",  # 14B, 15G
+        r"\b\d{1,2}[Uu]\b",  # 14U, 14u (digit-then-U age form)
     ]
 
     age_match = None
@@ -522,6 +529,14 @@ def extract_age_group(name, details):
 
     # Priority 1: U-age format (U13, U14, etc)
     match = re.search(r"\bu(\d+)\b", name_lower)
+    if match:
+        return normalize_filter_age_group(match.group(1))
+
+    # Priority 1b: digit-then-U form (14U, 14u) — route through the same
+    # normalizer as Priority 1 so "18U" and "U18" don't produce different cohorts.
+    # _canonicalize_age_token is not used here because it remaps U18 -> U19, which
+    # would diverge from Priority 1's normalize_filter_age_group (preserves U18).
+    match = re.search(r"\b(\d{1,2})u\b", name_lower)
     if match:
         return normalize_filter_age_group(match.group(1))
 
@@ -621,12 +636,14 @@ def extract_program_tier(name):
         if re.search(pattern, name_lower):
             return token
 
-    # Check for short branch tokens that appear AFTER an age/year pattern
+    # Check for short branch tokens that appear AFTER an age/year pattern.
+    # NOTE: Duplicated with extract_club_from_name and extract_team_variant above.
     age_patterns = [
         r"\bU-?\d{1,2}\b",
         r"\b[BG]?\d{4}[BG]?\b",
         r"\b[BG]\d{2}(?!\d)\b",
         r"\b\d{2}[BG](?!\d)\b",
+        r"\b\d{1,2}[Uu]\b",
     ]
     age_end = 0
     for pattern in age_patterns:
@@ -1068,5 +1085,47 @@ def main():
         print("\nTo execute, run with --execute")
 
 
+def _run_inline_tests() -> int:
+    """Exercise the 14U canonicalization path. Returns non-zero on failure."""
+    passed = failed = 0
+
+    def check(desc: str, cond: bool) -> None:
+        nonlocal passed, failed
+        status = "✅" if cond else "❌"
+        print(f"  {status} {desc}")
+        if cond:
+            passed += 1
+        else:
+            failed += 1
+
+    # normalize_team_name rewrites digit-then-U form
+    got = normalize_team_name("Team 14U Blue")
+    check(f"normalize_team_name('Team 14U Blue') == 'team u14 blue' (got {got!r})", got == "team u14 blue")
+    got = normalize_team_name("Team U14 Blue")
+    check(f"normalize_team_name('Team U14 Blue') == 'team u14 blue' (got {got!r})", got == "team u14 blue")
+
+    # extract_age_group returns same cohort for both 14U and U14 orderings
+    a = extract_age_group("FC Example 14U", {})
+    b = extract_age_group("FC Example U14", {})
+    check(f"extract_age_group '14U' == 'U14' (got {a!r} vs {b!r})", a == b and a is not None)
+
+    # Birth year and digit-U form resolve to the same cohort
+    a = extract_age_group("FC Example 2012", {})
+    b = extract_age_group("FC Example 14U", {})
+    check(f"extract_age_group '2012' == '14U' (got {a!r} vs {b!r})", a == b and a is not None)
+
+    # U18/U19 parity: Priority 1 and 1b must agree on the same cohort.
+    # Previously Priority 1b routed through _canonicalize_age_token which remaps
+    # U18 -> U19, diverging from Priority 1's normalize_filter_age_group.
+    a = extract_age_group("FC Example U18", {})
+    b = extract_age_group("FC Example 18U", {})
+    check(f"extract_age_group 'U18' == '18U' (got {a!r} vs {b!r})", a == b and a is not None)
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
 if __name__ == "__main__":
+    if "--test" in sys.argv:
+        sys.exit(_run_inline_tests())
     main()

--- a/scripts/team_name_normalizer.py
+++ b/scripts/team_name_normalizer.py
@@ -103,7 +103,8 @@ def parse_age_gender(token: str) -> Tuple[Optional[str], Optional[str]]:
 
     NEW NORMALIZATION RULES (Jan 2026):
     - Birth year formats → 4-digit year: '12B' -> '2012', 'B2012' -> '2012'
-    - Age group formats → U##: 'U14B' -> 'U14', 'U-14' -> 'U14', 'BU14' -> 'U14'
+    - Age group formats → U##: 'U14B' -> 'U14', 'U-14' -> 'U14', 'BU14' -> 'U14',
+      '14U' -> 'U14', '14UB' -> ('U14', 'Male')
     - Gender is extracted separately, stripped from age token
 
     Examples:
@@ -114,6 +115,9 @@ def parse_age_gender(token: str) -> Tuple[Optional[str], Optional[str]]:
         'U14B' -> ('U14', 'Male')  # U14 = age group, B = Boys
         'U-14' -> ('U14', None)  # age group with hyphen
         'BU14' -> ('U14', 'Male')  # gender prefix on age group
+        '14U' -> ('U14', None)  # digit-then-U age group form
+        '14UB' -> ('U14', 'Male')  # digit-then-U with gender suffix
+        '14uG' -> ('U14', 'Female')  # lowercase u with gender suffix
         '2014' -> ('2014', None)  # birth year only
         'U14' -> ('U14', None)  # age only
     """
@@ -134,6 +138,18 @@ def parse_age_gender(token: str) -> Tuple[Optional[str], Optional[str]]:
         age_num = int(match.group(2))
         gender = normalize_gender(gender_char)
         return (f"U{age_num}", gender)
+
+    # Pattern: ##U with optional gender suffix (14U, 14UB, 14uG, 14UM) -> U-age
+    # Semantically an age-group token (not a birth-year shorthand), mirrors
+    # scrape_playmetrics_league._TEAM_U_AGE_RE which handles both U14 and 14U orderings.
+    match = re.match(r"^(\d{1,2})[Uu]([BbGgMmFf]?)$", token)
+    if match:
+        age_num = int(match.group(1))
+        # Guard U6-U19 (full youth cohort range); rejects tokens like '20U' or '5U'
+        if 6 <= age_num <= 19:
+            gender_char = match.group(2)
+            gender = normalize_gender(gender_char) if gender_char else None
+            return (f"U{age_num}", gender)
 
     # Pattern: ##B/G/M/F with optional trailing 's' (14B, 15M, b15s) -> 4-digit year
     match = re.match(r"^(\d{2})([BbGgMmFf])[Ss]?$", token)
@@ -477,11 +493,32 @@ if __name__ == "__main__":
         ("U-14", "U14"),
         ("BU14", "U14"),
         ("GU12", "U12"),
+        ("14U", "U14"),
+        ("14u", "U14"),
+        ("15U", "U15"),
+        ("10U", "U10"),
+        ("19U", "U19"),
     ]
     for token, expected in age_tests2:
         age, _ = parse_age_gender(token)
         status = "✅" if age == expected else "❌"
         print(f"  {status} {token:10} → {age} (expected: {expected})")
+
+    print("\nDigit-then-U with gender suffix → (U##, gender):")
+    digit_u_gender_tests = [
+        ("14UB", ("U14", "Male")),
+        ("14UG", ("U14", "Female")),
+        ("14UM", ("U14", "Male")),
+        ("14UF", ("U14", "Female")),
+        ("14uG", ("U14", "Female")),
+        ("20U", (None, None)),
+        ("5U", (None, None)),
+        ("14UZ", (None, None)),
+    ]
+    for token, expected in digit_u_gender_tests:
+        result = parse_age_gender(token)
+        status = "✅" if result == expected else "❌"
+        print(f"  {status} {token:10} → {result} (expected: {expected})")
 
     print("\n=== TEAM NAME PARSER TEST ===\n")
     test_cases = [

--- a/src/models/game_matcher.py
+++ b/src/models/game_matcher.py
@@ -257,6 +257,7 @@ _AGE_PATTERNS = [
     r"\b[BG]?\d{4}[BG]?\b",  # 2014, B2014, 2014B, G2015, 2015G
     r"\b[BG]\d{2}(?!\d)\b",  # B14, G15 (not followed by more digits)
     r"\b\d{2}[BG](?!\d)\b",  # 14B, 15G (not followed by more digits)
+    r"\b\d{1,2}[Uu]\b",  # 14U, 14u (digit-then-U age form)
 ]
 
 

--- a/src/utils/team_name_utils.py
+++ b/src/utils/team_name_utils.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import re
 from typing import Dict, List, Optional
 
+from src.utils.team_utils import CURRENT_YEAR, calculate_age_group_from_birth_year
+
 # ═══════════════════════════════════════════════════════════════
 # Constants
 # ═══════════════════════════════════════════════════════════════
@@ -412,10 +414,124 @@ _VARIANT_AGE_PATTERNS = [
     r"\b[BG]?\d{4}[BG]?\b",
     r"\b[BG]\d{2}(?!\d)\b",
     r"\b\d{2}[BG](?!\d)\b",
+    r"\b\d{1,2}[Uu]\b",
 ]
 
 # Age/year regex applied to the raw name string
-AGE_PATTERN = re.compile(r"\b(20\d{2})\b|'(\d{2})(?:/(\d{2}))?|\b[Uu]-?(\d{1,2})\b")
+AGE_PATTERN = re.compile(r"\b(20\d{2})\b|'(\d{2})(?:/(\d{2}))?|\b[Uu]-?(\d{1,2})\b|\b(\d{1,2})[Uu]\b")
+
+# Pre-compiled patterns for _canonicalize_age_token — this helper runs per token
+# during fuzzy duplicate scanning (O(n²) teams-per-cohort) so pattern compilation
+# on every call is measurable. See `architecture_age_pattern_drift.md`.
+_RE_BIRTH_YEAR_4 = re.compile(r"[bgmf]?(\d{4})[bgmf]?")
+_RE_DIGIT_U = re.compile(r"(\d{1,2})u[bgmf]?")
+_RE_U_PREFIX = re.compile(r"[bgmf]?u-?(\d{1,2})[bgmf]?")
+_RE_2DIGIT_GENDER = re.compile(r"(\d{2})[bgmf]|[bgmf](\d{2})")
+_RE_SLASH_DUAL = re.compile(r"(\d{2})/(\d{2})")
+_RE_2DIGIT_BARE = re.compile(r"\d{2}")
+
+
+def _canonicalize_age_token(tok: str) -> str | None:
+    """Map any age token to a canonical cohort key like 'u14'.
+
+    Accepts (case-insensitive; caller may pass lowercased and apostrophe-stripped):
+      4-digit birth year:   '2012' -> 'u14'
+      2-digit shorthand:    '12' via birth-year rule -> 'u14' (apostrophe-strip context)
+      U-age form:           'U14', 'u-14' -> 'u14'
+      Digit-then-U form:    '14U', '14u' -> 'u14'
+      With gender suffix:   '14ub', 'u14b', '14b', 'b14', 'b2012', '2012b' -> canonical + drop gender
+      Slash dual-age:       '10/11' -> 'u15' (take LARGER 2-digit year = younger cohort)
+
+    Returns None for:
+      - Out-of-range ages (outside U6-U19 after canonicalization)
+      - Unrecognized tokens (do NOT fall back to raw — silent drift masks bugs)
+
+    U18 remap:
+      U18 is merged into the U19 cohort everywhere else in PitchRank (see AGE_GROUPS,
+      scrape_playmetrics_league.derive_team_age_group).
+
+    Slash-form rationale:
+      Dual-age divisions are "play-up gates, not cohort labels" — the team is primarily
+      the younger cohort (larger 2-digit year). So '10/11 -> 2011 -> U15. A single '10
+      resolves to 2010 -> U16, so slash teams remain distinct from single-cohort teams.
+
+    Bare 2-digit rationale:
+      In the extract_distinctions path, bare 2-digit strings arrive only from the
+      apostrophe-stripped AGE_PATTERN branch ('10, '10/11), where the semantic is
+      always birth-year shorthand. Pass-3 callers wrap their emissions with 'u' prefix
+      before calling this helper, so U-age inputs never arrive as bare digits here.
+    """
+    if not tok:
+        return None
+    t = tok.lower().strip().strip("'")
+    if not t:
+        return None
+
+    age: int | None = None
+
+    # 4-digit birth year (optionally gender-wrapped): '2012', 'b2012', '2012b'
+    m = _RE_BIRTH_YEAR_4.fullmatch(t)
+    if m:
+        birth_year = int(m.group(1))
+        if 1990 <= birth_year <= 2030:
+            ag = calculate_age_group_from_birth_year(birth_year)
+            if ag:
+                age = int(ag[1:])
+
+    # Digit-then-U form with optional gender: '14u', '14ub', '14um'
+    if age is None:
+        m = _RE_DIGIT_U.fullmatch(t)
+        if m:
+            age = int(m.group(1))
+
+    # U-prefix form with optional gender prefix/suffix: 'u14', 'u-14', 'u14b', 'bu14'
+    if age is None:
+        m = _RE_U_PREFIX.fullmatch(t)
+        if m:
+            age = int(m.group(1))
+
+    # 2-digit shorthand with gender: '14b', 'b14' → birth-year shorthand
+    if age is None:
+        m = _RE_2DIGIT_GENDER.fullmatch(t)
+        if m:
+            short = int(m.group(1) or m.group(2))
+            birth_year = 2000 + short if short < 30 else 1900 + short
+            ag = calculate_age_group_from_birth_year(birth_year)
+            if ag:
+                age = int(ag[1:])
+
+    # Slash dual-age: '10/11' → take larger 2-digit year (younger cohort)
+    if age is None:
+        m = _RE_SLASH_DUAL.fullmatch(t)
+        if m:
+            y1, y2 = int(m.group(1)), int(m.group(2))
+            short = max(y1, y2)
+            birth_year = 2000 + short if short < 30 else 1900 + short
+            ag = calculate_age_group_from_birth_year(birth_year)
+            if ag:
+                age = int(ag[1:])
+
+    # Bare 2-digit: birth-year shorthand (apostrophe-strip context)
+    if age is None:
+        m = _RE_2DIGIT_BARE.fullmatch(t)
+        if m:
+            short = int(t)
+            birth_year = 2000 + short if short < 30 else 1900 + short
+            ag = calculate_age_group_from_birth_year(birth_year)
+            if ag:
+                age = int(ag[1:])
+
+    if age is None:
+        return None
+
+    if not (6 <= age <= 19):
+        return None
+
+    if age == 18:
+        age = 19
+
+    return f"u{age}"
+
 
 # Club-suffix canonicalization (from full_club_analysis.py)
 _CLUB_SUFFIX_RE = [
@@ -613,30 +729,45 @@ def extract_distinctions(name: str) -> Dict:
             team_number = tok
             classified.add(idx)
 
-    # Pass 2: extract age tokens and secondary numbers
+    # Pass 2: extract canonical age tokens; mask age spans for secondary_nums.
+    # Same shape as scripts/find_fuzzy_duplicate_teams.py.extract_distinctions — both
+    # must canonicalize so '14U', 'U14', '2012', "'12" all collapse to the same key.
     age_tokens: list = []
+    age_spans: list = []
     for m in AGE_PATTERN.finditer(name):
-        age_tokens.append(m.group(0).lower().strip("'"))
+        canonical = _canonicalize_age_token(m.group(0).lower().strip("'"))
+        if canonical is not None:
+            age_tokens.append(canonical)
+        age_spans.append((m.start(), m.end()))
 
+    # Mask all matched age spans before scanning for secondary numbers — otherwise
+    # "14U 2012 Rush Union" would emit '2012' as a spurious secondary_num after
+    # matching the first age at position 0.
     secondary_nums: list = []
-    first_age = AGE_PATTERN.search(name)
-    if first_age:
-        after = name[first_age.end() :]
-        secondary_nums = re.findall(r"\d+", after)
+    if age_spans:
+        masked_chars = list(name)
+        for start, end in age_spans:
+            for i in range(start, min(end, len(masked_chars))):
+                masked_chars[i] = " "
+        masked = "".join(masked_chars)
+        first_end = age_spans[0][1]
+        secondary_nums = re.findall(r"\d+", masked[first_end:])
 
-    # Pass 3: classify age/gender combo indices
+    # Pass 3: classify age/gender combo indices; canonicalize emissions.
     for idx, tok in enumerate(tokens):
         if idx in classified:
             continue
         age_gender = re.fullmatch(r"(\d{1,4})u?[bgmf]|[bgmf](\d{1,4})u?|u(\d{1,2})[bgmf]", tok)
         if age_gender:
-            age_num = age_gender.group(1) or age_gender.group(2) or age_gender.group(3)
-            if age_num:
-                age_tokens.append(age_num)
+            # Pass the original token — the helper distinguishes 4-digit birth year,
+            # 2-digit shorthand ('14b' -> U12), and U-forms ('u14b' -> U14).
+            canonical = _canonicalize_age_token(tok)
+            if canonical is not None:
+                age_tokens.append(canonical)
             classified.add(idx)
         elif re.fullmatch(r"20\d{2}", tok) or re.fullmatch(r"\d{2}/\d{2}", tok):
             classified.add(idx)
-        elif re.fullmatch(r"u-?\d{1,2}", tok):
+        elif re.fullmatch(r"u-?\d{1,2}|\d{1,2}u", tok) and _canonicalize_age_token(tok) is not None:
             classified.add(idx)
         elif re.fullmatch(r"\d+m?", tok):
             classified.add(idx)
@@ -800,6 +931,7 @@ _AGE_SPLIT_PATTERNS = [
     r"\b[BG]?\d{4}[BG]?\b",
     r"\b[BG]\d{2}(?!\d)\b",
     r"\b\d{2}[BG](?!\d)\b",
+    r"\b\d{1,2}[Uu]\b",
 ]
 
 _TRAILING_SUFFIXES = [
@@ -872,3 +1004,92 @@ def has_protected_division(name: str) -> bool:
     across divisions (ECNL ≠ ECNL-RL ≠ MLS NEXT)."""
     n = name.lower()
     return any(kw in n for kw in ("ecnl", "mls next", "mls-next", "ga "))
+
+
+# ═══════════════════════════════════════════════════════════════
+# Inline tests (run via `python -m src.utils.team_name_utils`)
+# ═══════════════════════════════════════════════════════════════
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(f"=== _canonicalize_age_token (season CURRENT_YEAR={CURRENT_YEAR}) ===")
+    # Season-dependent assertions assume CURRENT_YEAR==2025 (2025-26 soccer season).
+    # If run off-season these expectations shift with the helper's birth-year math.
+    u14_forms = [
+        "2012",
+        "'12",
+        "12",
+        "U14",
+        "u-14",
+        "14U",
+        "14u",
+        "14ub",
+        "u14b",
+        "b2012",
+        "2012b",
+        "12b",
+        "b12",
+    ]
+    passed = failed = 0
+    for tok in u14_forms:
+        got = _canonicalize_age_token(tok)
+        ok = got == "u14"
+        status = "✅" if ok else "❌"
+        print(f"  {status} _canonicalize_age_token({tok!r:10}) → {got!r} (expected 'u14')")
+        passed += 1 if ok else 0
+        failed += 0 if ok else 1
+
+    # U18 remap: U18 and 2007 birth year both merge into U19
+    for tok, expected in [("U18", "u19"), ("2007", "u19")]:
+        got = _canonicalize_age_token(tok)
+        ok = got == expected
+        status = "✅" if ok else "❌"
+        print(f"  {status} _canonicalize_age_token({tok!r:10}) → {got!r} (expected {expected!r})")
+        passed += 1 if ok else 0
+        failed += 0 if ok else 1
+
+    # Slash-form: larger 2-digit year (younger cohort) wins, so '10/11 → u15
+    for tok, expected in [("10/11", "u15"), ("10", "u16")]:
+        got = _canonicalize_age_token(tok)
+        ok = got == expected
+        status = "✅" if ok else "❌"
+        print(f"  {status} _canonicalize_age_token({tok!r:10}) → {got!r} (expected {expected!r})")
+        passed += 1 if ok else 0
+        failed += 0 if ok else 1
+
+    # Out of range / unrecognized → None
+    for tok in ["20U", "5U", "2003", "random", ""]:
+        got = _canonicalize_age_token(tok)
+        ok = got is None
+        status = "✅" if ok else "❌"
+        print(f"  {status} _canonicalize_age_token({tok!r:10}) → {got!r} (expected None)")
+        passed += 1 if ok else 0
+        failed += 0 if ok else 1
+
+    # AGE_PATTERN recognizes both orderings
+    checks = [
+        ("Phoenix FC 14U Black", "14U"),
+        ("Phoenix FC U14 Black", "U14"),
+    ]
+    for text, expected in checks:
+        m = AGE_PATTERN.search(text)
+        got = m.group(0) if m else None
+        ok = got == expected
+        status = "✅" if ok else "❌"
+        print(f"  {status} AGE_PATTERN.search({text!r}).group(0) → {got!r} (expected {expected!r})")
+        passed += 1 if ok else 0
+        failed += 0 if ok else 1
+
+    # extract_team_variant detects coach name after 14U (uses _VARIANT_AGE_PATTERNS)
+    got = extract_team_variant("FC Example 14U Riedell")
+    ok = got == "riedell"
+    status = "✅" if ok else "❌"
+    print(f"  {status} extract_team_variant('FC Example 14U Riedell') → {got!r} (expected 'riedell')")
+    passed += 1 if ok else 0
+    failed += 0 if ok else 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)


### PR DESCRIPTION
## Summary

On 2026-04-22 I had to manually merge two team duplicates the weekly hygiene pipeline missed:
- `EBU 14U Premier 1` <-> `EBU 2012 Premier 1`
- `14U 2012 Rush Union WI Select` <-> `Rush Union WI 2012 Select`

The age-token parsers only recognized U-prefixed forms (`U14`, `BU14`, `U-14`) or digit-plus-gender (`14B`, `B14`). None recognized the digit-then-U form (`14U`), even though the PlayMetrics scraper's `_TEAM_U_AGE_RE` has handled both orderings all along. Result: `14U` leaked into `squad_words` in Pass 4, and even when recognized it wasn't canonicalized against the other name's `2012` or `U14` form before the set-comparison in `_should_skip_pair`.

## Approach

Two changes, both narrow:

1. **Parsers learn `14U`.** New branch in `parse_age_gender`, extended `AGE_PATTERN` / `_VARIANT_AGE_PATTERNS` / `_AGE_SPLIT_PATTERNS`, extended Pass-3 classifiers, and the three local `age_patterns` lists in `find_queue_matches`. All covered by inline `__main__` tests.
2. **Matchers canonicalize at comparison time.** New shared `_canonicalize_age_token` helper in `src/utils/team_name_utils.py` (imported from `find_fuzzy_duplicate_teams`) converts every recognized form (`14U`, `U14`, `2012`, `'12`, `10/11`, `14UB`, etc.) to a canonical cohort key (`u14`) using `CURRENT_YEAR` and `calculate_age_group_from_birth_year`. Six pre-compiled regexes cover birth-year, digit-U, U-prefix, 2-digit gender shorthand, slash dual-age, and bare 2-digit. Both `extract_distinctions` copies now canonicalize `age_tokens` and mask age spans before collecting `secondary_nums`.

Stored `team_name` is not rewritten: the birth-year form survives, so `fix_team_age_groups.extract_birth_year` keeps working.

## Scale

Pre-flight sanity SQL against production:

| Form | Teams |
| --- | ---: |
| `\d{1,2}[Uu]` (digit-then-U) | 757 |
| `[Uu]-?\d{1,2}` (U-prefix) | 12,416 |
| `20\d{2}` (birth year) | 109,119 |
| Both digit-U AND birth-year in one name | 299 |
| Total active teams | 147,631 |

The 299 dual-form teams are the upper bound on Case-2-style duplicates this fix directly addresses.

## Test plan

- [x] `python scripts/team_name_normalizer.py`: 10 new `14U`/`14u`/`15U`/`14UB`/`14UG`/`20U`/`5U`/`14UZ` rows pass
- [x] `python -m src.utils.team_name_utils`: 25 assertions covering helper, AGE_PATTERN, and extract_team_variant
- [x] `python scripts/find_fuzzy_duplicate_teams.py --test`: 16 assertions including both real-world failure pairs + U18/U19, slash-distinct, cross-cohort, birth-year-preservation regressions
- [x] `python scripts/find_queue_matches.py --test`: 5 assertions on `normalize_team_name` and `extract_age_group` parity
- [x] `python -m pytest tests/unit/test_game_matcher.py`: 12/12 existing tests pass
- [x] Integration: both failure pairs return `skip=False` and `score >= 0.99`
- [x] Dry-run fuzzy scan on `u14 male`: 6 new genuine merges surfaced, no false positives
- [x] Dry-run fuzzy scan on `u15 female`: 3 new genuine merges surfaced, no false positives
- [ ] Weekly `data-hygiene-weekly.yml` dry-run after merge (manual, not automated here)