### PR TITLE
fix(dashboard): unbreak scrape status RPC and show full team UUID

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1164,7 +1164,7 @@ elif section == "📈 Database Import Stats":
                 lambda: db.rpc(
                     'get_scrape_eligibility_counts',
                     {'p_provider_id': selected_provider_id},
-                ).execute()
+                )
             )
             counts_row = (counts_result.data or [{}])[0]
             recent_count = int(counts_row.get('recent_count') or 0)
@@ -1207,7 +1207,7 @@ elif section == "📈 Database Import Stats":
                                 lambda p=pid: db.rpc(
                                     'get_scrape_eligibility_counts',
                                     {'p_provider_id': p},
-                                ).execute()
+                                )
                             )
                             p_row = (p_counts_res.data or [{}])[0]
                             p_recent_ct = int(p_row.get('recent_count') or 0)
@@ -4708,7 +4708,7 @@ elif section == "✏️ Manual Team Edit":
                     'Gender': t.get('gender', ''),
                     'State': t.get('state_code', ''),
                     'Deprecated': '⚠️' if t.get('is_deprecated') else '',
-                    'ID': t['team_id_master'][:8] + '...'
+                    'ID': t['team_id_master']
                 }
                 for t in st.session_state.edit_search_results
             ])
@@ -4775,7 +4775,8 @@ elif section == "✏️ Manual Team Edit":
                     else:
                         st.success("✅ ACTIVE")
                 with status_cols[1]:
-                    st.info(f"🆔 {team['team_id_master'][:12]}...")
+                    st.caption("🆔 Team ID (click copy icon)")
+                    st.code(team['team_id_master'], language=None)
                 with status_cols[2]:
                     st.info(f"📅 Age: {team.get('age_group', 'N/A').upper()}")
                 with status_cols[3]:


### PR DESCRIPTION
## Summary

Two dashboard bugs in the Streamlit admin UI:

- **Database Import Stats → Team Scraping Status** raised `Error loading scraping status: 'SingleAPIResponse' object has no attribute 'execute'`. The `get_scrape_eligibility_counts` RPC was being executed twice: the lambda called `.execute()`, and `execute_with_retry` then called `.execute()` on the already-resolved `SingleAPIResponse`. Dropped the inner `.execute()` to match the pattern used by every other `execute_with_retry` call in this file (e.g. `dashboard.py:643-645`, `:682-684`).
- **Manual Team Edit** truncated `team_id_master` in the search-results dataframe (`[:8] + '...'`) and in the loaded-team status badge (`[:12] + '...'`), so the full UUID was neither visible nor copyable. Search results now contain the full UUID (Streamlit cells are click-to-copy) and the status column uses `st.code` for a copy button.

## Test plan

- [ ] Open the `📈 Database Import Stats` section; the Team Scraping Status counts render without the `SingleAPIResponse` error for "All Providers" and for a specific provider.
- [ ] Expand "Per-Provider Breakdown"; each row shows counts (not "Error: ...").
- [ ] Open `✏️ Manual Team Edit`, search a team, confirm the `ID` column in the results table shows the full 36-char UUID and a single cell can be copied.
- [ ] Load a team and confirm the `🆔 Team ID` column shows the full UUID with a copy-to-clipboard icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)