### PR TITLE
fix(rankings): show more rows on mobile before scroll

### DIFF
--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -423,7 +423,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                 </div>
 
                 {/* Virtualized Table Body */}
-                <div ref={parentRef} className="rankings-body overflow-auto h-[400px] sm:h-[500px] md:h-[600px]">
+                <div ref={parentRef} className="rankings-body overflow-auto h-[660px] sm:h-[780px] md:h-[900px]">
                   <div
                     style={{
                       height: `${totalHeight}px`,

--- a/frontend/components/skeletons/RankingsTableSkeleton.tsx
+++ b/frontend/components/skeletons/RankingsTableSkeleton.tsx
@@ -17,7 +17,7 @@ export function RankingsTableSkeleton({ rows = 10 }: { rows?: number }) {
     () => false
   );
 
-  if (!isClient) return <div className="min-h-[480px]" />;
+  if (!isClient) return <div className="min-h-[660px]" />;
 
   return <TableSkeleton rows={rows} />;
 }


### PR DESCRIPTION
## Summary
- Bump rankings table scroll container from `400/500/600px` to `660/780/900px` so mobile shows ~11 rows (was ~7), sm shows ~13, md shows ~15
- Bump SSR skeleton placeholder to `min-h-[660px]` to match the new mobile height and avoid layout shift on hydration

## Test plan
- [ ] Open rankings page on mobile viewport, confirm 10+ rows visible without scrolling the table
- [ ] Confirm no layout shift between skeleton and hydrated table on slow 3G

🤖 Generated with [Claude Code](https://claude.com/claude-code)