### PR TITLE
feat(sincsports): scrape tournament games via schedule.aspx (bypasses VIP blur)

### DIFF
--- a/scripts/scrape_sincsports_tournament_schedule.py
+++ b/scripts/scrape_sincsports_tournament_schedule.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Scrape and import every game in a SincSports tournament via schedule.aspx.
+
+Iterates every division in the tournament, parses each fixture (date, time,
+team_ids, scores, status), normalizes to the per-team-perspective JSONL shape
+the existing ``import_games_enhanced.py`` pipeline consumes, and (with
+``--auto-import``) hands off to that pipeline.
+
+Replaces ``scripts/scrape_sincsports_by_tournament_teams.py`` for tournament
+game ingestion: that script hits per-team ``games.aspx`` pages which respect
+SincSports' VIP blur and silently miss most games. ``schedule.aspx`` is not
+gated by the per-team blur, so coverage is roughly 2× and scores are clean.
+
+Example:
+    python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565
+    python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565 --auto-import
+    python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565 --year 2025 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+from rich.console import Console  # noqa: E402
+
+from src.scrapers.sincsports_schedule import (  # noqa: E402
+    SincSportsScheduleScraper,
+    TournamentGame,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+console = Console()
+
+_env_local = Path(".env.local")
+if _env_local.exists():
+    load_dotenv(_env_local)
+else:
+    load_dotenv()
+
+RAW_DIR = Path("data/raw")
+
+
+def parse_date_iso(mdy: Optional[str]) -> Optional[str]:
+    """``"4/18/2026"`` -> ``"2026-04-18"`` (or ``None`` if unparseable)."""
+    if not mdy:
+        return None
+    try:
+        return datetime.strptime(mdy, "%m/%d/%Y").strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def perspective_record(g: TournamentGame, *, perspective: str) -> dict:
+    """Build the dict shape that ``import_games_enhanced.py`` expects.
+
+    Mirrors the output of ``SincSportsScraper._game_data_to_dict`` so the
+    downstream pipeline doesn't need to learn about a new format. ``perspective``
+    is ``"H"`` or ``"A"`` — perspective from which the team_id is the row's
+    primary team.
+    """
+    is_home = perspective == "H"
+    team_id = g.home_id if is_home else g.away_id
+    team_name = g.home_name if is_home else g.away_name
+    opp_id = g.away_id if is_home else g.home_id
+    opp_name = g.away_name if is_home else g.home_name
+    goals_for = g.home_score if is_home else g.away_score
+    goals_against = g.away_score if is_home else g.home_score
+    if goals_for is None or goals_against is None:
+        result = "U"
+    elif goals_for > goals_against:
+        result = "W"
+    elif goals_for < goals_against:
+        result = "L"
+    else:
+        result = "D"
+
+    return {
+        "provider_id": "sincsports",
+        "team_id": team_id,
+        "opponent_id": opp_id,
+        "team_name": team_name,
+        "opponent_name": opp_name,
+        "game_date": parse_date_iso(g.date),
+        "home_away": "H" if is_home else "A",
+        "goals_for": goals_for,
+        "goals_against": goals_against,
+        "result": result,
+        "competition": (g.division_name or g.division_code or "").strip(),
+        "venue": g.venue,
+        "club_name": "",
+        "opponent_club_name": "",
+        "meta": {
+            "source_url": (f"https://soccer.sincsports.com/schedule.aspx?tid={g.tournament_id}&div={g.division_code}"),
+            "scraped_at": datetime.now().isoformat(),
+            "club_name": "",
+            "opponent_club_name": "",
+            "tournament_id": g.tournament_id,
+            "division_code": g.division_code,
+            "division_name": g.division_name,
+            "game_num": g.game_num,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--tid", required=True, help="Tournament ID (e.g., TZ2565)")
+    p.add_argument("--year", type=int, default=2026, help="Tournament year (default: 2026)")
+    p.add_argument(
+        "--include-cancelled",
+        action="store_true",
+        help="Include Cancelled games in the JSONL output (default: skip)",
+    )
+    p.add_argument(
+        "--include-scheduled",
+        action="store_true",
+        help="Include Scheduled-but-not-yet-played games in the JSONL output (default: skip)",
+    )
+    p.add_argument("--auto-import", action="store_true", help="Run import_games_enhanced.py after scraping")
+    p.add_argument("--dry-run", action="store_true", help="Print summary only; no JSONL or import")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    scraper = SincSportsScheduleScraper()
+    try:
+        all_games = scraper.fetch_tournament(args.tid, year=args.year)
+    except Exception as e:
+        console.print(f"[red]Failed to scrape tournament {args.tid}: {e}[/red]")
+        return 1
+
+    from collections import Counter
+
+    by_status = Counter(g.status for g in all_games)
+    console.print(
+        f"[cyan]Tournament {args.tid} ({args.year}): {len(all_games)} games "
+        f"({dict(by_status)})  errors: {len(scraper.errors)}[/cyan]"
+    )
+
+    keep = [
+        g
+        for g in all_games
+        if g.status == "Played"
+        or (args.include_cancelled and g.status == "Cancelled")
+        or (args.include_scheduled and g.status == "Scheduled")
+    ]
+    keep = [g for g in keep if g.date]  # drop unscheduled rows lacking a date
+    console.print(f"[cyan]After status/date filter: {len(keep)} games to emit[/cyan]")
+
+    if args.dry_run:
+        return 0
+
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    out = RAW_DIR / f"sincsports_games_tournament_{args.tid}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.jsonl"
+    with open(out, "w", encoding="utf-8") as f:
+        for g in keep:
+            for perspective in ("H", "A"):
+                f.write(json.dumps(perspective_record(g, perspective=perspective)) + "\n")
+    console.print(f"[green]Wrote {len(keep) * 2} per-team records -> {out}[/green]")
+
+    if not args.auto_import:
+        console.print(f"\nTo import:  python scripts/import_games_enhanced.py {out} sincsports")
+        return 0
+
+    console.print("[cyan]Running import_games_enhanced.py ...[/cyan]")
+    rc = subprocess.run(
+        ["python", "scripts/import_games_enhanced.py", str(out), "sincsports"],
+        check=False,
+    ).returncode
+    if rc != 0:
+        console.print(f"[red]Import exited with code {rc}[/red]")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scrapers/sincsports_schedule.py
+++ b/src/scrapers/sincsports_schedule.py
@@ -1,0 +1,239 @@
+"""SincSports tournament schedule scraper.
+
+Parses ``schedule.aspx?tid=<TID>&div=<DIV>`` — the per-division fixture
+list for a tournament. Complementary to ``sincsports.py`` (per-team
+``games.aspx``) and ``sincsports_events.py`` (per-tournament team list at
+``teamlist.aspx``).
+
+**Why** — the per-team ``games.aspx`` flow respects SincSports' VIP
+paywall: most events are CSS-blurred for non-paying users and the
+existing parser intentionally skips them. The schedule.aspx page is
+NOT subject to the same blur — every fixture across every division of
+the tournament is rendered with date, time, team_ids, scores, and
+status. For the 2026 Puri Cup this produces 443 played games vs. the
+~224 the per-team scrape recovered; ~2× coverage with cleaner scores.
+
+**Wire format** — each tournament root page links every active division
+via ``?div=<DIV>`` query strings. Per division, every game is a
+``<div class="form-row game-row">`` containing:
+
+- date + time + game number (col-md-3)
+- home team + away team links (col-md-5) with team_ids in the URL
+- scores in two ``<div style='color:#A63351;...'>`` elements (col-3)
+- status / venue (col-md-4) — ``<font color='red'>Cancelled</font>``
+  marks cancellations
+
+The ``parse_division`` and ``parse_tournament_index`` functions are pure
+— unit tests run against committed fixtures with no network. The
+``SincSportsScheduleScraper`` class wraps them with the existing
+``SincSportsClubsScraper`` HTTP session (shared SINCSPORTS_* throttle
+env vars) for live fetching.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import re
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+from src.scrapers.sincsports_clubs import SincSportsClubsScraper
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://soccer.sincsports.com"
+SCHEDULE_PATH = "/schedule.aspx"
+
+_TEAMID_HREF_RE = re.compile(r"teamid=([A-Z0-9]+)", re.IGNORECASE)
+_DIV_QS_RE = re.compile(r"[?&]div=([A-Z0-9]+)", re.IGNORECASE)
+_DATE_RE = re.compile(r"(\d{1,2}/\d{1,2}/\d{4})")
+_TIME_RE = re.compile(r"(\d{1,2}:\d{2}\s*(?:AM|PM))")
+_GAME_NUM_RE = re.compile(r"#(\d+)")
+
+
+@dataclass
+class TournamentGame:
+    """One fixture from a tournament's schedule.aspx division page."""
+
+    tournament_id: str
+    division_code: str
+    division_name: Optional[str]
+    game_num: Optional[str]
+    date: Optional[str]  # MM/DD/YYYY (raw); the driver normalizes to YYYY-MM-DD
+    time: Optional[str]  # e.g., "10:40 AM"
+    home_id: str
+    home_name: Optional[str]
+    home_score: Optional[int]
+    away_id: str
+    away_name: Optional[str]
+    away_score: Optional[int]
+    status: str  # "Played" | "Cancelled" | "Scheduled"
+    venue: Optional[str]
+
+
+def _parse_team_block(team_div: Optional[Tag]) -> tuple[Optional[str], Optional[str]]:
+    if not team_div:
+        return (None, None)
+    team_link = team_div.find("a", href=re.compile(r"/team/team\.aspx.*teamid=", re.IGNORECASE))
+    name_link = team_div.find("a", href=re.compile(r"schedule\.aspx.*team="))
+    team_id = None
+    if team_link:
+        m = _TEAMID_HREF_RE.search(team_link.get("href", "") or "")
+        if m:
+            team_id = m.group(1).upper()
+    name = name_link.get_text(strip=True) if name_link else None
+    return (team_id, name)
+
+
+def _parse_score_col(card: Tag) -> tuple[Optional[int], Optional[int]]:
+    """Score lives in `col-3 text-right` as two color-styled <div>s."""
+    score_col = card.find("div", class_=lambda c: c and "col-3" in c and "text-right" in c)
+    if not score_col:
+        return (None, None)
+    score_divs = [d for d in score_col.find_all("div") if (d.get("style") or "").startswith("color:")]
+    if len(score_divs) < 2:
+        return (None, None)
+    try:
+        return (int(score_divs[0].get_text(strip=True)), int(score_divs[1].get_text(strip=True)))
+    except ValueError:
+        return (None, None)
+
+
+def parse_division(html: str, tournament_id: str, division_code: str) -> List[TournamentGame]:
+    """Pure parser for one ``schedule.aspx?tid=X&div=Y`` page.
+
+    Returns one ``TournamentGame`` per fixture with both team_ids resolved.
+    Empty modal cards (no team links) are dropped silently. Status is
+    ``"Cancelled"`` when a red ``<font>`` tag is present, ``"Played"`` when
+    a numeric score is present, else ``"Scheduled"``.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    games: List[TournamentGame] = []
+
+    for card in soup.find_all("div", class_=lambda c: c and "form-row" in c and "game-row" in c):
+        text = card.get_text(" ", strip=True)
+        date_m = _DATE_RE.search(text)
+        time_m = _TIME_RE.search(text)
+        num_m = _GAME_NUM_RE.search(text)
+
+        home_id, home_name = _parse_team_block(card.find("div", class_="hometeam"))
+        away_id, away_name = _parse_team_block(card.find("div", class_="awayteam"))
+        if not home_id or not away_id:
+            continue  # empty / placeholder card
+
+        division_name = None
+        big = card.find("span", class_="bigOnly")
+        if big:
+            division_name = big.get_text(strip=True)
+
+        home_score, away_score = _parse_score_col(card)
+
+        cancelled = card.find("font", color="red")
+        if cancelled:
+            status = cancelled.get_text(strip=True) or "Cancelled"
+        elif home_score is not None and away_score is not None:
+            status = "Played"
+        else:
+            status = "Scheduled"
+
+        # Venue is typically the second <span> in col-md-4 after the division name
+        # (often a TTMap link to a numbered field). We capture the visible text.
+        venue: Optional[str] = None
+        col_md_4 = card.find("div", class_=lambda c: c and "col-md-4" in c)
+        if col_md_4:
+            venue_link = col_md_4.find("a", href=re.compile(r"TTMap\.aspx"))
+            if venue_link:
+                venue = venue_link.get_text(strip=True)
+
+        games.append(
+            TournamentGame(
+                tournament_id=tournament_id,
+                division_code=division_code,
+                division_name=division_name,
+                game_num=num_m.group(1) if num_m else None,
+                date=date_m.group(1) if date_m else None,
+                time=time_m.group(1) if time_m else None,
+                home_id=home_id,
+                home_name=home_name,
+                home_score=home_score,
+                away_id=away_id,
+                away_name=away_name,
+                away_score=away_score,
+                status=status,
+                venue=venue,
+            )
+        )
+    return games
+
+
+def parse_tournament_index(html: str) -> List[str]:
+    """Return the deduped list of division codes referenced from the tournament root.
+
+    Drops the special ``N`` placeholder (a dropdown sentinel).
+    """
+    codes = {m.group(1).upper() for m in _DIV_QS_RE.finditer(html or "")}
+    codes.discard("N")
+    return sorted(codes)
+
+
+class SincSportsScheduleScraper:
+    """Live wrapper for ``schedule.aspx`` parsing.
+
+    Reuses ``SincSportsClubsScraper``'s requests session so all SincSports
+    scrapers share the same UA, retry adapter, and SINCSPORTS_DELAY_MIN/MAX
+    throttle knobs. The class adds a fetch-and-parse loop; tests hit the
+    pure ``parse_*`` functions directly without any network.
+    """
+
+    def __init__(
+        self,
+        delay_min: Optional[float] = None,
+        delay_max: Optional[float] = None,
+        timeout: Optional[int] = None,
+    ):
+        self._http = SincSportsClubsScraper(delay_min=delay_min, delay_max=delay_max, timeout=timeout)
+        self.session: requests.Session = self._http.session
+        self.delay_min: float = self._http.delay_min
+        self.delay_max: float = self._http.delay_max
+        self.timeout: int = self._http.timeout
+        self.errors: List[dict] = []
+
+    def fetch_division_codes(self, tid: str, year: int = 2026) -> List[str]:
+        """Fetch the tournament root and return every active division code."""
+        url = f"{BASE_URL}{SCHEDULE_PATH}?tid={tid}&year={year}&stid={tid}&syear={year}"
+        logger.info(f"Fetching tournament index: {url}")
+        resp = self.session.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        time.sleep(random.uniform(self.delay_min, self.delay_max))
+        return parse_tournament_index(resp.text)
+
+    def fetch_division(self, tid: str, division_code: str, year: int = 2026) -> List[TournamentGame]:
+        """Fetch and parse one (tournament, division) schedule page."""
+        url = f"{BASE_URL}{SCHEDULE_PATH}?tid={tid}&year={year}&stid={tid}&syear={year}&div={division_code}"
+        logger.info(f"Fetching division: {url}")
+        resp = self.session.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        time.sleep(random.uniform(self.delay_min, self.delay_max))
+        return parse_division(resp.text, tid, division_code)
+
+    def fetch_tournament(self, tid: str, year: int = 2026) -> List[TournamentGame]:
+        """Iterate every division in a tournament and return all games.
+
+        Per-division failures are recorded on ``self.errors`` and the loop
+        continues — partial results are preferable to losing the whole run.
+        """
+        codes = self.fetch_division_codes(tid, year=year)
+        logger.info(f"Tournament {tid}: {len(codes)} divisions to scrape")
+        all_games: List[TournamentGame] = []
+        for code in codes:
+            try:
+                all_games.extend(self.fetch_division(tid, code, year=year))
+            except Exception as e:
+                logger.error(f"Division {code} failed: {e}")
+                self.errors.append({"division": code, "error": str(e)})
+        return all_games

--- a/tests/fixtures/sincsports_events/schedule_puri_u14f01.html
+++ b/tests/fixtures/sincsports_events/schedule_puri_u14f01.html
@@ -1,0 +1,2442 @@
+   
+<!DOCTYPE html>
+<html lang="en">
+<head id="ctl00_Head1"><link rel="icon" href="https://sincsports.com/assets/img/icon.png" /><script async src='https://www.googletagmanager.com/gtag/js?id=G-MWQCTPQQ4B'></script><script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-MWQCTPQQ4B');</script> <script async src='https://www.googletagmanager.com/gtag/js?id=G-VPCZKRG724'></script><script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date());gtag('config', 'G-VPCZKRG724');</script> 
+    <!-- Required meta tags -->
+    <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /><title>
+	Schedules - 2026 Puri Champions Cup & College Showcase
+</title><meta name="description" />
+    <link rel="stylesheet" href="/bs/all.css?v=1.4" /><link rel="stylesheet" href="/css/tt10.css?v=3.0" /><link href="/css/material/6.1.95/css/materialdesignicons.min.css" rel="stylesheet" type="text/css" />
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            }); var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-WRWM2NVJ');</script>
+<!-- End Google Tag Manager -->
+        <link href='/photos/tid/tz2565/css/tz2565.css?v=10012024.102927' type='text/css' rel='stylesheet' /><style type='text/css'> #content { background-color:#fff !important;margin:5px; } </style><link href='https://fonts.googleapis.com/css?family=Ubuntu+Condensed|Economica|Roboto:100|POPPINS|Cairo' rel='stylesheet' type='text/css'>
+    <script src='/js/tt10.js?v=4.1' ></script>
+    
+    <script type="text/javascript">
+
+        function showPanel(p) {
+
+            if (p != "6") {
+                $("div.tabsection").hide();
+                $("span.sectionmsg").hide();
+                $("#ctl00_ContentPlaceHolder1_lblScheduleNote").hide();
+                $("#ctl00_ContentPlaceHolder1_lblStandingsNote").hide();
+                $("#ctl00_ContentPlaceHolder1_lblBracketNote").hide();
+            }
+            
+            if (p == "1") {
+                $("#ctl00_ContentPlaceHolder1_divSchedule").show();
+                $("#ctl00_ContentPlaceHolder1_lblScheduleNote").show();
+            }
+            else if (p == "2") {
+                $("#ctl00_ContentPlaceHolder1_divStandings").show();
+                $("#ctl00_ContentPlaceHolder1_lblStandingsNote").show();
+            }
+            else if (p == "3") {
+                $("#ctl00_ContentPlaceHolder1_divBracket").show();
+                $("#ctl00_ContentPlaceHolder1_lblBracketNote").show();
+            }
+            else if (p == "4") {
+                $("#ctl00_ContentPlaceHolder1_divControl").show();
+            }
+            else if (p == "5") {
+                $("#ctl00_ContentPlaceHolder1_divPitching").show();
+            }
+            else if (p == "6") {
+                $("#ctl00_ContentPlaceHolder1_divFindGame").show();
+                $("div.searcharea").hide();
+            }
+        }
+        function NextBox(hvcode, num) {
+            var hv = hvcode.substring(0, 1);
+            var code;
+            if (String(getElement(hvcode + num).value).length == 2) {
+                if (hvcode.length == 2)
+                    code = hvcode.substring(1, 2)
+                else
+                    code = "";
+                if (hv == "H")
+                    getElement("V" + code + String(num)).focus();
+                else
+                    if (code == "") {
+                        if (getElement("H" + String(num + 1)) != null)
+                            getElement("H" + String(num + 1)).focus();
+                    }
+                    else
+                        if (code == "A")
+                            getElement("HB" + String(num)).focus();
+                        else if (code == "B")
+                            getElement("HC" + String(num)).focus();
+                        else
+                            if (getElement("HA" + String(num + 1)) != null)
+                                getElement("HA" + String(num + 1)).focus();
+            }
+        }
+
+        $(document).ready(function () {
+            $('td.tipsy').tipsy({ gravity: 'n' });
+            $('td.tip').tipsy({ gravity: 'n' });
+            $("#thebody").removeAttr("style");
+            $('form input').on('keypress', function (e) {
+                return e.which !== 13;
+            });
+            
+        });
+        //$(document).ready(function(){(adsbygoogle = window.adsbygoogle || []).push({})});
+    </script>
+    <style type="text/css">
+        .btns { display: inline-block; margin-bottom: 0; font-weight: normal; text-align: center; vertical-align: middle; 
+                touch-action: manipulation; cursor: pointer; background-image: none; border: 1px solid transparent; 
+                white-space: nowrap; padding: 6px 12px; font-size: 14px; line-height: 1.428571429; border-radius: 0px; -webkit-user-select: none; 
+                -moz-user-select: none; -ms-user-select: none; user-select: none; }
+        #schedlist { list-style-type:none;}
+        i.mdi.sched { cursor: pointer; font-size: 14pt; float: right;color:lightgray; }
+        #ctl00_ContentPlaceHolder1_divScreen, #topMenu, div.searcharea, #ctl00_ContentPlaceHolder1_divFindGame {  font-family: Ubuntu Condensed;}
+        #ctl00_ContentPlaceHolder1_divScreen * { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
+        table.gameTable tr td { cursor: pointer; }
+        .r90 { display:inline-block;-webkit-transform: rotate(90deg);-moz-transform: rotate(90deg);-ms-transform: rotate(90deg);-o-transform: rotate(90deg);
+               filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+        }
+        #topMenu { padding:0px;margin:0;list-style-type:none;}
+        #topMenu li { padding:10px; background-color:#efefef;float:left; }
+        #topMenu li:hover { background-color:#ddd; }
+        #topMenu li a { color:#000; text-decoration:none;}
+        #topMenu li ul.top-sub { list-style-type:none;margin:0;padding:0;position:absolute;z-index:2; display:none; }
+        #topMenu li ul.top-sub li{ float:none;}
+        div.searcharea { padding:6px 13px; border:1px solid #ccc; color:#777;cursor:pointer;}
+        span.btns { font-size: 9pt; width: 75px; margin: 10px 10px 0 0; background-color:#fff; padding: 6px 0px; }
+        span.btns i { font-size:32px; }
+        span.ctrlbtn { margin:10px 0 0 0 ;}
+        span.btns:hover { background-color:#f0f1f3!important; }
+        h3 { color: #383838; font-family: Ubuntu Condensed; font-size: 18pt; padding: 5px 0 5px 0}
+        #ctl00_ContentPlaceHolder1_divButtons h3, #ctl00_ContentPlaceHolder1_divControl h3 { margin:0 0 0 15px;padding:0;font-family: Ubuntu Condensed;}
+        #divStds h3 { margin:8px 0 0 15px;padding:0;font-family: Ubuntu Condensed;}
+        input.scorebox { width:25px;float:right;height:23px;margin-bottom:4px;margin-top:2px;text-align:right;border-width:0px;background-color:gainsboro;color:#A63351;font-family: Ubuntu Condensed;}
+        .bluebtn { font-size: 9pt; color: white !important; margin: 0 10px 0 0; background-color: #015CAB;font-family: Ubuntu Condensed; }
+        .printbtn { margin-right:5px;font-size:22px;color:#015CAB;}
+        div.msg-section { text-align:center;color:#383838;font-size: 13pt;}
+        div.msg-section span { display:block;font-family: Ubuntu Condensed;}
+        div.header-bar { padding: 15px; background-color: #f0f1f3!important; }
+        div.changebox { padding: 3px 0 3px 0;  color: white; font-weight: bold; text-align: center; font-size: 9pt;color:#fff; }
+        #ctl00_ContentPlaceHolder1_divControl div.row, #divStds div.col-md-12  { border-bottom: 1px solid gainsboro; padding:6px 0; }
+        #ctl00_ContentPlaceHolder1_divControl { font-size:11pt;}
+        div.hora { color:#A63351;display:inline-block;margin-right:4px;}
+        #ctl00_pnlMainRow { overflow-y:hidden; }
+        .game-row { border-bottom:1px solid gainsboro; }
+        .game-row span, .hometeam, .awayteam { display:block;padding:5px 0px;}
+        div.big-gray { background-color:lightgray; padding:3px;}
+        .sched-logo{ width:24px;margin-right:5px }
+        .std-heading { font-weight:bold;color:#A63351; }
+        img.std-logo { width:50px;}
+        .pt4 {padding-top:4px;}
+        @media all and (min-width: 999px) {
+            .bigpad { padding-top:13px;}
+            .smallOnly { display:none; }
+            .ename { font-size:26pt}
+        }
+        @media all and (max-width:998px) {
+            h3 { font-size:12pt;}
+            .d-cell {  background-color: #f0f1f3!important; }
+            .game-row { margin-top:10px }
+            .bigOnly { display:none;}
+            .ename { font-size:18pt}
+            .searchsect { margin-top:5px;}
+            #topMenu { background-color:#efefef;margin-top:5px;}
+                #topMenu:after { content: ""; display: table; clear: both; }
+            #topMenu li {width:50%; box-sizing:border-box;}
+        }
+        ins { background-color:transparent !important; margin:0 auto;display:block!important;}
+
+        table.bracket {
+  border-collapse: separate; /* ok */
+  border-spacing: 0;
+  font-family: "Ubuntu Condensed", system-ui, sans-serif;
+}
+
+table.bracket tr { 
+  height: 18px;              /* uniform base row height */
+}
+
+table.bracket td {
+  padding: 0 !important;     /* padding MUST NOT affect row height */
+  vertical-align: middle;
+}
+table.bracket td.bottom {
+  padding: 0 !important;     /* padding MUST NOT affect row height */
+  vertical-align: bottom!important;
+}
+table.bracket td.top {
+  padding: 0 !important;     /* padding MUST NOT affect row height */
+  vertical-align: top!important;
+}
+
+table.bracket td .cell {      /* use this for visual padding */
+  padding: 4px 6px;
+  line-height: 1.1;
+}
+
+/* your line cell */
+.bordertoprightbottom {
+  border-top: 1px solid #333;
+  border-right: 1px solid #333;
+  border-bottom: 1px solid #333;
+}
+
+/* optional: plain cells without borders */
+.bordernone { border: 0; }
+
+    </style>
+
+    <style type="text/css">
+        @media(max-width:999px) {
+            .mainRow { overflow-x:auto;}
+        }
+    </style>
+<style type="text/css">
+.eo_tag_style{}
+</style>
+<style type="text/css">
+table.eo_no_border_spacing { border-spacing: 0; border-collapse: collapse; }
+table.eo_td_no_padding td {padding: 0px;}
+table.eo_border_collapse { border-collapse: collapse; }
+.eo_align_center { text-align: center;}
+.eo_align_left { text-align: left;}
+.eo_transparent { filter:alpha(opacity=0);-moz-opacity:0.0;opacity:0.0; }
+.eo_fullheight { height: 100%; }
+.eo_fullwidth { width: 100%; }
+a.eo_plain_link.link { border: none; }
+a.eo_plain_link.visited { border: none; }
+a.eo_plain_link.hover { border: none; }
+a.eo_plain_link.active { border: none; }
+ul.eo_list { list-style-type: none; margin: 0px; padding: 0px; }
+ul.eo_list li { list-style: none; margin: 0px; padding: 0px; white-space: nowrap; }
+.eo_text { font-family: Verdana; font-size: 10px; }
+
+</style>
+<style type="text/css">
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame1 {background-color:#fff;border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding-bottom:5px;padding-left:8px;padding-right:3px;padding-top:0}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame2 {background-color:#fff;border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;color:#383838;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame3 {background-color:#d2d2d2;font-family:tahoma;font-size:8pt}
+
+
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential1 {background-color:#fff;border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding-bottom:5px;padding-left:8px;padding-right:3px;padding-top:0}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential2 {background-color:#fff;border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;color:#383838;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential3 {background-color:#d2d2d2;font-family:tahoma;font-size:8pt}
+
+
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect1 {background-color:#fff;border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding-bottom:5px;padding-left:8px;padding-right:3px;padding-top:0}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect2 {background-color:#fff;border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;color:#383838;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px}
+.eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect3 {background-color:#d2d2d2;font-family:tahoma;font-size:8pt}
+
+
+.eo_css_ctrl_ctl00_DialogHelp1 {background-color:#fff;border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding-bottom:5px;padding-left:8px;padding-right:3px;padding-top:0}
+.eo_css_ctrl_ctl00_DialogHelp2 {background-color:#fff;border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;color:#383838;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px}
+.eo_css_ctrl_ctl00_DialogHelp3 {background-color:#d2d2d2;font-family:tahoma;font-size:8pt}
+
+
+.eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager1 {background-color:#fff;border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding-bottom:5px;padding-left:8px;padding-right:3px;padding-top:0}
+.eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager2 {background-color:#fff;border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;color:#383838;padding-bottom:4px;padding-left:4px;padding-right:4px;padding-top:4px}
+.eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager3 {background-color:#d2d2d2;font-family:tahoma;font-size:8pt}
+
+</style></head>
+<body id="thebody">
+    
+        <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRWM2NVJ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+        
+    <form name="aspnetForm" method="post" action="./schedule.aspx?tid=TZ2565&amp;year=2026&amp;stid=TZ2565&amp;syear=2026&amp;div=U14F01" id="aspnetForm">
+<div>
+<input type="hidden" name="eo_cb_id" id="eo_cb_id" value="" />
+<input type="hidden" name="ctl00_navbar_cpSearch_trigger" id="ctl00_navbar_cpSearch_trigger" value="" />
+<input type="hidden" name="ctl00_navbar_cpSearch_param" id="ctl00_navbar_cpSearch_param" value="" />
+<input type="hidden" name="__eo_sc" id="__eo_sc" value="" />
+<input type="hidden" name="ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl_trigger" id="ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl_trigger" value="" />
+<input type="hidden" name="ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl_param" id="ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl_param" value="" />
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_cpPanel_trigger" id="ctl00_ContentPlaceHolder1_cpPanel_trigger" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_cpPanel_param" id="ctl00_ContentPlaceHolder1_cpPanel_param" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame_trigger" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame_trigger" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame_param" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame_param" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields_trigger" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields_trigger" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields_param" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields_param" value="" />
+<input type="hidden" name="__LASTFOCUS" id="__LASTFOCUS" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential_trigger" id="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential_trigger" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential_param" id="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential_param" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy_trigger" id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy_trigger" value="" />
+<input type="hidden" name="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy_param" id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy_param" value="" />
+<input type="hidden" name="ctl00_DialogHelp_ctl00_cpHelpPanel_trigger" id="ctl00_DialogHelp_ctl00_cpHelpPanel_trigger" value="" />
+<input type="hidden" name="ctl00_DialogHelp_ctl00_cpHelpPanel_param" id="ctl00_DialogHelp_ctl00_cpHelpPanel_param" value="" />
+<input type="hidden" name="ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager_trigger" id="ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager_trigger" value="" />
+<input type="hidden" name="ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager_param" id="ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager_param" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKMTg2NDUzNTE5NA9kFgJmD2QWBAIBD2QWBAIBD2QWAmYPFgIeBFRleHQF7QM8c2NyaXB0IGFzeW5jIHNyYz0naHR0cHM6Ly93d3cuZ29vZ2xldGFnbWFuYWdlci5jb20vZ3RhZy9qcz9pZD1HLU1XUUNUUFFRNEInPjwvc2NyaXB0PjxzY3JpcHQ+IHdpbmRvdy5kYXRhTGF5ZXIgPSB3aW5kb3cuZGF0YUxheWVyIHx8IFtdOyBmdW5jdGlvbiBndGFnKCl7ZGF0YUxheWVyLnB1c2goYXJndW1lbnRzKTt9IGd0YWcoJ2pzJywgbmV3IERhdGUoKSk7IGd0YWcoJ2NvbmZpZycsICdHLU1XUUNUUFFRNEInKTs8L3NjcmlwdD4gPHNjcmlwdCBhc3luYyBzcmM9J2h0dHBzOi8vd3d3Lmdvb2dsZXRhZ21hbmFnZXIuY29tL2d0YWcvanM/aWQ9Ry1WUENaS1JHNzI0Jz48L3NjcmlwdD48c2NyaXB0PiB3aW5kb3cuZGF0YUxheWVyID0gd2luZG93LmRhdGFMYXllciB8fCBbXTsgZnVuY3Rpb24gZ3RhZygpe2RhdGFMYXllci5wdXNoKGFyZ3VtZW50cyk7fSBndGFnKCdqcycsIG5ldyBEYXRlKCkpO2d0YWcoJ2NvbmZpZycsICdHLVZQQ1pLUkc3MjQnKTs8L3NjcmlwdD4gZAIODxYCHwAFyAI8bGluayBocmVmPScvcGhvdG9zL3RpZC90ejI1NjUvY3NzL3R6MjU2NS5jc3M/dj0xMDAxMjAyNC4xMDI5MjcnIHR5cGU9J3RleHQvY3NzJyByZWw9J3N0eWxlc2hlZXQnIC8+PHN0eWxlIHR5cGU9J3RleHQvY3NzJz4gI2NvbnRlbnQgeyBiYWNrZ3JvdW5kLWNvbG9yOiNmZmYgIWltcG9ydGFudDttYXJnaW46NXB4OyB9IDwvc3R5bGU+PGxpbmsgaHJlZj0naHR0cHM6Ly9mb250cy5nb29nbGVhcGlzLmNvbS9jc3M/ZmFtaWx5PVVidW50dStDb25kZW5zZWR8RWNvbm9taWNhfFJvYm90bzoxMDB8UE9QUElOU3xDYWlybycgcmVsPSdzdHlsZXNoZWV0JyB0eXBlPSd0ZXh0L2Nzcyc+ZAIFD2QWHAIBD2QWDAIBDw8WAh4LTmF2aWdhdGVVcmwFDS9EZWZhdWx0LmFzcHhkZAIDDxYCHwBlZAIFDxYCHwAF5iE8bGkgY2xhc3M9J25hdi1pdGVtIGRyb3Bkb3duJz48YSBjbGFzcz0nbmF2LWxpbmsnIGhyZWY9JyMnPjxpIGNsYXNzPSdtZGkgbWRpLW1lbnUgZC1sZy1ibG9jayBkLW5vbmUnPjwvaT48c3BhbiBjbGFzcz0nZC1sZy1ub25lIGQtYmxvY2snPk1FTlU8L3NwYW4+PC9hPjx1bCBjbGFzcz0nZG1sIGRyb3Bkb3duLW1lbnUnPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSc+PGEgaHJlZj0nL1RUTWFzc01haWwuYXNweD90aWQ9VFoyNTY1JyBjbGFzcz0nZHJvcGRvd24tbGluayc+Q29udGFjdCBFdmVudDxpbWcgc3JjPScvaW1hZ2VzL3NtYmFyL21haWwucG5nJyBjbGFzcz0nZmxvYXQtcmlnaHQnIGJvcmRlcj0nMCcgLz48L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9Jy9kYXNoLmFzcHg/aWQ9JnRpZD1UWjI1NjUmdGFza3M9WSZzaW5jPU4nIGNsYXNzPSdkcm9wZG93bi1saW5rJz5FdmVudCBUYXNrczwvYT48L2xpPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSBkcm9wcmlnaHQnPjxhIGhyZWY9JyMnIGNsYXNzPSdkcm9wZG93bi1saW5rIGRyb3Bkb3duLXRvZ2dsZScgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5NeSBBY2NvdW50PC9hPjx1bCBjbGFzcz0nZHJvcGRvd24tbWVudSc+PGxpIGNsYXNzPSdkcm9wZG93bi1pdGVtJz48YSBocmVmPSdUVExvZ2luLmFzcHgnIGNsYXNzPSdkcm9wZG93bi1saW5rJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkxvZ2luIHRvIHZpZXcgeW91ciBhY2NvdW50PC9hPjwvbGk+PC91bD48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0gZHJvcHJpZ2h0Jz48YSBocmVmPScjJyBjbGFzcz0nZHJvcGRvd24tbGluayBkcm9wZG93bi10b2dnbGUnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+U29jY2VyIGluIGNvbGxlZ2U8L2E+PHVsIGNsYXNzPSdkcm9wZG93bi1tZW51Jz48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J2NvbGxlZ2VzLmFzcHgnIGNsYXNzPSdkcm9wZG93bi1saW5rJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkNvbGxlZ2VzPC9hPjwvbGk+PGxpIGNsYXNzPSdkcm9wZG93bi1pdGVtJz48YSBocmVmPSdldmVudHMuYXNweCcgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+VG91cm5hbWVudHM8L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J2V2ZW50cy5hc3B4P2xlYWd1ZXM9WScgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+TGVhZ3VlczwvYT48L2xpPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSc+PGEgaHJlZj0nc2ljQ2x1YnMuYXNweCcgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+VGVhbXM8L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J3NpY0F0aGxldGVzLmFzcHgnIGNsYXNzPSdkcm9wZG93bi1saW5rJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkF0aGxldGVzPC9hPjwvbGk+PC91bD48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0gZHJvcHJpZ2h0Jz48YSBocmVmPScjJyBjbGFzcz0nZHJvcGRvd24tbGluayBkcm9wZG93bi10b2dnbGUnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+VVNBIFJhbms8L2E+PHVsIGNsYXNzPSdkcm9wZG93bi1tZW51Jz48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J2h0dHBzOi8vdXNhLnNpbmNzcG9ydHMuY29tL3JhbmsvYWJvdXQnIHRhcmdldD0nX2JsYW5rJyBjbGFzcz0nZHJvcGRvd24tbGluaycgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5Ib3cgVVNBIFJhbmsgd29ya3M8L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J2h0dHBzOi8vdXNhLnNpbmNzcG9ydHMuY29tL3JhbmsvdmlldycgdGFyZ2V0PSdfYmxhbmsnIGNsYXNzPSdkcm9wZG93bi1saW5rJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPlZpZXcgUmFua2luZ3M8L2E+PC9saT48L3VsPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSBkcm9wcmlnaHQnPjxhIGhyZWY9JyMnIGNsYXNzPSdkcm9wZG93bi1saW5rIGRyb3Bkb3duLXRvZ2dsZScgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5TaW5jU3BvcnRzPC9hPjx1bCBjbGFzcz0nZHJvcGRvd24tbWVudSc+PGxpIGNsYXNzPSdkcm9wZG93bi1pdGVtJz48YSBocmVmPSdodHRwOi8vc2luY215dGVhbS5jb20nIHRhcmdldD0nX2JsYW5rJyBjbGFzcz0nZHJvcGRvd24tbGluaycgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5TaW5jIE15IFRlYW08L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9Jy9zaWNUb3VybmFtZW50cy5hc3B4JyBjbGFzcz0nZHJvcGRvd24tbGluaycgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5VcGNvbWluZyBFdmVudHM8L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9J2h0dHBzOi8vd3d3LnNpbmNzcG9ydHMuY29tJyB0YXJnZXQ9J19ibGFuaycgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+UHJvbW90ZSBZb3VyIEV2ZW50PC9hPjwvbGk+PC91bD48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0gZHJvcHJpZ2h0Jz48YSBocmVmPScjJyBjbGFzcz0nZHJvcGRvd24tbGluayBkcm9wZG93bi10b2dnbGUnIGRhdGEtdG9nZ2xlPSdkcm9wZG93bic+SGVscCAmIFN1cHBvcnQ8L2E+PHVsIGNsYXNzPSdkcm9wZG93bi1tZW51Jz48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9Jy9zaWNTdXBwb3J0LmFzcHgnIGNsYXNzPSdkcm9wZG93bi1saW5rJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkNvbnRhY3QgVXM8L2E+PC9saT48L3VsPjwvbGk+PC91bD48L2xpPjxsaSBjbGFzcz0nbmF2LWl0ZW0nPjxhIGhyZWY9Jy9UVEludHJvLmFzcHg/dGlkPVRaMjU2NSZ0YWI9MSZzdWI9MCcgIGNsYXNzPSduYXYtbGluayc+SG9tZTwvYT48L2xpPjxsaSBjbGFzcz0nbmF2LWl0ZW0nPjxhIGhyZWY9Jy9UVEFwcGx5MC5hc3B4P3RpZD1UWjI1NjUmdGFiPTImc3ViPTAnICBjbGFzcz0nbmF2LWxpbmsnPkFwcGx5PC9hPjwvbGk+PGxpIGNsYXNzPSduYXYtaXRlbSc+PGEgaHJlZj0nL1RUU2NoZWR1bGVzLmFzcHg/dGlkPVRaMjU2NSZ0YWI9MyZzdWI9MCcgIGNsYXNzPSduYXYtbGluayc+U2NoZWR1bGVzPC9hPjwvbGk+PGxpIGNsYXNzPSduYXYtaXRlbSBkcm9wZG93bic+PGEgaHJlZj0nIycgY2xhc3M9J25hdi1saW5rIGRyb3Bkb3duLXRvZ2dsZScgZGF0YS10b2dnbGU9J2Ryb3Bkb3duJz5JbmZvcm1hdGlvbjwvYT48dWwgY2xhc3M9J2Ryb3Bkb3duLW1lbnUnPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSc+PGEgaHJlZj0nL1RUTW9yZS5hc3B4P3RpZD1UWjI1NjUmdGFiPTQmc3ViPTEmUXVhbD1NSVNDJlNlcT0yJyAgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnPkRvY3VtZW50czwvYT48L2xpPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSc+PGEgaHJlZj0nL1RUTW9yZS5hc3B4P3RpZD1UWjI1NjUmdGFiPTQmc3ViPTImUXVhbD1NSVNDJlNlcT01JyAgY2xhc3M9J2Ryb3Bkb3duLWxpbmsnPkZpZWxkczwvYT48L2xpPjwvdWw+PC9saT48bGkgY2xhc3M9J25hdi1pdGVtIGRyb3Bkb3duJz48YSBocmVmPScjJyBjbGFzcz0nbmF2LWxpbmsgZHJvcGRvd24tdG9nZ2xlJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkNoZWNrIEluPC9hPjx1bCBjbGFzcz0nZHJvcGRvd24tbWVudSc+PGxpIGNsYXNzPSdkcm9wZG93bi1pdGVtJz48YSBocmVmPScvVFRNb3JlLmFzcHg/dGlkPVRaMjU2NSZ0YWI9NSZzdWI9MSZRdWFsPU1JU0MmU2VxPTMnICBjbGFzcz0nZHJvcGRvd24tbGluayc+UmVxdWlyZW1lbnRzPC9hPjwvbGk+PC91bD48L2xpPjxsaSBjbGFzcz0nbmF2LWl0ZW0nPjxhIGhyZWY9Jy9UVFRlYW1MaXN0LmFzcHg/dGlkPVRaMjU2NSZ0YWI9NiZzdWI9MCcgIGNsYXNzPSduYXYtbGluayc+VGVhbXM8L2E+PC9saT48bGkgY2xhc3M9J25hdi1pdGVtIGRyb3Bkb3duJz48YSBocmVmPScjJyBjbGFzcz0nbmF2LWxpbmsgZHJvcGRvd24tdG9nZ2xlJyBkYXRhLXRvZ2dsZT0nZHJvcGRvd24nPkNvbGxlZ2UgQ29hY2hlczwvYT48dWwgY2xhc3M9J2Ryb3Bkb3duLW1lbnUnPjxsaSBjbGFzcz0nZHJvcGRvd24taXRlbSc+PGEgaHJlZj0nL1RUQ29sbGVnZVJlZ2lzdGVyLmFzcHg/dGlkPVRaMjU2NSZ0YWI9NyZzdWI9MScgIGNsYXNzPSdkcm9wZG93bi1saW5rJz5Db2FjaCBSZWdpc3RyYXRpb248L2E+PC9saT48bGkgY2xhc3M9J2Ryb3Bkb3duLWl0ZW0nPjxhIGhyZWY9Jy9UVENvbGxlZ2VMaXN0LmFzcHg/dGlkPVRaMjU2NSZ0YWI9NyZzdWI9MicgIGNsYXNzPSdkcm9wZG93bi1saW5rJz5BdHRlbmRpbmcgQ29hY2hlczwvYT48L2xpPjwvdWw+PC9saT5kAgcPDxYGHghDc3NDbGFzcwVCbmF2YmFyLWJ0biBidG4gYnRuLXNtIGJ0bi1waWxsIGJ0bi13aGl0ZSBsaWZ0IG1sLWF1dG8gdGV4dC1wcmltYXJ5HwAFEExvZyBJbiAvIFNpZ24gVXAeBF8hU0ICAmRkAg8PZWQCEQ9kFgJmD2VkAgMPZWQCBQ9kFgYCAw8WAh8AZWQCBA8WAh8ABQY8YnIgLz5kAgcPZBYCAgEPZRYCAgUPPCsACQBkAgcPZBYCAgEPZBYCAgEPDxYCHghJbWFnZVVybAUsL3Bob3Rvcy90aWQvVFoyNTY1L2Jhbm5lci5wbmc/dj0xMDAxMjQxMDMwNDJkZAIND2QWAgIDD2QWBAIBDw8WBB8CBQZkLW5vbmUfAwICZGQCAw8PFgQfAgUJY29sLW1kLTEyHwMCAmQWAgIHD2QWFgIBDxYCHwAFfTxsaT48YSBocmVmPSdzY2hlZHVsZS5hc3B4P2Rpdj1OJnRpZD1UWjI1NjUmeWVhcj0yMDI2JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYnPjxpIGNsYXNzPSdtZGkgbWRpLW1lbnUnPjwvaT4gRElWSVNJT05TPC9hPjwvbGk+ZAIFDxYCHgVzdHlsZQUNZGlzcGxheTpub25lO2QCCQ8PFgIfAAUuMjAyNiBQdXJpIENoYW1waW9ucyBDdXAgJiBDb2xsZWdlIFNob3djYXNlPGJyPmRkAg0PDxYEHwBlHgdWaXNpYmxlaGRkAhMPZBYMAgEPD2QWAh8FBQlkaXNwbGF5OjtkAgMPD2QWAh8FBQ1kaXNwbGF5Om5vbmU7ZAIFDw9kFgIfBQUNZGlzcGxheTpub25lO2QCCw8PFgIfBmhkZAIPDw8WAh8GaGRkAhEPZBYMAgEPFgIfBQUNZGlzcGxheTpub25lOxYCAgEPDxYCHwZoZGQCAw8WAh8FBQlkaXNwbGF5OjsWBAIBD2QWBgIBDxYCHwAFOzxoMz5VbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3ZlciBTY2hlZHVsZTwvaDM+ZAIND2QWAgIBDxAPFgIfBmhkZBYAZAIRD2QWAgIDDw8WAh8GaGRkAgcPFgIfAAWIWzxkaXYgaWQ9J2RpdkdhbWVzJyBzdHlsZT0nZm9udC1zaXplOjExcHQ7cGFkZGluZzowcHg7Zm9udC1mYW1pbHk6VWJ1bnR1IENvbmRlbnNlZCxzYW5zLXNlcmlmOyc+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U2F0dXJkYXk8L3NwYW4+PHNwYW4+NC8xOC8yMDI2PC9zcGFuPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC02IHRleHQtbWQtbGVmdCB0ZXh0LXJpZ2h0Jz48c3Bhbj4xMDo0MCBBTTwvc3Bhbj48c3Bhbj4jMDAyNDA8YnIgLz48L3NwYW4+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLW1kLTUnPjxkaXYgY2xhc3M9J3Jvdyc+PGRpdiBjbGFzcz0nY29sLTknPjxkaXYgY2xhc3M9J2hvbWV0ZWFtJz48YSBocmVmPScvdGVhbS90ZWFtLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbWlkPUlMRjEyMjU1Jz48ZGl2IGNsYXNzPSdob3JhJz5IOiA8L2Rpdj48L2E+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09SUxGMTIyNTUmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxPlJvY2tmb3JkIFJhcHRvcnMgRzIwMTIgRUNOTDwvYT48L2Rpdj48ZGl2IGNsYXNzPSdhd2F5dGVhbSc+PGEgaHJlZj0vdGVhbS90ZWFtLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbWlkPUlBRjEyMDM5PjxkaXYgY2xhc3M9J2hvcmEnPkE6IDwvZGl2PjwvYT48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1JQUYxMjAzOSZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDE+RkMgQW1lcmljYSAoSUEpIEZDQSBGSVJFPC9hPjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC0zIHRleHQtcmlnaHQnPiZuYnNwOzxkaXYgY2xhc3M9J2NsZWFyJz48L2Rpdj4mbmJzcDs8L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGI+PGZvbnQgY29sb3I9J3JlZCc+Q2FuY2VsbGVkPC9mb250PjwvYj48L3NwYW4+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTInPjwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2Zvcm0tcm93IGdhbWUtcm93JyBzdHlsZT0nYm9yZGVyLWxlZnQ6NXB4IHNvbGlkIHRyYW5zcGFyZW50Jz48ZGl2IGNsYXNzPSdjb2wtbWQtMyBkLWNlbGwnPjxkaXYgY2xhc3M9J3Jvdyc+PGRpdiBjbGFzcz0nY29sLTYnPjxzcGFuPlNhdHVyZGF5PC9zcGFuPjxzcGFuPjQvMTgvMjAyNjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtNiB0ZXh0LW1kLWxlZnQgdGV4dC1yaWdodCc+PHNwYW4+MTA6NDAgQU08L3NwYW4+PHNwYW4+IzAwMjQxPGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjA2Myc+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMDYzJnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5PU0MgMjAxMkcgT3JhbmdlPC9hPjwvZGl2PjxkaXYgY2xhc3M9J2F3YXl0ZWFtJz48YSBocmVmPS90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9V0lGMTIwNzY+PGRpdiBjbGFzcz0naG9yYSc+QTogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMDc2JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5NYWRpc29uIDU2ZXJzIDIwMTIgR2lybHMgUmVkPC9hPjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC0zIHRleHQtcmlnaHQnPiZuYnNwOzxkaXYgY2xhc3M9J2NsZWFyJz48L2Rpdj4mbmJzcDs8L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGI+PGZvbnQgY29sb3I9J3JlZCc+Q2FuY2VsbGVkPC9mb250PjwvYj48L3NwYW4+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTInPjwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2Zvcm0tcm93IGdhbWUtcm93JyBzdHlsZT0nYm9yZGVyLWxlZnQ6NXB4IHNvbGlkIHRyYW5zcGFyZW50Jz48ZGl2IGNsYXNzPSdjb2wtbWQtMyBkLWNlbGwnPjxkaXYgY2xhc3M9J3Jvdyc+PGRpdiBjbGFzcz0nY29sLTYnPjxzcGFuPlNhdHVyZGF5PC9zcGFuPjxzcGFuPjQvMTgvMjAyNjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtNiB0ZXh0LW1kLWxlZnQgdGV4dC1yaWdodCc+PHNwYW4+MTI6MjAgUE08L3NwYW4+PHNwYW4+IzAwMjM5PGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjE3Nyc+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMTc3JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5FQlUgMTRVIEdJUkxTJyBQUkVNSUVSIDE8L2E+PC9kaXY+PGRpdiBjbGFzcz0nYXdheXRlYW0nPjxhIGhyZWY9L3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjE5Nj48ZGl2IGNsYXNzPSdob3JhJz5BOiA8L2Rpdj48L2E+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09V0lGMTIxOTYmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxPlJVU0ggVU5JT04gV0kgMjAxMkcgUFJFTUlFUjwvYT48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMyB0ZXh0LXJpZ2h0Jz48ZGl2IHN0eWxlPSdjb2xvcjojQTYzMzUxO21hcmdpbi10b3A6NXB4Oyc+MjwvZGl2PjxkaXYgY2xhc3M9J2NsZWFyJz48L2Rpdj48ZGl2IHN0eWxlPSdjb2xvcjojQTYzMzUxO21hcmdpbi10b3A6OXB4Oyc+NjwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC00Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC0xMCB0ZXh0LW1kLWxlZnQgdGV4dC1jZW50ZXInPjxzcGFuIGNsYXNzPSdiaWdPbmx5Jz5VbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3Zlcjwvc3Bhbj48c3Bhbj48YSBocmVmPSdUVE1hcC5hc3B4P3RpZD1UWjI1NjUmc2l0ZT0xMTA2MSZnYW1laWQ9NzMzNDEyOCc+MjEwIChHcmFzcyk8L2E+PC9zcGFuPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC0yJz48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdmb3JtLXJvdyBnYW1lLXJvdycgc3R5bGU9J2JvcmRlci1sZWZ0OjVweCBzb2xpZCB0cmFuc3BhcmVudCc+PGRpdiBjbGFzcz0nY29sLW1kLTMgZC1jZWxsJz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC02Jz48c3Bhbj5TYXR1cmRheTwvc3Bhbj48c3Bhbj40LzE4LzIwMjY8L3NwYW4+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTYgdGV4dC1tZC1sZWZ0IHRleHQtcmlnaHQnPjxzcGFuPjM6NDAgUE08L3NwYW4+PHNwYW4+IzAwMjQyPGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1JQUYxMjAzOSc+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPUlBRjEyMDM5JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5GQyBBbWVyaWNhIChJQSkgRkNBIEZJUkU8L2E+PC9kaXY+PGRpdiBjbGFzcz0nYXdheXRlYW0nPjxhIGhyZWY9L3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjA2Mz48ZGl2IGNsYXNzPSdob3JhJz5BOiA8L2Rpdj48L2E+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09V0lGMTIwNjMmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxPk9TQyAyMDEyRyBPUkFOR0U8L2E+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTMgdGV4dC1yaWdodCc+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjVweDsnPjE8L2Rpdj48ZGl2IGNsYXNzPSdjbGVhcic+PC9kaXY+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjlweDsnPjM8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGEgaHJlZj0nVFRNYXAuYXNweD90aWQ9VFoyNTY1JnNpdGU9MTEyNDMmZ2FtZWlkPTczMzQxMzEnPjExMSAoR3Jhc3MpPC9hPjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U2F0dXJkYXk8L3NwYW4+PHNwYW4+NC8xOC8yMDI2PC9zcGFuPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC02IHRleHQtbWQtbGVmdCB0ZXh0LXJpZ2h0Jz48c3Bhbj41OjIwIFBNPC9zcGFuPjxzcGFuPiMwMDI0MzxiciAvPjwvc3Bhbj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNSc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtOSc+PGRpdiBjbGFzcz0naG9tZXRlYW0nPjxhIGhyZWY9Jy90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9V0lGMTIxNzcnPjxkaXYgY2xhc3M9J2hvcmEnPkg6IDwvZGl2PjwvYT48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjE3NyZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDE+RUJVIDE0VSBHSVJMUycgUFJFTUlFUiAxPC9hPjwvZGl2PjxkaXYgY2xhc3M9J2F3YXl0ZWFtJz48YSBocmVmPS90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9SUxGMTIyNTU+PGRpdiBjbGFzcz0naG9yYSc+QTogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPUlMRjEyMjU1JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5ST0NLRk9SRCBSQVBUT1JTIEcyMDEyIEVDTkw8L2E+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTMgdGV4dC1yaWdodCc+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjVweDsnPjE8L2Rpdj48ZGl2IGNsYXNzPSdjbGVhcic+PC9kaXY+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjlweDsnPjU8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGEgaHJlZj0nVFRNYXAuYXNweD90aWQ9VFoyNTY1JnNpdGU9MTEwNjEmZ2FtZWlkPTczMzQxMzInPjIwNiAoR3Jhc3MpPC9hPjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U2F0dXJkYXk8L3NwYW4+PHNwYW4+NC8xOC8yMDI2PC9zcGFuPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC02IHRleHQtbWQtbGVmdCB0ZXh0LXJpZ2h0Jz48c3Bhbj42OjAwIFBNPC9zcGFuPjxzcGFuPiMwMDI0NDxiciAvPjwvc3Bhbj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNSc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtOSc+PGRpdiBjbGFzcz0naG9tZXRlYW0nPjxhIGhyZWY9Jy90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9V0lGMTIwNzYnPjxkaXYgY2xhc3M9J2hvcmEnPkg6IDwvZGl2PjwvYT48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjA3NiZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDE+TWFkaXNvbiA1NmVycyAyMDEyIEdpcmxzIFJlZDwvYT48L2Rpdj48ZGl2IGNsYXNzPSdhd2F5dGVhbSc+PGEgaHJlZj0vdGVhbS90ZWFtLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbWlkPVdJRjEyMTk2PjxkaXYgY2xhc3M9J2hvcmEnPkE6IDwvZGl2PjwvYT48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjE5NiZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDE+UlVTSCBVTklPTiBXSSAyMDEyRyBQUkVNSUVSPC9hPjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC0zIHRleHQtcmlnaHQnPjxkaXYgc3R5bGU9J2NvbG9yOiNBNjMzNTE7bWFyZ2luLXRvcDo1cHg7Jz4wPC9kaXY+PGRpdiBjbGFzcz0nY2xlYXInPjwvZGl2PjxkaXYgc3R5bGU9J2NvbG9yOiNBNjMzNTE7bWFyZ2luLXRvcDo5cHg7Jz4xPC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLW1kLTQnPjxkaXYgY2xhc3M9J3Jvdyc+PGRpdiBjbGFzcz0nY29sLTEwIHRleHQtbWQtbGVmdCB0ZXh0LWNlbnRlcic+PHNwYW4gY2xhc3M9J2JpZ09ubHknPlVuZGVyIDE0IEdpcmxzIEZpcnN0IERpdmlzaW9uLi0gQ3Jvc3NvdmVyPC9zcGFuPjxzcGFuPjxhIGhyZWY9J1RUTWFwLmFzcHg/dGlkPVRaMjU2NSZzaXRlPTExMDYxJmdhbWVpZD03MzM0MTMzJz4yMDcgKEdyYXNzKTwvYT48L3NwYW4+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTInPjwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2Zvcm0tcm93IGJnLWxpZ2h0Jz48ZGl2IGNsYXNzPSdjb2wgdGV4dC1jZW50ZXIgcC0zJz5TdW5kYXksIEFwcmlsIDE5LCAyMDI2PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U3VuZGF5PC9zcGFuPjxzcGFuPjQvMTkvMjAyNjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtNiB0ZXh0LW1kLWxlZnQgdGV4dC1yaWdodCc+PHNwYW4+MTI6MjAgUE08L3NwYW4+PHNwYW4+IzAwMjQ1PGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjA2Myc+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMDYzJnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5PU0MgMjAxMkcgT3JhbmdlPC9hPjwvZGl2PjxkaXYgY2xhc3M9J2F3YXl0ZWFtJz48YSBocmVmPS90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9V0lGMTIxNzc+PGRpdiBjbGFzcz0naG9yYSc+QTogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMTc3JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5FQlUgMTRVIEdJUkxTJyBQUkVNSUVSIDE8L2E+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTMgdGV4dC1yaWdodCc+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjVweDsnPjI8L2Rpdj48ZGl2IGNsYXNzPSdjbGVhcic+PC9kaXY+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjlweDsnPjI8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGEgaHJlZj0nVFRNYXAuYXNweD90aWQ9VFoyNTY1JnNpdGU9MTEyNDMmZ2FtZWlkPTczMzQxMzQnPjExMSAoR3Jhc3MpPC9hPjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U3VuZGF5PC9zcGFuPjxzcGFuPjQvMTkvMjAyNjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtNiB0ZXh0LW1kLWxlZnQgdGV4dC1yaWdodCc+PHNwYW4+MTI6MjAgUE08L3NwYW4+PHNwYW4+IzAwMjQ3PGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjA3Nic+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMDc2JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5NYWRpc29uIDU2ZXJzIDIwMTIgR2lybHMgUmVkPC9hPjwvZGl2PjxkaXYgY2xhc3M9J2F3YXl0ZWFtJz48YSBocmVmPS90ZWFtL3RlYW0uYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtaWQ9SUxGMTIyNTU+PGRpdiBjbGFzcz0naG9yYSc+QTogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPUlMRjEyMjU1JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5ST0NLRk9SRCBSQVBUT1JTIEcyMDEyIEVDTkw8L2E+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTMgdGV4dC1yaWdodCc+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjVweDsnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjbGVhcic+PC9kaXY+PGRpdiBzdHlsZT0nY29sb3I6I0E2MzM1MTttYXJnaW4tdG9wOjlweDsnPjE8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtMTAgdGV4dC1tZC1sZWZ0IHRleHQtY2VudGVyJz48c3BhbiBjbGFzcz0nYmlnT25seSc+VW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXI8L3NwYW4+PHNwYW4+PGEgaHJlZj0nVFRNYXAuYXNweD90aWQ9VFoyNTY1JnNpdGU9MTEyNDMmZ2FtZWlkPTczMzQxMzYnPjExMyAoR3Jhc3MpPC9hPjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cgZ2FtZS1yb3cnIHN0eWxlPSdib3JkZXItbGVmdDo1cHggc29saWQgdHJhbnNwYXJlbnQnPjxkaXYgY2xhc3M9J2NvbC1tZC0zIGQtY2VsbCc+PGRpdiBjbGFzcz0ncm93Jz48ZGl2IGNsYXNzPSdjb2wtNic+PHNwYW4+U3VuZGF5PC9zcGFuPjxzcGFuPjQvMTkvMjAyNjwvc3Bhbj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtNiB0ZXh0LW1kLWxlZnQgdGV4dC1yaWdodCc+PHNwYW4+MTI6MjAgUE08L3NwYW4+PHNwYW4+IzAwMjQ2PGJyIC8+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC01Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC05Jz48ZGl2IGNsYXNzPSdob21ldGVhbSc+PGEgaHJlZj0nL3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1XSUYxMjE5Nic+PGRpdiBjbGFzcz0naG9yYSc+SDogPC9kaXY+PC9hPjxhIGhyZWY9c2NoZWR1bGUuYXNweD90aWQ9VFoyNTY1JnllYXI9MjAyNiZ0ZWFtPVdJRjEyMTk2JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYmZGl2PVUxNEYwMT5SVVNIIFVOSU9OIFdJIDIwMTJHIFBSRU1JRVI8L2E+PC9kaXY+PGRpdiBjbGFzcz0nYXdheXRlYW0nPjxhIGhyZWY9L3RlYW0vdGVhbS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW1pZD1JQUYxMjAzOT48ZGl2IGNsYXNzPSdob3JhJz5BOiA8L2Rpdj48L2E+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09SUFGMTIwMzkmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxPkZDIEFtZXJpY2EgKElBKSBGQ0EgRklSRTwvYT48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMyB0ZXh0LXJpZ2h0Jz48ZGl2IHN0eWxlPSdjb2xvcjojQTYzMzUxO21hcmdpbi10b3A6NXB4Oyc+MTwvZGl2PjxkaXYgY2xhc3M9J2NsZWFyJz48L2Rpdj48ZGl2IHN0eWxlPSdjb2xvcjojQTYzMzUxO21hcmdpbi10b3A6OXB4Oyc+MDwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC00Jz48ZGl2IGNsYXNzPSdyb3cnPjxkaXYgY2xhc3M9J2NvbC0xMCB0ZXh0LW1kLWxlZnQgdGV4dC1jZW50ZXInPjxzcGFuIGNsYXNzPSdiaWdPbmx5Jz5VbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3Zlcjwvc3Bhbj48c3Bhbj48YSBocmVmPSdUVE1hcC5hc3B4P3RpZD1UWjI1NjUmc2l0ZT0xMTA2MSZnYW1laWQ9NzMzNDEzNSc+MjIwIChHcmFzcyk8L2E+PC9zcGFuPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC0yJz48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj5kAgcPFgIfBQUNZGlzcGxheTpub25lOxYCAgEPZRYCAgEPZBYGAgEPFgIfAAXxATxhIGhyZWY9J3NjaGVkdWxlLmFzcHg/Z3JvdXA9QUxMJnRpZD1UWjI1NjUmeWVhcj0yMDI2JnN0aWQ9VFoyNTY1JnN5ZWFyPTIwMjYnPjxpIGNsYXNzPSdtZGkgbWRpLWNhbGVuZGFyIHNjaGVkJyBzdHlsZT0nZmxvYXQ6bGVmdDtmb250LXNpemU6MTZwdDttYXJnaW46LTNweCAxMHB4IDAgMDtjb2xvcjojMDE1Q0FCOyc+PC9pPjwvYT5VbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3ZlciBTdGFuZGluZ3NkAgUPDxYCHwAF3gE8YSBocmVmPSdUVFJlc3VsdHMyLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxJyBjbGFzcz0nYnRucycgU3R5bGU9J2Zsb2F0OnJpZ2h0O2ZvbnQtc2l6ZTo5cHQ7Y29sb3I6d2hpdGU7d2lkdGg6ODBweDttYXJnaW46MCAxMHB4IDAgMDtiYWNrZ3JvdW5kLWNvbG9yOiMwMTVDQUI7cGFkZGluZzo2cHggMHB4Oyc+RGV0YWlsczwvYT5kZAIJDw8WAh8ABf9ePGRpdiBpZD0nZGl2U3Rkcycgc3R5bGU9J2ZvbnQtc2l6ZToxMXB0O3BhZGRpbmc6MHB4O2ZvbnQtZmFtaWx5OlVidW50dSBDb25kZW5zZWQsc2Fucy1zZXJpZjsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IGdhbWUtcm93Jz48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGgzPjxhIGhyZWY9J3NjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZncm91cD1BJz5Hcm91cCBBPC9hPjwvaDM+PC9kaXY+PGRpdiBjbGFzcz0nY29sLW1kLTInPiZuYnNwOzwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC02JyBzdHlsZT0ncGFkZGluZy1sZWZ0OjBweDtwYWRkaW5nLXJpZ2h0OjBweDsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IGJpZ09ubHkgc3RkLWhlYWRpbmcgYmlncGFkJz48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dhbWVzIFBsYXllZCc+R1A8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1dpbnMnPlc8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0xvc3Nlcyc+TDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nVGllcyc+VDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgRm9yJz5HRjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgU2NvcmVkIC0gTWF4IG9mIDMnPkdGMzwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgQWdhaW5zdCc+R0E8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWwgRGlmZmVyZW50aWFsJz5HRDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nUG9pbnRzJz5QdHM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZSBicmVha2VyIHVzZWQgdG8gZGV0ZXJtaW5lIHBsYWNlbWVudCc+VEI8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLW1kLTYnPjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wtMSc+MS48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PGltZyBzcmM9Jy9waG90b3MvY2x1Yi93aTEwNy5qcGcnIGNsYXNzPSdzdGQtbG9nbyc+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTggcHQ0Jz48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjE3NyZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDEjaGRnPkVCVSAxNFUgR0lSTFMnIFBSRU1JRVIgMTwvYT48c3BhbiBjbGFzcz0nZC1ibG9jayBmbG9hdC1yaWdodCc+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC02JyBzdHlsZT0ncGFkZGluZy1sZWZ0OjBweDtwYWRkaW5nLXJpZ2h0OjBweDsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IHNtYWxsT25seSBzdGQtaGVhZGluZyc+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHYW1lcyBQbGF5ZWQnPkdQPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdXaW5zJz5XPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdMb3NzZXMnPkw8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZXMnPlQ8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEZvcic+R0Y8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIFNjb3JlZCAtIE1heCBvZiAzJz5HRjM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEFnYWluc3QnPkdBPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FsIERpZmZlcmVudGlhbCc+R0Q8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1BvaW50cyc+UHRzPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdUaWUgYnJlYWtlciB1c2VkIHRvIGRldGVybWluZSBwbGFjZW1lbnQnPlRCPC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cnPjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjM8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4wPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MjwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjE8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz41PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+NTwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjEzPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+LTg8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz44PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGhyIC8+PGRpdiBjbGFzcz0nZm9ybS1yb3cnPjxkaXYgY2xhc3M9J2NvbC1tZC02Jz48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLTEnPjIuPC9kaXY+PGRpdiBjbGFzcz0nY29sLTInPjxpbWcgc3JjPScvcGhvdG9zL2NsdWIvaWEwMzAuanBnJyBjbGFzcz0nc3RkLWxvZ28nPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC04IHB0NCc+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09SUFGMTIwMzkmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxI2hkZz5GQyBBbWVyaWNhIChJQSkgRkNBIEZJUkU8L2E+PHNwYW4gY2xhc3M9J2QtYmxvY2sgZmxvYXQtcmlnaHQnPjwvc3Bhbj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNicgc3R5bGU9J3BhZGRpbmctbGVmdDowcHg7cGFkZGluZy1yaWdodDowcHg7Jz48ZGl2IGNsYXNzPSdmb3JtLXJvdyBzbWFsbE9ubHkgc3RkLWhlYWRpbmcnPjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR2FtZXMgUGxheWVkJz5HUDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nV2lucyc+VzwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nTG9zc2VzJz5MPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdUaWVzJz5UPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBGb3InPkdGPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBTY29yZWQgLSBNYXggb2YgMyc+R0YzPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBBZ2FpbnN0Jz5HQTwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbCBEaWZmZXJlbnRpYWwnPkdEPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdQb2ludHMnPlB0czwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nVGllIGJyZWFrZXIgdXNlZCB0byBkZXRlcm1pbmUgcGxhY2VtZW50Jz5UQjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4yPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjI8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4wPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MTwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjE8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz40PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+LTM8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4xPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGhyIC8+PGRpdiBjbGFzcz0nZm9ybS1yb3cnPjxkaXYgY2xhc3M9J2NvbC1tZC02Jz48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLTEnPjMuPC9kaXY+PGRpdiBjbGFzcz0nY29sLTInPjxpbWcgc3JjPScvcGhvdG9zL2NsdWIvd2kwMDMuanBnJyBjbGFzcz0nc3RkLWxvZ28nPjwvZGl2PjxkaXYgY2xhc3M9J2NvbC04IHB0NCc+PGEgaHJlZj1zY2hlZHVsZS5hc3B4P3RpZD1UWjI1NjUmeWVhcj0yMDI2JnRlYW09V0lGMTIwNzYmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZkaXY9VTE0RjAxI2hkZz5NYWRpc29uIDU2ZXJzIDIwMTIgR2lybHMgUmVkPC9hPjxzcGFuIGNsYXNzPSdkLWJsb2NrIGZsb2F0LXJpZ2h0Jz48L3NwYW4+PC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sLW1kLTYnIHN0eWxlPSdwYWRkaW5nLWxlZnQ6MHB4O3BhZGRpbmctcmlnaHQ6MHB4Oyc+PGRpdiBjbGFzcz0nZm9ybS1yb3cgc21hbGxPbmx5IHN0ZC1oZWFkaW5nJz48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dhbWVzIFBsYXllZCc+R1A8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1dpbnMnPlc8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0xvc3Nlcyc+TDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nVGllcyc+VDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgRm9yJz5HRjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgU2NvcmVkIC0gTWF4IG9mIDMnPkdGMzwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgQWdhaW5zdCc+R0E8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWwgRGlmZmVyZW50aWFsJz5HRDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nUG9pbnRzJz5QdHM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZSBicmVha2VyIHVzZWQgdG8gZGV0ZXJtaW5lIHBsYWNlbWVudCc+VEI8L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MjwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4yPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4wPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MjwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPi0yPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjwvZGl2PjwvZGl2PjwvZGl2PjwvZGl2PjxociAvPjxkaXYgY2xhc3M9J2Zvcm0tcm93IGdhbWUtcm93Jz48ZGl2IGNsYXNzPSdjb2wtbWQtNCc+PGgzPjxhIGhyZWY9J3NjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmc3RpZD1UWjI1NjUmc3llYXI9MjAyNiZncm91cD1CJz5Hcm91cCBCPC9hPjwvaDM+PC9kaXY+PGRpdiBjbGFzcz0nY29sLW1kLTInPiZuYnNwOzwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC02JyBzdHlsZT0ncGFkZGluZy1sZWZ0OjBweDtwYWRkaW5nLXJpZ2h0OjBweDsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IGJpZ09ubHkgc3RkLWhlYWRpbmcgYmlncGFkJz48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dhbWVzIFBsYXllZCc+R1A8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1dpbnMnPlc8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0xvc3Nlcyc+TDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nVGllcyc+VDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgRm9yJz5HRjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgU2NvcmVkIC0gTWF4IG9mIDMnPkdGMzwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbHMgQWdhaW5zdCc+R0E8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWwgRGlmZmVyZW50aWFsJz5HRDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nUG9pbnRzJz5QdHM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZSBicmVha2VyIHVzZWQgdG8gZGV0ZXJtaW5lIHBsYWNlbWVudCc+VEI8L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLW1kLTYnPjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wtMSc+MS48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PGltZyBzcmM9Jy9waG90b3MvY2x1Yi93aTE4MC5qcGcnIGNsYXNzPSdzdGQtbG9nbyc+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTggcHQ0Jz48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjE5NiZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDEjaGRnPlJ1c2ggVW5pb24gV0kgMjAxMkcgUHJlbWllcjwvYT48c3BhbiBjbGFzcz0nZC1ibG9jayBmbG9hdC1yaWdodCc+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC02JyBzdHlsZT0ncGFkZGluZy1sZWZ0OjBweDtwYWRkaW5nLXJpZ2h0OjBweDsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IHNtYWxsT25seSBzdGQtaGVhZGluZyc+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHYW1lcyBQbGF5ZWQnPkdQPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdXaW5zJz5XPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdMb3NzZXMnPkw8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZXMnPlQ8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEZvcic+R0Y8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIFNjb3JlZCAtIE1heCBvZiAzJz5HRjM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEFnYWluc3QnPkdBPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FsIERpZmZlcmVudGlhbCc+R0Q8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1BvaW50cyc+UHRzPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdUaWUgYnJlYWtlciB1c2VkIHRvIGRldGVybWluZSBwbGFjZW1lbnQnPlRCPC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cnPjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjM8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4zPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz44PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+NTwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjI8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz42PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MjU8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48aHIgLz48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLW1kLTYnPjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wtMSc+Mi48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PGltZyBzcmM9Jy9waG90b3MvY2x1Yi9pbDAxMi5qcGcnIGNsYXNzPSdzdGQtbG9nbyc+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTggcHQ0Jz48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1JTEYxMjI1NSZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDEjaGRnPlJvY2tmb3JkIFJhcHRvcnMgRzIwMTIgRUNOTDwvYT48c3BhbiBjbGFzcz0nZC1ibG9jayBmbG9hdC1yaWdodCc+PC9zcGFuPjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbC1tZC02JyBzdHlsZT0ncGFkZGluZy1sZWZ0OjBweDtwYWRkaW5nLXJpZ2h0OjBweDsnPjxkaXYgY2xhc3M9J2Zvcm0tcm93IHNtYWxsT25seSBzdGQtaGVhZGluZyc+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHYW1lcyBQbGF5ZWQnPkdQPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdXaW5zJz5XPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdMb3NzZXMnPkw8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1RpZXMnPlQ8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEZvcic+R0Y8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIFNjb3JlZCAtIE1heCBvZiAzJz5HRjM8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J0dvYWxzIEFnYWluc3QnPkdBPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FsIERpZmZlcmVudGlhbCc+R0Q8L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wnPjxkaXYgY2xhc3M9J3RpcCcgb3JpZ2luYWwtdGl0bGU9J1BvaW50cyc+UHRzPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdUaWUgYnJlYWtlciB1c2VkIHRvIGRldGVybWluZSBwbGFjZW1lbnQnPlRCPC9kaXY+PC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nZm9ybS1yb3cnPjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjI8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4yPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz42PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+NDwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjE8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz41PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MTc8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz48L2Rpdj48L2Rpdj48L2Rpdj48L2Rpdj48aHIgLz48ZGl2IGNsYXNzPSdmb3JtLXJvdyc+PGRpdiBjbGFzcz0nY29sLW1kLTYnPjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wtMSc+My48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtMic+PGltZyBzcmM9Jy9waG90b3MvY2x1Yi93aTA5Ni5qcGcnIGNsYXNzPSdzdGQtbG9nbyc+PC9kaXY+PGRpdiBjbGFzcz0nY29sLTggcHQ0Jz48YSBocmVmPXNjaGVkdWxlLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYmdGVhbT1XSUYxMjA2MyZzdGlkPVRaMjU2NSZzeWVhcj0yMDI2JmRpdj1VMTRGMDEjaGRnPk9TQyAyMDEyRyBPcmFuZ2U8L2E+PHNwYW4gY2xhc3M9J2QtYmxvY2sgZmxvYXQtcmlnaHQnPjwvc3Bhbj48L2Rpdj48L2Rpdj48L2Rpdj48ZGl2IGNsYXNzPSdjb2wtbWQtNicgc3R5bGU9J3BhZGRpbmctbGVmdDowcHg7cGFkZGluZy1yaWdodDowcHg7Jz48ZGl2IGNsYXNzPSdmb3JtLXJvdyBzbWFsbE9ubHkgc3RkLWhlYWRpbmcnPjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR2FtZXMgUGxheWVkJz5HUDwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nV2lucyc+VzwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nTG9zc2VzJz5MPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdUaWVzJz5UPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBGb3InPkdGPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBTY29yZWQgLSBNYXggb2YgMyc+R0YzPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdHb2FscyBBZ2FpbnN0Jz5HQTwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nR29hbCBEaWZmZXJlbnRpYWwnPkdEPC9kaXY+PC9kaXY+PGRpdiBjbGFzcz0nY29sJz48ZGl2IGNsYXNzPSd0aXAnIG9yaWdpbmFsLXRpdGxlPSdQb2ludHMnPlB0czwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2NvbCc+PGRpdiBjbGFzcz0ndGlwJyBvcmlnaW5hbC10aXRsZT0nVGllIGJyZWFrZXIgdXNlZCB0byBkZXRlcm1pbmUgcGxhY2VtZW50Jz5UQjwvZGl2PjwvZGl2PjwvZGl2PjxkaXYgY2xhc3M9J2Zvcm0tcm93Jz48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4yPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MTwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjA8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4xPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+NTwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjU8L2Rpdj48ZGl2IGNsYXNzPSdjb2wgYmlncGFkJz4zPC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+MjwvZGl2PjxkaXYgY2xhc3M9J2NvbCBiaWdwYWQnPjE0PC9kaXY+PGRpdiBjbGFzcz0nY29sIGJpZ3BhZCc+PC9kaXY+PC9kaXY+PC9kaXY+PC9kaXY+PGhyIC8+PC9kaXY+ZGQCCQ8WAh8FBSZ3aWR0aDoxMDAlO292ZXJmbG93OmF1dG87ZGlzcGxheTpub25lOxYGAgcPDxYCHwZoZGQCCQ8PFgIfBmhkZAILDxAPFgIfBmhkZGRkAgsPFgIfBQUNZGlzcGxheTpub25lOxYMAgEPDxYCHwAFZzxhIGhyZWY9J1RUUHVibGljQWNjZXNzLmFzcHg/dGlkPVRaMjU2NSZ5ZWFyPTIwMjYnIGNsYXNzPSdidG5zIGJ0bnMtcHJpbWFyeSBibHVlYnRuIGZyaWdodCc+UHVibGlzaDwvYT5kZAIdDxYCHwZoZAIfDxAPFgYeDURhdGFUZXh0RmllbGQFBG5hbWUeDkRhdGFWYWx1ZUZpZWxkBQhkaXZpc2lvbh4LXyFEYXRhQm91bmRnZBAVPANBbGwcVW5kZXIgMDggQm95cyBGaXJzdCBEaXZpc2lvbilVbmRlciAwOSBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3ZlchxVbmRlciAwOSBCb3lzIFRoaXJkIERpdmlzaW9uIVVuZGVyIDA5IEJveXMgRm91cnRoIERpdmlzaW9uIE9uZSxVbmRlciAwOSBCb3lzIEZvdXJ0aCBEaXZpc2lvbiBPbmUgIENyb3Nzb3ZlciBVbmRlciAwOS8xMCBHaXJscyBGaXJzdCBEaXZpc2lvbilVbmRlciAxMCBCb3lzIFNlY29uZCBEaXZpc2lvbi4tIENyb3Nzb3ZlchxVbmRlciAxMCBCb3lzIFRoaXJkIERpdmlzaW9uHVVuZGVyIDEwIEJveXMgRm91cnRoIERpdmlzaW9uKFVuZGVyIDEwIEJveXMgRmlmdGggRGl2aXNpb24uLSBDcm9zc292ZXIdVW5kZXIgMTEgR2lybHMgRmlyc3QgRGl2aXNpb24qVW5kZXIgMTEgR2lybHMgU2Vjb25kIERpdmlzaW9uLi0gQ3Jvc3NvdmVyKVVuZGVyIDExIEdpcmxzIFRoaXJkIERpdmlzaW9uLi0gQ3Jvc3NvdmVyHFVuZGVyIDExIEJveXMgRmlyc3QgRGl2aXNpb24dVW5kZXIgMTEgQm95cyBTZWNvbmQgRGl2aXNpb24cVW5kZXIgMTEgQm95cyBUaGlyZCBEaXZpc2lvbiFVbmRlciAxMSBCb3lzIEZvdXJ0aCBEaXZpc2lvbiBPbmUhVW5kZXIgMTEgQm95cyBGb3VydGggRGl2aXNpb24gVHdvLlVuZGVyIDEyIEdpcmxzIDl2OSBTZWNvbmQgRGl2aXNpb24uLSBDcm9zc292ZXIdVW5kZXIgMTIgR2lybHMgVGhpcmQgRGl2aXNpb24cVW5kZXIgMTIgQm95cyBGaXJzdCBEaXZpc2lvbilVbmRlciAxMiBCb3lzIFNlY29uZCBEaXZpc2lvbi4tIENyb3Nzb3ZlcihVbmRlciAxMiBCb3lzIFRoaXJkIERpdmlzaW9uLi0gQ3Jvc3NvdmVyKVVuZGVyIDEyIEJveXMgRm91cnRoIERpdmlzaW9uLi0gQ3Jvc3NvdmVyKFVuZGVyIDEyIEJveXMgRmlmdGggRGl2aXNpb24uLSBDcm9zc292ZXIdVW5kZXIgMTMgR2lybHMgRmlyc3QgRGl2aXNpb24qVW5kZXIgMTMgR2lybHMgU2Vjb25kIERpdmlzaW9uLi0gQ3Jvc3NvdmVyHlVuZGVyIDEzIEdpcmxzIEZvdXJ0aCBEaXZpc2lvbh9VbmRlciAxMiBHaXJscyAxMXZzMTEgIERpdmlzaW9uKFVuZGVyIDEzIEJveXMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXIdVW5kZXIgMTMgQm95cyBTZWNvbmQgRGl2aXNpb24oVW5kZXIgMTMgQm95cyBUaGlyZCBEaXZpc2lvbi4tIENyb3Nzb3Zlch1VbmRlciAxMyBCb3lzIEZvdXJ0aCBEaXZpc2lvbilVbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3ZlcipVbmRlciAxNCBHaXJscyBTZWNvbmQgRGl2aXNpb24uLSBDcm9zc292ZXIdVW5kZXIgMTQgR2lybHMgVGhpcmQgRGl2aXNpb24dVW5kZXIgMTQgQm95cyBTZWNvbmQgRGl2aXNpb24cVW5kZXIgMTQgQm95cyBUaGlyZCBEaXZpc2lvbh1VbmRlciAxNCBCb3lzIEZvdXJ0aCBEaXZpc2lvbh1VbmRlciAxNSBHaXJscyBGaXJzdCBEaXZpc2lvbh5VbmRlciAxNSBHaXJscyBTZWNvbmQgRGl2aXNpb24dVW5kZXIgMTUgQm95cyBTZWNvbmQgRGl2aXNpb24sVW5kZXIgMTUgQm95cyBUaGlyZCBEaXZpc2lvbiBPbmUuLSBDcm9zc292ZXIrVW5kZXIgMTUgQm95cyBUaGlyZCBEaXZpc2lvblR3by4tIENyb3Nzb3ZlcilVbmRlciAxNSBCb3lzIEZvdXJ0aCBEaXZpc2lvbi4tIENyb3Nzb3ZlchxVbmRlciAxNSBCb3lzIEZpZnRoIERpdmlzaW9uHFVuZGVyIDE2IEJveXMgRmlyc3QgRGl2aXNpb24pVW5kZXIgMTYgQm95cyBTZWNvbmQgRGl2aXNpb24uLSBDcm9zc292ZXIcVW5kZXIgMTYgQm95cyBUaGlyZCBEaXZpc2lvbilVbmRlciAxNiBCb3lzIEZvdXJ0aCBEaXZpc2lvbi4tIENyb3Nzb3Zlch1VbmRlciAxNyBHaXJscyBGaXJzdCBEaXZpc2lvbhxVbmRlciAxNyBCb3lzIEZpcnN0IERpdmlzaW9uHFVuZGVyIDE3IEJveXMgVGhpcmQgRGl2aXNpb24nVW5kZXIgMTcgQm95cyBGb3VydGggRGl2aXNpb24gQ3Jvc3NvdmVyK1VuZGVyIDE4LzE5IEJveXMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXIgVW5kZXIgMTgvMTkgQm95cyBTZWNvbmQgRGl2aXNpb24yVW5kZXIgMTgvMTkgQm95cyBUaGlyZCBEaXZpc2lvbiAuLSBPbmUuLSBDcm9zc292ZXIjVW5kZXIgMTgvMTkgQm95cyBUaGlyZCBEaXZpc2lvbiBUd28dVW5kZXIgMTkgQm95cyBGb3VydGggRGl2aXNpb24VPAAGVTA4TTAxBlUwOUYwMQZVMDlNMDEGVTA5TTAyBlUwOU0wMwZVMTBGMDEGVTEwTTAxBlUxME0wMgZVMTBNMDMGVTEwTTA0BlUxMUYwMQZVMTFGMDIGVTExRjAzBlUxMU0wMQZVMTFNMDIGVTExTTAzBlUxMU0wNAZVMTFNMDUGVTEyRjAxBlUxMkYwMgZVMTJNMDEGVTEyTTAyBlUxMk0wMwZVMTJNMDQGVTEyTTA1BlUxM0YwMQZVMTNGMDIGVTEzRjAzBlUxM0YwNAZVMTNNMDEGVTEzTTAyBlUxM00wMwZVMTNNMDQGVTE0RjAxBlUxNEYwMgZVMTRGMDMGVTE0TTAxBlUxNE0wMgZVMTRNMDMGVTE1RjAxBlUxNUYwMgZVMTVNMDEGVTE1TTAyBlUxNU0wMwZVMTVNMDQGVTE1TTA1BlUxNk0wMQZVMTZNMDIGVTE2TTAzBlUxNk0wNAZVMTdGMDEGVTE3TTAxBlUxN00wMgZVMTdNMDMGVTE5TTAxBlUxOU0wMgZVMTlNMDMGVTE5TTA0BlUxOU0wNRQrAzxnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dkZAIhDw8WAh8ABQExZGQCIw8QDxYCHwZoZGQWAGQCUQ9kFhICAQ8PFgIfAAVAU2NoZWR1bGluZyBPcHRpb25zIGZvciBVbmRlciAxNCBHaXJscyBGaXJzdCBEaXZpc2lvbi4tIENyb3Nzb3ZlcmRkAgcPEA8WBh8HBQV0aXRsZR8IBQhzZXF1ZW5jZR8JZ2QQFQERTm8gTm90ZSBEaXNwbGF5ZWQVAQEwFCsDAWdkZAIJDxYCHwAFMzxhIGhyZWY9J1RUVGV4dC5hc3B4P3F1YWw9RElWUyZzZXE9TkVXJnRpZD1UWjI1NjUnPmQCDw8PFgIfAAWvATxpbWcgc3JjPSdpbWFnZXMvMjAwOS9oZWxwMTUucG5nJyBzdHlsZT0nY3Vyc29yOnBvaW50ZXI7aGVpZ2h0OjE1cHg7JyBvbmNsaWNrPSdqYXZhc2NyaXB0OmVvX0NhbGxiYWNrKCJjcEhlbHBQYW5lbCIsICI5MDF8MXwwfDkwMSIpO2VvX0dldE9iamVjdCgiRGlhbG9nSGVscCIpLnNob3coZmFsc2UpOycgLz5kZAIRDxBkEBULA04vQQExATIBMwE0ATUBNgE3ATgBOQIxMBULAAExATIBMwE0ATUBNgE3ATgBOQIxMBQrAwtnZ2dnZ2dnZ2dnZ2RkAhMPDxYCHwAFrwE8aW1nIHNyYz0naW1hZ2VzLzIwMDkvaGVscDE1LnBuZycgc3R5bGU9J2N1cnNvcjpwb2ludGVyO2hlaWdodDoxNXB4Oycgb25jbGljaz0namF2YXNjcmlwdDplb19DYWxsYmFjaygiY3BIZWxwUGFuZWwiLCAiOTA0fDF8MHw5MDQiKTtlb19HZXRPYmplY3QoIkRpYWxvZ0hlbHAiKS5zaG93KGZhbHNlKTsnIC8+ZGQCFw8PFgIfAGVkZAIfDw8WAh8ABa8BPGltZyBzcmM9J2ltYWdlcy8yMDA5L2hlbHAxNS5wbmcnIHN0eWxlPSdjdXJzb3I6cG9pbnRlcjtoZWlnaHQ6MTVweDsnIG9uY2xpY2s9J2phdmFzY3JpcHQ6ZW9fQ2FsbGJhY2soImNwSGVscFBhbmVsIiwgIjkwMnwxfDB8OTAyIik7ZW9fR2V0T2JqZWN0KCJEaWFsb2dIZWxwIikuc2hvdyhmYWxzZSk7JyAvPmRkAikPDxYCHwAFrwE8aW1nIHNyYz0naW1hZ2VzLzIwMDkvaGVscDE1LnBuZycgc3R5bGU9J2N1cnNvcjpwb2ludGVyO2hlaWdodDoxNXB4Oycgb25jbGljaz0namF2YXNjcmlwdDplb19DYWxsYmFjaygiY3BIZWxwUGFuZWwiLCAiOTAzfDF8MHw5MDMiKTtlb19HZXRPYmplY3QoIkRpYWxvZ0hlbHAiKS5zaG93KGZhbHNlKTsnIC8+ZGQCDQ8WAh8FBTh3aWR0aDoxMDAlO292ZXJmbG93OmF1dG87ZGlzcGxheTpub25lO3RleHQtYWxpZ246Y2VudGVyOxYCAgEPZBYCAgUPPCsACQBkAhUPZBYCAgEPD2QPD2QFtAJBQU1hZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5MGJDNXdibWNDQXhsK0wybHRZV2RsY3k4eU1ERXpMMjF2WkdGc0wzUXVjRzVuQkFNYWZpOXBiV0ZuWlhNdk1qQXhNeTl0YjJSaGJDOTBjaTV3Ym1jSEF4bCtMMmx0WVdkbGN5OHlNREV6TDIxdlpHRnNMMnd1Y0c1bkNBTVpmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzl5TG5CdVp3c0RHbjR2YVcxaFoyVnpMekl3TVRNdmJXOWtZV3d2WW13dWNHNW5EUU1aZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5aUxuQnVadzhER240dmFXMWhaMlZ6THpJd01UTXZiVzlrWVd3dlluSXVjRzVuQUFBPTwrAA4BAAVUREFNRllteGhZMnNOQWpJQUFBQXdBdzl5WlhOcGVtRmliR1ZFYVdGc2IyYzJBVDBER0g0dmFXMWhaMlZ6TDJOc2IzTmxSR2xoYkc5bkxuQnVad0FBFgJmD2QWAgIBDw9kD2QF5ANCd1BqQW50RGIyNTBjbTlzU1VRNlluUnVSR1ZzWlhSbE8xQmhjbUZ0WlhSbGNqcGtaV3hsZEdWOUxIdERiMjUwY205c1NVUTZZblJ1VlhCa1lYUmxPMUJoY21GdFpYUmxjanB6WVhabGZTeDdRMjl1ZEhKdmJFbEVPa0owYmtGa1pFTmhjbVE3VUdGeVlXMWxkR1Z5T21Ga1pFTmhjbVI5TEh0RGIyNTBjbTlzU1VRNlluUnVVMk52Y21VN1VHRnlZVzFsZEdWeU9uTmhkbVY5TEh0RGIyNTBjbTlzU1VRNlFuUnVSR1ZzUTJGeVpEdFFZWEpoYldWMFpYSTZaR1ZzUTJGeVpIMHNlME52Ym5SeWIyeEpSRHBDZEc1RGJHVmhjanRRWVhKaGJXVjBaWEk2WTJ4bFlYSkRhR0Z1WjJWOUxIdERiMjUwY205c1NVUTZZblJ1VDFBN1VHRnlZVzFsZEdWeU9tOTJaWEp5YVdSbFVHOXBiblJ6ZlN4N1EyOXVkSEp2YkVsRU9tSjBia1pzYVhBN1VHRnlZVzFsZEdWeU9tWnNhWEI5TEh0RGIyNTBjbTlzU1VRNlluUnVSWGhqYkhWa1pUdFFZWEpoYldWMFpYSTZaWGhqYkhWa1pYMEFBQT09FgICAQ9kFgICOw9kFgICAQ8PZA9kBTBCd01mZTBOdmJuUnliMnhKUkRwa1pHeFdaVzUxWlR0UVlYSmhiV1YwWlhJNmZRQUEWAgIBDxBkZBYAZAIZD2QWIAILDw8WAh8ABQZVMTRGMDFkZAITDw8WAh8ABQZUWjI1NjVkZAIZDw8WAh8ABQQyMDI2ZGQCHQ8PFgIfAAUGVFoyNTY1ZGQCHw8PFgIfAAUFSUwwMTJkZAIhDw8WAh8AZWRkAiMPDxYCHwAFAVlkZAIlDw8WAh8ABQEwZGQCJw8PFgIfAGVkZAIzDw8WAh8AZWRkAjUPDxYCHwBlZGQCOw8PFgIfAAUpVW5kZXIgMTQgR2lybHMgRmlyc3QgRGl2aXNpb24uLSBDcm9zc292ZXJkZAI9Dw8WAh8AZWRkAkcPDxYCHwBkZGQCSw8PFgIfAAUEMjAyNmRkAlEPDxYCHwAFCDQvNy8yMDI2ZGQCGw8PZA8PZAW0AkFBTWFmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzkwYkM1d2JtY0NBeGwrTDJsdFlXZGxjeTh5TURFekwyMXZaR0ZzTDNRdWNHNW5CQU1hZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5MGNpNXdibWNIQXhsK0wybHRZV2RsY3k4eU1ERXpMMjF2WkdGc0wyd3VjRzVuQ0FNWmZpOXBiV0ZuWlhNdk1qQXhNeTl0YjJSaGJDOXlMbkJ1WndzREduNHZhVzFoWjJWekx6SXdNVE12Ylc5a1lXd3ZZbXd1Y0c1bkRRTVpmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzlpTG5CdVp3OERHbjR2YVcxaFoyVnpMekl3TVRNdmJXOWtZV3d2WW5JdWNHNW5BQUE9PCsADgEABVREQU1GWW14aFkyc05BaklBQUFBd0F3OXlaWE5wZW1GaWJHVkVhV0ZzYjJjMkFUMERHSDR2YVcxaFoyVnpMMk5zYjNObFJHbGhiRzluTG5CdVp3QUEWAmYPZBYCAgEPD2QPZAVAQndNcWUwTnZiblJ5YjJ4SlJEcHljSFJFYVdabVpYSmxiblJwWVd3N1VHRnlZVzFsZEdWeU9uTmhkbVY5QUFBPWQCHQ8PZA8PZAW0AkFBTWFmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzkwYkM1d2JtY0NBeGwrTDJsdFlXZGxjeTh5TURFekwyMXZaR0ZzTDNRdWNHNW5CQU1hZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5MGNpNXdibWNIQXhsK0wybHRZV2RsY3k4eU1ERXpMMjF2WkdGc0wyd3VjRzVuQ0FNWmZpOXBiV0ZuWlhNdk1qQXhNeTl0YjJSaGJDOXlMbkJ1WndzREduNHZhVzFoWjJWekx6SXdNVE12Ylc5a1lXd3ZZbXd1Y0c1bkRRTVpmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzlpTG5CdVp3OERHbjR2YVcxaFoyVnpMekl3TVRNdmJXOWtZV3d2WW5JdWNHNW5BQUE9PCsADgEABVREQU1GWW14aFkyc05BaklBQUFBd0F3OXlaWE5wZW1GaWJHVkVhV0ZzYjJjMkFUMERHSDR2YVcxaFoyVnpMMk5zYjNObFJHbGhiRzluTG5CdVp3QUEWAmYPZBYCAgEPZWQCHw8PFgIfBmdkZAIhDw8WAh8GZ2RkAg8PFgIfAAWAATxhIGhyZWY9Jy9UVE1hc3NNYWlsLmFzcHg/dGlkPVRaMjU2NSc+Q29udGFjdCBVczwvYT48YnIgLz48YSBocmVmPScvVFRTY2hlZHVsZXMuYXNweD90aWQ9VFoyNTY1Jz5TY2hlZHVsZXMgJiBTdGFuZGluZ3M8L2E+PGJyIC8+ZAIRDxYCHwAF0AE8YSBocmVmPScvVFRGaW5kTWUuYXNweD90aWQ9VFoyNTY1Jz5Mb2dpbiBIZWxwPC9hPjxiciAvPjxhIGhyZWY9Jy9jb250YWN0LmFzcHg/dGlkPVRaMjU2NSc+Q29udGFjdCBTdXBwb3J0PC9hPjxiciAvPjxhIGhyZWY9J2h0dHA6Ly93d3cuc2luY3Nwb3J0cy5jb20vbW9iaWxlLmFzcHgnIHRhcmdldD0nX2JsYW5rJz5Eb3dubG9hZCB0aGUgbW9iaWxlIGFwcCE8L2E+ZAITDw8WBh8ABTc8aW1nIHNyYz0nL2ltYWdlcy91c2EtbG9nby1kYXJrLnBuZycgY2xhc3M9J3VzYWxvZ28nIC8+HwEFGWh0dHA6Ly91c2F0b3VybmFtZW50cy5jb20eBlRhcmdldAUGX2JsYW5rZGQCFQ8WAh8ABQQyMDI2ZAIXDw8WAh8BBSUvcHJpdmFjeS5hc3B4P3RpZD1UWjI1NjUmc2luYz1OJnNpYz1OZGQCGQ8PFgIfAQUqL2Nvb2tpZXBvbGljeS5hc3B4P3RpZD1UWjI1NjUmc2luYz1OJnNpYz1OZGQCHQ8PZA8PZAW0AkFBTWFmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzkwYkM1d2JtY0NBeGwrTDJsdFlXZGxjeTh5TURFekwyMXZaR0ZzTDNRdWNHNW5CQU1hZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5MGNpNXdibWNIQXhsK0wybHRZV2RsY3k4eU1ERXpMMjF2WkdGc0wyd3VjRzVuQ0FNWmZpOXBiV0ZuWlhNdk1qQXhNeTl0YjJSaGJDOXlMbkJ1WndzREduNHZhVzFoWjJWekx6SXdNVE12Ylc5a1lXd3ZZbXd1Y0c1bkRRTVpmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzlpTG5CdVp3OERHbjR2YVcxaFoyVnpMekl3TVRNdmJXOWtZV3d2WW5JdWNHNW5BQUE9PCsADgEABUhNQU1QY21WemFYcGhZbXhsUkdsaGJHOW5OZ0lBQUFBQVBRTVlmaTlwYldGblpYTXZZMnh2YzJWRWFXRnNiMmN1Y0c1bkFBQT0WAmYPZBYCAgEPZWQCIQ9kFgICAQ8PZA8PZAW0AkFBTWFmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzkwYkM1d2JtY0NBeGwrTDJsdFlXZGxjeTh5TURFekwyMXZaR0ZzTDNRdWNHNW5CQU1hZmk5cGJXRm5aWE12TWpBeE15OXRiMlJoYkM5MGNpNXdibWNIQXhsK0wybHRZV2RsY3k4eU1ERXpMMjF2WkdGc0wyd3VjRzVuQ0FNWmZpOXBiV0ZuWlhNdk1qQXhNeTl0YjJSaGJDOXlMbkJ1WndzREduNHZhVzFoWjJWekx6SXdNVE12Ylc5a1lXd3ZZbXd1Y0c1bkRRTVpmaTlwYldGblpYTXZNakF4TXk5dGIyUmhiQzlpTG5CdVp3OERHbjR2YVcxaFoyVnpMekl3TVRNdmJXOWtZV3d2WW5JdWNHNW5BQUE9PCsADgEABVREQU1GWW14aFkyc05BaklBQUFBd0F3OXlaWE5wZW1GaWJHVkVhV0ZzYjJjMkFUMERHSDR2YVcxaFoyVnpMMk5zYjNObFJHbGhiRzluTG5CdVp3QUEWAmYPZBYCAgEPZWQCJQ8PFgIfBmhkZBgBBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WPAUnY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYkFsbEJyYWNrZXRzBSNjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiT25lUGFnZQUjY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYkJ5VmVudWUFImN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JCeUNsdWIFH2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJEVEYFH2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJEVEYFH2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJERlQFH2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJERlQFImN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JIaWRlVVMFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JIaWRlVVMyBSRjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiTWlkbmlnaHQFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkQ0JGdWxsRGl2BSJjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJENCUmVwb3J0BSFjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJENCQ29kZXMFIGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JMaW5rBR5jdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJENCSEEFIWN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJJbml0MQUhY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRyYkluaXQxBSFjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHJiSW5pdDIFIWN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJJbml0MgUhY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRyYkluaXQzBSFjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHJiSW5pdDMFIGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkcmJTWWVzBR9jdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHJiU05vBR9jdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHJiU05vBSBjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHJiT1llcwUfY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRyYk9ObwUfY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRyYk9ObwUmY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYkFkdmFuY2VBbGwFJWN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JMb2NrUEdBbGwFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JMb2NrQWxsBSNjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiU3RkQ29sMQUjY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZENvbDIFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRDb2wzBSNjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiU3RkQ29sNAUjY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZENvbDUFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRDb2w2BSNjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiU3RkQ29sNwUjY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZENvbDgFI2N0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRDb2w5BSRjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiU3RkQ29sMTAFJGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRDb2wxMQUkY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZENvbDEyBSRjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJGNiU3RkQ29sMTMFJGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRDb2wxNAUjY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZFNob3cFJGN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkY2JTdGRMaW5rcwUiY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYlN0ZEFsbAUfY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSRjYldUTAU/Y3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSR1cGRHYW1lJERpYWxvZ1VwZEdhbWUkY3RsMDAkY2JSZWZyZXNoBTpjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHVwZEdhbWUkRGlhbG9nVXBkR2FtZSRjdGwwMCRDQk9UBTpjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHVwZEdhbWUkRGlhbG9nVXBkR2FtZSRjdGwwMCRDQlBLBUBjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHVwZEdhbWUkRGlhbG9nVXBkR2FtZSRjdGwwMCRjYkRGb3JmZWl0BT9jdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHVwZEdhbWUkRGlhbG9nVXBkR2FtZSRjdGwwMCRjYkZvcmZlaXQFOmN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkdXBkR2FtZSREaWFsb2dVcGRHYW1lJGN0bDAwJENCVE0FPmN0bDAwJENvbnRlbnRQbGFjZUhvbGRlcjEkdXBkR2FtZSREaWFsb2dVcGRHYW1lJGN0bDAwJGNiUG9pbnRzBUFjdGwwMCRDb250ZW50UGxhY2VIb2xkZXIxJHVwZEdhbWUkRGlhbG9nVXBkR2FtZSRjdGwwMCRjYkNhbmNlbGxlZAU9Y3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSR1cGRHYW1lJERpYWxvZ1VwZEdhbWUkY3RsMDAkQ0JIQ2FyZAU9Y3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSR1cGRHYW1lJERpYWxvZ1VwZEdhbWUkY3RsMDAkQ0JBQ2FyZAVCY3RsMDAkQ29udGVudFBsYWNlSG9sZGVyMSR1cGRHYW1lJERpYWxvZ1VwZEdhbWUkY3RsMDAkY2JGdWxsVXBkYXRlZC4nFK/IuAtyV0YTCrd4bIn5OYc=" />
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
+    }
+}
+//]]>
+</script>
+
+
+
+<script type="text/javascript">
+//<![CDATA[
+if (typeof(EO25264)=='undefined'){EO25264=new Object();EO25264.f=new Object();EO25264.g=new Object();EO25264.r=new Object();EO25264.g.a=EO25264.r;EO25264.r.getVersion=function(){return "25.264";};EO25264.r.getLoader=function(){return typeof(EO25264.g.d)!='undefined'?EO25264.g.d:null;};EO25264.r.getNS=function(){return "EO25264";};};
+EO25264.r.product='EO.Web';
+EO25264.r.form='aspnetForm';
+EO25264.r.autoInit=false;
+EO25264.r.handlerUrl='/eo_web.ashx';
+
+//]]>
+</script>
+<script type="text/javascript" src="/js/eo/eo.18ccd2b5-5bb4-4e32-aeb3-adc32338a5de.js"></script>
+<script type="text/javascript" src="/js/eo/eo.310dad10-dab1-44a7-a637-c218ef9aa3b7.js"></script>
+<script type="text/javascript" src="/js/eo/eo.86c43cce-ff60-427d-9a37-1e16debbe456.js"></script>
+<script type="text/javascript" src="/js/eo/eo.e1a21eb1-352a-4a42-b2b6-bbacb24a29d1.js"></script>
+<script type="text/javascript" src="/js/eo/eo.1690bc33-6c82-4e45-a64c-c8c0fde91095.js"></script><div id="eo_root"></div>
+<script type="text/javascript" src="/js/eo/eo.20891133-56ac-42df-9870-2d95a8ab231e.js"></script>
+<script type="text/javascript" src="/js/eo/eo.59fe8f2b-e671-41c5-9491-e9b2df72e9ec.js"></script>
+<script type="text/javascript" src="/js/eo/eo.54ab8d54-4fdd-42e1-a5ec-62c40a48bb49.js"></script>
+<script type="text/javascript" src="/js/eo/eo.e955a919-0660-48a3-972b-6a7e7c13879e.js"></script>
+<script type="text/javascript" src="/js/eo/eo.a81cac04-7396-436e-96d4-99acb86cb2be.js"></script>
+        
+<nav id="nav" class="navbar navbar-expand-lg navbar-light bg-gray-200 border-bottom fixed-top p-2 pr-0 pl-0 shadow">
+    <div class="container-fluid">
+        <!-- Brand -->
+        <a id="ctl00_navbar_lnkSportLogo" class="navbar-brand d-inline-block d-md-none" href="/Default.aspx">
+            <img src="/images/sincsports/sinc_line.png" alt="SincSports" style="height:35px;" />
+        </a>
+        <!-- Toggler -->
+        <a class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" 
+            aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+            <i class="mdi mdi-menu"></i>
+        </a>
+        <!-- Collapse -->
+        <div class="collapse navbar-collapse" id="navbarCollapse">
+            <!-- Toggler -->
+            <a class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" 
+                    aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+                <i class="mdi mdi-menu"></i>
+            </a>
+            <!-- Navigation -->
+            <ul class="navbar-nav w-100">
+                
+                <li class='nav-item dropdown'><a class='nav-link' href='#'><i class='mdi mdi-menu d-lg-block d-none'></i><span class='d-lg-none d-block'>MENU</span></a><ul class='dml dropdown-menu'><li class='dropdown-item'><a href='/TTMassMail.aspx?tid=TZ2565' class='dropdown-link'>Contact Event<img src='/images/smbar/mail.png' class='float-right' border='0' /></a></li><li class='dropdown-item'><a href='/dash.aspx?id=&tid=TZ2565&tasks=Y&sinc=N' class='dropdown-link'>Event Tasks</a></li><li class='dropdown-item dropright'><a href='#' class='dropdown-link dropdown-toggle' data-toggle='dropdown'>My Account</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='TTLogin.aspx' class='dropdown-link' data-toggle='dropdown'>Login to view your account</a></li></ul><li class='dropdown-item dropright'><a href='#' class='dropdown-link dropdown-toggle' data-toggle='dropdown'>Soccer in college</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='colleges.aspx' class='dropdown-link' data-toggle='dropdown'>Colleges</a></li><li class='dropdown-item'><a href='events.aspx' class='dropdown-link' data-toggle='dropdown'>Tournaments</a></li><li class='dropdown-item'><a href='events.aspx?leagues=Y' class='dropdown-link' data-toggle='dropdown'>Leagues</a></li><li class='dropdown-item'><a href='sicClubs.aspx' class='dropdown-link' data-toggle='dropdown'>Teams</a></li><li class='dropdown-item'><a href='sicAthletes.aspx' class='dropdown-link' data-toggle='dropdown'>Athletes</a></li></ul><li class='dropdown-item dropright'><a href='#' class='dropdown-link dropdown-toggle' data-toggle='dropdown'>USA Rank</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='https://usa.sincsports.com/rank/about' target='_blank' class='dropdown-link' data-toggle='dropdown'>How USA Rank works</a></li><li class='dropdown-item'><a href='https://usa.sincsports.com/rank/view' target='_blank' class='dropdown-link' data-toggle='dropdown'>View Rankings</a></li></ul><li class='dropdown-item dropright'><a href='#' class='dropdown-link dropdown-toggle' data-toggle='dropdown'>SincSports</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='http://sincmyteam.com' target='_blank' class='dropdown-link' data-toggle='dropdown'>Sinc My Team</a></li><li class='dropdown-item'><a href='/sicTournaments.aspx' class='dropdown-link' data-toggle='dropdown'>Upcoming Events</a></li><li class='dropdown-item'><a href='https://www.sincsports.com' target='_blank' class='dropdown-link' data-toggle='dropdown'>Promote Your Event</a></li></ul><li class='dropdown-item dropright'><a href='#' class='dropdown-link dropdown-toggle' data-toggle='dropdown'>Help & Support</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='/sicSupport.aspx' class='dropdown-link' data-toggle='dropdown'>Contact Us</a></li></ul></li></ul></li><li class='nav-item'><a href='/TTIntro.aspx?tid=TZ2565&tab=1&sub=0'  class='nav-link'>Home</a></li><li class='nav-item'><a href='/TTApply0.aspx?tid=TZ2565&tab=2&sub=0'  class='nav-link'>Apply</a></li><li class='nav-item'><a href='/TTSchedules.aspx?tid=TZ2565&tab=3&sub=0'  class='nav-link'>Schedules</a></li><li class='nav-item dropdown'><a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>Information</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='/TTMore.aspx?tid=TZ2565&tab=4&sub=1&Qual=MISC&Seq=2'  class='dropdown-link'>Documents</a></li><li class='dropdown-item'><a href='/TTMore.aspx?tid=TZ2565&tab=4&sub=2&Qual=MISC&Seq=5'  class='dropdown-link'>Fields</a></li></ul></li><li class='nav-item dropdown'><a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>Check In</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='/TTMore.aspx?tid=TZ2565&tab=5&sub=1&Qual=MISC&Seq=3'  class='dropdown-link'>Requirements</a></li></ul></li><li class='nav-item'><a href='/TTTeamList.aspx?tid=TZ2565&tab=6&sub=0'  class='nav-link'>Teams</a></li><li class='nav-item dropdown'><a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>College Coaches</a><ul class='dropdown-menu'><li class='dropdown-item'><a href='/TTCollegeRegister.aspx?tid=TZ2565&tab=7&sub=1'  class='dropdown-link'>Coach Registration</a></li><li class='dropdown-item'><a href='/TTCollegeList.aspx?tid=TZ2565&tab=7&sub=2'  class='dropdown-link'>Attending Coaches</a></li></ul></li>
+                <li class=" flex-grow-1"></li>
+                <li class="nav-item dropdown">
+                    <a id="ctl00_navbar_lnkLogin" class="navbar-btn btn btn-sm btn-pill btn-white lift ml-auto text-primary" href="/TTLogin.aspx">Log In / Sign Up</a>
+                    
+              </li>
+            </ul>
+
+
+        </div>
+    </div>
+</nav>
+<div class="collapse mt-10" id="searchTB">
+    <div class="container">
+        <div class="d-flex">
+            <select name="ctl00$navbar$ddlSearchType" id="ctl00_navbar_ddlSearchType" class="form-control mr-2">
+	<option value="people">People Search</option>
+	<option value="event">Event Search</option>
+	<option value="usarank">USA Rank ID</option>
+
+</select>
+            <input name="ctl00$navbar$tbSearch" type="text" id="ctl00_navbar_tbSearch" class="form-control mr-2" />
+            <a href="#" class="btn btn-primary" onclick="eo_Callback('cpSearch', 'search'); return false;">Search</a>
+        </div>
+        <div>
+            <div style="position:absolute; top:-1000px;"><input type="hidden" name="eo_version" value="25.2.64.0" /><input type="hidden" name="eo_style_keys" value="/wFk" /><input type="hidden" name="__eo_obj_states"></div>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.r.product='EO.Web';
+EO25264.r.debug=0;
+EO25264.r.aspnet11=0;
+var eo_culture_i=eval('({"name":"","numberFormat":{"CurrencyDecimalDigits":2,"CurrencyDecimalSeparator":".","IsReadOnly":true,"CurrencyGroupSizes":[3],"NumberGroupSizes":[3],"PercentGroupSizes":[3],"CurrencyGroupSeparator":",","CurrencySymbol":"\u00A4","NaNSymbol":"NaN","CurrencyNegativePattern":0,"NumberNegativePattern":1,"PercentPositivePattern":0,"PercentNegativePattern":0,"NegativeInfinitySymbol":"-Infinity","NegativeSign":"-","NumberDecimalDigits":2,"NumberDecimalSeparator":".","NumberGroupSeparator":",","CurrencyPositivePattern":0,"PositiveInfinitySymbol":"Infinity","PositiveSign":"+","PercentDecimalDigits":2,"PercentDecimalSeparator":".","PercentGroupSeparator":",","PercentSymbol":"%","PerMilleSymbol":"\u2030","NativeDigits":["0","1","2","3","4","5","6","7","8","9"],"DigitSubstitution":1},"dateTimeFormat":{"AMDesignator":"AM","Calendar":{"MinSupportedDateTime":"@-62135568000000@","MaxSupportedDateTime":"@253402300799999@","AlgorithmType":1,"CalendarType":1,"Eras":[1],"TwoDigitYearMax":2029,"IsReadOnly":true},"DateSeparator":"/","FirstDayOfWeek":0,"CalendarWeekRule":0,"FullDateTimePattern":"dddd, dd MMMM yyyy HH:mm:ss","LongDatePattern":"dddd, dd MMMM yyyy","LongTimePattern":"HH:mm:ss","MonthDayPattern":"MMMM dd","PMDesignator":"PM","RFC1123Pattern":"ddd, dd MMM yyyy HH\':\'mm\':\'ss \'GMT\'","ShortDatePattern":"MM/dd/yyyy","ShortTimePattern":"HH:mm","SortableDateTimePattern":"yyyy\'-\'MM\'-\'dd\'T\'HH\':\'mm\':\'ss","TimeSeparator":":","UniversalSortableDateTimePattern":"yyyy\'-\'MM\'-\'dd HH\':\'mm\':\'ss\'Z\'","YearMonthPattern":"yyyy MMMM","AbbreviatedDayNames":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"ShortestDayNames":["Su","Mo","Tu","We","Th","Fr","Sa"],"DayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"AbbreviatedMonthNames":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",""],"MonthNames":["January","February","March","April","May","June","July","August","September","October","November","December",""],"IsReadOnly":true,"NativeCalendarName":"Gregorian Calendar","AbbreviatedMonthGenitiveNames":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",""],"MonthGenitiveNames":["January","February","March","April","May","June","July","August","September","October","November","December",""]}})');//eo_culture_i
+var eo_culture=eval('({"name":"en-US","numberFormat":{"CurrencyDecimalDigits":2,"CurrencyDecimalSeparator":".","IsReadOnly":false,"CurrencyGroupSizes":[3],"NumberGroupSizes":[3],"PercentGroupSizes":[3],"CurrencyGroupSeparator":",","CurrencySymbol":"$","NaNSymbol":"NaN","CurrencyNegativePattern":0,"NumberNegativePattern":1,"PercentPositivePattern":0,"PercentNegativePattern":0,"NegativeInfinitySymbol":"-Infinity","NegativeSign":"-","NumberDecimalDigits":2,"NumberDecimalSeparator":".","NumberGroupSeparator":",","CurrencyPositivePattern":0,"PositiveInfinitySymbol":"Infinity","PositiveSign":"+","PercentDecimalDigits":2,"PercentDecimalSeparator":".","PercentGroupSeparator":",","PercentSymbol":"%","PerMilleSymbol":"‰","NativeDigits":["0","1","2","3","4","5","6","7","8","9"],"DigitSubstitution":1},"dateTimeFormat":{"AMDesignator":"AM","Calendar":{"MinSupportedDateTime":new Date(-62135568000000),"MaxSupportedDateTime":new Date(253402300799999),"AlgorithmType":1,"CalendarType":1,"Eras":[1],"TwoDigitYearMax":2029,"IsReadOnly":false},"DateSeparator":"/","FirstDayOfWeek":0,"CalendarWeekRule":0,"FullDateTimePattern":"dddd, MMMM dd, yyyy h:mm:ss tt","LongDatePattern":"dddd, MMMM dd, yyyy","LongTimePattern":"h:mm:ss tt","MonthDayPattern":"MMMM dd","PMDesignator":"PM","RFC1123Pattern":"ddd, dd MMM yyyy HH\u0027:\u0027mm\u0027:\u0027ss \u0027GMT\u0027","ShortDatePattern":"M/d/yyyy","ShortTimePattern":"h:mm tt","SortableDateTimePattern":"yyyy\u0027-\u0027MM\u0027-\u0027dd\u0027T\u0027HH\u0027:\u0027mm\u0027:\u0027ss","TimeSeparator":":","UniversalSortableDateTimePattern":"yyyy\u0027-\u0027MM\u0027-\u0027dd HH\u0027:\u0027mm\u0027:\u0027ss\u0027Z\u0027","YearMonthPattern":"MMMM, yyyy","AbbreviatedDayNames":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"ShortestDayNames":["Su","Mo","Tu","We","Th","Fr","Sa"],"DayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"AbbreviatedMonthNames":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",""],"MonthNames":["January","February","March","April","May","June","July","August","September","October","November","December",""],"IsReadOnly":false,"NativeCalendarName":"Gregorian Calendar","AbbreviatedMonthGenitiveNames":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",""],"MonthGenitiveNames":["January","February","March","April","May","June","July","August","September","October","November","December",""]}})');//eo_culture
+
+//]]>
+</script>
+<table id="ctl00_navbar_cpSearch" style="width:100%;width:100%;">
+	<tbody>
+		<tr>
+			<td>
+                
+            </td>
+		</tr>
+	</tbody>
+</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_navbar_cpSearch=1;EO25264.r._o_ctl00_navbar_cpSearch=EO25264.f.acg(EO25264.r._o_ctl00_navbar_cpSearch,"cpSearch",new EO25264.f.aaum([[,"ctl00_navbar_cpSearch","Callback","ctl00$navbar$cpSearch",,,,,,,"__doPostBack('ctl00$navbar$cpSearch','_eo_arg_')"],,"__doPostBack('ctl00$navbar$cpSearch','')",,,,,,[],"<div class='loading'></div>",,,,,,,,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_navbar_cpSearch,1,null, 0);});
+//]]>
+</script>
+
+        </div>
+    </div>
+</div>
+
+<style type="text/css">
+.mergeAthleteDiv 
+{
+	font-family: Arial, Helvetica, sans-serif; font-size: 12px; width:250px;z-index: 10000000;margin-top:68px;
+	color: #000; padding: 10px 10px 5px 10px; -webkit-border-bottom-right-radius: 10px;-moz-border-radius-bottomright: 10px;background: #fefefe;
+	background:-moz-linear-gradient(top,#fefefe 0%,#b7b7b7); background: -webkit-gradient(linear, left top, left bottom, from(#fefefe),to(#b7b7b7));
+	border: 0px solid #474747;-moz-box-shadow:0px 0px 0px rgba(000,000,000,0.5),inset 0px 0px 9px rgba(255,255,255,1);
+	-webkit-box-shadow: 0px 0px 0px rgba(000,000,000,0.5),inset 0px 0px 9px rgba(255,255,255,1);
+	-moz-box-shadow: 2px 5px 15px #9a9a9a;-webkit-box-shadow: 3px 5px 15px #9a9a9a;
+}
+
+</style>
+<script type="text/javascript" language="javascript">
+    function MergeAthlete(img, Athleteid) {
+        $(".amerge").attr("src", "/images/mergeSignRed.png");
+        $(".pmerge").hide();
+        $(".merge").hide();
+        $(img).hide();
+        eo_Callback('ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl', Athleteid + "|" + img.id);
+        return false;
+    }
+
+    function cancelAthleteMerge() {
+        $(".amerge").attr("src", "/images/mergeSign.png");
+        $(".pmerge").show();
+        $(".amerge").show();
+        $(".merge").show();
+        var showthis = $('ctl00_navbar_sicAthleteMerge_lblFirstAthleteId').html();
+        if (showthis != "")
+            $('#' + showthis).show();
+        eo_Callback('ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl', 'clear');
+        return false;
+        
+    }
+</script>
+<table id="ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl">
+	<tbody>
+		<tr>
+			<td>
+        
+</td>
+		</tr>
+	</tbody>
+</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl=1;EO25264.r._o_ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl=EO25264.f.acg(EO25264.r._o_ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl,"cpMergeAthleteControl",new EO25264.f.aaum([[,"ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl","Callback","ctl00$navbar$sicAthleteMerge$cpMergeAthleteControl",,,,,,,"__doPostBack('ctl00$navbar$sicAthleteMerge$cpMergeAthleteControl','_eo_arg_')"],,"__doPostBack('ctl00$navbar$sicAthleteMerge$cpMergeAthleteControl','')",,,,,,[],,,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_navbar_sicAthleteMerge_cpMergeAthleteControl,1,null, 0);});
+//]]>
+</script>
+
+
+
+<!-- Begin EO.Web Dialog dialogHandleAlert.  -->
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+<table id="ctl00_navbar_dialogHandleAlert" border="0" class="eo_no_border_spacing" style="width:400px;display:none;">
+	<tr><td align="left"><div id="ctl00_navbar_dialogHandleAlert_headerDiv"  ><div style="position:relative;z-index:2;"><div id="ctl00_navbar_dialogHandleAlert_headerHtml">SincSports Alert</div><table id="ctl00_navbar_dialogHandleAlert_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_navbar_dialogHandleAlert_close" alt="" style="display:none"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_navbar_dialogHandleAlert_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" align="left" valign="top">
+        <p>
+        </p>
+        <span id="ctl00_navbar_dialogHandleAlert_ctl00_lblType"></span>
+        <div class="text-center">
+             <a id="ctl00_navbar_dialogHandleAlert_ctl00_lnkHandleAlert" class="btn btn-danger">Handle Alert</a>
+        </div>
+       
+    </td></tr></table></td></tr><tr><td><div id="ctl00_navbar_dialogHandleAlert_footerDiv" style="position:relative;width:auto;"><table id="ctl00_navbar_dialogHandleAlert_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_navbar_dialogHandleAlert_footer"  class="eo_align_center"></td></tr></table></div></td></tr>
+</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_navbar_dialogHandleAlert=1;EO25264.r._o_ctl00_navbar_dialogHandleAlert=EO25264.f.acg(EO25264.r._o_ctl00_navbar_dialogHandleAlert,"dialogHandleAlert",new EO25264.f.bak([[[,"ctl00_navbar_dialogHandleAlert","Dialog","ctl00$navbar$dialogHandleAlert",,,,,,,"__doPostBack('ctl00$navbar$dialogHandleAlert','_eo_arg_')"],,,,,,,,,[]],,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_navbar_dialogHandleAlert_ctl00","ctl00_navbar_dialogHandleAlert_ctl01"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_navbar_dialogHandleAlert,1,300, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+<!-- End EO.Web Dialog dialogHandleAlert.  -->
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#searchlnk").click(function (e) {
+            $("#searchTB").toggle("collapse");
+            e.preventDefault();
+        });
+        //if ($("#nav").height > 58)
+        //    $("#nav").css("font-size", "10pt");
+        $("#ctl00_navbar_ddlSearchType").change(function () {
+            if ($(this).val() == "event") {
+                $('#ctl00_navbar_tbSearch').autocomplete({
+                    source: function (request, response) {
+                        $.ajax({
+                            type: "POST",
+                            contentType: "application/json; charset=utf-8",
+                            url: "/services/AutoComplete.asmx/GetTournaments",
+                            dataType: "json",
+                            data: "{'state':'', 'prefix':'" + request.term + "'}",
+                            success: function (data) {
+                                response($.map(data.d, function (item) {
+                                    return {
+                                        label: item.Name,
+                                        value: item.Value
+                                    }
+                                }))
+                            }
+                        });
+                    },
+                    minLength: 3,
+                    select: function (event, ui) {
+                        window.location = "TTIntro.aspx?register=Y&tid=" + ui.item.value;
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                        alert(textStatus);
+                    }
+                });
+
+            }
+            else {
+                $('#ctl00_navbar_tbSearch').autocomplete("destroy");
+                $('#ctl00_navbar_tbSearch').removeData('autocomplete');
+            }
+        });
+
+    })
+</script>
+<style type="text/css">
+    #searchTB { max-height: 260px; overflow: auto; }
+    div.dropdown-menu div.list-group a:hover { background-color: #efefef; }
+    .blink_me {
+  animation: blinker 2s linear infinite;
+}
+    .dml {    left: 0 !important;
+    -webkit-transform: none !important ;
+    transform:  none !important ;}
+
+@keyframes blinker {
+  50% {
+    opacity: 0;
+  }
+}
+</style>
+
+        
+<!-- Begin EO.Web ScriptManager MyEOScriptManager.  -->
+
+<!-- End EO.Web ScriptManager MyEOScriptManager.  -->
+
+        <a id="demo_link" href="#" style="float: right; position: fixed; top: 0; right: 0;"></a>
+           
+<link href="/css/helpPanel.CSS?v=4.1" type="text/css" rel="stylesheet" />
+ <script type="text/javascript">
+
+     $(document).ready(function () {
+         var height = $(window).height();
+         $("img.hlptb").css("top", (height / 2) + "px");
+     });
+
+     function showHelp(el) {
+         var isOpen = false;
+         if ($(el).css('display') == 'none')
+             isOpen = false;
+         else
+             isOpen = true;
+         closeHelp();
+         if (!isOpen) {
+             $(el).slideToggle('slow');
+
+         }
+     }
+     function closeHelp() {
+         $('.answer_div').slideUp();
+     }
+     function showHelpTab() {
+         $('#ctl00_hPanelText_imgShowHelp').hide();
+         $('#helpdiv').animate({ width: 'toggle' }, function () {
+             $(document).ready(function () {
+                 var height = $(window).height() - 70;
+                 console.log(height);
+                 console.log($("div.helpbottom").height());
+                 height -= $("div.helpbottom").height();
+                 $("#divhh").css("max-height", height + "px");
+
+             });
+         });
+
+     }
+     function hideHelpTab() {
+         $('#helpdiv').hide();
+         $('#ctl00_hPanelText_imgShowHelp').show();
+     }
+
+ </script>
+<img id="ctl00_hPanelText_imgShowHelp" class="hlptb" onclick="showHelpTab();" src="images/help/help_tab_new.png" style="border-width:0px;position:fixed;cursor:pointer;z-index:600000;top:55px; right:0px;width:23px;height:120px;" />
+<div class="slide-out-div" id="helpdiv" style="display:none;line-height:140%;height:100%;position:fixed;right:0;font-size:10pt;">
+<div id='divhh' style="overflow-x:hidden; overflow-y:auto">
+    <div class="helptop">
+        <div style='border-bottom:1px solid #a0a0a0;'>
+            <img src="/images/help/sincHelp45.png" style='float:left;' />
+            <img src="/images/help/close.png" class='closehelp' onclick='hideHelpTab();' />
+            <div class='clr'></div>
+        </div>
+        <div>
+            <span id="ctl00_hPanelText_lblHeader" style="font-size:12pt;"></span>
+            <span id="ctl00_hPanelText_lblIntro" style="line-height:130%;"></span><br />
+            
+            <br />
+        </div>
+    </div>
+
+
+</div>
+<div style="position:fixed; bottom:0;padding-bottom:10px; text-align:center;width:300px" class="helpbottom"> 
+       
+        <span id="ctl00_hPanelText_lblHelpQ">
+        Can't find what you need?</span><br />
+        <a href="/sicsupport.aspx" class="contactBtn">Contact Us</a>
+
+</div>
+</div>
+
+        <div id="thethings">
+            <header id="banner">
+                <div id="ctl00_pnlBanner_Wrap" class="banner_wrap container p-0">
+	
+                    <a href="#" id="ctl00_siteLogo">
+                        <img id="ctl00_imgLogo" src="/photos/tid/TZ2565/banner.png?v=100124103042" alt="Event Logo" style="border-width:0px;width:100%;" />
+                    </a>
+                
+</div>
+            </header>
+            <nav id="navigation">
+                <div id="navwrap">
+                    <div id="ctl00_pnlUpdMenu">
+
+</div>
+                    
+
+                </div>
+                <div class="clear"></div>
+            </nav>
+            
+                <div id="ctl00_pnlPage" class="card my-3 container pageArea pt-4 pb-4" style="overflow:auto;">
+	
+                    
+                <div id="subNav">
+                    
+                </div>
+
+                <div id="ctl00_pnlMainRow" class="form-row mainrow">
+		
+                    <div id="ctl00_pnlSide" class="d-none">
+			
+                    
+		</div>
+
+                    <div id="ctl00_pnlMainContent" class="col-md-12">
+			
+                        <div id="belowNav">
+                            <div id="belowNavWrap" style="position: relative;">
+                                
+                            </div>
+                        </div>
+                        <div class="content">
+                            <div class="container">
+                                
+                                
+                            </div>
+                            
+                            
+    <!-- Content Goes in here -->
+    <div>
+        <div>
+            <div class="form-row row">
+                <div class="col-md-6 col-8">
+                     <ul id="topMenu">
+                        <li><a href='schedule.aspx?div=N&tid=TZ2565&year=2026&stid=TZ2565&syear=2026'><i class='mdi mdi-menu'></i> DIVISIONS</a></li>
+                    </ul>
+                </div>
+                <div class="col-md-6 col-4 text-right">
+                    <div class="searchsect">
+                        <div class="fright r8 searcharea">
+                            <span id="ctl00_ContentPlaceHolder1_lblFindGameBtn" OnClick="showPanel(&#39;6&#39;);"><i class="mdi mdi-magnify"></i> Find Game</span></div>
+                        <div id="ctl00_ContentPlaceHolder1_divFindGame" style="display:none;" class="tabsection fright form-inline">
+                            Game #:
+                            <input name="ctl00$ContentPlaceHolder1$TBGameNumber2" type="text" maxlength="6" id="ctl00_ContentPlaceHolder1_TBGameNumber2" class="form-control form-control-xs" style="width:64px;" />
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$Button4" value="Search" id="ctl00_ContentPlaceHolder1_Button4" class="btn btn-xs btn-primary" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="clear"></div>
+        <div class="msg-section">
+            <span id="ctl00_ContentPlaceHolder1_lblIntro" style="margin-top:10px;"></span>
+            <span id="ctl00_ContentPlaceHolder1_LblHdg1" class="ename">2026 Puri Champions Cup & College Showcase<br></span>
+            <span id="ctl00_ContentPlaceHolder1_LblHdg2" style="font-size: 20pt;"></span>
+            
+            <span id="ctl00_ContentPlaceHolder1_LblOnline"></span>
+            <span id="ctl00_ContentPlaceHolder1_LblText"></span>
+        </div>
+        
+        
+    </div>
+    <div id="ctl00_ContentPlaceHolder1_divScreen">
+        <div>
+            <span id="ctl00_ContentPlaceHolder1_lblScheduleNote" class="sectionmsg" style="display:;"></span>
+            <span id="ctl00_ContentPlaceHolder1_lblStandingsNote" class="sectionmsg" style="display:none;"></span>
+            
+            <span id="ctl00_ContentPlaceHolder1_lblBracketNote" class="sectionmsg" style="display:none;"></span>
+        </div>
+        <div class="container-fluid">
+
+            <span id="ctl00_ContentPlaceHolder1_lblSchedulesBtn" Onclick="showPanel(&#39;1&#39;);" class="btns">
+                <i class='mdi mdi-calendar-text'></i><br />Schedule</span>
+            <span id="ctl00_ContentPlaceHolder1_lblStandingsBtn" Onclick="showPanel(&#39;2&#39;);" class="btns">
+                <i class='mdi mdi-chart-bar'></i><br />Standings</span>
+            
+            
+            
+            <div class="clear"></div>
+        </div>
+        <div id="ctl00_ContentPlaceHolder1_pnlTabs" style="background-color:White;overflow: visible; min-height: 400px;">
+				
+            <div id="ctl00_ContentPlaceHolder1_divDivisions" class="tabsection" style="display:none;">
+                
+            </div>
+            <div id="ctl00_ContentPlaceHolder1_divSchedule" class="tabsection container-fluid" style="display:;">
+               
+                <div id="ctl00_ContentPlaceHolder1_divButtons">
+                    <div class="header-bar form-row">
+                        <div class="col-7">
+                            <h3>Under 14 Girls First Division.- Crossover Schedule</h3>
+                        </div>
+                        <div class="col-5">
+                            
+                            <span id="ctl00_ContentPlaceHolder1_lblAddGame" style="float: right"></span>
+                            <a id="ctl00_ContentPlaceHolder1_btnPrintSchedules" class="d-block float-right tip" title="Save as PDF" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$btnPrintSchedules&#39;,&#39;&#39;)" style="margin:0 10px 0 0;"><i class='mdi mdi-printer printbtn'></i></a>
+                            <a id="ctl00_ContentPlaceHolder1_btnExtractSched" class="d-block float-right tip" title="Download to excel" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$btnExtractSched&#39;,&#39;&#39;)" style="margin: 0 10px 0 0;"><i class='mdi mdi-grid printbtn'></i></a>
+                            
+                        </div>
+                        <div class="clear"></div>
+                    </div>
+                    
+                    
+                    
+                </div>
+
+                <span id="ctl00_ContentPlaceHolder1_lblOutput2"></span>
+                
+
+<style type="text/css">
+    .parallelogram { width: 100%; height: 100px; padding-top: 35px; /*transform: skew(-20deg);*/ color: #000; font-size: 160% }
+    .br6 { border-right-width: 6px !important; background-color: transparent; border-bottom-width: 6px; border-bottom-color: transparent !important; }
+    .bl6 { border-left-width: 6px !important; background-color: transparent; border-bottom-width: 6px; border-bottom-color: transparent !important; }
+    .mcard { transition: all .5s ease; }
+    .mcard:hover { background-color:#f0f1f3;}
+</style>
+
+<div id="ctl00_ContentPlaceHolder1_SicSchedule_pnlGames">
+
+				</div>
+
+
+
+
+
+
+                     
+                <div id='divGames' style='font-size:11pt;padding:0px;font-family:Ubuntu Condensed,sans-serif;'><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>10:40 AM</span><span>#00240<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=ILF12255'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=ILF12255&stid=TZ2565&syear=2026&div=U14F01>Rockford Raptors G2012 ECNL</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=IAF12039><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=IAF12039&stid=TZ2565&syear=2026&div=U14F01>FC America (IA) FCA FIRE</a></div></div><div class='col-3 text-right'>&nbsp;<div class='clear'></div>&nbsp;</div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><b><font color='red'>Cancelled</font></b></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>10:40 AM</span><span>#00241<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12063'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12063&stid=TZ2565&syear=2026&div=U14F01>OSC 2012G Orange</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12076><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12076&stid=TZ2565&syear=2026&div=U14F01>Madison 56ers 2012 Girls Red</a></div></div><div class='col-3 text-right'>&nbsp;<div class='clear'></div>&nbsp;</div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><b><font color='red'>Cancelled</font></b></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>12:20 PM</span><span>#00239<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12177'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12177&stid=TZ2565&syear=2026&div=U14F01>EBU 14U GIRLS' PREMIER 1</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12196><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12196&stid=TZ2565&syear=2026&div=U14F01>RUSH UNION WI 2012G PREMIER</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>2</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>6</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11061&gameid=7334128'>210 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>3:40 PM</span><span>#00242<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=IAF12039'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=IAF12039&stid=TZ2565&syear=2026&div=U14F01>FC America (IA) FCA FIRE</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12063><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12063&stid=TZ2565&syear=2026&div=U14F01>OSC 2012G ORANGE</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>1</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>3</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11243&gameid=7334131'>111 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>5:20 PM</span><span>#00243<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12177'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12177&stid=TZ2565&syear=2026&div=U14F01>EBU 14U GIRLS' PREMIER 1</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=ILF12255><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=ILF12255&stid=TZ2565&syear=2026&div=U14F01>ROCKFORD RAPTORS G2012 ECNL</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>1</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>5</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11061&gameid=7334132'>206 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Saturday</span><span>4/18/2026</span></div><div class='col-6 text-md-left text-right'><span>6:00 PM</span><span>#00244<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12076'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12076&stid=TZ2565&syear=2026&div=U14F01>Madison 56ers 2012 Girls Red</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12196><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12196&stid=TZ2565&syear=2026&div=U14F01>RUSH UNION WI 2012G PREMIER</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>0</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>1</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11061&gameid=7334133'>207 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row bg-light'><div class='col text-center p-3'>Sunday, April 19, 2026</div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Sunday</span><span>4/19/2026</span></div><div class='col-6 text-md-left text-right'><span>12:20 PM</span><span>#00245<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12063'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12063&stid=TZ2565&syear=2026&div=U14F01>OSC 2012G Orange</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12177><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12177&stid=TZ2565&syear=2026&div=U14F01>EBU 14U GIRLS' PREMIER 1</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>2</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>2</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11243&gameid=7334134'>111 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Sunday</span><span>4/19/2026</span></div><div class='col-6 text-md-left text-right'><span>12:20 PM</span><span>#00247<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12076'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12076&stid=TZ2565&syear=2026&div=U14F01>Madison 56ers 2012 Girls Red</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=ILF12255><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=ILF12255&stid=TZ2565&syear=2026&div=U14F01>ROCKFORD RAPTORS G2012 ECNL</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>0</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>1</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11243&gameid=7334136'>113 (Grass)</a></span></div><div class='col-2'></div></div></div></div><div class='form-row game-row' style='border-left:5px solid transparent'><div class='col-md-3 d-cell'><div class='row'><div class='col-6'><span>Sunday</span><span>4/19/2026</span></div><div class='col-6 text-md-left text-right'><span>12:20 PM</span><span>#00246<br /></span></div></div></div><div class='col-md-5'><div class='row'><div class='col-9'><div class='hometeam'><a href='/team/team.aspx?tid=TZ2565&year=2026&teamid=WIF12196'><div class='hora'>H: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12196&stid=TZ2565&syear=2026&div=U14F01>RUSH UNION WI 2012G PREMIER</a></div><div class='awayteam'><a href=/team/team.aspx?tid=TZ2565&year=2026&teamid=IAF12039><div class='hora'>A: </div></a><a href=schedule.aspx?tid=TZ2565&year=2026&team=IAF12039&stid=TZ2565&syear=2026&div=U14F01>FC America (IA) FCA FIRE</a></div></div><div class='col-3 text-right'><div style='color:#A63351;margin-top:5px;'>1</div><div class='clear'></div><div style='color:#A63351;margin-top:9px;'>0</div></div></div></div><div class='col-md-4'><div class='row'><div class='col-10 text-md-left text-center'><span class='bigOnly'>Under 14 Girls First Division.- Crossover</span><span><a href='TTMap.aspx?tid=TZ2565&site=11061&gameid=7334135'>220 (Grass)</a></span></div><div class='col-2'></div></div></div></div></div>
+                <div id="ctl00_ContentPlaceHolder1_divPublish" class="row">
+                    <div class="col-md-3 changebox" style="background-color: red;">
+                        Past 24 Hours
+                    </div>
+                    <div class="col-md-3 changebox" style="background-color: orange;">
+                        Past 3 Days
+                    </div>
+                    <div class="col-md-3 changebox" style="background-color: yellow; color: black;">
+                        Past Week
+                    </div>
+                    <div class="col-md-3 changebox" style="background-color: green;">
+                        Past 10 Days
+                    </div>
+                </div>
+                <div class="clear"></div>
+                <br />
+                
+                
+            </div>
+
+            <div class="text-center">
+                
+        </div>
+
+            <div id="ctl00_ContentPlaceHolder1_divStandings" style="display:none;" class="tabsection">
+                <table id="ctl00_ContentPlaceHolder1_cpPanel" style="width:100%;width:100%;">
+					<tbody>
+						<tr>
+							<td>
+                    <div id="ctl00_ContentPlaceHolder1_divStands">
+                        <div class="container-fluid">
+                            <div class="header-bar form-row">
+                            <div class="col">
+                                <div style="padding-top: 5px; float: left;">
+                                <a href='schedule.aspx?group=ALL&tid=TZ2565&year=2026&stid=TZ2565&syear=2026'><i class='mdi mdi-calendar sched' style='float:left;font-size:16pt;margin:-3px 10px 0 0;color:#015CAB;'></i></a>Under 14 Girls First Division.- Crossover Standings
+                                </div>
+                                <a id="ctl00_ContentPlaceHolder1_btnPrintStandings" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$btnPrintStandings&#39;,&#39;&#39;)"><i class='mdi mdi-printer fright printbtn'></i></a>
+                                <span id="ctl00_ContentPlaceHolder1_lblShowMe"><a href='TTResults2.aspx?tid=TZ2565&year=2026&stid=TZ2565&syear=2026&div=U14F01' class='btns' Style='float:right;font-size:9pt;color:white;width:80px;margin:0 10px 0 0;background-color:#015CAB;padding:6px 0px;'>Details</a></span>
+                                <div style="float: right; margin: 0 10px 0 0;">
+                                    
+                                </div>
+                                <div class="clear"></div>
+                            </div>
+                            
+                            </div>
+                        </div>
+                        <div class="p-md-0 p-2">
+                            <span id="ctl00_ContentPlaceHolder1_lblStds"><div id='divStds' style='font-size:11pt;padding:0px;font-family:Ubuntu Condensed,sans-serif;'><div class='form-row game-row'><div class='col-md-4'><h3><a href='schedule.aspx?tid=TZ2565&year=2026&stid=TZ2565&syear=2026&group=A'>Group A</a></h3></div><div class='col-md-2'>&nbsp;</div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row bigOnly std-heading bigpad'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div></div></div><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>1.</div><div class='col-2'><img src='/photos/club/wi107.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12177&stid=TZ2565&syear=2026&div=U14F01#hdg>EBU 14U GIRLS' PREMIER 1</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>3</div><div class='col bigpad'>0</div><div class='col bigpad'>2</div><div class='col bigpad'>1</div><div class='col bigpad'>5</div><div class='col bigpad'>5</div><div class='col bigpad'>13</div><div class='col bigpad'>-8</div><div class='col bigpad'>8</div><div class='col bigpad'></div></div></div></div><hr /><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>2.</div><div class='col-2'><img src='/photos/club/ia030.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=IAF12039&stid=TZ2565&syear=2026&div=U14F01#hdg>FC America (IA) FCA FIRE</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>2</div><div class='col bigpad'>0</div><div class='col bigpad'>2</div><div class='col bigpad'>0</div><div class='col bigpad'>1</div><div class='col bigpad'>1</div><div class='col bigpad'>4</div><div class='col bigpad'>-3</div><div class='col bigpad'>1</div><div class='col bigpad'></div></div></div></div><hr /><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>3.</div><div class='col-2'><img src='/photos/club/wi003.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12076&stid=TZ2565&syear=2026&div=U14F01#hdg>Madison 56ers 2012 Girls Red</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>2</div><div class='col bigpad'>0</div><div class='col bigpad'>2</div><div class='col bigpad'>0</div><div class='col bigpad'>0</div><div class='col bigpad'>0</div><div class='col bigpad'>2</div><div class='col bigpad'>-2</div><div class='col bigpad'>0</div><div class='col bigpad'></div></div></div></div><hr /><div class='form-row game-row'><div class='col-md-4'><h3><a href='schedule.aspx?tid=TZ2565&year=2026&stid=TZ2565&syear=2026&group=B'>Group B</a></h3></div><div class='col-md-2'>&nbsp;</div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row bigOnly std-heading bigpad'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div></div></div><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>1.</div><div class='col-2'><img src='/photos/club/wi180.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12196&stid=TZ2565&syear=2026&div=U14F01#hdg>Rush Union WI 2012G Premier</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>3</div><div class='col bigpad'>3</div><div class='col bigpad'>0</div><div class='col bigpad'>0</div><div class='col bigpad'>8</div><div class='col bigpad'>5</div><div class='col bigpad'>2</div><div class='col bigpad'>6</div><div class='col bigpad'>25</div><div class='col bigpad'></div></div></div></div><hr /><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>2.</div><div class='col-2'><img src='/photos/club/il012.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=ILF12255&stid=TZ2565&syear=2026&div=U14F01#hdg>Rockford Raptors G2012 ECNL</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>2</div><div class='col bigpad'>2</div><div class='col bigpad'>0</div><div class='col bigpad'>0</div><div class='col bigpad'>6</div><div class='col bigpad'>4</div><div class='col bigpad'>1</div><div class='col bigpad'>5</div><div class='col bigpad'>17</div><div class='col bigpad'></div></div></div></div><hr /><div class='form-row'><div class='col-md-6'><div class='form-row'><div class='col-1'>3.</div><div class='col-2'><img src='/photos/club/wi096.jpg' class='std-logo'></div><div class='col-8 pt4'><a href=schedule.aspx?tid=TZ2565&year=2026&team=WIF12063&stid=TZ2565&syear=2026&div=U14F01#hdg>OSC 2012G Orange</a><span class='d-block float-right'></span></div></div></div><div class='col-md-6' style='padding-left:0px;padding-right:0px;'><div class='form-row smallOnly std-heading'><div class='col'><div class='tip' original-title='Games Played'>GP</div></div><div class='col'><div class='tip' original-title='Wins'>W</div></div><div class='col'><div class='tip' original-title='Losses'>L</div></div><div class='col'><div class='tip' original-title='Ties'>T</div></div><div class='col'><div class='tip' original-title='Goals For'>GF</div></div><div class='col'><div class='tip' original-title='Goals Scored - Max of 3'>GF3</div></div><div class='col'><div class='tip' original-title='Goals Against'>GA</div></div><div class='col'><div class='tip' original-title='Goal Differential'>GD</div></div><div class='col'><div class='tip' original-title='Points'>Pts</div></div><div class='col'><div class='tip' original-title='Tie breaker used to determine placement'>TB</div></div></div><div class='form-row'><div class='col bigpad'>2</div><div class='col bigpad'>1</div><div class='col bigpad'>0</div><div class='col bigpad'>1</div><div class='col bigpad'>5</div><div class='col bigpad'>5</div><div class='col bigpad'>3</div><div class='col bigpad'>2</div><div class='col bigpad'>14</div><div class='col bigpad'></div></div></div></div><hr /></div></span>
+                            <span id="ctl00_ContentPlaceHolder1_lbStandingsNote" style="font-size:9pt;">
+                                Click any team name to see the full schedule for that team.<br />
+                            </span>
+                            
+                            <span style="font-size:9pt;">
+                                For further information on the standings, contact the tournment director<br />
+                            </span>
+                            <div style="width: 100%; text-align: left;">
+                                <br />
+                                <span id="ctl00_ContentPlaceHolder1_lblTBInstructions"></span>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+						</tr>
+					</tbody>
+				</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_cpPanel=1;EO25264.r._o_ctl00_ContentPlaceHolder1_cpPanel=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_cpPanel,"cpPanel",new EO25264.f.aaum([[,"ctl00_ContentPlaceHolder1_cpPanel","Callback","ctl00$ContentPlaceHolder1$cpPanel",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$cpPanel','_eo_arg_')"],,"__doPostBack('ctl00$ContentPlaceHolder1$cpPanel','')",,,,,,[],"<div class='loading'></div>",,,,,,,,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_cpPanel,1,null, 0);});
+//]]>
+</script>
+
+            </div>
+            <div id="ctl00_ContentPlaceHolder1_divBracket" style="width:100%;overflow:auto;display:none;" class="tabsection">
+                <div class="header-bar">
+                    <div>
+                        <div style="padding-top: 5px; float: left;">
+                        
+                    </div>
+                    <a id="ctl00_ContentPlaceHolder1_btnPrintBrackets" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$btnPrintBrackets&#39;,&#39;&#39;)"><i class='mdi mdi-printer fright printbtn'></i></a>
+                    <input type="submit" name="ctl00$ContentPlaceHolder1$BtnExtractToExcel" value="Extract" id="ctl00_ContentPlaceHolder1_BtnExtractToExcel" class="btns btns-primary bluebtn fright" />
+                    
+                    
+                    
+                    <span style="font-size: 9pt; float: right; margin: 7px 10px 0 0;"><input id="ctl00_ContentPlaceHolder1_cbAllBrackets" type="checkbox" name="ctl00$ContentPlaceHolder1$cbAllBrackets" /><label for="ctl00_ContentPlaceHolder1_cbAllBrackets">All</label></span>
+                    <span style="font-size: 9pt; float: right; margin: 7px 10px 0 0;"><input id="ctl00_ContentPlaceHolder1_cbOnePage" type="checkbox" name="ctl00$ContentPlaceHolder1$cbOnePage" /><label for="ctl00_ContentPlaceHolder1_cbOnePage">Fit on Page</label></span>
+                    <div class="clear"></div>
+                    </div>
+                    
+                </div>
+                <table id="ctl00_ContentPlaceHolder1_Table6" cellspacing="0" cellpadding="0" align="Center" border="0" style="border-collapse:collapse;">
+					<tr id="ctl00_ContentPlaceHolder1_tr1">
+						<td><table id="ctl00_ContentPlaceHolder1_TableB1" cellspacing="0" cellpadding="0" border="0" style="color:Black;font-size:7pt;width:100%;border-collapse:collapse;">
+
+						</table></td>
+					</tr>
+				</table>
+            </div>
+            <div id="ctl00_ContentPlaceHolder1_divControl" style="display:none;" class="container-fluid">
+                <div>
+                    <div class="header-bar form-row">
+                        <div class="col-md-12">
+                            <h3>Administrative Functions
+                            <span id="ctl00_ContentPlaceHolder1_lblPublish"><a href='TTPublicAccess.aspx?tid=TZ2565&year=2026' class='btns btns-primary bluebtn fright'>Publish</a></span>
+                                <input type="submit" name="ctl00$ContentPlaceHolder1$BtnHide" value="Hide Games" onclick="return confirm(&#39;Are you sure you want to HIDE all schedules from the public.&#39;);" id="ctl00_ContentPlaceHolder1_BtnHide" class="btns btns-primary bluebtn fright" />
+                                
+                            </h3>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Extract all games in the schedule to a spreadsheet on your computer
+                        </div>
+                        <div class="col-md-3">
+                            <input type="button" name="ctl00$ContentPlaceHolder1$BtnExtract" value="Extract All Games" onclick="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$BtnExtract&#39;,&#39;&#39;)" id="ctl00_ContentPlaceHolder1_BtnExtract" style="font-size:8pt;width:130px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Refresh all of the hardcopy schedules AND standings
+                        </div>
+                        <div class="col-md-3">
+                            <input type="button" name="ctl00$ContentPlaceHolder1$BtnRefresh" value="Refresh Schedules" onclick="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$BtnRefresh&#39;,&#39;&#39;)" id="ctl00_ContentPlaceHolder1_BtnRefresh" style="font-size:8pt;width:130px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Reset divisons with crossover games
+                        </div>
+                        <div class="col-md-3">
+                            <input type="button" name="ctl00$ContentPlaceHolder1$BtnXOvers" value="Reset Crossovers" onclick="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$BtnXOvers&#39;,&#39;&#39;)" id="ctl00_ContentPlaceHolder1_BtnXOvers" style="font-size:8pt;width:130px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Enter a game number to go to the division that includes that game
+                        </div>
+                        <div class="col-md-3">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$BtnGameNumber" value="Game" id="ctl00_ContentPlaceHolder1_BtnGameNumber" style="font-size:8pt;width:75px;" />
+                    	    <input name="ctl00$ContentPlaceHolder1$TBGameNumber" type="text" maxlength="5" id="ctl00_ContentPlaceHolder1_TBGameNumber" style="font-size:8pt;width:60px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Update the text that will be displayed when the schedules are offline
+                        </div>
+                        <div class="col-md-3">
+                            <a id="ctl00_ContentPlaceHolder1_lnkSchedText1" class="navlink" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$lnkSchedText1&#39;,&#39;&#39;)" style="color:Blue;font-size:8pt;">Add Offline Text</a>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Update the text that will be displayed on the schedule page when the schedules are online
+                        </div>
+                        <div class="col-md-3">
+                            <a id="ctl00_ContentPlaceHolder1_lnkSchedText2" class="navlink" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$lnkSchedText2&#39;,&#39;&#39;)" style="color:Blue;font-size:8pt;">Add Schedule Text</a>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Update the text that will be displayed on the standings page when the schedules are online
+                        </div>
+                        <div class="col-md-3">
+                            <a id="ctl00_ContentPlaceHolder1_LinkButton1" class="navlink" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$LinkButton1&#39;,&#39;&#39;)" style="color:Blue;font-size:8pt;">Add Standings Text</a>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Update the text that will be displayed onthe bracket page when the schedules are online
+                        </div>
+                        <div class="col-md-3">
+                            <a id="ctl00_ContentPlaceHolder1_LinkButton2" class="navlink" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$LinkButton2&#39;,&#39;&#39;)" style="color:Blue;font-size:8pt;">Add Bracket Text</a>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-9">
+                            Update the text that will print on the bottom of the schedule printouts
+                        </div>
+                        <div class="col-md-3">
+                            <a id="ctl00_ContentPlaceHolder1_lnkSchedText3" class="navlink" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$lnkSchedText3&#39;,&#39;&#39;)" style="color:Blue;font-size:8pt;">Add Text to Print-out</a>
+                        </div>
+                    </div>
+                    
+                    
+                </div>
+                <div class="clear"></div>
+                <div>
+                    <div class="header-bar form-row">
+                        <div class="col-md-12">
+                            <h3>Schedule Options for all Divisions</h3>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Default Division
+                        </div>
+                        <div class="col-md-6">
+                            <select name="ctl00$ContentPlaceHolder1$DDLDiv" id="ctl00_ContentPlaceHolder1_DDLDiv" style="width:370px;margin-left: 10px;">
+					<option selected="selected" value="">All</option>
+					<option value="U08M01">Under 08 Boys First Division</option>
+					<option value="U09F01">Under 09 Girls First Division.- Crossover</option>
+					<option value="U09M01">Under 09 Boys Third Division</option>
+					<option value="U09M02">Under 09 Boys Fourth Division One</option>
+					<option value="U09M03">Under 09 Boys Fourth Division One  Crossover</option>
+					<option value="U10F01">Under 09/10 Girls First Division</option>
+					<option value="U10M01">Under 10 Boys Second Division.- Crossover</option>
+					<option value="U10M02">Under 10 Boys Third Division</option>
+					<option value="U10M03">Under 10 Boys Fourth Division</option>
+					<option value="U10M04">Under 10 Boys Fifth Division.- Crossover</option>
+					<option value="U11F01">Under 11 Girls First Division</option>
+					<option value="U11F02">Under 11 Girls Second Division.- Crossover</option>
+					<option value="U11F03">Under 11 Girls Third Division.- Crossover</option>
+					<option value="U11M01">Under 11 Boys First Division</option>
+					<option value="U11M02">Under 11 Boys Second Division</option>
+					<option value="U11M03">Under 11 Boys Third Division</option>
+					<option value="U11M04">Under 11 Boys Fourth Division One</option>
+					<option value="U11M05">Under 11 Boys Fourth Division Two</option>
+					<option value="U12F01">Under 12 Girls 9v9 Second Division.- Crossover</option>
+					<option value="U12F02">Under 12 Girls Third Division</option>
+					<option value="U12M01">Under 12 Boys First Division</option>
+					<option value="U12M02">Under 12 Boys Second Division.- Crossover</option>
+					<option value="U12M03">Under 12 Boys Third Division.- Crossover</option>
+					<option value="U12M04">Under 12 Boys Fourth Division.- Crossover</option>
+					<option value="U12M05">Under 12 Boys Fifth Division.- Crossover</option>
+					<option value="U13F01">Under 13 Girls First Division</option>
+					<option value="U13F02">Under 13 Girls Second Division.- Crossover</option>
+					<option value="U13F03">Under 13 Girls Fourth Division</option>
+					<option value="U13F04">Under 12 Girls 11vs11  Division</option>
+					<option value="U13M01">Under 13 Boys First Division.- Crossover</option>
+					<option value="U13M02">Under 13 Boys Second Division</option>
+					<option value="U13M03">Under 13 Boys Third Division.- Crossover</option>
+					<option value="U13M04">Under 13 Boys Fourth Division</option>
+					<option value="U14F01">Under 14 Girls First Division.- Crossover</option>
+					<option value="U14F02">Under 14 Girls Second Division.- Crossover</option>
+					<option value="U14F03">Under 14 Girls Third Division</option>
+					<option value="U14M01">Under 14 Boys Second Division</option>
+					<option value="U14M02">Under 14 Boys Third Division</option>
+					<option value="U14M03">Under 14 Boys Fourth Division</option>
+					<option value="U15F01">Under 15 Girls First Division</option>
+					<option value="U15F02">Under 15 Girls Second Division</option>
+					<option value="U15M01">Under 15 Boys Second Division</option>
+					<option value="U15M02">Under 15 Boys Third Division One.- Crossover</option>
+					<option value="U15M03">Under 15 Boys Third DivisionTwo.- Crossover</option>
+					<option value="U15M04">Under 15 Boys Fourth Division.- Crossover</option>
+					<option value="U15M05">Under 15 Boys Fifth Division</option>
+					<option value="U16M01">Under 16 Boys First Division</option>
+					<option value="U16M02">Under 16 Boys Second Division.- Crossover</option>
+					<option value="U16M03">Under 16 Boys Third Division</option>
+					<option value="U16M04">Under 16 Boys Fourth Division.- Crossover</option>
+					<option value="U17F01">Under 17 Girls First Division</option>
+					<option value="U17M01">Under 17 Boys First Division</option>
+					<option value="U17M02">Under 17 Boys Third Division</option>
+					<option value="U17M03">Under 17 Boys Fourth Division Crossover</option>
+					<option value="U19M01">Under 18/19 Boys First Division.- Crossover</option>
+					<option value="U19M02">Under 18/19 Boys Second Division</option>
+					<option value="U19M03">Under 18/19 Boys Third Division .- One.- Crossover</option>
+					<option value="U19M04">Under 18/19 Boys Third Division Two</option>
+					<option value="U19M05">Under 19 Boys Fourth Division</option>
+
+				</select>
+                        </div>
+                        <div class="col-md-3">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Default Round
+                        </div>
+                        <div class="col-md-3">
+                            <div style="padding-left: 10px;">
+                                <span id="ctl00_ContentPlaceHolder1_LblDRound" style="font-size:9pt;font-weight:bold;">1</span>
+                            </div>
+                            
+                        </div>
+                        <div id="ctl00_ContentPlaceHolder1_divPostScores1" class="col-md-3" style="text-align: right;">
+                            Post Scores
+                        </div>
+                        <div class="col-md-3">
+                            <select name="ctl00$ContentPlaceHolder1$DDLScores" id="ctl00_ContentPlaceHolder1_DDLScores" style="width:120px;margin-left: 10px;">
+					<option selected="selected" value="Y">Yes</option>
+					<option value="N">No</option>
+					<option value="O">No Points</option>
+
+				</select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Group Display
+                        </div>
+                        <div class="col-md-3">
+                            <select name="ctl00$ContentPlaceHolder1$DDLGroup" id="ctl00_ContentPlaceHolder1_DDLGroup" style="width:120px;margin-left: 10px;">
+					<option value="teamonly">Team Only</option>
+					<option value="club">Club/Team</option>
+					<option selected="selected" value="teamclub">Team/Club</option>
+					<option value="state">Team/State</option>
+
+				</select>
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            Division Menu
+                        </div>
+                        <div class="col-md-3">
+                            <select name="ctl00$ContentPlaceHolder1$DDLDivMenu" id="ctl00_ContentPlaceHolder1_DDLDivMenu" style="width:120px;margin-left: 10px;">
+					<option selected="selected" value="">3 Level (U18)</option>
+					<option value="90">3 Level (90)/91</option>
+					<option value="91">3 Level 90/(91)</option>
+					<option value="2Level">Division only</option>
+					<option value="TA">Custom</option>
+
+				</select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Schedule
+                        </div>
+                        <div class="col-md-3">
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_cbByVenue" type="checkbox" name="ctl00$ContentPlaceHolder1$cbByVenue" /><label for="ctl00_ContentPlaceHolder1_cbByVenue">By Venue</label></span>
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            Schedule
+                        </div>
+                        <div class="col-md-3">
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_cbByClub" type="checkbox" name="ctl00$ContentPlaceHolder1$cbByClub" /><label for="ctl00_ContentPlaceHolder1_cbByClub">By Club</label></span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Game Sort
+                        </div>
+                        <div class="col-md-4">
+                            <span style="margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_rbDTF">Date, Time, Field</label><input id="ctl00_ContentPlaceHolder1_rbDTF" type="radio" name="ctl00$ContentPlaceHolder1$rbSort" value="rbDTF" /></span>
+                            <span style="margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_rbDFT">Date, Field, Time</label><input id="ctl00_ContentPlaceHolder1_rbDFT" type="radio" name="ctl00$ContentPlaceHolder1$rbSort" value="rbDFT" /></span>
+                        </div>
+                        <div class="col-md-2" style="text-align: right;">
+                            Hide UnScheduled
+                        </div>
+                        <div class="col-md-3">
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_cbHideUS" type="checkbox" name="ctl00$ContentPlaceHolder1$cbHideUS" /><label for="ctl00_ContentPlaceHolder1_cbHideUS">Public</label></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_cbHideUS2" type="checkbox" name="ctl00$ContentPlaceHolder1$cbHideUS2" /><label for="ctl00_ContentPlaceHolder1_cbHideUS2">Staff</label></span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            First Display Day
+                        </div>
+                        <div class="col-md-3">
+                       	    <input name="ctl00$ContentPlaceHolder1$tbFirstDate" type="text" maxlength="10" id="ctl00_ContentPlaceHolder1_tbFirstDate" style="border-color:Black;border-width:1px;border-style:solid;width:85px;" />
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            Last Display Day
+                        </div>
+                        <div class="col-md-3">
+                       	    <input name="ctl00$ContentPlaceHolder1$tbLastDate" type="text" maxlength="10" id="ctl00_ContentPlaceHolder1_tbLastDate" style="border-color:Black;border-width:1px;border-style:solid;width:85px;" />
+                        </div>
+                    </div>
+                    <div id="ctl00_ContentPlaceHolder1_pnlMidnight" class="row">
+					
+                        <div class="col text-center">
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_cbMidnight">Start next day at midnight</label><input id="ctl00_ContentPlaceHolder1_cbMidnight" type="checkbox" name="ctl00$ContentPlaceHolder1$cbMidnight" /></span>
+                        </div>
+                    
+				</div>
+                    <div class="row">
+                        <div class="col-md-9" style="text-align: right;">
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_CBFullDiv">Full Div.</label><input id="ctl00_ContentPlaceHolder1_CBFullDiv" type="checkbox" name="ctl00$ContentPlaceHolder1$CBFullDiv" checked="checked" /></span>
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_CBReport">Report</label><input id="ctl00_ContentPlaceHolder1_CBReport" type="checkbox" name="ctl00$ContentPlaceHolder1$CBReport" /></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_CBCodes">Codes</label><input id="ctl00_ContentPlaceHolder1_CBCodes" type="checkbox" name="ctl00$ContentPlaceHolder1$CBCodes" checked="checked" /></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_cbLink">Link</label><input id="ctl00_ContentPlaceHolder1_cbLink" type="checkbox" name="ctl00$ContentPlaceHolder1$cbLink" /></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_CBHA">H/A</label><input id="ctl00_ContentPlaceHolder1_CBHA" type="checkbox" name="ctl00$ContentPlaceHolder1$CBHA" checked="checked" /></span>
+                            
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_rbInit1">Schedules</label><input id="ctl00_ContentPlaceHolder1_rbInit1" type="radio" name="ctl00$ContentPlaceHolder1$rbInit" value="rbInit1" /></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_rbInit2">Standings</label><input id="ctl00_ContentPlaceHolder1_rbInit2" type="radio" name="ctl00$ContentPlaceHolder1$rbInit" value="rbInit2" /></span>
+                            <span style="font-family:verdana;font-size:7pt;margin-left: 10px;"><label for="ctl00_ContentPlaceHolder1_rbInit3">Brackets</label><input id="ctl00_ContentPlaceHolder1_rbInit3" type="radio" name="ctl00$ContentPlaceHolder1$rbInit" value="rbInit3" /></span>
+                        </div>
+                        <div class="col-md-3">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$Button1" value="Submit" id="ctl00_ContentPlaceHolder1_Button1" style="font-family:verdana;font-size:7pt;width:70px;margin-left: 10px;" />
+                        </div>
+                    </div>
+                </div>
+                <div class="clear"></div>
+                <div id="ctl00_ContentPlaceHolder1_DivisionTable" style="margin: 10px 0 10px 0">
+                    <div class="header-bar form-row">
+                        <div class="col-md-12">
+                            <h3>
+                                <span id="ctl00_ContentPlaceHolder1_lblDivOpt">Scheduling Options for Under 14 Girls First Division.- Crossover</span></h3>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Division Name
+                        </div>
+                        <div class="col-md-6">
+                            <input name="ctl00$ContentPlaceHolder1$tbDivName" type="text" value="Under 14 Girls First Division.- Crossover" maxlength="50" id="ctl00_ContentPlaceHolder1_tbDivName" style="font-size:8pt;width:370px;margin-left: 10px;" />
+                        </div>
+                        <div class="col-md-3">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$BtnUpdDiv" value="Submit" id="ctl00_ContentPlaceHolder1_BtnUpdDiv" style="font-family:verdana;font-size:7pt;width:70px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Division Note
+                        </div>
+                        <div class="col-md-9">
+                            <select name="ctl00$ContentPlaceHolder1$ddlDivNote" id="ctl00_ContentPlaceHolder1_ddlDivNote" style="font-size:8pt;width:330px;margin: 0 10px 0 10px;">
+					<option selected="selected" value="0">No Note Displayed</option>
+
+				</select>
+                            <a href='TTText.aspx?qual=DIVS&seq=NEW&tid=TZ2565'>
+                            <img id="ctl00_ContentPlaceHolder1_Image28" src="images/2009/plusrnd15.png" style="width:15px;border-width:0px;" />
+                            </a>
+                            &nbsp;
+                            <span id="ctl00_ContentPlaceHolder1_lblHelp901" style="margin-left: 10px;"><img src='images/2009/help15.png' style='cursor:pointer;height:15px;' onclick='javascript:eo_Callback("cpHelpPanel", "901|1|0|901");eo_GetObject("DialogHelp").show(false);' /></span>
+                        </div>
+                    </div>
+                    <div>
+                        <div style="padding: 5px 100px 5px 100px; color: blue;">
+                            Do NOT set the MAX score Differential unless you want to BLOCK entry of scores that are higher 
+                            (e.g. if you set the Max to 4, a 9-1 game will be recorded as 5-1. <b>This is not that same as 
+                            setting tiebreakers in the scoring rules</b>).
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            Max Score Differential
+                        </div>
+                        <div class="col-md-6">
+                            <select name="ctl00$ContentPlaceHolder1$ddlMaxDiff" id="ctl00_ContentPlaceHolder1_ddlMaxDiff" style="width:60px;margin-left: 10px;">
+					<option value="">N/A</option>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+					<option value="9">9</option>
+					<option value="10">10</option>
+
+				</select>&nbsp;
+                            <span id="ctl00_ContentPlaceHolder1_lblHelp904"><img src='images/2009/help15.png' style='cursor:pointer;height:15px;' onclick='javascript:eo_Callback("cpHelpPanel", "904|1|0|904");eo_GetObject("DialogHelp").show(false);' /></span>&nbsp;
+                            <span id="ctl00_ContentPlaceHolder1_lblMaxDiffForDivisions" onclick="eo_Callback(&#39;cpDifferential&#39;, &#39;load&#39;);eo_GetObject(&#39;Dialog_Differential&#39;).show(true);" style="color:Blue;cursor: pointer;">Set differential by division</span>
+                        </div>
+                        <div class="col-md-3">
+                            <span id="ctl00_ContentPlaceHolder1_lblDivMaxDiff"></span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div id="ctl00_ContentPlaceHolder1_divPostScores2" class="col-md-3" style="text-align: right;">
+                            Post Scores
+                        </div>
+                        <div class="col-md-3">
+                            <span style="margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_rbSYes" type="radio" name="ctl00$ContentPlaceHolder1$rbShow" value="rbSYes" checked="checked" /><label for="ctl00_ContentPlaceHolder1_rbSYes">Yes</label></span>
+                            &nbsp;
+                            <span style="margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_rbSNo" type="radio" name="ctl00$ContentPlaceHolder1$rbShow" value="rbSNo" /><label for="ctl00_ContentPlaceHolder1_rbSNo">No</label></span>
+                            &nbsp;
+                            <span id="ctl00_ContentPlaceHolder1_lblHelp902" style="margin-left: 10px;"><img src='images/2009/help15.png' style='cursor:pointer;height:15px;' onclick='javascript:eo_Callback("cpHelpPanel", "902|1|0|902");eo_GetObject("DialogHelp").show(false);' /></span>
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            Scoring Rules
+                        </div>
+                        <div class="col-md-3">
+                            <select name="ctl00$ContentPlaceHolder1$ddlScoringRules" id="ctl00_ContentPlaceHolder1_ddlScoringRules" style="width:120px;margin-left: 10px;">
+					<option selected="selected" value="0">Default</option>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7">7</option>
+					<option value="8">8</option>
+					<option value="9">9</option>
+
+				</select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div id="ctl00_ContentPlaceHolder1_divShowGames2" class="col-md-3" style="text-align: right;">
+                            Show Games
+                        </div>
+                        <div class="col-md-9">
+                            <span style="margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_rbOYes" type="radio" name="ctl00$ContentPlaceHolder1$rbOnline" value="rbOYes" checked="checked" /><label for="ctl00_ContentPlaceHolder1_rbOYes">Yes</label></span>
+                            <span style="margin-left: 10px;"><input id="ctl00_ContentPlaceHolder1_rbONo" type="radio" name="ctl00$ContentPlaceHolder1$rbOnline" value="rbONo" /><label for="ctl00_ContentPlaceHolder1_rbONo">No</label></span>
+                            <span id="ctl00_ContentPlaceHolder1_lblHelp903" style="margin-left: 10px;"><img src='images/2009/help15.png' style='cursor:pointer;height:15px;' onclick='javascript:eo_Callback("cpHelpPanel", "903|1|0|903");eo_GetObject("DialogHelp").show(false);' /></span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            &nbsp;
+                        </div>
+                        <div class="col-md-6">
+                            Clear team overrides so system can update games
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$btnClearOverride" value="Clear Overrides" id="ctl00_ContentPlaceHolder1_btnClearOverride" style="font-family:verdana;font-size:7pt;width:170px;margin-left: 10px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_cbAdvanceAll">All Divisions</label><input id="ctl00_ContentPlaceHolder1_cbAdvanceAll" type="checkbox" name="ctl00$ContentPlaceHolder1$cbAdvanceAll" /></span>
+                        </div>
+                        <div class="col-md-6">
+                            Set all games 'based on points' using the current point results
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$btnAdvance" value="Advance Teams" id="ctl00_ContentPlaceHolder1_btnAdvance" style="font-family:verdana;font-size:7pt;width:170px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_cbLockPGAll">All Divisions</label><input id="ctl00_ContentPlaceHolder1_cbLockPGAll" type="checkbox" name="ctl00$ContentPlaceHolder1$cbLockPGAll" /></span>
+                        </div>
+                        <div class="col-md-6">
+                            Lock the games 'based on points' in this division so the system does not change teams.  Set all games to "counting games" and unlock standings.
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$btnLockP" value="Lock Point Games" id="ctl00_ContentPlaceHolder1_btnLockP" style="font-family:verdana;font-size:7pt;width:170px;" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3" style="text-align: right;">
+                            <span style="font-family:verdana;font-size:7pt;"><label for="ctl00_ContentPlaceHolder1_cbLockAll">All Divisions</label><input id="ctl00_ContentPlaceHolder1_cbLockAll" type="checkbox" name="ctl00$ContentPlaceHolder1$cbLockAll" /></span>
+                        </div>
+                        <div class="col-md-6">
+                            Lock the division so the system does not change the standings/points
+                        </div>
+                        <div class="col-md-3" style="text-align: right;">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$btnLockS" value="Lock Standings" id="ctl00_ContentPlaceHolder1_btnLockS" style="font-family:verdana;font-size:7pt;width:170px;" />
+                        </div>
+                    </div>
+                </div>
+                <div class="clear"></div>
+                <div>
+                    <div class="header-bar form-row">
+                        <div class="col-md-12">
+                            <h3>Standings</h3>
+
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol1">Games Played</label><input id="ctl00_ContentPlaceHolder1_cbStdCol1" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol1" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol2">Wins</label><input id="ctl00_ContentPlaceHolder1_cbStdCol2" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol2" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol3">Losses</label><input id="ctl00_ContentPlaceHolder1_cbStdCol3" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol3" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol4">Ties</label><input id="ctl00_ContentPlaceHolder1_cbStdCol4" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol4" checked="checked" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol5">Percent</label><input id="ctl00_ContentPlaceHolder1_cbStdCol5" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol5" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol6">Goals For</label><input id="ctl00_ContentPlaceHolder1_cbStdCol6" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol6" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol7">Goals For Max</label><input id="ctl00_ContentPlaceHolder1_cbStdCol7" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol7" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol8">Goals Against</label><input id="ctl00_ContentPlaceHolder1_cbStdCol8" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol8" checked="checked" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol9">Goals Against Max</label><input id="ctl00_ContentPlaceHolder1_cbStdCol9" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol9" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol10">Percent</label><input id="ctl00_ContentPlaceHolder1_cbStdCol10" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol10" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol11">Goal Differential</label><input id="ctl00_ContentPlaceHolder1_cbStdCol11" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol11" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol12">Goal Differential Max</label><input id="ctl00_ContentPlaceHolder1_cbStdCol12" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol12" checked="checked" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol13">Points</label><input id="ctl00_ContentPlaceHolder1_cbStdCol13" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol13" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdCol14">Tie Breaker</label><input id="ctl00_ContentPlaceHolder1_cbStdCol14" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdCol14" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdShow">Show</label><input id="ctl00_ContentPlaceHolder1_cbStdShow" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdShow" checked="checked" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdLinks">Links</label><input id="ctl00_ContentPlaceHolder1_cbStdLinks" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdLinks" checked="checked" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbStdAll">All</label><input id="ctl00_ContentPlaceHolder1_cbStdAll" type="checkbox" name="ctl00$ContentPlaceHolder1$cbStdAll" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <label for="ctl00_ContentPlaceHolder1_cbWTL">Win/Tie/Loss</label><input id="ctl00_ContentPlaceHolder1_cbWTL" type="checkbox" name="ctl00$ContentPlaceHolder1$cbWTL" />
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            Sequence&nbsp;
+                            <select name="ctl00$ContentPlaceHolder1$ddDivSeq" id="ctl00_ContentPlaceHolder1_ddDivSeq" style="width:90px;">
+					<option selected="selected" value="">Age/Sex</option>
+					<option value="divname">Name</option>
+					<option value="sexname">Sex/Name</option>
+					<option value="DivisionDesc">Age/Sex Rev</option>
+
+				</select>
+                        </div>
+                        <div class="col-3" style="text-align: right">
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$btnStandings" value="Submit" id="ctl00_ContentPlaceHolder1_btnStandings" style="font-family:verdana;font-size:7pt;width:50px;" />
+                        </div>
+                    </div>
+                </div>
+                <div class="clear"></div>
+            </div>
+            <div id="ctl00_ContentPlaceHolder1_divPitching" style="width:100%;overflow:auto;display:none;text-align:center;" class="tabsection">
+                
+
+
+<div class="left">
+    <span id="ctl00_ContentPlaceHolder1_sPitching_lblStaffMsg"></span>
+</div>
+<div class="right" style="padding-right: 10px;">
+    <input type="submit" name="ctl00$ContentPlaceHolder1$sPitching$btnGenerateReport" value="Generate Report" id="ctl00_ContentPlaceHolder1_sPitching_btnGenerateReport" />
+</div>
+<div class="clr"></div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+        
+			</div>
+        <span id="ctl00_ContentPlaceHolder1_lblIntro2"></span>
+    </div>
+    
+    
+
+
+    <link rel="stylesheet" href="css/ui/custom/jquery-ui-1.8.23.custom.css" type="text/css" />
+    <link rel="stylesheet" href="js/ui/jquery.ui.timepicker.css?v=0.3.4" type="text/css" />
+    <script type="text/javascript" src="js/ui/jquery.ui.timepicker.js?v=0.3.3"></script>
+
+<style type="text/css">
+    select.updGameOpt { width:210px; }
+    img.ui-datepicker-trigger {height:18px;margin-left:2px;}
+    .td1 { width:220px;border-right:1px solid #999; vertical-align:top; }
+    .td2 { padding-left:10px; vertical-align:top; }
+    .td3 { width:150px; text-align:right; vertical-align:top; }
+    .lblw { width:60px;padding-top:4px; }
+    .ddlm { margin-left:62px; }
+</style>
+
+
+
+			<!-- Begin EO.Web Dialog DialogUpdGame.  -->
+			
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+			<table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_bdt" cellspacing="0" cellpadding="0" border="0" style="display:none"><tr><td style="font-size:1px"><img src="/images/2013/modal/tl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/t.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/tr.png" alt="" tabindex="-1" /></td></tr><tr><td style="background-image:url('/images/2013/modal/l.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td><td><table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame" border="0" class="eo_no_border_spacing" style="width:770px;display:none;">
+	<tr><td align="left"><div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_headerDiv"   class="eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame1"><div style="position:relative;z-index:2;"><div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_headerHtml">Game Information</div><table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_close" alt="" src="/images/closeDialog.png"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" class="eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame2" align="left" valign="top">
+
+<div style="width:770px;height:480px;overflow:auto;margin:0 auto;">
+    <table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame">
+		<tbody>
+			<tr>
+				<td>
+    <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblNoAccess"></span>
+    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlPrimaryGameInfo" style="font-size:8pt;">
+					
+        <table border="0" cellpadding="2" cellspacing="0" width="750" style='font-size:8pt;'>
+            <tr>
+                <td style="vertical-align:top;">
+                    <input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnDelete" value="Delete Game" onclick="return confirm(&#39;Are you sure you want to delete this game?&#39;);" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnDelete" class="btn fleft btn-xs btn-link text-danger" /></td>
+                <td style="text-align:left;">
+                <h3 style="margin:2px auto 2px 50px;">Add a Game</h3>
+                </td>
+                <td class="td3">
+                    <span class="right" style="font-size:8pt;"><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbRefresh" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbRefresh" checked="checked" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbRefresh">Refresh</label></span>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="3">
+                    
+                    
+                </td>
+            </tr>
+            <tr>
+                <td class='td1'>
+                    
+                    <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlGameInfo" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGameInfo" class="updGameOpt">
+						<option value="DT">Game date and time</option>
+						<option value="D">Enter date only</option>
+						<option value="DP">Enter date only (Show pending)</option>
+						<option value="U">Unscheduled</option>
+
+					</select>  
+                </td>
+                <td class='td2'>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlDate" class="left" style="padding-right:10px;width:180px;">
+						
+                    <div class="lblw left">
+                        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblDate">Date: </span></div>
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbDate" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbDate" class="left" style="width:70px;" />
+                    
+					</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlTime" class="left" style="width:155px">
+						
+                        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblTime">Time: </span>
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbTime" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbTime" style="width:80px;" />
+                        <a id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnGrid" href="javascript:__doPostBack(&#39;ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnGrid&#39;,&#39;&#39;)" style="margin-top:3px;font-size:12pt;color:#015CAB;"><i class='mdi mdi-grid fright'></i></a>
+                    
+					</div>
+                </td>
+                <td class="td3" rowspan="5">
+                    <div class="r8" style="background:#fff;border:1px solid #999;padding:3px 5px;line-height:22px;">
+                        <h4 style="text-align:left;margin:2px auto;">
+                            <img id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ImgVerified" title="Game has been Verified" class="left" src="images/ch.gif" style="border-width:0px;" />
+                            <input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnScore" value="Update Score" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnScore" class="btn btn-primary btn-xs small" />
+                        </h4>
+                        <div class="clr"></div>
+                        Home Score:
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbHScore" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHScore" style="width:35px;" /><br />
+                        Away Score:
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbAScore" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAScore" style="width:35px;" /><br />
+                        <span style="float:left;"><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBOT" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$CBOT" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBOT">Overtime</label></span>
+                        <label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBPK">Shootout</label><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBPK" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$CBPK" /><br />
+                        <span style="float:left;"><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbDForfeit" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbDForfeit" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbDForfeit">Dbl Forfeit</label></span>
+                        <label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbForfeit">Forfeit</label><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbForfeit" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbForfeit" /><br />
+                        <label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBTM">Text Msg</label><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBTM" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$CBTM" />
+                        
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class='td1'>
+                    <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomeType" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType" class="updGameOpt">
+						<option value="T">Select Home Team</option>
+						<option value="P">Determine by points</option>
+						<option value="G">Determine from prior game</option>
+						<option value="O">Override</option>
+
+					</select>
+                </td>
+                <td class='td2'>
+                    <div class="lblw left">Home:</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeTeam" class="left" style="width:270px;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomeTeam" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeTeam" style="width:270px;">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlOtherHome" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherHome" style="width:270px;display:none;margin-top:7px;">
+
+						</select>
+                        <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeByReg" style="width:270px;display:none;margin-top:5px;">
+							
+                            <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbHomeReg" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHomeReg" style="width:50px;" />&nbsp;
+                            <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblHomeByReg"></span>
+                        
+						</div>
+                    
+					</div>
+                    
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePoints" class="left" style="display:none;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomeGroup" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeGroup">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomePlace" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomePlace">
+
+						</select>
+                    
+					</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePrior" class="left" style="display:none;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomeGameNumber" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeGameNumber" style="width:125px;">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHomeFinish" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeFinish">
+							<option value="1">Winner</option>
+							<option value="2">Loser</option>
+
+						</select>
+                    
+					</div>
+                    <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbHomeOverride" type="text" maxlength="45" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHomeOverride" class="left" style="width:270px;display:none;" />
+                </td>
+                
+            </tr>
+            <tr>
+                <td class='td1'>
+                    <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayType" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType" class="updGameOpt">
+						<option value="T">Select Away Team</option>
+						<option value="P">Determine by points</option>
+						<option value="G">Determine from prior game</option>
+						<option value="O">Override</option>
+
+					</select>
+                </td>
+                <td class='td2'>
+                    <div class="lblw left">Away:</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayTeam" class="left" style="width:270px;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayTeam" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayTeam" style="width:270px;">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlOtherAway" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherAway" style="width:270px;display:none;margin-top:7px;">
+
+						</select>
+                        <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayByReg" style="width:270px;display:none;margin-top:5px;">
+							
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbAwayReg" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAwayReg" style="width:50px;" />&nbsp;
+                        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblAwayByReg"></span>
+                        
+						</div>
+                    
+					</div>
+                    
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPoints" class="left" style="display:none;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayGroup" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayGroup">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayPlace" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayPlace">
+
+						</select>
+                    
+					</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPrior" class="left" style="display:none;">
+						
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayGameNumber" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayGameNumber" style="width:125px;">
+
+						</select>
+                        <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAwayFinish" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayFinish">
+							<option value="1">Winner</option>
+							<option value="2">Loser</option>
+
+						</select>
+                    
+					</div>
+                    <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbAwayOverride" type="text" maxlength="45" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAwayOverride" class="left" style="width:270px;display:none;" />
+                </td>
+            </tr>
+            <tr>
+                <td class='td1'>
+                    <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlFieldType" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlFieldType" class="updGameOpt" onchange="">
+						<option value="F">Select a Venue/Field</option>
+						<option value="C">Type in a field name</option>
+
+					</select>
+                    <div class="lblw left">
+                        <input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnUpdate" value="Save Game Changes" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnUpdate" class="btn btn-primary btn-xs small" />
+                    </div>
+                </td>
+                <td class='td2'>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlVenue">
+						
+                        <div style="position:absolute; top:-1000px;"><input type="hidden" name="_eo_js_modules" value="/js/eo/eo.310dad10-dab1-44a7-a637-c218ef9aa3b7.js|i|/js/eo/eo.86c43cce-ff60-427d-9a37-1e16debbe456.js|fmt|/js/eo/eo.e1a21eb1-352a-4a42-b2b6-bbacb24a29d1.js|u|/js/eo/eo.1690bc33-6c82-4e45-a64c-c8c0fde91095.js|c|/js/eo/eo.20891133-56ac-42df-9870-2d95a8ab231e.js|ei|/js/eo/eo.59fe8f2b-e671-41c5-9491-e9b2df72e9ec.js|e|/js/eo/eo.54ab8d54-4fdd-42e1-a5ec-62c40a48bb49.js|pop|/js/eo/eo.e955a919-0660-48a3-972b-6a7e7c13879e.js|dd|/js/eo/eo.a81cac04-7396-436e-96d4-99acb86cb2be.js|dg" /></div>
+<table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields" style="font-size:10pt;font-size:10pt;">
+							<tbody>
+								<tr>
+									<td>
+                            <div class="lblw left">Venue:</div>
+                                <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlVenue" onchange="javascript:setTimeout(&#39;__doPostBack(\&#39;ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlVenue\&#39;,\&#39;\&#39;)&#39;, 0)" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlVenue" class="left" style="width:270px;">
+
+									</select>
+                            <div class="lblw left clr" style='margin-top:6px;'>Field:</div> 
+                            <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlField" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlField" class="left" style="width:270px;margin-top:6px;">
+
+									</select>
+                        </td>
+								</tr>
+							</tbody>
+						</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields=1;EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields,"cpFields",new EO25264.f.aaum([[,"ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields","Callback","ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpFields",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpFields','_eo_arg_')"],,"__doPostBack('ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpFields','')",,,,,,[["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlVenue"]],"<div class='loading'></div>",,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpFields,1,null, 0);});
+//]]>
+</script>
+
+                    
+					</div>
+                    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlFieldOverride" style="display:none;">
+						
+                        <div class="lblw left">Venue:</div>
+                        <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbFieldName" type="text" maxlength="45" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbFieldName" class="left" style="width:270px;" />
+                    
+					</div>
+                </td>
+            </tr>
+            <tr>
+                <td class="td1">
+                    <div class="lblw left">
+                        <input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnMail" value="Send note to teams" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnMail" class="btn btn-xs btn-light small" />
+                    </div>                
+                </td>
+                <td class="td2">
+                    <div class="lblw left">Type:</div>
+                    <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlGameType" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGameType" class="left" style="width:270px;">
+						<option value="R">Round Robin</option>
+						<option value="FZ">Consolation</option>
+						<option value="P">Play In</option>
+						<option value="F">Final</option>
+						<option value="S">Semi Final</option>
+						<option value="Q">Quarter Final</option>
+						<option value="1">Sweet 16</option>
+						<option value="3">Round of 32</option>
+						<option value="6">Round of 64</option>
+						<option value="8">Round of 128</option>
+						<option value="5">Round of 256</option>
+						<option value="F3">Third Place</option>
+						<option value="F5">Fifth Place</option>
+						<option value="F7">Seventh Place</option>
+						<option value="F9">Ninth Place</option>
+						<option value="FB">Eleventh Place</option>
+						<option value="FD">Thirteenth Place</option>
+						<option value="FF">Fifteenth Place</option>
+						<option value="FH">Seventeenth Place</option>
+						<option value="FJ">Nineteenth Place</option>
+						<option value="FL">Twenty-first Place</option>
+						<option value="FN">Twenty-third Place</option>
+						<option value="FP">Twenty-fifth Place</option>
+						<option value="FR">Twenty-seventh Place</option>
+						<option value="FT">Twenty-ninth Place</option>
+						<option value="FG">Final (Gold)</option>
+						<option value="FS">Final (Silver)</option>
+						<option value="FO">Final (Bronze)</option>
+						<option value="FE">Final (Seeding)</option>
+						<option value="FX">Final (Cust)</option>
+						<option value="FI">Final - If Necessary</option>
+						<option value="SP">To Winner Bracket</option>
+
+					</select>
+                </td>
+            </tr>
+            <tr>
+                <td class='td1'>
+                    <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblRound"></span>
+                    <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblGame"></span>
+                    
+                </td>
+                <td class='td2'>
+                    <input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbPoints" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbPoints" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbPoints">Points game <img src='images/st.png' height='15px' /> - Game counts in standings</label><br />
+                    <input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbCancelled" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbCancelled" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbCancelled">Game was cancelled</label>
+                    <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbCancelled" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbCancelled" placeholder="Reason" />
+                </td>
+                <td style="text-align:right;">
+                    <a id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lnkAdvanced" onclick="$(&#39;#&lt;%=pnlCards.ClientID %>&#39;).slideToggle();">Advanced Options <i class='mdi mdi-menu-down'></i></a>
+                </td>
+            </tr>
+        </table>
+        
+    
+				</div>
+    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlCards" style="display:none;">
+					 
+    
+        <table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tblPCards" cellspacing="0" cellpadding="2" border="0" style="border-width:0px;font-size:10pt;width:750px;border-collapse:collapse;">
+						<tr id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TRCard1">
+							<td align="right">
+						Home Card
+					</td><td><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBHCard" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$CBHCard" onclick="ShowHCard();" /></td><td align="left" colspan="2"><select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLHAthletes" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLHAthletes" style="font-family:verdana;font-size:8pt;width:220px;">
+
+							</select><input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$TBHNo" type="text" maxlength="2" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHNo" placeholder="#" style="font-size:8pt;width:50px;" /><input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$TBHAthlete" type="text" maxlength="25" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHAthlete" placeholder="Name" style="font-size:8pt;width:170px;" />
+                        &nbsp;
+						Code
+						<select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLPCards" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLPCards" style="font-size:8pt;width:75px;">
+
+							</select></td><td align="right"><input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnAddCard" value="Add Card" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_BtnAddCard" style="font-family:verdana;font-size:7pt;width:100px;" /></td>
+						</tr><tr id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TRCard2">
+							<td align="right">
+						Away Card
+					</td><td><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBACard" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$CBACard" onclick="ShowACard();" /></td><td align="left" colspan="2"><select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLAAthletes" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLAAthletes" style="font-family:verdana;font-size:8pt;width:220px;">
+
+							</select><input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$TBANo" type="text" maxlength="2" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBANo" placeholder="#" style="font-size:8pt;width:50px;" /><input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$TBAAthlete" type="text" maxlength="25" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBAAthlete" placeholder="Name" style="font-size:8pt;width:170px;" /></td><td align="right"><input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnDelCard" value="Delete Card" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_BtnDelCard" style="font-family:verdana;font-size:7pt;width:100px;" /></td>
+						</tr><tr id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TRCard3">
+							<td align="right">
+						Cards
+					</td><td></td><td align="left" colspan="2"><select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLCards" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLCards" style="font-family:verdana;font-size:8pt;width:220px;">
+
+							</select></td><td align="right"><input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnFlip" value="Flip H/A" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnFlip" class="right" style="font-size:7pt;width:100px;" /></td>
+						</tr><tr>
+							<td align="right">Override Points:</td><td></td><td colspan="2">
+                        Home:
+			                <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLHPoints" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLHPoints" style="width:50px;">
+								<option value="">NO</option>
+								<option value="10">10</option>
+								<option value="9">9</option>
+								<option value="8">8</option>
+								<option value="7">7</option>
+								<option value="6">6</option>
+								<option value="5">5</option>
+								<option value="4">4</option>
+								<option value="3">3</option>
+								<option value="2">2</option>
+								<option value="1">1</option>
+								<option value="0">0</option>
+								<option value="00">00</option>
+								<option value="-1">-1</option>
+								<option value="-2">-2</option>
+								<option value="-3">-3</option>
+								<option value="-4">-4</option>
+								<option value="-5">-5</option>
+								<option value="-6">-6</option>
+								<option value="-7">-7</option>
+								<option value="-8">-8</option>
+								<option value="-9">-9</option>
+								<option value="-10">-10</option>
+
+							</select>
+                        Away:
+			                <select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$DDLVPoints" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLVPoints" style="width:50px;">
+								<option value="">NO</option>
+								<option value="10">10</option>
+								<option value="9">9</option>
+								<option value="8">8</option>
+								<option value="7">7</option>
+								<option value="6">6</option>
+								<option value="5">5</option>
+								<option value="4">4</option>
+								<option value="3">3</option>
+								<option value="2">2</option>
+								<option value="1">1</option>
+								<option value="0">0</option>
+								<option value="00">00</option>
+								<option value="-1">-1</option>
+								<option value="-2">-2</option>
+								<option value="-3">-3</option>
+								<option value="-4">-4</option>
+								<option value="-5">-5</option>
+								<option value="-6">-6</option>
+								<option value="-7">-7</option>
+								<option value="-8">-8</option>
+								<option value="-9">-9</option>
+								<option value="-10">-10</option>
+
+							</select></td><td align="right"><input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnOP" value="Override Points" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnOP" class="right" style="font-size:7pt;width:100px;" /></td>
+						</tr><tr id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_trCrew">
+							<td align="right">Crew</td><td></td><td colspan="2" style="font-weight:bold;"><select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlGS" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGS" style="width:218px;">
+
+							</select></td><td id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TableCell1" align="right"><input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnExclude" value="Exclude" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_btnExclude" class="right" style="font-size:7pt;width:100px;" /></td>
+						</tr><tr id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_trCustom">
+							<td align="right">
+                        Icons
+					</td><td></td><td align="left" colspan="2">
+                        Home&nbsp;
+						<select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlHIcon" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHIcon" style="font-size:8pt;width:100px;">
+
+							</select>
+                        &nbsp;&nbsp;Away&nbsp;
+						<select name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$ddlAIcon" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAIcon" style="font-size:8pt;width:100px;">
+
+							</select></td><td align="right"></td>
+						</tr>
+					</table>
+    <input type="submit" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnClear" value="Clear Last Change" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_BtnClear" /> 
+    <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblLast"></span>
+    
+				</div>
+
+    <div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlSinc" style="display:none;">
+					
+    <h3>SincSports Only</h3>
+        Round: <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbRoundNo" type="text" maxlength="3" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbRoundNo" style="width:50px;" />&nbsp;
+        Game: <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbRoundGame" type="text" maxlength="3" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbRoundGame" style="width:50px;" />
+        <br />
+
+        Division: <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$tbDiv" type="text" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbDiv" /><br />
+        Game: <input name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$TBGameNo" type="text" maxlength="5" id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBGameNo" style="font-size:8pt;width:50px;" />
+        <br /><input id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbFullUpdate" type="checkbox" name="ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cbFullUpdate" /><label for="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbFullUpdate">Update Game 2 (Group and TeamNo)</label>
+
+        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblDiv"></span>
+        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblDirector" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblUserID" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblEntity" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_Lbltype" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_Lbltid" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_Lblyear" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblDel" style="visibility:hidden;"></span>
+		<span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_LblReq" style="visibility:hidden;"></span>
+    	
+	    
+	    
+	    
+        
+        <span id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_lblGameLen"></span>
+    
+				</div>
+
+    <script type="text/javascript">
+        function closeThisDialog(dialog, arg) {
+        if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbRefresh').attr("checked") == "checked")
+            window.location.reload();
+        }
+        $(document).ready(function () {
+
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbCancelled').hide();
+            if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbCancelled').attr("checked") == "checked")
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbCancelled').show();
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cbCancelled').click(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbCancelled').toggle();
+            });
+
+            //Add the on Change functions
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGameInfo').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlDate').show();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlTime').show();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGameInfo').val() == "U") {
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlDate').hide();
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlTime').hide();
+                }
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlGameInfo').val() != "DT") {
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlTime').hide();
+                }
+
+            });
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlFieldType').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlVenue').show();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlFieldOverride').show();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlFieldType').val() == "F") {
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlFieldOverride').hide();
+                }
+                else {
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlVenue').hide();
+                }
+            });
+
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeTeam').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePoints').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePrior').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHomeOverride').hide();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType').val() == "T")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeTeam').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType').val() == "P")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePoints').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType').val() == "G")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomePrior').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeType').val() == "O")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHomeOverride').show();
+            });
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayTeam').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPoints').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPrior').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAwayOverride').hide();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType').val() == "T")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayTeam').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType').val() == "P")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPoints').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType').val() == "G")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayPrior').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayType').val() == "O")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAwayOverride').show();
+            });
+
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayTeam').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherAway').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayByReg').hide();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayTeam').val() == "")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherAway').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlAwayTeam').val() == "R")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlAwayByReg').show();
+            });
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeTeam').change(function () {
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherHome').hide();
+                $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeByReg').hide();
+                if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeTeam').val() == "")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlOtherHome').show();
+                else if ($('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_ddlHomeTeam').val() == "R")
+                    $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_pnlHomeByReg').show();
+            });
+
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbTime').timepicker({
+                showPeriod: true,
+                showLeadingZero: true,
+                showDeselectButton: true,
+                defaultTime: '0:00',
+                showCloseButton: true
+            });
+            $('#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbDate').datepicker({
+                showOn: "both",
+                buttonImage: "images/calendar.png",
+                buttonImageOnly: true
+            });
+            $("#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHomeReg").keydown(function (event) {
+                if (event.keyCode == 46 || event.keyCode == 8 || event.keyCode == 9 || event.keyCode == 27 || event.keyCode == 13 ||
+                        (event.keyCode == 65 && event.ctrlKey === true) ||
+                        (event.keyCode >= 35 && event.keyCode <= 39)) {
+                    return;
+                }
+                else {
+                    if (event.shiftKey || (event.keyCode < 48 || event.keyCode > 57) && (event.keyCode < 96 || event.keyCode > 105)) {
+                        event.preventDefault();
+                    }
+                }
+            });
+            $("#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAwayReg").keydown(function (event) {
+                if (event.keyCode == 46 || event.keyCode == 8 || event.keyCode == 9 || event.keyCode == 27 || event.keyCode == 13 ||
+                        (event.keyCode == 65 && event.ctrlKey === true) ||
+                        (event.keyCode >= 35 && event.keyCode <= 39)) {
+                    return;
+                }
+                else {
+                    if (event.shiftKey || (event.keyCode < 48 || event.keyCode > 57) && (event.keyCode < 96 || event.keyCode > 105)) {
+                        event.preventDefault();
+                    }
+                }
+            });
+            $("#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbHScore").keydown(function (event) {
+                if (event.keyCode == 46 || event.keyCode == 8 || event.keyCode == 9 || event.keyCode == 27 || event.keyCode == 13 ||
+                        (event.keyCode == 65 && event.ctrlKey === true) ||
+                        (event.keyCode >= 35 && event.keyCode <= 39)) {
+                    return;
+                }
+                else {
+                    if (event.shiftKey || (event.keyCode < 48 || event.keyCode > 57) && (event.keyCode < 96 || event.keyCode > 105)) {
+                        event.preventDefault();
+                    }
+                }
+            });
+            $("#ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_tbAScore").keydown(function (event) {
+                if (event.keyCode == 46 || event.keyCode == 8 || event.keyCode == 9 || event.keyCode == 27 || event.keyCode == 13 ||
+                        (event.keyCode == 65 && event.ctrlKey === true) ||
+                        (event.keyCode >= 35 && event.keyCode <= 39)) {
+                    return;
+                }
+                else {
+                    if (event.shiftKey || (event.keyCode < 48 || event.keyCode > 57) && (event.keyCode < 96 || event.keyCode > 105)) {
+                        event.preventDefault();
+                    }
+                }
+            });
+
+        });
+
+        function ShowHCard() {
+            if (document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBHCard").checked) {
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLHAthletes").style.display = '';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHAthlete").style.display = 'none';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHNo").style.display = 'none';
+            }
+            else {
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLHAthletes").style.display = 'none';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHAthlete").style.display = '';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBHNo").style.display = '';
+            }
+        }
+
+        function ShowACard() {
+            if (document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_CBACard").checked) {
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLAAthletes").style.display = '';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBAAthlete").style.display = 'none';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBANo").style.display = 'none';
+            }
+            else {
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_DDLAAthletes").style.display = 'none';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBAAthlete").style.display = '';
+                document.getElementById("ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_TBANo").style.display = '';
+            }
+        }
+    
+</script>
+    </td>
+			</tr>
+		</tbody>
+	</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame=1;EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame,"cpGame",new EO25264.f.aaum([[,"ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame","Callback","ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpGame",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpGame','_eo_arg_')"],,"__doPostBack('ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$cpGame','')",,,,,,[["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnDelete","delete"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnUpdate","save"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnAddCard","addCard"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnScore","save"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnDelCard","delCard"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$BtnClear","clearChange"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnOP","overridePoints"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnFlip","flip"],["ctl00$ContentPlaceHolder1$updGame$DialogUpdGame$ctl00$btnExclude","exclude"]],"<div class='loading'></div>",,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00_cpGame,1,null, 0);});
+//]]>
+</script>
+
+    
+</div>
+</td></tr></table></td></tr><tr><td><div id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_footerDiv" style="position:relative;width:auto;"><table id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_footer"  class="eo_align_center eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame3">
+</td></tr></table></div></td></tr>
+</table></td><td style="background-image:url('/images/2013/modal/r.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td></tr><tr><td style="font-size:1px"><img src="/images/2013/modal/bl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/b.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/br.png" alt="" tabindex="-1" /></td></tr></table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_updGame_DialogUpdGame=1;EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame,"DialogUpdGame",new EO25264.f.bak([[[,"ctl00_ContentPlaceHolder1_updGame_DialogUpdGame","Dialog","ctl00$ContentPlaceHolder1$updGame$DialogUpdGame",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$updGame$DialogUpdGame','_eo_arg_')"],["/images/2013/modal/tl.png","/images/2013/modal/t.png","/images/2013/modal/tr.png","/images/2013/modal/l.png","/images/2013/modal/r.png","/images/2013/modal/bl.png","/images/2013/modal/b.png","/images/2013/modal/br.png"],,,"None",,,,,[]],"black",50,,,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame1","eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame1",,"eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame2",,,,,,,,,,,,,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame3",,,,,,"resizableDialog","closeThisDialog",,,,,,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl00","ctl00_ContentPlaceHolder1_updGame_DialogUpdGame_ctl01",,"/images/closeDialog.png"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_updGame_DialogUpdGame,1,500, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+			<!-- End EO.Web Dialog DialogUpdGame.  -->
+			
+    
+    <div id="ctl00_ContentPlaceHolder1_pnlLabels" style="display: none;">
+				
+        <span id="ctl00_ContentPlaceHolder1_LblStaffID"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSiteID">0</span>
+        <span id="ctl00_ContentPlaceHolder1_LblFieldID">0</span>
+        <span id="ctl00_ContentPlaceHolder1_LblDirect"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSIC"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblDiv">U14F01</span>
+        <span id="ctl00_ContentPlaceHolder1_LblGameCard"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSequence"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSex"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSTid">TZ2565</span>
+        <span id="ctl00_ContentPlaceHolder1_lbl1TID"></span>
+        <span id="ctl00_ContentPlaceHolder1_lbl1Year"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblSYear">2026</span>
+        <span id="ctl00_ContentPlaceHolder1_LblTeamID"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblTid">TZ2565</span>
+        <span id="ctl00_ContentPlaceHolder1_LblTClub">IL012</span>
+        <span id="ctl00_ContentPlaceHolder1_LblShow"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblScores">Y</span>
+        <span id="ctl00_ContentPlaceHolder1_LblWeekend">0</span>
+        <span id="ctl00_ContentPlaceHolder1_LblOneGroup"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblLineBreak"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblCodes"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblHomeAway"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblLink"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblReport"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblShowSeed"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblNo"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblFullAccess"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblClubId"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblHdg">Under 14 Girls First Division.- Crossover</span>
+        <span id="ctl00_ContentPlaceHolder1_lblDirectory"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblBalanceDue"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblViewAll"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblAlwaysVerify"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblAccess"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblUserID"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblVerify"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblYear">2026</span>
+        <span id="ctl00_ContentPlaceHolder1_LblGameTasks"></span>
+        <span id="ctl00_ContentPlaceHolder1_LblAgeName"></span>
+        <span id="ctl00_ContentPlaceHolder1_lblPublishDate">4/7/2026</span>
+        <span id="ctl00_ContentPlaceHolder1_lblPenaltyCards"></span>
+    <input name="ctl00$ContentPlaceHolder1$G1" type="text" value="7334129" id="ctl00_ContentPlaceHolder1_G1" /><input name="ctl00$ContentPlaceHolder1$G2" type="text" value="7334130" id="ctl00_ContentPlaceHolder1_G2" /><input name="ctl00$ContentPlaceHolder1$G3" type="text" value="7334128" id="ctl00_ContentPlaceHolder1_G3" /><input name="ctl00$ContentPlaceHolder1$G4" type="text" value="7334131" id="ctl00_ContentPlaceHolder1_G4" /><input name="ctl00$ContentPlaceHolder1$G5" type="text" value="7334132" id="ctl00_ContentPlaceHolder1_G5" /><input name="ctl00$ContentPlaceHolder1$G6" type="text" value="7334133" id="ctl00_ContentPlaceHolder1_G6" /><input name="ctl00$ContentPlaceHolder1$G7" type="text" value="7334134" id="ctl00_ContentPlaceHolder1_G7" /><input name="ctl00$ContentPlaceHolder1$G8" type="text" value="7334136" id="ctl00_ContentPlaceHolder1_G8" /><input name="ctl00$ContentPlaceHolder1$G9" type="text" value="7334135" id="ctl00_ContentPlaceHolder1_G9" /><input name="ctl00$ContentPlaceHolder1$TBCount" type="text" value="10" id="ctl00_ContentPlaceHolder1_TBCount" />
+			</div>
+
+    
+			<!-- Begin EO.Web Dialog Dialog_Differential.  -->
+			
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+			<table id="ctl00_ContentPlaceHolder1_Dialog_Differential_bdt" cellspacing="0" cellpadding="0" border="0" style="display:none"><tr><td style="font-size:1px"><img src="/images/2013/modal/tl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/t.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/tr.png" alt="" tabindex="-1" /></td></tr><tr><td style="background-image:url('/images/2013/modal/l.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td><td><table id="ctl00_ContentPlaceHolder1_Dialog_Differential" border="0" class="eo_no_border_spacing" style="display:none;">
+	<tr><td align="left"><div id="ctl00_ContentPlaceHolder1_Dialog_Differential_headerDiv"   class="eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential1"><div style="position:relative;z-index:2;"><div id="ctl00_ContentPlaceHolder1_Dialog_Differential_headerHtml">Set Max Differential</div><table id="ctl00_ContentPlaceHolder1_Dialog_Differential_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_ContentPlaceHolder1_Dialog_Differential_close" alt="" src="/images/closeDialog.png"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_ContentPlaceHolder1_Dialog_Differential_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" class="eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential2" align="left" valign="top">
+
+            <div style='height: 400px; width: 570px; overflow: auto;'>
+
+                <table id="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential">
+		<tbody>
+			<tr>
+				<td>
+                    <span id="ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_lblOutput" style="color:Red;font-weight:bold;"></span><br />
+                    
+                </td>
+			</tr>
+		</tbody>
+	</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential=1;EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential,"cpDifferential",new EO25264.f.aaum([[,"ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential","Callback","ctl00$ContentPlaceHolder1$Dialog_Differential$ctl00$cpDifferential",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$Dialog_Differential$ctl00$cpDifferential','_eo_arg_')"],,"__doPostBack('ctl00$ContentPlaceHolder1$Dialog_Differential$ctl00$cpDifferential','')",,,,,,[["ctl00$ContentPlaceHolder1$Dialog_Differential$ctl00$rptDifferential","save"]],"<div class='loading'></div>",,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00_cpDifferential,1,null, 0);});
+//]]>
+</script>
+
+            </div>
+        </td></tr></table></td></tr><tr><td><div id="ctl00_ContentPlaceHolder1_Dialog_Differential_footerDiv" style="position:relative;width:auto;"><table id="ctl00_ContentPlaceHolder1_Dialog_Differential_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_ContentPlaceHolder1_Dialog_Differential_footer"  class="eo_align_center eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential3"></td></tr></table></div></td></tr>
+</table></td><td style="background-image:url('/images/2013/modal/r.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td></tr><tr><td style="font-size:1px"><img src="/images/2013/modal/bl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/b.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/br.png" alt="" tabindex="-1" /></td></tr></table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_Dialog_Differential=1;EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential,"Dialog_Differential",new EO25264.f.bak([[[,"ctl00_ContentPlaceHolder1_Dialog_Differential","Dialog","ctl00$ContentPlaceHolder1$Dialog_Differential",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$Dialog_Differential','_eo_arg_')"],["/images/2013/modal/tl.png","/images/2013/modal/t.png","/images/2013/modal/tr.png","/images/2013/modal/l.png","/images/2013/modal/r.png","/images/2013/modal/bl.png","/images/2013/modal/b.png","/images/2013/modal/br.png"],,,"None",,,,,[]],"black",50,"LightGrey",,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential1","eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential1",,"eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential2",,,600,,,,,,,,,,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_Dialog_Differential3",,,,,,"resizableDialog",,,,,,,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_ContentPlaceHolder1_Dialog_Differential_ctl00","ctl00_ContentPlaceHolder1_Dialog_Differential_ctl01",,"/images/closeDialog.png"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_Dialog_Differential,1,450, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+			<!-- End EO.Web Dialog Dialog_Differential.  -->
+			
+    
+			<!-- Begin EO.Web Dialog DialogSelect.  -->
+			
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+			<table id="ctl00_ContentPlaceHolder1_DialogSelect_bdt" cellspacing="0" cellpadding="0" border="0" style="display:none"><tr><td style="font-size:1px"><img src="/images/2013/modal/tl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/t.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/tr.png" alt="" tabindex="-1" /></td></tr><tr><td style="background-image:url('/images/2013/modal/l.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td><td><table id="ctl00_ContentPlaceHolder1_DialogSelect" border="0" class="eo_no_border_spacing" style="width:600px;display:none;">
+	<tr><td align="left"><div id="ctl00_ContentPlaceHolder1_DialogSelect_headerDiv"   class="eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect1"><div style="position:relative;z-index:2;"><div id="ctl00_ContentPlaceHolder1_DialogSelect_headerHtml">Schedule View</div><table id="ctl00_ContentPlaceHolder1_DialogSelect_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_ContentPlaceHolder1_DialogSelect_close" alt="" src="/images/closeDialog.png"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_ContentPlaceHolder1_DialogSelect_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" class="eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect2" align="left" valign="top">
+            <div style="height: 400px; width: 100%; overflow: auto;">
+                <table id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy" style="width:100%;width:100%;">
+		<tbody>
+			<tr>
+				<td>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <span id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_lblDateError" style="color:Red;font-weight:bold;float:left;"></span>
+                            <div class="clear"></div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            From&nbsp;
+                            <input name="ctl00$ContentPlaceHolder1$DialogSelect$ctl00$tbFromDate" type="text" id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbFromDate" style="width:100px;" />
+                        </div>
+                        <div class="col-md-6">
+                            To&nbsp;
+                            <input name="ctl00$ContentPlaceHolder1$DialogSelect$ctl00$tbToDate" type="text" id="ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbToDate" style="width:100px;" />
+                        </div>
+                    </div>
+                    <div class="clear"></div>
+                    
+                    <script type="text/javascript">
+                        $(document).ready(function () {
+                            $('#ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbFromDate').datepicker({
+                                showOn: "button",
+                                buttonImage: "/images/calendar.png",
+                                buttonImageOnly: true
+                            });
+                            $('#ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbToDate').datepicker({
+                                showOn: "button",
+                                buttonImage: "/images/calendar.png",
+                                buttonImageOnly: true
+                            });
+                            $("a.schedview").click(function (e) {
+
+                                var sdate = $('#ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbFromDate').val();
+                                var edate = $('#ctl00_ContentPlaceHolder1_DialogSelect_ctl00_tbToDate').val();
+
+                                var url = $(this).attr("data-url");
+                                url += "&starttime=" + sdate + "&endtime=" + edate;
+                                window.location = url;
+                                e.preventDefault()
+
+                            })
+                        });
+                    </script>
+                </td>
+			</tr>
+		</tbody>
+	</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy=1;EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy,"cbpViewBy",new EO25264.f.aaum([[,"ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy","Callback","ctl00$ContentPlaceHolder1$DialogSelect$ctl00$cbpViewBy",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$DialogSelect$ctl00$cbpViewBy','_eo_arg_')"],,"__doPostBack('ctl00$ContentPlaceHolder1$DialogSelect$ctl00$cbpViewBy','')",,,,,,[],"<div class='loading'></div>",,,,,,,,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect_ctl00_cbpViewBy,1,null, 0);});
+//]]>
+</script>
+
+            </div>
+        </td></tr></table></td></tr><tr><td><div id="ctl00_ContentPlaceHolder1_DialogSelect_footerDiv" style="position:relative;width:auto;"><table id="ctl00_ContentPlaceHolder1_DialogSelect_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_ContentPlaceHolder1_DialogSelect_footer"  class="eo_align_center eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect3">
+        </td></tr></table></div></td></tr>
+</table></td><td style="background-image:url('/images/2013/modal/r.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td></tr><tr><td style="font-size:1px"><img src="/images/2013/modal/bl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/b.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/br.png" alt="" tabindex="-1" /></td></tr></table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_ContentPlaceHolder1_DialogSelect=1;EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect=EO25264.f.acg(EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect,"DialogSelect",new EO25264.f.bak([[[,"ctl00_ContentPlaceHolder1_DialogSelect","Dialog","ctl00$ContentPlaceHolder1$DialogSelect",,,,,,,"__doPostBack('ctl00$ContentPlaceHolder1$DialogSelect','_eo_arg_')"],["/images/2013/modal/tl.png","/images/2013/modal/t.png","/images/2013/modal/tr.png","/images/2013/modal/l.png","/images/2013/modal/r.png","/images/2013/modal/bl.png","/images/2013/modal/b.png","/images/2013/modal/br.png"],,,,,,,,[]],"black",50,,,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect1","eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect1",,"eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect2",,,,,,,,,,,,,,,,,,"eo_css_ctrl_ctl00_ContentPlaceHolder1_DialogSelect3",,,,,,"resizableDialog",,,,,,,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_ContentPlaceHolder1_DialogSelect_ctl00","ctl00_ContentPlaceHolder1_DialogSelect_ctl01",,"/images/closeDialog.png"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_ContentPlaceHolder1_DialogSelect,1,450, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+			<!-- End EO.Web Dialog DialogSelect.  -->
+			
+    <input name="ctl00$ContentPlaceHolder1$tbSiteAccess" type="text" id="ctl00_ContentPlaceHolder1_tbSiteAccess" style="width:135px;" />
+    <input type="submit" name="ctl00$ContentPlaceHolder1$btnScoreKeeper" value="Scorekeeper Access" id="ctl00_ContentPlaceHolder1_btnScoreKeeper" class="btn btn-primary btn-xs" />
+    
+    <!-- Content Ends Here -->
+<input name="ctl00$ContentPlaceHolder1$ThisPageMasterFile" type="text" value="/TT10.master" id="ctl00_ContentPlaceHolder1_ThisPageMasterFile" style="display:none;" />
+                            
+                            
+                        </div>
+                        
+                    
+		</div>
+                
+	</div>
+            
+</div>
+            <div id="tfooter" class="ubuntufont pt-8">
+                
+                <div class="footerWrap">
+                    <div id="eFoot">
+                        <div class="fContents">
+                            Event Information<br />
+                            <a href='/TTMassMail.aspx?tid=TZ2565'>Contact Us</a><br /><a href='/TTSchedules.aspx?tid=TZ2565'>Schedules & Standings</a><br />
+                        </div>
+                    </div>
+                    <div id="sincFoot">
+                        <div class="fContents">
+                            SincSports.com Help<br />
+                            <a href='/TTFindMe.aspx?tid=TZ2565'>Login Help</a><br /><a href='/contact.aspx?tid=TZ2565'>Contact Support</a><br /><a href='http://www.sincsports.com/mobile.aspx' target='_blank'>Download the mobile app!</a>
+                        </div>
+                    </div>
+                    <div id="sincLogo">
+                        <a id="ctl00_lnkUSA" class="usa_lnk" rel="noopener" href="http://usatournaments.com" target="_blank"><img src='/images/usa-logo-dark.png' class='usalogo' /></a>
+                        <a id="powered" href="http://sincsports.com" target="_blank" rel="noopener">
+                            <img src="/images/blank.gif" border="0" class="fleft" /></a>
+                    </div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+            <div id="bottom" class="ubuntufont">
+                <div class="footerWrap">
+                    &copy;
+                    2026
+                    SincSports&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a id="ctl00_lnkPrivacyPolicy" href="/privacy.aspx?tid=TZ2565&amp;sinc=N&amp;sic=N">Privacy Policy</a>
+                    &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a id="ctl00_lnkCookiePolicy" href="/cookiepolicy.aspx?tid=TZ2565&amp;sinc=N&amp;sic=N">Cookie Policy</a>
+                </div>
+            </div>
+        </div>
+
+        
+        
+        
+<!-- Begin EO.Web Dialog DialogHelp.  -->
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+<table id="ctl00_DialogHelp_bdt" cellspacing="0" cellpadding="0" border="0" style="display:none"><tr><td style="font-size:1px"><img src="/images/2013/modal/tl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/t.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/tr.png" alt="" tabindex="-1" /></td></tr><tr><td style="background-image:url('/images/2013/modal/l.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td><td><table id="ctl00_DialogHelp" border="0" class="eo_no_border_spacing" style="width:593px;display:none;">
+	<tr><td align="left"><div id="ctl00_DialogHelp_headerDiv"   class="eo_css_ctrl_ctl00_DialogHelp1"><div style="position:relative;z-index:2;"><div id="ctl00_DialogHelp_headerHtml"></div><table id="ctl00_DialogHelp_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_DialogHelp_close" alt="" src="/images/closeDialog.png"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_DialogHelp_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" class="eo_css_ctrl_ctl00_DialogHelp2" align="left" valign="top">
+                <table id="ctl00_DialogHelp_ctl00_cpHelpPanel">
+		<tbody>
+			<tr>
+				<td>
+                    <div id="hpdiv" style="max-height:550px; overflow:auto;">
+                    
+                        
+                        <br />
+                    </div>
+                </td>
+			</tr>
+		</tbody>
+	</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_DialogHelp_ctl00_cpHelpPanel=1;EO25264.r._o_ctl00_DialogHelp_ctl00_cpHelpPanel=EO25264.f.acg(EO25264.r._o_ctl00_DialogHelp_ctl00_cpHelpPanel,"cpHelpPanel",new EO25264.f.aaum([[,"ctl00_DialogHelp_ctl00_cpHelpPanel","Callback","ctl00$DialogHelp$ctl00$cpHelpPanel",,,,,,,"__doPostBack('ctl00$DialogHelp$ctl00$cpHelpPanel','_eo_arg_')"],,"__doPostBack('ctl00$DialogHelp$ctl00$cpHelpPanel','')",,,,,,[],"<img src='images/loading2.gif' /> Loading...",,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_DialogHelp_ctl00_cpHelpPanel,1,null, 0);});
+//]]>
+</script>
+
+            </td></tr></table></td></tr><tr><td><div id="ctl00_DialogHelp_footerDiv" style="position:relative;width:auto;"><table id="ctl00_DialogHelp_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_DialogHelp_footer"  class="eo_align_center eo_css_ctrl_ctl00_DialogHelp3"></td></tr></table></div></td></tr>
+</table></td><td style="background-image:url('/images/2013/modal/r.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td></tr><tr><td style="font-size:1px"><img src="/images/2013/modal/bl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/b.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/br.png" alt="" tabindex="-1" /></td></tr></table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_DialogHelp=1;EO25264.r._o_ctl00_DialogHelp=EO25264.f.acg(EO25264.r._o_ctl00_DialogHelp,"DialogHelp",new EO25264.f.bak([[[,"ctl00_DialogHelp","Dialog","ctl00$DialogHelp",,,,,,,"__doPostBack('ctl00$DialogHelp','_eo_arg_')"],["/images/2013/modal/tl.png","/images/2013/modal/t.png","/images/2013/modal/tr.png","/images/2013/modal/l.png","/images/2013/modal/r.png","/images/2013/modal/bl.png","/images/2013/modal/b.png","/images/2013/modal/br.png"],,,,,,,,[]],,,,,,,,,,"eo_css_ctrl_ctl00_DialogHelp1","eo_css_ctrl_ctl00_DialogHelp1",,"eo_css_ctrl_ctl00_DialogHelp2",,,,,,,,,,,,,,,,,,"eo_css_ctrl_ctl00_DialogHelp3",,,,,,"resizableDialog",,,,,,0,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_DialogHelp_ctl00","ctl00_DialogHelp_ctl01",,"/images/closeDialog.png"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_DialogHelp,1,0, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+<!-- End EO.Web Dialog DialogHelp.  -->
+
+        
+<div id="smMessageBar">
+    <div>
+        <span id="ctl00_sicMessage_lblMsg" class="spanDisplayMessage"></span>
+        <img id="csmb" src="/images/blank.gif" />
+    </div>
+</div>
+
+        
+        
+<script type="text/javascript">
+    function openDialog() {
+        $("[id$=headerDiv]").addClass("dHeader");
+    }
+</script>
+<style type="text/css">
+    .dHeader { color:black;font-family:'Segoe UI Light', Tahoma, Helvetica, Arial, Verdana, sans-serif;font-size:18pt;padding:0 3px 5px 8px;background-color:#fff;border:0px; }
+</style>
+
+<!-- Begin EO.Web Dialog Dialog_ContentManager.  -->
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asv();
+//]]>
+</script>
+<table id="ctl00_SICCM_Dialog_ContentManager_bdt" cellspacing="0" cellpadding="0" border="0" style="display:none"><tr><td style="font-size:1px"><img src="/images/2013/modal/tl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/t.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/tr.png" alt="" tabindex="-1" /></td></tr><tr><td style="background-image:url('/images/2013/modal/l.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td><td><table id="ctl00_SICCM_Dialog_ContentManager" border="0" class="eo_no_border_spacing" style="width:800px;display:none;">
+	<tr><td align="left"><div id="ctl00_SICCM_Dialog_ContentManager_headerDiv"   class="eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager1"><div style="position:relative;z-index:2;"><div id="ctl00_SICCM_Dialog_ContentManager_headerHtml">SINC Content Manager</div><table id="ctl00_SICCM_Dialog_ContentManager_headerTableR" border="0" cellspacing="0" cellpadding="0" style="position:absolute;right:0px;top:0px;"><tr><td valign="middle"><img id="ctl00_SICCM_Dialog_ContentManager_close" alt="" src="/images/closeDialog.png"/></td></tr></table></div></div></td></tr><tr ><td valign="top"><table id="ctl00_SICCM_Dialog_ContentManager_contentTable" border="0" style="width:100%;height:100%;" class="eo_no_border_spacing" ><tr><td height="100%" class="eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager2" align="left" valign="top">
+<table id="ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager">
+		<tbody>
+			<tr>
+				<td>
+    
+        
+        
+        
+        
+        </td>
+			</tr>
+		</tbody>
+	</table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("i|c", function(){EO25264.g.b.ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager=1;EO25264.r._o_ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager=EO25264.f.acg(EO25264.r._o_ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager,"cbpContentManager",new EO25264.f.aaum([[,"ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager","Callback","ctl00$SICCM$Dialog_ContentManager$ctl00$cbpContentManager",,,,,,,"__doPostBack('ctl00$SICCM$Dialog_ContentManager$ctl00$cbpContentManager','_eo_arg_')"],,"__doPostBack('ctl00$SICCM$Dialog_ContentManager$ctl00$cbpContentManager','')",,,,,,[],"<div class='loading'></div>",,,,,,,0,0]),"Callback");EO25264.f.ahm(EO25264.r._o_ctl00_SICCM_Dialog_ContentManager_ctl00_cbpContentManager,1,null, 0);});
+//]]>
+</script>
+
+    </td></tr></table></td></tr><tr><td><div id="ctl00_SICCM_Dialog_ContentManager_footerDiv" style="position:relative;width:auto;"><table id="ctl00_SICCM_Dialog_ContentManager_footerTable" border="0" cellspacing="0" cellpadding="0" style="width:100%;"><tr><td  id="ctl00_SICCM_Dialog_ContentManager_footer"  class="eo_align_center eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager3"></td></tr></table></div></td></tr>
+</table></td><td style="background-image:url('/images/2013/modal/r.png');background-repeat:repeat-y;font-size:1px;" valign="top"></td></tr><tr><td style="font-size:1px"><img src="/images/2013/modal/bl.png" alt="" tabindex="-1" /></td><td style="background-image:url('/images/2013/modal/b.png');background-repeat:repeat-x;font-size:1px;"></td><td style="font-size:1px"><img src="/images/2013/modal/br.png" alt="" tabindex="-1" /></td></tr></table>
+<script type="text/javascript">
+//<![CDATA[
+EO25264.g.d.k("ldr|i|fmt|u|ei|e|pop|dd|c|dg", function(){EO25264.g.b.ctl00_SICCM_Dialog_ContentManager=1;EO25264.r._o_ctl00_SICCM_Dialog_ContentManager=EO25264.f.acg(EO25264.r._o_ctl00_SICCM_Dialog_ContentManager,"Dialog_ContentManager",new EO25264.f.bak([[[,"ctl00_SICCM_Dialog_ContentManager","Dialog","ctl00$SICCM$Dialog_ContentManager",,,,,,,"__doPostBack('ctl00$SICCM$Dialog_ContentManager','_eo_arg_')"],["/images/2013/modal/tl.png","/images/2013/modal/t.png","/images/2013/modal/tr.png","/images/2013/modal/l.png","/images/2013/modal/r.png","/images/2013/modal/bl.png","/images/2013/modal/b.png","/images/2013/modal/br.png"],,,,,,,,[]],"black",50,,,,,,,,"eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager1","eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager1",,"eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager2",,,,,,,,,,,,,,,,,,"eo_css_ctrl_ctl00_SICCM_Dialog_ContentManager3",,,,,,"resizableDialog",,,,,,,,"/js/eo/eo.b07569df-aab1-4833-b62f-f5d642a057b3.html",,"ctl00_SICCM_Dialog_ContentManager_ctl00","ctl00_SICCM_Dialog_ContentManager_ctl01",,"/images/closeDialog.png"]),"Dialog");EO25264.f.ahm(EO25264.r._o_ctl00_SICCM_Dialog_ContentManager,1,550, 0);});
+//]]>
+</script>
+
+<script type="text/javascript">
+//<![CDATA[
+EO25264.f.asw();
+//]]>
+</script>
+
+<!-- End EO.Web Dialog Dialog_ContentManager.  -->
+
+
+        
+        
+    
+<div>
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="8E87A3C4" />
+</div>
+<script src="/WebResource.axd?d=j0a4_h54crQEQkbke0AMrvP6Mf7DTCgvGTFtXMwe5BoIo5hjKInNEL-d3yipUc5ufAwdoz4C82HDU6nAKRhm4wBe22U1&amp;t=638901397900000000" type="text/javascript"></script>
+</form>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            if ($('ul.navbar-nav').height() >= 40) 
+                $("ul.navbar-nav").addClass("navbar-condensed");
+        });
+    </script>
+    <style type="text/css">
+        .navbar-condensed li a{ padding-left:.5rem !important; padding-right:.5rem !important }
+    </style>
+    <script src="/bs/all.js"></script>
+    
+</body>
+
+</html>

--- a/tests/unit/test_sincsports_schedule.py
+++ b/tests/unit/test_sincsports_schedule.py
@@ -1,0 +1,120 @@
+"""Unit tests for the SincSports schedule.aspx parser.
+
+Scope follows the repo convention: pure-function parser tests against
+committed fixtures, no HTTP mocking. Live fetch is exercised by the
+operator dry-run on the driver script.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.scrapers.sincsports_schedule import (
+    parse_division,
+    parse_tournament_index,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "sincsports_events"
+
+
+@pytest.fixture
+def puri_u14f01_html() -> str:
+    return (FIXTURES / "schedule_puri_u14f01.html").read_text(encoding="utf-8")
+
+
+class TestParseTournamentIndex:
+    def test_extracts_div_codes_from_root(self, puri_u14f01_html):
+        # The fixture is a single division page; its own div code is referenced
+        # from the URL. Live tournament-root pages reference all 60 divisions —
+        # that path is exercised by the live operator dry-run.
+        codes = parse_tournament_index(puri_u14f01_html)
+        assert "U14F01" in codes
+
+    def test_drops_n_sentinel(self):
+        html = "<a href='?div=U14F01'>x</a> <a href='?div=N'>x</a>"
+        codes = parse_tournament_index(html)
+        assert "U14F01" in codes
+        assert "N" not in codes
+
+    def test_empty_html_returns_empty(self):
+        assert parse_tournament_index("") == []
+        assert parse_tournament_index("<html></html>") == []
+
+    def test_codes_uppercased_and_sorted(self):
+        html = "<a href='?div=u14f02'>a</a> <a href='?div=U14F01'>b</a>"
+        codes = parse_tournament_index(html)
+        assert codes == ["U14F01", "U14F02"]
+
+
+class TestParseDivision:
+    def test_puri_u14f01_extracts_all_games(self, puri_u14f01_html):
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        # The Puri Cup U14F01 division is a 6-team round-robin: 9 games.
+        assert len(games) == 9
+
+    def test_each_game_has_team_ids_and_perspective(self, puri_u14f01_html):
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        for g in games:
+            assert g.tournament_id == "TZ2565"
+            assert g.division_code == "U14F01"
+            assert g.home_id and g.away_id
+            assert g.home_id != g.away_id
+            assert g.home_id.upper() == g.home_id
+            assert g.away_id.upper() == g.away_id
+            assert g.home_name and g.away_name
+
+    def test_played_games_have_scores(self, puri_u14f01_html):
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        played = [g for g in games if g.status == "Played"]
+        assert len(played) >= 5  # 7 played + 2 cancelled in this division
+        for g in played:
+            assert g.home_score is not None
+            assert g.away_score is not None
+            assert 0 <= g.home_score <= 30
+            assert 0 <= g.away_score <= 30
+
+    def test_cancelled_games_have_no_scores(self, puri_u14f01_html):
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        cancelled = [g for g in games if g.status == "Cancelled"]
+        assert len(cancelled) == 2
+        for g in cancelled:
+            assert g.home_score is None
+            assert g.away_score is None
+
+    def test_known_game_extracted_correctly(self, puri_u14f01_html):
+        """Spot-check #00242 — FC America 1, OSC 3 on 4/18/2026."""
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        match = [g for g in games if g.game_num == "00242"]
+        assert len(match) == 1
+        g = match[0]
+        assert g.home_id == "IAF12039"
+        assert g.away_id == "WIF12063"
+        assert g.home_score == 1
+        assert g.away_score == 3
+        assert g.status == "Played"
+        assert g.date == "4/18/2026"
+        assert "FC America" in g.home_name
+        assert "OSC" in g.away_name
+
+    def test_division_name_extracted(self, puri_u14f01_html):
+        games = parse_division(puri_u14f01_html, "TZ2565", "U14F01")
+        with_name = [g for g in games if g.division_name]
+        assert len(with_name) > 0
+        # Heading is "Under 14 Girls First Division.- Crossover" or similar
+        assert any("Under 14" in (g.division_name or "") for g in games)
+
+    def test_empty_html_returns_no_games(self):
+        assert parse_division("", "TZ2565", "U14F01") == []
+        assert parse_division("<html></html>", "TZ2565", "U14F01") == []
+
+    def test_no_team_links_skipped(self):
+        """Cards with empty hometeam/awayteam divs are dropped silently."""
+        html = (
+            "<div class='form-row game-row'>"
+            "<div class='col-md-3 d-cell'><span>Saturday</span><span>4/18/2026</span><span>10:40 AM</span><span>#999</span></div>"
+            "<div class='col-md-5'><div class='hometeam'></div><div class='awayteam'></div></div>"
+            "</div>"
+        )
+        assert parse_division(html, "TZ2565", "ZZZ") == []


### PR DESCRIPTION
Third SincSports scraper, complementing #663 (clubs discovery) and #667 (event/teamlist discovery). Targets ``schedule.aspx?tid=<TID>&div=<DIV>`` — the per-division fixture list of a tournament — to recover the games the per-team ``games.aspx`` route can't see.

## Why

The existing per-team flow (``src/scrapers/sincsports.py::SincSportsScraper.scrape_team_games``) **respects SincSports' VIP paywall**: most events on a team's page are CSS-blurred for non-paying users and the parser intentionally skips them. The schedule.aspx page is unaffected by this blur — every fixture across every division is rendered with date, time, team_ids, scores, and status.

Validated against the 2026 Puri Champions Cup (TZ2565):

| Source | Games captured |
|---|---|
| Per-team games.aspx (existing) | 224 |
| Schedule.aspx (this PR) | **443 played + 63 cancelled = 506 total** |

~2× coverage with cleaner scores and uniform metadata.

## What's in the box

- ``src/scrapers/sincsports_schedule.py`` — new ``SincSportsScheduleScraper``. Reuses ``SincSportsClubsScraper``'s session/throttle. Two pure-function parsers (``parse_division``, ``parse_tournament_index``) for fixture-driven tests.
- ``scripts/scrape_sincsports_tournament_schedule.py`` — driver. ``--tid X`` iterates every division, builds per-team JSONL records (matching ``SincSportsScraper._game_data_to_dict`` shape), optional ``--auto-import``. Status filters: defaults to Played-only; ``--include-cancelled``/``--include-scheduled`` for completeness.
- ``tests/fixtures/sincsports_events/schedule_puri_u14f01.html`` — captured Puri Cup U14F01 division.
- ``tests/unit/test_sincsports_schedule.py`` — 12 tests covering happy path, scores, cancellations, division-name extraction, malformed inputs.

## Usage

\`\`\`bash
# Dry-run summary only
python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565 --dry-run

# Scrape all played games to JSONL (no import)
python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565

# Scrape + auto-import
python scripts/scrape_sincsports_tournament_schedule.py --tid TZ2565 --auto-import
\`\`\`

## Verification

- [x] 12 new unit tests pass; 75 SincSports tests total pass (no regressions on clubs/events/matcher).
- [x] Live tournament-iteration scrape against Puri Cup: 506 games across 59 divisions in ~3 min, 0 errors.
- [x] Sample game spot-check: #00242 (FC America 1, OSC 3, 4/18/2026) extracts correctly.

## Known follow-up

When ``--auto-import`` was tested on the Puri Cup output, ``import_games_enhanced.py`` reported ``games_processed: 882, accepted: 0, duplicates_skipped: 442`` — every record was treated as a duplicate of either prior 224 imports (via per-team path) or its own H/A perspective sibling within the same batch. The scraper-side data is correct; the importer-side dedup logic needs investigation to know why net-new games (the ~219 that the per-team path missed) didn't land. **Out of scope for this PR** — flagging as a follow-up because the scraper deliverable is independently valuable (data on disk + ready-to-feed JSONL + clean unit-test foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)