### PR TITLE
fix(seo): move rankings pillar below table to surface data first

### DIFF
--- a/frontend/app/rankings/page.tsx
+++ b/frontend/app/rankings/page.tsx
@@ -73,8 +73,6 @@ export default function RankingsPage() {
         </p>
       </section>
 
-      <RankingsPillar />
-
       <RankingsPageContent region="national" ageGroup="u12" gender="male" />
 
       {/* Browse by State — server-rendered for Googlebot crawlability */}
@@ -98,6 +96,8 @@ export default function RankingsPage() {
           ))}
         </div>
       </section>
+
+      <RankingsPillar />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Rankings table now renders immediately after the H1 + intro paragraph on `/rankings`.
- `<RankingsPillar />` (FAQ, state guide grid, deep copy) moved beneath the existing "Browse by State" section.
- No schema or metadata changes — FAQPage + CollectionPage JSON-LD still emit at the top of the page, so SEO signal is preserved.

## Rationale
The pillar content added a full screen of text between the H1 and the actual rankings table. Standard pattern for data-table pillar pages (ESPN, KenPom, Transfermarkt) is: short intro → data → supporting content.

## Test plan
- [ ] Visit `/rankings` in preview — rankings table visible without scrolling past the pillar.
- [ ] View page source — FAQPage and CollectionPage JSON-LD still present.
- [ ] Verify Browse by State and the moved pillar still render below the table.