### PR TITLE
fix(hygiene): pass club_name to extract_team_variant to stop variant leak

### DIFF
--- a/scripts/find_fuzzy_duplicate_teams.py
+++ b/scripts/find_fuzzy_duplicate_teams.py
@@ -479,15 +479,17 @@ def score_team_pair(team_a: dict, team_b: dict) -> float | None:
 
     norm_a = normalize_team_name(name_a)
     norm_b = normalize_team_name(name_b)
-    var_a = extract_team_variant(name_a)
-    var_b = extract_team_variant(name_b)
+    club_a = (team_a.get("club_name") or "").strip().lower()
+    club_b = (team_b.get("club_name") or "").strip().lower()
+    # Pass club name so club words (e.g. 'Union' in 'Rush Union Wisconsin')
+    # aren't returned as a phantom variant when the duplicate omits the club.
+    var_a = extract_team_variant(name_a, club_a)
+    var_b = extract_team_variant(name_b, club_b)
     if var_a != var_b:
         return None
 
     score = SequenceMatcher(None, norm_a, norm_b).ratio()
 
-    club_a = (team_a.get("club_name") or "").strip().lower()
-    club_b = (team_b.get("club_name") or "").strip().lower()
     if club_a and club_b and club_a == club_b:
         score = min(1.0, score + 0.15)
         # When clubs match, also score with club words stripped —
@@ -812,6 +814,20 @@ def _run_inline_tests() -> int:
     check(
         "slash-form '10/11 (u15) stays distinct from '10 (u16)",
         _should_skip_pair("Phoenix '10/11 Red", "Phoenix '10 Red", club_name="Phoenix") is True,
+    )
+
+    # Variant-gate regression — club words like 'Union' must not leak as a
+    # phantom variant when the duplicate side omits the club prefix.
+    rush_a = {"team_id_master": "A", "team_name": "2012 Premier", "club_name": "Rush Union Wisconsin"}
+    rush_b = {
+        "team_id_master": "B",
+        "team_name": "Rush Union Wisconsin 2012 Premier",
+        "club_name": "Rush Union Wisconsin",
+    }
+    rush_score = score_team_pair(rush_a, rush_b)
+    check(
+        "Rush Union 2012 Premier (no-club ↔ with-club) scores instead of None",
+        rush_score is not None and rush_score >= 0.90,
     )
 
     print(f"\n{passed} passed, {failed} failed")

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -197,12 +197,16 @@ TEAM_COLORS = {
 TEAM_DIRECTIONS = {"north", "south", "east", "west", "central"}
 
 
-def extract_team_variant(name):
+def extract_team_variant(name, club_name: str = ""):
     """Extract team variant (color, direction, coach name, roman numeral) from team name.
 
     Teams like 'FC Dallas 2014 Blue' and 'FC Dallas 2014 Gold' are DIFFERENT teams.
     Also 'Select North' and 'Select South' are DIFFERENT teams.
     Coach names like 'Atletico Dallas 15G Riedell' and 'Atletico Dallas 15G Davis' are DIFFERENT teams.
+
+    When ``club_name`` is provided, its words are added to the skip set so that
+    club tokens (e.g. 'Union' in 'Rush Union Wisconsin') don't get returned as
+    a phantom coach/squad variant when the duplicate side omits the club prefix.
     """
     if not name:
         return None
@@ -445,6 +449,12 @@ def extract_team_variant(name):
 
     # All non-variant words (union of all exclusion sets)
     _skip_words = common_words | region_codes | program_names | TEAM_COLORS | TEAM_DIRECTIONS
+
+    # Club tokens are never variants — strip them so duplicates whose stored
+    # name omits the club prefix don't produce a phantom variant from a club word.
+    if club_name:
+        club_tokens = {w.strip("-()[].,").lower() for w in club_name.replace("-", " ").split()}
+        _skip_words = _skip_words | (club_tokens - {""})
 
     def _extract_candidate(text):
         """Find the first unknown word in *text* that looks like a coach/squad name."""


### PR DESCRIPTION
## Summary
- `extract_team_variant()` walked back from the age token searching for a coach/squad word but had no way to know which words belonged to the club. For 'Rush Union Wisconsin 2012 Premier' it returned `'union'` because that token isn't in any skip set; the duplicate 'Rush Union Wisconsin' team stored as just `'2012 Premier'` returned `None`. The variant gate in `score_team_pair` then silently dropped the pair before `_should_skip_pair` or `min_score` even ran.
- Adds an optional `club_name` arg to `extract_team_variant` (default `''` keeps every existing caller intact) that adds the club's tokens to the variant skip set.
- `score_team_pair` now passes `club_a`/`club_b` through to both variant calls.
- Adds an inline regression test (`python scripts/find_fuzzy_duplicate_teams.py --test`) for the Rush Union pair.

## Test plan
- [x] `python scripts/find_fuzzy_duplicate_teams.py --test` → 17/17 pass (new Rush Union check + 16 existing)
- [x] Direct verification: `score_team_pair` for the Rush Union pair returns `1.0`
- [x] Coach-name detection still works (`'Atletico Dallas 15G Riedell'` w/ club → `'riedell'`)
- [x] Color detection still works (`'FC Dallas 2014 Blue'` w/ club → `'blue'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)