### PR TITLE
fix(seo): restore '| PitchRank' suffix on state ranking page titles

### DIFF
--- a/frontend/app/rankings/[region]/page.tsx
+++ b/frontend/app/rankings/[region]/page.tsx
@@ -79,8 +79,8 @@ export async function generateMetadata({ params }: StateOverviewPageProps): Prom
   const isNational = region.toLowerCase() === 'national';
 
   const title = isNational
-    ? 'National Youth Soccer Rankings 2026 — Updated Weekly'
-    : `${stateInfo.name} Youth Soccer Rankings 2026 — Updated Weekly`;
+    ? 'National Youth Soccer Rankings 2026 — Updated Weekly | PitchRank'
+    : `${stateInfo.name} Youth Soccer Rankings 2026 — Updated Weekly | PitchRank`;
 
   const description = isNational
     ? 'National youth soccer rankings for all age groups. 77K+ teams ranked across 700K+ games analyzed. See where your team stands. Updated weekly.'


### PR DESCRIPTION
## Summary
Pre-existing bug found during the 2026-04-23 SEO audit smoke test: `/rankings/[region]` pages render without the `| PitchRank` brand suffix in the `<title>` tag, despite the root layout defining `title.template: '%s | PitchRank'`.

**Observed before:** `Maryland Youth Soccer Rankings 2026 — Updated Weekly`
**After this fix:** `Maryland Youth Soccer Rankings 2026 — Updated Weekly | PitchRank`

Cause appears to be that `rankings/layout.tsx` sets `title` as a plain string (becomes `title.default` for that segment), and the combination with `generateMetadata` returning a plain-string title in the child page does not inherit the root template. Simplest and lowest-risk fix: append the brand manually in the state page's `generateMetadata`. The other pages with static `metadata` exports continue to work via the root template, so no behavior change there.

## Test plan
- [x] Ran locally at `/rankings/md`, `/rankings/ca`, `/rankings/national` — all show correct single `| PitchRank` suffix
- [x] Verified no doubled brand (template path is not active here, confirmed by observation)
- [ ] Production verify post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)