### PR TITLE
fix(sincsports): install numpy/pandas for matcher transitive imports

### DIFF
--- a/.github/workflows/sincsports-team-discovery.yml
+++ b/.github/workflows/sincsports-team-discovery.yml
@@ -77,7 +77,13 @@ jobs:
       - name: Install deps
         run: |
           pip install --upgrade pip
-          pip install supabase python-dotenv requests beautifulsoup4 rich
+          # numpy + pandas are required transitively: the SincSports matcher
+          # imports config.settings, which triggers src.rankings.__init__.py
+          # and loads the calculator/glicko/data_adapter chain. Those modules
+          # need numpy/pandas at import time even though discovery itself
+          # never calls them. rapidfuzz is optional (matcher falls back to
+          # difflib) so it stays out of the minimal list.
+          pip install supabase python-dotenv requests beautifulsoup4 rich numpy pandas
 
       - name: Full-grid warning summary
         if: inputs.states == '' && inputs.ages == '' && inputs.genders == ''


### PR DESCRIPTION
Second GHA failure on the same workflow: `ModuleNotFoundError: No module named 'numpy'` on `from src.models.sincsports_matcher import SincSportsGameMatcher`.

Root cause: the matcher imports \`config.settings.MATCHING_CONFIG\`, which pulls in \`src.rankings.__init__.py\`. That init eagerly loads \`calculator.py\` / \`glicko_engine.py\` / \`data_adapter.py\`, all of which import numpy and pandas at module level. Local dev has these installed; the workflow's minimal pip list didn't.

Pragmatic fix: add numpy + pandas to the workflow's pip install. Rapidfuzz stays out because the matcher has a difflib fallback for that one.

Longer-term the \`src/rankings/__init__.py\` eager-load could be made lazy so that \`from config.settings import X\` doesn't drag in the rankings stack, but that's a repo-wide refactor — noted for the improvements backlog in a follow-up if desired.

## Verification

- Local `from scripts.discover_sincsports_teams import main` imports cleanly
- Previous WI U14 Female dry-run still returns 58 teams, 0 errors

## Test plan

- [ ] Re-trigger GHA workflow with \`states=WI, ages=u14, genders=female, dry_run=false\`
- [ ] Confirm CSV + manifest + low-conf audit artifacts land on the run page

🤖 Generated with [Claude Code](https://claude.com/claude-code)