### PR TITLE
fix(test): update anon-checkout assertion for subscription mode

### DIFF
--- a/frontend/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/checkout/__tests__/route.test.ts
@@ -75,7 +75,7 @@ describe('POST /api/stripe/checkout', () => {
     expect(body.url).toBe('https://checkout.stripe.com/anon');
     expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        customer_creation: 'always',
+        mode: 'subscription',
         metadata: { anonymous_checkout: 'true' },
       })
     );


### PR DESCRIPTION
## Summary

The Stripe checkout anonymous-path test was asserting `customer_creation: 'always'`, which the route at `app/api/stripe/checkout/route.ts:124` **intentionally stopped sending** when the anonymous path moved to `mode: 'subscription'`. Stripe rejects `customer_creation` in subscription-mode sessions and auto-creates the customer — the inline comment spells it out.

**Stale test, not a code regression.** Swap the outdated assertion for `mode: 'subscription'`, which preserves the test's intent (verify anon-checkout is in subscription mode with the right metadata) while asserting on a value the route actually sends. Total assertions in the call unchanged (still 2 keys checked inside `expect.objectContaining`).

This was the sole Frontend Tests failure on main; cleanup after the CI Quality Gate baseline PR (#656).

## Test plan
- [ ] CI Frontend Tests job green (87→88 passing, 1 failed→0 failed)
- [x] Targeted run locally: `npx vitest run app/api/stripe/checkout/__tests__/route.test.ts` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)