### PR TITLE
docs(sincsports): warn that GHA runners hit bot-protection on sicclubs.aspx

### DIFF
--- a/.github/workflows/sincsports-team-discovery.yml
+++ b/.github/workflows/sincsports-team-discovery.yml
@@ -1,5 +1,21 @@
 name: SincSports Team Discovery
 
+# ⚠ KNOWN LIMITATION (observed 2026-04-24): GitHub-hosted runner IPs get a
+# 29MB non-envelope response from sicclubs.aspx instead of the expected EO
+# callback CDATA. This trips `_validate_response_shape` and the scraper
+# aborts with CaptchaOrBlockError("blocked") after 3 retries. Residential
+# IPs work normally — the 29MB response is almost certainly a bot-protection
+# interstitial keyed on the ubuntu-latest runner IP range.
+#
+# WORKAROUND until this is addressed: run discovery from an operator
+# workstation via CLI, e.g.:
+#   cd <repo>
+#   python scripts/discover_sincsports_teams.py --states WI --ages u14 --genders female
+# Scope arg parity with this workflow is intentional — the CLI and the
+# workflow take the same --states/--ages/--genders CSVs.
+#
+# Potential future fixes tracked in .turbo/improvements.md.
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Documents the SincSports GHA limitation observed on PR #663's first live invocation:

- ubuntu-latest runner IPs get a 29 MB non-envelope response from `sicclubs.aspx`
- Residential IPs get the expected ~100 KB-700 KB EO callback CDATA
- The scraper's `_validate_response_shape` correctly treats the malformed response as a shape-fail, hits the 3-strike block threshold, and aborts with `CaptchaOrBlockError("blocked")`
- No code regression — the workflow is simply unusable from GHA today

Changes here:
- Top-of-file comment in the workflow explaining the limitation and pointing operators at the CLI invocation
- Backlog entry in `.turbo/improvements.md` capturing three long-term options (residential-IP proxy, self-hosted runner, Playwright warm-up) for whoever picks it up

The workflow stays in the repo because the pre-flight hygiene check, artifact upload config, and permission scoping are all still valuable — it just runs on operator workstations via the CLI for now, not via GHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)