### PR TITLE
Shell 02: MatchBalance storage layer (event identity, scenario locking, run state machine)

### DIFF
--- a/src/scrapers/provider.py
+++ b/src/scrapers/provider.py
@@ -4,14 +4,15 @@ Shell-01 foundations for the MatchBalance backtest intake pipeline. Defines:
 
 - ``ProviderScraper`` ABC — the cohort/team/canonical-ID surface every provider
   implements.
-- Dataclasses ``EventMetadata``, ``ScrapedTeam``, ``CanonicalResolution`` —
-  the wire format between scraper and downstream persistence.
+- Dataclasses ``ScrapedTeam``, ``CanonicalResolution`` — the wire format
+  between scraper and downstream persistence. ``EventMetadata`` lives in
+  ``src.tournaments.storage.event_metadata`` and is re-exported here.
 - ``UnsupportedProviderError`` — raised when a provider row is missing or a
   URL does not route to a known provider.
 - ``get_provider_scraper`` — URL-pattern factory.
-- Path helpers ``_derive_event_key`` / ``_intake_path`` — wire-compatible with
-  Shell 02's directory re-keying (``__unknown__`` placeholder until that
-  shell lands the season_year convention).
+- Path helpers ``_derive_event_key`` / ``_intake_path`` — thin shims over
+  ``src.tournaments.storage`` that fall back to the ``__unknown`` season
+  segment for Shell 01 callers that don't populate ``season_year``.
 
 ``RateLimitedError`` lives in ``src.scrapers._http`` and is re-exported here
 for caller convenience.
@@ -26,6 +27,9 @@ from pathlib import Path
 from typing import Any
 
 from src.scrapers._http import RateLimitedError
+from src.tournaments.storage.event_key import event_key as _storage_event_key
+from src.tournaments.storage.event_key import intake_dir as _storage_intake_dir
+from src.tournaments.storage.event_metadata import EventMetadata
 
 __all__ = [
     "CanonicalResolution",
@@ -40,19 +44,6 @@ __all__ = [
 
 class UnsupportedProviderError(Exception):
     """Raised when a provider URL or code has no scraper registered."""
-
-
-@dataclass(frozen=True)
-class EventMetadata:
-    """Event-level metadata scraped from the provider landing page."""
-
-    provider_code: str
-    provider_event_id: str
-    event_name: str
-    event_slug: str
-    event_start_date: str | None
-    scrape_ts: str
-    series_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -126,16 +117,18 @@ class ProviderScraper(ABC):
 def _derive_event_key(meta: EventMetadata) -> str:
     """Return the storage key for an event.
 
-    Shell 01 uses ``__unknown__`` as the season-year placeholder; Shell 02
-    owns the season-year convention + migration. Keep the three-segment
-    ``provider__eventid__season`` shape so Shell 02 only needs to re-key.
+    Thin shim over ``storage.event_key.event_key``. When ``meta.season_year``
+    is ``None`` (Shell 01 callers that don't populate it), the legacy
+    ``__unknown`` segment is used; the rekey migration in
+    ``storage.event_key.rekey_unknown_directories`` is the sanctioned path
+    for upgrading those keys once a season_year becomes derivable.
     """
-    return f"{meta.provider_code}__{meta.provider_event_id}__unknown"
+    return _storage_event_key(meta.provider_code, meta.provider_event_id, meta.season_year)
 
 
 def _intake_path(event_key: str) -> Path:
     """Resolve the on-disk ``raw_scrape.jsonl`` location for an event key."""
-    return Path("reports") / event_key / "intake" / "raw_scrape.jsonl"
+    return _storage_intake_dir(event_key) / "raw_scrape.jsonl"
 
 
 _GOTSPORT_EVENT_URL = re.compile(

--- a/src/tournaments/storage/__init__.py
+++ b/src/tournaments/storage/__init__.py
@@ -1,0 +1,170 @@
+"""Storage layer for the MatchBalance backtest intake.
+
+A pure-Python library that owns every file I/O, schema-version, and
+scenario-locking primitive used by the Streamlit triage UI (Shell 03+) and
+the existing ``backtest_tournament_event.py`` CLI. No UI, no Supabase
+ownership — callers compose this layer with their own clients.
+
+Layout (per spec §8):
+
+    reports/<event_key>/
+      intake/                       # SHARED across scenarios (immutable scrape output)
+        raw_scrape.jsonl            # IntakeJournal (re-exported from src.scrapers)
+        event_metadata.json
+      scenarios/<name>/
+        overrides.jsonl
+        group_structure_summary.csv
+        event_team_registry.csv
+        constraints.json
+        runs/<run_id>/              # promoted run dir (atomic from <run_id>.tmp/)
+
+Public API is re-exported here; modules under ``storage/`` are the
+implementation. ``read_versioned_json`` from ``_io`` is intentionally
+package-private — external callers compose ``assert_supported_version`` +
+``read_json`` directly.
+"""
+
+from __future__ import annotations
+
+from src.tournaments.storage.constraints import (
+    CohortConstraints,
+    read_constraints,
+    write_constraints,
+)
+from src.tournaments.storage.event_key import (
+    RekeyMigrationResult,
+    derive_season_year,
+    event_dir,
+    event_key,
+    intake_dir,
+    parse_event_key,
+    rekey_unknown_directories,
+    reports_dir,
+    run_dir,
+    scenario_dir,
+    scenarios_dir,
+)
+from src.tournaments.storage.event_metadata import (
+    EventMetadata,
+    read_event_metadata,
+    write_event_metadata,
+)
+from src.tournaments.storage.frozen_medians import (
+    FrozenMedians,
+    compute_frozen_medians,
+    read_frozen_medians,
+    write_frozen_medians,
+)
+from src.tournaments.storage.games_import import (
+    GamesImportStatus,
+    check_games_import_status,
+)
+from src.tournaments.storage.overrides import append_override, load_overrides
+from src.tournaments.storage.raw_scrape import (
+    DURABLE_ACTIONS,
+    IntakeJournal,
+    JournalCorruptionError,
+    RemovedTeamsDiff,
+    compute_skip_set,
+    load_raw_scrape,
+)
+from src.tournaments.storage.registry import (
+    TeamRegistryEntry,
+    read_registry,
+    write_registry,
+)
+from src.tournaments.storage.rescrape import RescrapeReport, merge_rescrape
+from src.tournaments.storage.run_layout import (
+    RunStateError,
+    cancel_run,
+    create_staging_run,
+    fail_run,
+    list_runs,
+    promote_run,
+)
+from src.tournaments.storage.scenario import (
+    ScenarioExistsError,
+    ScenarioLockError,
+    acquire_scenario_lock,
+    branch_scenario,
+    ensure_scenario,
+    list_scenarios,
+)
+from src.tournaments.storage.schema_version import (
+    SCHEMA_VERSION,
+    SchemaVersionError,
+    assert_supported_version,
+    stamp_schema_version,
+)
+from src.tournaments.storage.structure import (
+    CohortStructure,
+    DivisionStructure,
+    read_structure,
+    write_structure,
+)
+
+__all__ = [
+    # event identity
+    "event_key",
+    "parse_event_key",
+    "derive_season_year",
+    "rekey_unknown_directories",
+    "RekeyMigrationResult",
+    # paths
+    "reports_dir",
+    "event_dir",
+    "intake_dir",
+    "scenarios_dir",
+    "scenario_dir",
+    "run_dir",
+    # dataclasses
+    "EventMetadata",
+    "TeamRegistryEntry",
+    "DivisionStructure",
+    "CohortStructure",
+    "CohortConstraints",
+    "FrozenMedians",
+    "RescrapeReport",
+    # status types / version
+    "GamesImportStatus",
+    "SCHEMA_VERSION",
+    "SchemaVersionError",
+    "stamp_schema_version",
+    "assert_supported_version",
+    # readers / writers
+    "read_event_metadata",
+    "write_event_metadata",
+    "read_registry",
+    "write_registry",
+    "read_structure",
+    "write_structure",
+    "read_constraints",
+    "write_constraints",
+    "read_frozen_medians",
+    "write_frozen_medians",
+    "compute_frozen_medians",
+    "append_override",
+    "load_overrides",
+    "load_raw_scrape",
+    # operations
+    "merge_rescrape",
+    "ensure_scenario",
+    "branch_scenario",
+    "list_scenarios",
+    "ScenarioExistsError",
+    "ScenarioLockError",
+    "acquire_scenario_lock",
+    "create_staging_run",
+    "promote_run",
+    "fail_run",
+    "cancel_run",
+    "list_runs",
+    "RunStateError",
+    "check_games_import_status",
+    # raw-scrape re-exports
+    "IntakeJournal",
+    "JournalCorruptionError",
+    "RemovedTeamsDiff",
+    "compute_skip_set",
+    "DURABLE_ACTIONS",
+]

--- a/src/tournaments/storage/_io.py
+++ b/src/tournaments/storage/_io.py
@@ -1,0 +1,146 @@
+"""Atomic file I/O helpers used by every storage module.
+
+Conventions captured here so callers don't reinvent them:
+
+- ``write_json`` / ``write_csv`` write to ``<path>.tmp`` then ``os.replace``
+  for crash-safe file replacement (mirrors ``intake_journal.py:284``).
+- ``append_jsonl`` follows the newline-first protocol from
+  ``intake_journal.py:175-179`` (``"\\n" + json.dumps(record)``, ``flush`` +
+  ``os.fsync`` per record).
+- ``read_versioned_json`` enforces the shell's "lenient on read, strict on
+  write" schema-version contract — package-private because external callers
+  who need versioned reads should compose ``assert_supported_version(read_json(path), source=...)``
+  directly using the public exports.
+- Path arguments accept ``Path | str``; cast to ``Path`` at the top.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage.schema_version import assert_supported_version
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Centralized so every storage writer that stamps a ``promoted_at`` /
+    ``failed_at`` / ``cancelled_at`` / ``computed_at`` field uses the same
+    timezone-aware format.
+    """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def write_json(path: Path | str, payload: dict[str, Any], *, indent: int = 2) -> None:
+    """Atomically write ``payload`` as JSON to ``path``.
+
+    Writes to ``<path>.tmp`` then ``os.replace`` for crash safety. The parent
+    directory is created with ``parents=True, exist_ok=True``. The temp file
+    is fsynced before the rename so a crash between write and rename leaves
+    the prior file intact (or absent).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    encoded = json.dumps(payload, ensure_ascii=False, indent=indent).encode("utf-8")
+    with open(tmp_path, "wb") as handle:
+        handle.write(encoded)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, path)
+
+
+def read_json(path: Path | str) -> dict[str, Any]:
+    """Read a JSON file. Does NOT enforce ``schema_version``.
+
+    Safe for unstamped JSON (``done.json`` / ``error.json`` /
+    ``cancelled.json`` run markers). For schema-stamped files, use
+    ``read_versioned_json`` (package-private) or compose
+    ``assert_supported_version(read_json(path), source=str(path))`` from the
+    public exports.
+    """
+    path = Path(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_versioned_json(path: Path | str) -> dict[str, Any]:
+    """Read a JSON file and enforce ``schema_version``.
+
+    Package-private; not in ``storage.__all__``. External callers compose
+    ``assert_supported_version`` + ``read_json`` themselves.
+    """
+    path = Path(path)
+    payload = read_json(path)
+    assert_supported_version(payload, source=str(path))
+    return payload
+
+
+def write_csv(
+    path: Path | str,
+    rows: list[dict[str, Any]],
+    *,
+    fieldnames: tuple[str, ...],
+) -> None:
+    """Atomically write ``rows`` to ``path`` with explicit column order.
+
+    ``fieldnames`` is required — callers pass declared module constants so
+    column order is stable across runs. Missing keys in a row write as the
+    empty string; extra keys are silently dropped.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    field_list = list(fieldnames)
+    with open(tmp_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=field_list, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in field_list})
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, path)
+
+
+def read_csv(path: Path | str) -> list[dict[str, Any]]:
+    """Read a CSV file via ``csv.DictReader``."""
+    path = Path(path)
+    with open(path, newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def append_jsonl(path: Path | str, record: dict[str, Any]) -> None:
+    """Append one record to a JSONL file using the newline-first protocol.
+
+    Mirrors ``src.scrapers.intake_journal.IntakeJournal.append`` at
+    ``intake_journal.py:175-179``: ``"\\n" + json.dumps(record)`` so a
+    partial-tail crash leaves prior records intact, then ``flush`` +
+    ``os.fsync`` for durability.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = ("\n" + json.dumps(record, ensure_ascii=False)).encode("utf-8")
+    with open(path, "ab") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def read_jsonl(path: Path | str) -> Iterator[dict[str, Any]]:
+    """Stream-read a JSONL file, yielding one dict per non-empty line.
+
+    Returns an empty iterator if the file does not exist.
+    """
+    path = Path(path)
+    if not path.exists():
+        return
+    raw = path.read_bytes()
+    for line in raw.split(b"\n"):
+        if not line.strip():
+            continue
+        yield json.loads(line)

--- a/src/tournaments/storage/constraints.py
+++ b/src/tournaments/storage/constraints.py
@@ -1,0 +1,117 @@
+"""Per-cohort seeding constraints — JSON-backed dataclass.
+
+Spec §7 names exactly four per-cohort constraints. v1 ships these four
+data-model-only fields and nothing more — the optimizer signature is
+unchanged in v1; the *post-run* Report Card metrics in Shell 07 compute
+violations from the optimizer output. v2 wires the fields into the
+optimizer.
+
+The on-disk shape is::
+
+    {
+      "schema_version": 1,
+      "cohorts": [
+        {
+          "cohort_age_group": "u14",
+          "cohort_gender": "Female",
+          "avoid_same_club_early": true,
+          "avoid_same_coach_early": true,
+          "avoid_same_state_pool": false,
+          "rematch_avoidance_scope": "same_event"
+        },
+        ...
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from src.tournaments.storage._io import read_versioned_json, write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import stamp_schema_version
+
+__all__ = [
+    "CohortConstraints",
+    "RematchAvoidanceScope",
+    "read_constraints",
+    "write_constraints",
+]
+
+
+RematchAvoidanceScope = Literal["same_event", "same_season", "prior_weekend"]
+_REMATCH_SCOPE_VALUES: frozenset[str] = frozenset(("same_event", "same_season", "prior_weekend"))
+
+
+@dataclass(frozen=True)
+class CohortConstraints:
+    """Spec §7 row defaults are enforced here, not in the JSON file.
+
+    A new constraints.json with no entries for a cohort yields the v1
+    defaults via ``CohortConstraints(cohort_age_group=..., cohort_gender=...)``.
+    """
+
+    cohort_age_group: str
+    cohort_gender: str
+    avoid_same_club_early: bool = True
+    avoid_same_coach_early: bool = True
+    avoid_same_state_pool: bool = False
+    rematch_avoidance_scope: RematchAvoidanceScope = "same_event"
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.rematch_avoidance_scope not in _REMATCH_SCOPE_VALUES:
+            raise ValueError(
+                f"rematch_avoidance_scope must be one of "
+                f"{sorted(_REMATCH_SCOPE_VALUES)}; got {self.rematch_avoidance_scope!r}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "CohortConstraints":
+        """Construct from a payload, defaulting missing fields to spec §7 values."""
+        return cls(
+            cohort_age_group=payload["cohort_age_group"],
+            cohort_gender=payload["cohort_gender"],
+            avoid_same_club_early=bool(payload.get("avoid_same_club_early", True)),
+            avoid_same_coach_early=bool(payload.get("avoid_same_coach_early", True)),
+            avoid_same_state_pool=bool(payload.get("avoid_same_state_pool", False)),
+            rematch_avoidance_scope=payload.get("rematch_avoidance_scope", "same_event"),
+            schema_version=int(payload.get("schema_version", 1)),
+        )
+
+
+def _constraints_path(scenario_path: Path) -> Path:
+    return scenario_path / "constraints.json"
+
+
+def read_constraints(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> list[CohortConstraints]:
+    """Read ``constraints.json`` and return one ``CohortConstraints`` per cohort entry."""
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    payload = read_versioned_json(_constraints_path(scenario_path))
+    cohorts = payload.get("cohorts") or []
+    return [CohortConstraints.from_dict(entry) for entry in cohorts]
+
+
+def write_constraints(
+    event_key: str,
+    scenario: str,
+    constraints: list[CohortConstraints],
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    """Write ``constraints.json`` with the schema-version stamp."""
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    payload = stamp_schema_version({"cohorts": [entry.to_dict() for entry in constraints]})
+    write_json(_constraints_path(scenario_path), payload)

--- a/src/tournaments/storage/event_key.py
+++ b/src/tournaments/storage/event_key.py
@@ -1,0 +1,273 @@
+"""Event-key derivation, scaffolding paths, and the one-shot rekey migration.
+
+Spec §6 defines the event-identity scheme as
+``(provider_code, provider_event_id, season_year)``. Shell 01 left a
+``__unknown`` placeholder for the season segment because it didn't yet own
+the season convention. This module owns it.
+
+**Back-compat with Shell 01 callers:** ``season_year`` is optional. When
+``None``, derivation falls back to the legacy ``__unknown`` form so
+existing callsites (e.g. ``src/scrapers/gotsport.py:2862-2869``) continue
+to work without modification.
+
+The rekey migration is non-destructive: directories that lack a derivable
+season_year remain in place. A subsequent metadata refresh + rekey call
+migrates them; the function never raises mid-loop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from src.tournaments.storage._io import read_json
+from src.tournaments.storage.schema_version import (
+    SchemaVersionError,
+    assert_supported_version,
+)
+
+__all__ = [
+    "RekeyMigrationResult",
+    "derive_season_year",
+    "event_dir",
+    "event_key",
+    "intake_dir",
+    "parse_event_key",
+    "rekey_unknown_directories",
+    "reports_dir",
+    "run_dir",
+    "scenario_dir",
+    "scenarios_dir",
+]
+
+
+_MIN_SEASON_YEAR: int = 2000
+
+_INVALID_SEGMENT_CHARS: tuple[str, ...] = ("/", "\\", "\x00")
+
+
+def _validate_segment(value: str, *, label: str) -> None:
+    """Reject empty / traversal / separator chars in a path segment.
+
+    Defense-in-depth against ``..`` / ``/`` / ``\\`` reaching ``Path``
+    joins. Internal callers (Streamlit, CLI) are operator-trusted today,
+    but the helpers in this module are now part of the public storage
+    surface — gate untrusted input at the constructor.
+    """
+    if not value:
+        raise ValueError(f"{label} must be non-empty")
+    if value in (".", ".."):
+        raise ValueError(f"{label} must not be '.' or '..': {value!r}")
+    for char in _INVALID_SEGMENT_CHARS:
+        if char in value:
+            raise ValueError(f"{label} must not contain {char!r}: {value!r}")
+
+
+def event_key(
+    provider_code: str,
+    provider_event_id: str,
+    season_year: int | None = None,
+) -> str:
+    """Return the canonical event key.
+
+    With ``season_year`` provided, returns
+    ``f"{provider_code}__{provider_event_id}__{season_year}"``. With
+    ``season_year=None``, returns the legacy ``__unknown`` form so Shell 01
+    callers don't need to populate the field.
+
+    Raises ``ValueError`` if ``provider_code`` or ``provider_event_id`` is
+    empty or contains the ``__`` segment separator, or if ``season_year`` is
+    provided and is not an int >= 2000.
+    """
+    _validate_segment(provider_code, label="provider_code")
+    _validate_segment(provider_event_id, label="provider_event_id")
+    if "__" in provider_code:
+        raise ValueError(f"provider_code must not contain '__': {provider_code!r}")
+    if "__" in provider_event_id:
+        raise ValueError(f"provider_event_id must not contain '__': {provider_event_id!r}")
+    if season_year is None:
+        return f"{provider_code}__{provider_event_id}__unknown"
+    if not isinstance(season_year, int) or isinstance(season_year, bool):
+        raise ValueError(f"season_year must be int, got {type(season_year).__name__}")
+    if season_year < _MIN_SEASON_YEAR:
+        raise ValueError(f"season_year must be >= {_MIN_SEASON_YEAR}, got {season_year}")
+    return f"{provider_code}__{provider_event_id}__{season_year}"
+
+
+def derive_season_year(event_start_date: str | None) -> int | None:
+    """Parse the year of an ISO ``YYYY-MM-DD`` date, or ``None``.
+
+    Strict ISO date — ``"2026"`` (year-only) and ``"2026-99-99"`` (invalid
+    month/day) both return ``None``. The storage layer never silently
+    invents a season_year; callers that have a reliable value from another
+    source populate ``season_year`` directly.
+    """
+    if event_start_date is None:
+        return None
+    try:
+        parsed = date.fromisoformat(event_start_date)
+    except (TypeError, ValueError):
+        return None
+    if parsed.year < _MIN_SEASON_YEAR:
+        return None
+    return parsed.year
+
+
+def parse_event_key(key: str) -> tuple[str, str, int | None]:
+    """Split an event key into ``(provider_code, provider_event_id, season_year)``.
+
+    Examples::
+
+        parse_event_key("gotsport__45224__unknown") -> ("gotsport", "45224", None)
+        parse_event_key("gotsport__45224__2026")    -> ("gotsport", "45224", 2026)
+        parse_event_key("gotsport__45224__abcd")    raises ValueError
+
+    The legacy ``unknown`` season segment is the ONLY non-int value
+    accepted; any other non-int segment raises ``ValueError`` (the rekey
+    migration is the sanctioned path for upgrading old keys).
+    """
+    parts = key.split("__")
+    if len(parts) != 3:
+        raise ValueError(f"event_key must have shape provider__eventid__season; got {key!r}")
+    provider_code, provider_event_id, season_segment = parts
+    if not provider_code or not provider_event_id:
+        raise ValueError(f"event_key has empty segments: {key!r}")
+    if season_segment == "unknown":
+        return provider_code, provider_event_id, None
+    if not season_segment.isdigit():
+        raise ValueError(f"event_key season segment must be 'unknown' or an int; got {season_segment!r}")
+    season_year = int(season_segment)
+    if season_year < _MIN_SEASON_YEAR:
+        raise ValueError(f"event_key season_year must be >= {_MIN_SEASON_YEAR}, got {season_year}")
+    return provider_code, provider_event_id, season_year
+
+
+def reports_dir(base_dir: Path | str = "reports") -> Path:
+    """Return the root reports directory."""
+    return Path(base_dir)
+
+
+def event_dir(event_key: str, *, base_dir: Path | str = "reports") -> Path:
+    """Return ``<reports>/<event_key>/``.
+
+    The ``event_key`` string is treated as a single path segment — pre-formed
+    keys still go through ``_validate_segment`` so a caller passing
+    ``"../etc"`` directly to ``event_dir`` (bypassing the ``event_key()``
+    constructor) cannot escape the reports root.
+    """
+    _validate_segment(event_key, label="event_key")
+    return reports_dir(base_dir) / event_key
+
+
+def intake_dir(event_key: str, *, base_dir: Path | str = "reports") -> Path:
+    """Return ``<event_dir>/intake/`` — the immutable, scenario-shared intake tier."""
+    return event_dir(event_key, base_dir=base_dir) / "intake"
+
+
+def scenarios_dir(event_key: str, *, base_dir: Path | str = "reports") -> Path:
+    """Return ``<event_dir>/scenarios/``."""
+    return event_dir(event_key, base_dir=base_dir) / "scenarios"
+
+
+def scenario_dir(event_key: str, name: str, *, base_dir: Path | str = "reports") -> Path:
+    """Return ``<scenarios_dir>/<name>/``."""
+    _validate_segment(name, label="scenario name")
+    return scenarios_dir(event_key, base_dir=base_dir) / name
+
+
+def run_dir(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Return ``<scenario_dir>/runs/<run_id>/``."""
+    _validate_segment(run_id, label="run_id")
+    return scenario_dir(event_key, scenario, base_dir=base_dir) / "runs" / run_id
+
+
+@dataclass(frozen=True)
+class RekeyMigrationResult:
+    """Per-call summary of ``rekey_unknown_directories``.
+
+    All tuples for immutability. ``failed`` and ``unmigrated`` are
+    informational — the function never raises mid-loop, so the caller is
+    responsible for surfacing these to the operator (e.g. a Streamlit
+    startup banner).
+    """
+
+    completed: tuple[tuple[str, str], ...]
+    """``(old_key, new_key)`` pairs that renamed successfully."""
+
+    failed: tuple[tuple[str, str], ...]
+    """``(old_key, error_str)`` pairs whose rename or read failed."""
+
+    unmigrated: tuple[str, ...]
+    """``old_key`` entries that lack ``intake/event_metadata.json``."""
+
+
+def rekey_unknown_directories(
+    base_dir: Path | str = "reports",
+) -> RekeyMigrationResult:
+    """Migrate ``<provider>__<eventid>__unknown/`` to season-stamped names.
+
+    Idempotent: a second call on the same ``base_dir`` finds no matching
+    directories and returns empty results. Non-destructive: directories
+    that fail to migrate (no derivable season_year, destination already
+    exists) remain in place and the function returns their reasons in
+    ``failed``. The function never raises mid-loop.
+    """
+    root = Path(base_dir)
+    if not root.exists():
+        return RekeyMigrationResult(completed=(), failed=(), unmigrated=())
+
+    completed: list[tuple[str, str]] = []
+    failed: list[tuple[str, str]] = []
+    unmigrated: list[str] = []
+
+    for entry in sorted(root.iterdir()):
+        old_key = entry.name
+        try:
+            if not entry.is_dir() or not old_key.endswith("__unknown"):
+                continue
+
+            metadata_path = entry / "intake" / "event_metadata.json"
+            if not metadata_path.exists():
+                unmigrated.append(old_key)
+                continue
+
+            payload = read_json(metadata_path)
+            assert_supported_version(payload, source=str(metadata_path))
+            season = derive_season_year(payload.get("event_start_date"))
+            if season is None:
+                failed.append((old_key, "no derivable season_year"))
+                continue
+
+            provider_code, provider_event_id, _ = parse_event_key(old_key)
+            new_key = event_key(provider_code, provider_event_id, season)
+            new_dir = root / new_key
+            if new_dir.exists():
+                failed.append((old_key, "destination already exists"))
+                continue
+
+            os.replace(entry, new_dir)
+            completed.append((old_key, new_key))
+        except (
+            FileNotFoundError,
+            FileExistsError,
+            OSError,
+            json.JSONDecodeError,
+            ValueError,
+            SchemaVersionError,
+        ) as exc:
+            failed.append((old_key, str(exc)))
+
+    return RekeyMigrationResult(
+        completed=tuple(completed),
+        failed=tuple(failed),
+        unmigrated=tuple(unmigrated),
+    )

--- a/src/tournaments/storage/event_metadata.py
+++ b/src/tournaments/storage/event_metadata.py
@@ -1,0 +1,89 @@
+"""``EventMetadata`` dataclass — event-level scrape result + storage round-trip.
+
+Moved here from ``src/scrapers/provider.py:45`` so the storage layer owns
+the canonical definition. Re-exported from ``src.scrapers.provider`` for
+back-compat with Shell 01 callers.
+
+The ``season_year`` field is **optional** — Shell 01 callers
+(``gotsport.fetch_event_metadata`` at ``gotsport.py:2862-2869``) construct
+without it and the legacy ``__unknown`` event-key form still applies via
+``storage.event_key.event_key(..., season_year=None)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage._io import read_versioned_json, write_json
+from src.tournaments.storage.event_key import intake_dir
+from src.tournaments.storage.schema_version import stamp_schema_version
+
+__all__ = [
+    "EventMetadata",
+    "read_event_metadata",
+    "write_event_metadata",
+]
+
+
+@dataclass(frozen=True)
+class EventMetadata:
+    """Event-level metadata scraped from the provider landing page.
+
+    ``season_year`` is optional for Shell 01 back-compat — when ``None``,
+    ``storage.event_key.event_key`` falls back to the ``__unknown`` form.
+    """
+
+    provider_code: str
+    provider_event_id: str
+    event_name: str
+    event_slug: str
+    event_start_date: str | None
+    scrape_ts: str
+    season_year: int | None = None
+    series_id: str | None = None
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "EventMetadata":
+        """Construct from a payload, tolerating a missing ``season_year``.
+
+        Schema-version validation is the read boundary's job (matches
+        ``CohortConstraints.from_dict`` / ``FrozenMedians.from_dict``).
+        Callers that don't go through ``read_event_metadata`` should
+        compose ``assert_supported_version(payload, source=...)`` first.
+        """
+        return cls(
+            provider_code=payload["provider_code"],
+            provider_event_id=payload["provider_event_id"],
+            event_name=payload["event_name"],
+            event_slug=payload["event_slug"],
+            event_start_date=payload.get("event_start_date"),
+            scrape_ts=payload["scrape_ts"],
+            season_year=payload.get("season_year"),
+            series_id=payload.get("series_id"),
+            schema_version=int(payload.get("schema_version", 1)),
+        )
+
+
+def read_event_metadata(event_key: str, *, base_dir: Path | str = "reports") -> EventMetadata:
+    """Read ``intake/event_metadata.json`` and return an ``EventMetadata``."""
+    path = intake_dir(event_key, base_dir=base_dir) / "event_metadata.json"
+    payload = read_versioned_json(path)
+    return EventMetadata.from_dict(payload)
+
+
+def write_event_metadata(
+    event_key: str,
+    meta: EventMetadata,
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    """Write ``meta`` to ``intake/event_metadata.json`` with the schema stamp."""
+    path = intake_dir(event_key, base_dir=base_dir) / "event_metadata.json"
+    write_json(path, stamp_schema_version(meta.to_dict()))

--- a/src/tournaments/storage/frozen_medians.py
+++ b/src/tournaments/storage/frozen_medians.py
@@ -1,0 +1,92 @@
+"""Per-division power_score medians, frozen at the start of a run.
+
+Used by the optimizer when an external team's strength must be approximated
+from its division-level peers — keeps the optimizer's input deterministic
+across rescrapes that happen mid-run. The Supabase query that produces the
+input ``power_scores_by_division`` lives outside this shell; this module
+just owns the computation + persistence.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage._io import read_versioned_json, utc_now_iso, write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import stamp_schema_version
+
+__all__ = [
+    "FrozenMedians",
+    "compute_frozen_medians",
+    "read_frozen_medians",
+    "write_frozen_medians",
+]
+
+
+@dataclass(frozen=True)
+class FrozenMedians:
+    """Per-division ``power_score`` median snapshot."""
+
+    medians_by_division: dict[str, float]
+    """``{division_name: median_power_score}``."""
+
+    computed_at: str
+    """UTC ISO-8601 timestamp."""
+
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "FrozenMedians":
+        return cls(
+            medians_by_division=dict(payload.get("medians_by_division") or {}),
+            computed_at=payload["computed_at"],
+            schema_version=int(payload.get("schema_version", 1)),
+        )
+
+
+def compute_frozen_medians(
+    power_scores_by_division: dict[str, list[float]],
+) -> FrozenMedians:
+    """Compute per-division medians from a mapping of division -> scores.
+
+    Pure function. Empty score lists are skipped (a division with no
+    members produces no median entry rather than raising).
+    """
+    medians: dict[str, float] = {}
+    for division, scores in power_scores_by_division.items():
+        if not scores:
+            continue
+        medians[division] = float(statistics.median(scores))
+    return FrozenMedians(medians_by_division=medians, computed_at=utc_now_iso())
+
+
+def _medians_path(scenario_path: Path) -> Path:
+    return scenario_path / "frozen_medians.json"
+
+
+def read_frozen_medians(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> FrozenMedians:
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    payload = read_versioned_json(_medians_path(scenario_path))
+    return FrozenMedians.from_dict(payload)
+
+
+def write_frozen_medians(
+    event_key: str,
+    scenario: str,
+    medians: FrozenMedians,
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    write_json(_medians_path(scenario_path), stamp_schema_version(medians.to_dict()))

--- a/src/tournaments/storage/games_import.py
+++ b/src/tournaments/storage/games_import.py
@@ -1,0 +1,64 @@
+"""Games-import status helper for the per-cohort run pre-flight gate.
+
+Spec §7 validation requires "Games coverage < 100%" surfacing as a blocker
+in backtest mode. This helper produces the three-state classification the
+UI consumes; the actual gate enforcement lives in Shell 04 (display) and
+Shell 06 (run pre-flight).
+
+Classification rules are conservative for v1 — final tuning of the
+"complete" criterion can move into Shell 06 if the binary check proves too
+strict in practice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Literal
+
+__all__ = [
+    "GamesImportStatus",
+    "check_games_import_status",
+]
+
+
+GamesImportStatus = Literal["not_imported", "partial", "complete"]
+
+
+def check_games_import_status(
+    event_name: str,
+    registered_team_ids: Iterable[str],
+    *,
+    supabase_client: Any,
+) -> GamesImportStatus:
+    """Bin the games-coverage state for a tournament event.
+
+    - 0 rows in ``games`` for ``event_name`` → ``"not_imported"``.
+    - At least one game per ``team_id_master`` in ``registered_team_ids``
+      → ``"complete"``.
+    - Otherwise → ``"partial"``.
+
+    Excluded games (``is_excluded=True``) are ignored — they aren't part of
+    the rankings pipeline and would inflate coverage falsely.
+    """
+    response = (
+        supabase_client.table("games")
+        .select("home_team_master_id,away_team_master_id")
+        .eq("event_name", event_name)
+        .eq("is_excluded", False)
+        .execute()
+    )
+    rows = response.data or []
+    if not rows:
+        return "not_imported"
+
+    teams_with_games: set[str] = set()
+    for row in rows:
+        for column in ("home_team_master_id", "away_team_master_id"):
+            value = row.get(column)
+            if value:
+                teams_with_games.add(str(value))
+
+    registered = {str(team_id) for team_id in registered_team_ids if team_id}
+    if registered and registered.issubset(teams_with_games):
+        return "complete"
+    return "partial"

--- a/src/tournaments/storage/overrides.py
+++ b/src/tournaments/storage/overrides.py
@@ -1,0 +1,59 @@
+"""Scenario-level intake-time overrides — append-only JSONL.
+
+Spec §10 fold-in 14: overrides survive rescrape via merge on
+``provider_team_id`` (cf. ``rescrape.merge_rescrape``). The append-only
+contract means there is no edit/delete API — corrections are new records
+with ``ts`` ordering. Replay-from-zero produces the canonical overrides
+state.
+
+Each record is stamped ``schema_version: 1`` on write and validated per
+record on load.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage._io import append_jsonl, read_jsonl
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import (
+    assert_supported_version,
+    stamp_schema_version,
+)
+
+__all__ = [
+    "append_override",
+    "load_overrides",
+]
+
+
+def _overrides_path(scenario_path: Path) -> Path:
+    return scenario_path / "overrides.jsonl"
+
+
+def append_override(
+    event_key: str,
+    scenario: str,
+    override: dict[str, Any],
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    """Append one override record. Stamps ``schema_version: 1`` automatically."""
+    path = _overrides_path(scenario_dir(event_key, scenario, base_dir=base_dir))
+    append_jsonl(path, stamp_schema_version(override))
+
+
+def load_overrides(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> list[dict[str, Any]]:
+    """Return all override records in insertion order, validating each schema version."""
+    path = _overrides_path(scenario_dir(event_key, scenario, base_dir=base_dir))
+    records: list[dict[str, Any]] = []
+    for index, record in enumerate(read_jsonl(path)):
+        assert_supported_version(record, source=f"{path}:record[{index}]")
+        records.append(record)
+    return records

--- a/src/tournaments/storage/raw_scrape.py
+++ b/src/tournaments/storage/raw_scrape.py
@@ -1,0 +1,46 @@
+"""Raw-scrape JSONL access — re-exports the Shell 01 IntakeJournal primitives.
+
+The storage layer doesn't reinvent the JSONL machinery; it re-exports
+``IntakeJournal`` and friends from ``src.scrapers.intake_journal`` so
+callers that work in scenario-relative terms have a single import surface.
+
+The convenience helper ``load_raw_scrape`` returns the latest-run-wins
+record list for an event_key — handy for Streamlit triage UIs that don't
+need the full ``IntakeJournal`` lifecycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.scrapers.intake_journal import (
+    DURABLE_ACTIONS,
+    IntakeJournal,
+    JournalCorruptionError,
+    RemovedTeamsDiff,
+    compute_skip_set,
+)
+
+__all__ = [
+    "DURABLE_ACTIONS",
+    "IntakeJournal",
+    "JournalCorruptionError",
+    "RemovedTeamsDiff",
+    "compute_skip_set",
+    "load_raw_scrape",
+]
+
+
+def load_raw_scrape(event_key: str, *, base_dir: Path | str = "reports") -> list[dict[str, Any]]:
+    """Return the latest-run-wins records from ``intake/raw_scrape.jsonl``.
+
+    Returns an empty list when the journal does not exist. The IntakeJournal
+    class still owns the read mechanics — this helper just unwraps the dict
+    into list form for read-only consumers.
+    """
+    journal = IntakeJournal(event_key=event_key, base_dir=base_dir)
+    if not journal.path.exists():
+        return []
+    store = journal.read()
+    return list(store.values())

--- a/src/tournaments/storage/registry.py
+++ b/src/tournaments/storage/registry.py
@@ -1,0 +1,190 @@
+"""Per-team event registry CSV — wire format mirrors the existing CLI consumer.
+
+Spec §8 line 302: *"the existing ``backtest_tournament_event.py`` CLI is
+unchanged for v1."* The columns the CLI reads from
+``event_team_registry.csv`` are authoritative — this storage library is a
+passthrough to that format.
+
+Authoritative column set (verified against
+``scripts/backtest_tournament_event.py:145-153, 167-217``):
+
+- Input columns the Streamlit layer writes / the CLI reads:
+  ``event_registration_id``, ``event_team_name``, ``event_age_group``,
+  ``display_age_group``, ``event_gender``, ``display_gender``,
+  ``event_club_name``, ``search_age_group``,
+  ``resolved_gotsport_provider_team_id``, ``canonical_resolution_status``,
+  ``in_scope_u10_u19`` (string ``"True"``/``"False"`` — see
+  ``backtest_tournament_event.py:177``), ``resolved_team_id_master``,
+  ``resolved_team_name``, ``resolved_club_name``.
+- Matcher-output columns the CLI appends and re-reads on a round trip:
+  ``matcher_status``, ``matcher_best_score``, ``matcher_second_score``,
+  ``matcher_score_gap``, ``matcher_resolved_team_id_master``,
+  ``matcher_resolved_team_name``, ``matcher_resolved_club_name``,
+  ``matcher_resolved_provider_team_id``.
+
+Schema-version stamp lives in the sibling ``event_team_registry.schema.json``
+(one stamp per file), not as a per-row dataclass field — JSON-backed
+dataclasses (``EventMetadata``, ``CohortConstraints``, ``FrozenMedians``)
+carry ``schema_version`` because they round-trip as a single dict.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage._io import read_csv, read_json, write_csv, write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import (
+    assert_supported_version,
+    stamp_schema_version,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FIELDNAMES",
+    "TeamRegistryEntry",
+    "read_registry",
+    "write_registry",
+]
+
+
+FIELDNAMES: tuple[str, ...] = (
+    # Input columns — Streamlit writes, CLI reads
+    "event_registration_id",
+    "event_team_name",
+    "event_age_group",
+    "display_age_group",
+    "event_gender",
+    "display_gender",
+    "event_club_name",
+    "search_age_group",
+    "resolved_gotsport_provider_team_id",
+    "canonical_resolution_status",
+    "in_scope_u10_u19",
+    "resolved_team_id_master",
+    "resolved_team_name",
+    "resolved_club_name",
+    # Matcher-output columns — CLI appends in this order
+    # (see ``backtest_tournament_event.py:168-175``)
+    "matcher_status",
+    "matcher_best_score",
+    "matcher_second_score",
+    "matcher_score_gap",
+    "matcher_resolved_team_id_master",
+    "matcher_resolved_team_name",
+    "matcher_resolved_club_name",
+    "matcher_resolved_provider_team_id",
+)
+
+
+@dataclass(frozen=True)
+class TeamRegistryEntry:
+    """One row of ``event_team_registry.csv``.
+
+    Every field is ``str`` to round-trip the CSV exactly — the CLI consumes
+    strings and the matcher stores numeric scores as ``int | float | ""``,
+    which only round-trips losslessly through string fields.
+
+    No ``schema_version`` field — schema versioning for the CSV-backed
+    registry lives in the sibling ``event_team_registry.schema.json`` (one
+    stamp per file), not per row.
+    """
+
+    event_registration_id: str = ""
+    event_team_name: str = ""
+    event_age_group: str = ""
+    display_age_group: str = ""
+    event_gender: str = ""
+    display_gender: str = ""
+    event_club_name: str = ""
+    search_age_group: str = ""
+    resolved_gotsport_provider_team_id: str = ""
+    canonical_resolution_status: str = ""
+    in_scope_u10_u19: str = ""
+    resolved_team_id_master: str = ""
+    resolved_team_name: str = ""
+    resolved_club_name: str = ""
+    matcher_status: str = ""
+    matcher_best_score: str = ""
+    matcher_second_score: str = ""
+    matcher_score_gap: str = ""
+    matcher_resolved_team_id_master: str = ""
+    matcher_resolved_team_name: str = ""
+    matcher_resolved_club_name: str = ""
+    matcher_resolved_provider_team_id: str = ""
+
+    def to_row(self) -> dict[str, str]:
+        """String-only round-trip — no type coercion (CLI consumes strings)."""
+        return {field.name: getattr(self, field.name) for field in fields(self)}
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> "TeamRegistryEntry":
+        """Construct from a CSV row, defaulting missing columns to ``""``.
+
+        Extra columns in the CSV are silently ignored (forward-compat
+        within ``schema_version: 1``; cf. ``write_registry`` policy).
+        """
+        kwargs = {field.name: str(row.get(field.name, "") or "") for field in fields(cls)}
+        return cls(**kwargs)
+
+
+def _schema_path(scenario_path: Path) -> Path:
+    return scenario_path / "event_team_registry.schema.json"
+
+
+def _csv_path(scenario_path: Path) -> Path:
+    return scenario_path / "event_team_registry.csv"
+
+
+def read_registry(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> list[TeamRegistryEntry]:
+    """Read the per-scenario team registry CSV.
+
+    Validates the sibling ``event_team_registry.schema.json`` via
+    ``assert_supported_version`` (raises ``SchemaVersionError`` on a newer
+    schema). A FIELDNAMES mismatch is **logged as a warning but does NOT
+    raise** — the CSV header itself is the authoritative wire-format check,
+    and v1.x adds of optional matcher-output columns must remain
+    forward-compatible within ``schema_version: 1``.
+    """
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    schema_path = _schema_path(scenario_path)
+    if schema_path.exists():
+        sidecar = read_json(schema_path)
+        assert_supported_version(sidecar, source=str(schema_path))
+        sidecar_fields = tuple(sidecar.get("fieldnames") or ())
+        if sidecar_fields and sidecar_fields != FIELDNAMES:
+            logger.warning(
+                "[registry] %s sibling FIELDNAMES drift; on-disk=%s expected=%s",
+                schema_path.name,
+                sidecar_fields,
+                FIELDNAMES,
+            )
+
+    rows = read_csv(_csv_path(scenario_path))
+    return [TeamRegistryEntry.from_row(row) for row in rows]
+
+
+def write_registry(
+    event_key: str,
+    scenario: str,
+    entries: list[TeamRegistryEntry],
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    """Write the per-scenario team registry CSV + sibling schema stamp."""
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    rows = [entry.to_row() for entry in entries]
+    write_csv(_csv_path(scenario_path), rows, fieldnames=FIELDNAMES)
+    write_json(
+        _schema_path(scenario_path),
+        stamp_schema_version({"fieldnames": list(FIELDNAMES)}),
+    )

--- a/src/tournaments/storage/rescrape.py
+++ b/src/tournaments/storage/rescrape.py
@@ -1,0 +1,76 @@
+"""Pure-function rescrape merge.
+
+Spec §10 fold-in 14: overrides survive rescrape via merge on
+``provider_team_id``. Removed teams surface in Shell 07's risk flags later
+— this module just reports them.
+
+The function operates on raw dicts (not ``IntakeJournal`` records or
+``ScrapedTeam`` instances) so callers compose it with whatever projection
+they want. Does **not** call ``compute_skip_set`` — that helper is for
+resume-during-scrape, not post-scrape diff.
+
+The result dataclass is in-memory only; never persisted. Mirrors
+``RemovedTeamsDiff`` at ``src/scrapers/intake_journal.py:76`` (frozen
+result, no ``schema_version`` field).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "RescrapeReport",
+    "merge_rescrape",
+]
+
+
+@dataclass(frozen=True)
+class RescrapeReport:
+    """In-memory summary of a rescrape merge keyed on ``provider_team_id``.
+
+    Orphan overrides — entries whose pid is in neither ``old_raw`` nor
+    ``new_raw`` — are silently absent from every bucket; callers that need
+    to surface them compute the residual themselves.
+    """
+
+    teams_added: tuple[str, ...]
+    """``provider_team_id`` values in the new scrape but not the old."""
+
+    teams_removed_but_overridden: tuple[str, ...]
+    """Pids in the old scrape but not the new, with an existing override."""
+
+    teams_with_preserved_overrides: tuple[str, ...]
+    """Pids present in both scrapes whose override survives merge-on-pid."""
+
+
+def _pid_set(rows: list[dict[str, Any]]) -> set[str]:
+    return {str(row["provider_team_id"]) for row in rows if row.get("provider_team_id") not in (None, "")}
+
+
+def merge_rescrape(
+    old_raw: list[dict[str, Any]],
+    new_raw: list[dict[str, Any]],
+    overrides: list[dict[str, Any]],
+) -> RescrapeReport:
+    """Merge two scrape snapshots and report override survivability.
+
+    ``overrides`` may contain multiple records per pid (the append-only
+    overrides log). Any pid with at least one override record is treated as
+    "has override" — the override semantics (replay, latest-wins) are the
+    Streamlit layer's contract, not this function's.
+    """
+    old_ids = _pid_set(old_raw)
+    new_ids = _pid_set(new_raw)
+    override_ids = _pid_set(overrides)
+
+    teams_added = tuple(sorted(new_ids - old_ids))
+    removed_ids = old_ids - new_ids
+    teams_removed_but_overridden = tuple(sorted(removed_ids & override_ids))
+    teams_with_preserved_overrides = tuple(sorted(new_ids & override_ids))
+
+    return RescrapeReport(
+        teams_added=teams_added,
+        teams_removed_but_overridden=teams_removed_but_overridden,
+        teams_with_preserved_overrides=teams_with_preserved_overrides,
+    )

--- a/src/tournaments/storage/run_layout.py
+++ b/src/tournaments/storage/run_layout.py
@@ -1,0 +1,191 @@
+"""Per-run directory state machine — staging → promoted/failed/cancelled.
+
+Spec §9 run state machine::
+
+    pending → running → completed  (rename .tmp/ → <run_id>/, done.json)
+                     → failed      (rename .tmp/ → .failed/, error.json)
+                     → cancelled   (rename .tmp/ → .cancelled/, cancelled.json)
+
+Only ``runs/<run_id>/`` directories (no suffix) with a ``done.json`` inside
+are valid completed runs. Failed/cancelled runs are kept for diagnosis.
+
+**Atomic-rename note for directories.** ``os.replace(src_dir, dst_dir)``
+raises ``OSError`` / ``ENOTEMPTY`` on Windows AND POSIX when ``dst_dir``
+exists and is non-empty. The ``intake_journal.compact()`` pattern at
+``intake_journal.py:284`` works for files because file-rename overwrites,
+but directory-rename does not. Each transition adds an explicit
+``dst.exists()`` precheck that turns the raw ``OSError`` into a typed
+``RunStateError`` with a clear message.
+
+**Marker JSON write protocol.** Each marker file (``done.json`` /
+``error.json`` / ``cancelled.json``) is written via ``_io.write_json``
+(atomic ``<path>.tmp`` + ``os.replace`` + ``fsync``) inside the staging
+``.tmp/`` directory **before** the directory rename. A power loss between
+marker write and directory rename leaves the marker durable in ``.tmp/``;
+the directory rename either completes atomically or doesn't — no partial
+``runs/<run_id>/`` ever exists without a ``done.json``.
+
+**Awareness of extended run-dir files.** Shell 06 produces
+``fallbacks.jsonl``, ``run_metadata.json``, ``run_overrides_audit.jsonl``
+inside the run directory. This module does not enumerate or validate them —
+they are caller-owned.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.tournaments.storage._io import utc_now_iso, write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import stamp_schema_version
+
+__all__ = [
+    "RunStateError",
+    "cancel_run",
+    "create_staging_run",
+    "fail_run",
+    "list_runs",
+    "promote_run",
+]
+
+
+class RunStateError(RuntimeError):
+    """Raised when a run-state transition cannot complete safely."""
+
+
+def _runs_root(event_key: str, scenario: str, base_dir: Path | str) -> Path:
+    return scenario_dir(event_key, scenario, base_dir=base_dir) / "runs"
+
+
+def create_staging_run(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Create ``runs/<run_id>.tmp/`` for an in-flight subprocess.
+
+    Raises ``RunStateError`` if ``<run_id>.tmp/`` or ``<run_id>/`` already
+    exists — both indicate a prior aborted run that needs manual cleanup
+    before the new run can stage.
+    """
+    runs_root = _runs_root(event_key, scenario, base_dir)
+    staging_dir = runs_root / f"{run_id}.tmp"
+    final_dir = runs_root / run_id
+    if staging_dir.exists():
+        raise RunStateError(f"refusing to stage — {staging_dir} already exists")
+    if final_dir.exists():
+        raise RunStateError(f"refusing to stage — {final_dir} already exists")
+    staging_dir.mkdir(parents=True, exist_ok=False)
+    return staging_dir
+
+
+def promote_run(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Promote ``runs/<run_id>.tmp/`` to ``runs/<run_id>/`` after writing ``done.json``.
+
+    Order: ``done.json`` is written via ``_io.write_json`` (fully fsynced)
+    BEFORE the directory rename so the marker is durable even if the
+    rename is interrupted.
+
+    Raises ``RunStateError`` if the staging dir is missing or the final dir
+    already exists.
+    """
+    runs_root = _runs_root(event_key, scenario, base_dir)
+    staging_dir = runs_root / f"{run_id}.tmp"
+    final_dir = runs_root / run_id
+    if not staging_dir.exists():
+        raise RunStateError(f"refusing to promote — staging dir missing at {staging_dir}")
+    if final_dir.exists():
+        raise RunStateError(f"refusing to promote — {final_dir} already exists; resolve manually")
+    write_json(
+        staging_dir / "done.json",
+        stamp_schema_version({"run_id": run_id, "promoted_at": utc_now_iso()}),
+    )
+    os.replace(staging_dir, final_dir)
+    return final_dir
+
+
+def fail_run(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    error: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Rename ``runs/<run_id>.tmp/`` to ``runs/<run_id>.failed/`` with ``error.json``."""
+    runs_root = _runs_root(event_key, scenario, base_dir)
+    staging_dir = runs_root / f"{run_id}.tmp"
+    failed_dir = runs_root / f"{run_id}.failed"
+    if not staging_dir.exists():
+        raise RunStateError(f"refusing to fail — staging dir missing at {staging_dir}")
+    if failed_dir.exists():
+        raise RunStateError(f"refusing to fail — {failed_dir} already exists")
+    write_json(
+        staging_dir / "error.json",
+        stamp_schema_version({"run_id": run_id, "failed_at": utc_now_iso(), "error": error}),
+    )
+    os.replace(staging_dir, failed_dir)
+    return failed_dir
+
+
+def cancel_run(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Rename ``runs/<run_id>.tmp/`` to ``runs/<run_id>.cancelled/`` with ``cancelled.json``."""
+    runs_root = _runs_root(event_key, scenario, base_dir)
+    staging_dir = runs_root / f"{run_id}.tmp"
+    cancelled_dir = runs_root / f"{run_id}.cancelled"
+    if not staging_dir.exists():
+        raise RunStateError(f"refusing to cancel — staging dir missing at {staging_dir}")
+    if cancelled_dir.exists():
+        raise RunStateError(f"refusing to cancel — {cancelled_dir} already exists")
+    write_json(
+        staging_dir / "cancelled.json",
+        stamp_schema_version({"run_id": run_id, "cancelled_at": utc_now_iso()}),
+    )
+    os.replace(staging_dir, cancelled_dir)
+    return cancelled_dir
+
+
+def list_runs(
+    event_key: str,
+    scenario: str,
+    *,
+    completed_only: bool = True,
+    base_dir: Path | str = "reports",
+) -> list[str]:
+    """Return run-id directory names under ``runs/``.
+
+    With ``completed_only=True`` (the default), only directories whose name
+    has no ``.tmp`` / ``.failed`` / ``.cancelled`` suffix AND that contain
+    a ``done.json`` are returned. With ``completed_only=False`` every
+    directory under ``runs/`` is returned (the caller does its own
+    filtering).
+    """
+    runs_root = _runs_root(event_key, scenario, base_dir)
+    if not runs_root.exists():
+        return []
+    names: list[str] = []
+    for entry in sorted(runs_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if completed_only:
+            if "." in entry.name:
+                continue
+            if not (entry / "done.json").exists():
+                continue
+        names.append(entry.name)
+    return names

--- a/src/tournaments/storage/scenario.py
+++ b/src/tournaments/storage/scenario.py
@@ -1,0 +1,168 @@
+"""Scenario directory scaffolding + per-scenario advisory lock.
+
+Spec §8 enforces a two-tier layout: ``intake/`` is shared across scenarios
+and ``scenarios/<name>/`` overlays it. Branching creates a new overlay
+without copying ``intake/`` (the scrape genuinely is shared).
+
+Spec §9 line 320 mandates a per-scenario file lock at
+``scenarios/<name>/.run.lock`` so two run subprocesses can't race the same
+scenario. ``acquire_scenario_lock`` implements it as an OS advisory lock —
+``fcntl.flock`` on POSIX, ``msvcrt.locking`` on Windows.
+
+**No-IO contract on the lockfile:** the helper opens the fd and immediately
+acquires the lock without any intervening reads or writes. Callers MUST NOT
+use the lockfile body for state (PID, holder name, etc.) — Windows
+``msvcrt.locking`` locks a 1-byte range from the current file pointer; any
+intervening I/O could shift the locked range. The lockfile is purely a
+presence/lock primitive.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import sys
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+from src.tournaments.storage.event_key import scenario_dir, scenarios_dir
+
+__all__ = [
+    "ScenarioExistsError",
+    "ScenarioLockError",
+    "acquire_scenario_lock",
+    "branch_scenario",
+    "ensure_scenario",
+    "list_scenarios",
+]
+
+
+class ScenarioExistsError(RuntimeError):
+    """Raised when ``branch_scenario`` finds the destination already exists."""
+
+
+class ScenarioLockError(RuntimeError):
+    """Raised when ``acquire_scenario_lock`` cannot acquire within ``timeout``."""
+
+
+def ensure_scenario(event_key: str, name: str, *, base_dir: Path | str = "reports") -> Path:
+    """Create ``scenarios/<name>/`` (idempotent).
+
+    Does NOT copy ``intake/`` — intake is shared at the event tier and
+    scenarios overlay (spec §8).
+    """
+    path = scenario_dir(event_key, name, base_dir=base_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def branch_scenario(
+    event_key: str,
+    src_name: str,
+    dst_name: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> Path:
+    """Copy ``scenarios/<src>/`` to ``scenarios/<dst>/``.
+
+    Excludes any nested ``intake/`` so a stray intake dir at the scenario
+    tier doesn't get cloned. Raises ``ScenarioExistsError`` if the
+    destination already exists; raises ``ValueError`` if src and dst are
+    the same name.
+    """
+    if src_name == dst_name:
+        raise ValueError(f"branch source and destination must differ: {src_name!r}")
+    src_path = scenario_dir(event_key, src_name, base_dir=base_dir)
+    dst_path = scenario_dir(event_key, dst_name, base_dir=base_dir)
+    if dst_path.exists():
+        raise ScenarioExistsError(f"scenario {dst_name!r} already exists at {dst_path}")
+    shutil.copytree(src_path, dst_path, ignore=shutil.ignore_patterns("intake"))
+    return dst_path
+
+
+def list_scenarios(event_key: str, *, base_dir: Path | str = "reports") -> list[str]:
+    """Return the directory names under ``scenarios/`` (sorted)."""
+    root = scenarios_dir(event_key, base_dir=base_dir)
+    if not root.exists():
+        return []
+    return sorted(entry.name for entry in root.iterdir() if entry.is_dir())
+
+
+def _build_platform_lock_pair() -> tuple[Callable[[int], None], Callable[[int], None]]:
+    """Build ``(lock_fn, unlock_fn)`` for the current platform.
+
+    Resolved once at module load — the platform branch and module imports
+    don't need to re-run on every ``acquire_scenario_lock`` call.
+    """
+    if sys.platform == "win32":
+        import msvcrt
+
+        def lock_fn(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+        def unlock_fn(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        def lock_fn(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def unlock_fn(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+    return lock_fn, unlock_fn
+
+
+_LOCK_FN, _UNLOCK_FN = _build_platform_lock_pair()
+
+
+@contextlib.contextmanager
+def acquire_scenario_lock(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+    timeout: float = 0.0,
+) -> Iterator[None]:
+    """Acquire the per-scenario advisory lock at ``scenarios/<name>/.run.lock``.
+
+    Timeout semantics:
+
+    - ``timeout == 0.0`` (default) — attempt acquire exactly once. Raise
+      ``ScenarioLockError`` immediately on contention.
+    - ``timeout > 0`` — retry with brief sleeps until elapsed time exceeds
+      ``timeout``, then raise.
+
+    The scenario directory must already exist (``ensure_scenario`` is the
+    sanctioned creator). Opening the lockfile in a missing directory raises
+    ``FileNotFoundError`` — that's a caller-ordering bug, not a lock bug.
+
+    The lock is released and the fd closed on exit. The lockfile itself is
+    NOT deleted — it persists for the next acquirer.
+    """
+    lock_path = scenario_dir(event_key, scenario, base_dir=base_dir) / ".run.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
+    locked = False
+    try:
+        deadline = time.monotonic() + timeout if timeout > 0 else None
+        while True:
+            try:
+                _LOCK_FN(fd)
+                locked = True
+                break
+            except (BlockingIOError, OSError):
+                if deadline is None or time.monotonic() >= deadline:
+                    raise ScenarioLockError(f"scenario {scenario!r} is locked by another process")
+                time.sleep(0.05)
+        yield
+    finally:
+        if locked:
+            try:
+                _UNLOCK_FN(fd)
+            finally:
+                os.close(fd)
+        else:
+            os.close(fd)

--- a/src/tournaments/storage/schema_version.py
+++ b/src/tournaments/storage/schema_version.py
@@ -1,0 +1,77 @@
+"""Schema-version constant + check + stamp helpers.
+
+Spec §8 line 311 mandates a per-file ``schema_version: 1`` stamp so future
+v2 schemas can refuse to load against v1 code without silent data loss.
+
+**Contract:** lenient on read, strict on write.
+
+- Readers tolerate a missing ``schema_version`` field and treat it as v1
+  (per spec §10 fold-in 16's "stamp only, no migrations" v1 contract).
+  This keeps Shell 01 raw-scrape JSONL records loadable without a
+  retroactive stamp pass.
+- Writers MUST route their payload through ``stamp_schema_version`` before
+  handing it to ``_io.write_json`` / ``_io.write_csv`` / ``_io.append_jsonl``.
+  v2's stricter check will rely on this discipline — a missing stamp on a
+  v1-era file is the only way the v2 reader can tell it's looking at v1
+  data and not corrupted v2.
+
+Forward migrations are deferred until v2 lands. Today, the only failure
+mode is loading a payload whose declared ``schema_version`` exceeds
+``SCHEMA_VERSION``, which raises ``SchemaVersionError``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SchemaVersionError",
+    "assert_supported_version",
+    "stamp_schema_version",
+]
+
+
+SCHEMA_VERSION: int = 1
+"""Current storage-layer schema version. Bump when a payload's required
+fields, types, or wire format change in a way the prior version can't read.
+"""
+
+
+class SchemaVersionError(RuntimeError):
+    """Raised when a payload's ``schema_version`` exceeds ``SCHEMA_VERSION``.
+
+    The reader will not silently downgrade — callers must either upgrade the
+    code or roll back the file. Mirrors the typed-error style of
+    ``src.scrapers.intake_journal.JournalCorruptionError``.
+    """
+
+
+def assert_supported_version(payload: dict[str, Any], *, source: str) -> None:
+    """Raise ``SchemaVersionError`` if ``payload`` claims a newer schema.
+
+    A missing ``schema_version`` field is treated as v1 (lenient on read).
+    A non-coercible value (e.g. ``None``, a non-numeric string) raises
+    ``SchemaVersionError`` rather than a raw ``TypeError`` / ``ValueError``
+    so callers (such as ``rekey_unknown_directories``) can rely on the
+    typed exception in their except clauses. ``source`` is included in the
+    error message so a single trace points the operator at the exact file.
+    """
+    raw = payload.get("schema_version", 1)
+    try:
+        got = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise SchemaVersionError(f"{source} has malformed schema_version={raw!r}: {exc}") from exc
+    if got > SCHEMA_VERSION:
+        raise SchemaVersionError(f"{source} has schema_version={got}; this build supports {SCHEMA_VERSION}")
+
+
+def stamp_schema_version(payload: dict[str, Any], *, version: int = SCHEMA_VERSION) -> dict[str, Any]:
+    """Return a new dict with ``schema_version`` set.
+
+    Strict on write: every storage writer MUST route its payload through
+    this helper. Centralizing the stamp prevents inconsistent stamping
+    across modules — a v2 schema check needs every v1-era file to have been
+    explicitly stamped.
+    """
+    return {**payload, "schema_version": version}

--- a/src/tournaments/storage/structure.py
+++ b/src/tournaments/storage/structure.py
@@ -1,0 +1,199 @@
+"""Per-cohort tournament structure dataclasses + CSV round-trip.
+
+Spec §7 defines the per-cohort structure inputs the Streamlit UI collects
+and the CLI consumes via ``group_structure_summary.csv`` (legacy filename
+preserved). v1 ships ``name / team_count / pool_sizes / advancement`` per
+division — the existing ``DivisionSpec`` contract at
+``src/tournaments/seeding_optimizer.py:35``. Richer per-division template
+fields (``pool_play_games``, ``knockout_format``) are deferred until a
+later shell needs them.
+
+Schema-version stamp lives in the sibling
+``group_structure_summary.schema.json`` (one stamp per file), not as a
+per-row dataclass field.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.tournaments.storage._io import read_csv, read_json, write_csv, write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.schema_version import (
+    assert_supported_version,
+    stamp_schema_version,
+)
+
+if TYPE_CHECKING:
+    from src.tournaments.seeding_optimizer import DivisionSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CohortStructure",
+    "DivisionStructure",
+    "FIELDNAMES",
+    "read_structure",
+    "write_structure",
+]
+
+
+FIELDNAMES: tuple[str, ...] = (
+    "cohort_age_group",
+    "cohort_gender",
+    "division_name",
+    "team_count",
+    "pool_sizes",
+    "advancement",
+)
+
+
+@dataclass(frozen=True)
+class DivisionStructure:
+    """One division within a cohort.
+
+    Field-for-field compatible with ``seeding_optimizer.DivisionSpec`` so
+    ``to_division_spec()`` is a direct construction.
+    """
+
+    name: str
+    team_count: int
+    pool_sizes: tuple[int, ...] = ()
+    advancement: str | None = None
+
+    def to_division_spec(self) -> "DivisionSpec":
+        """Return a ``DivisionSpec`` for the seeding optimizer.
+
+        Imported lazily so this module's import cost stays minimal — the
+        seeding optimizer pulls in ``itertools`` / ``math`` / heavy match
+        machinery that storage callers don't always need.
+        """
+        from src.tournaments.seeding_optimizer import DivisionSpec
+
+        return DivisionSpec(
+            name=self.name,
+            team_count=self.team_count,
+            pool_sizes=self.pool_sizes,
+            advancement=self.advancement,
+        )
+
+
+@dataclass(frozen=True)
+class CohortStructure:
+    """All divisions for one ``(age_group, gender)`` cohort."""
+
+    age_group: str
+    gender: str
+    divisions: tuple[DivisionStructure, ...]
+
+
+def _serialize_pool_sizes(pool_sizes: tuple[int, ...]) -> str:
+    """``(4, 4, 4)`` -> ``"4|4|4"``; ``()`` -> ``""``."""
+    return "|".join(str(size) for size in pool_sizes)
+
+
+def _deserialize_pool_sizes(raw: str) -> tuple[int, ...]:
+    """``"4|4|4"`` -> ``(4, 4, 4)``; ``""`` -> ``()``."""
+    raw = (raw or "").strip()
+    if not raw:
+        return ()
+    return tuple(int(part) for part in raw.split("|") if part.strip())
+
+
+def _schema_path(scenario_path: Path) -> Path:
+    return scenario_path / "group_structure_summary.schema.json"
+
+
+def _csv_path(scenario_path: Path) -> Path:
+    return scenario_path / "group_structure_summary.csv"
+
+
+def read_structure(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> list[CohortStructure]:
+    """Read ``group_structure_summary.csv`` and group rows by cohort.
+
+    Sibling ``group_structure_summary.schema.json`` is validated via
+    ``assert_supported_version`` (raises on a newer schema). FIELDNAMES
+    drift is logged as a warning, not raised — same forward-compat policy
+    as ``registry.read_registry``.
+    """
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    schema_path = _schema_path(scenario_path)
+    if schema_path.exists():
+        sidecar = read_json(schema_path)
+        assert_supported_version(sidecar, source=str(schema_path))
+        sidecar_fields = tuple(sidecar.get("fieldnames") or ())
+        if sidecar_fields and sidecar_fields != FIELDNAMES:
+            logger.warning(
+                "[structure] %s sibling FIELDNAMES drift; on-disk=%s expected=%s",
+                schema_path.name,
+                sidecar_fields,
+                FIELDNAMES,
+            )
+
+    rows = read_csv(_csv_path(scenario_path))
+    grouped: dict[tuple[str, str], list[DivisionStructure]] = defaultdict(list)
+    cohort_order: list[tuple[str, str]] = []
+    for row in rows:
+        cohort_key = (
+            str(row.get("cohort_age_group") or ""),
+            str(row.get("cohort_gender") or ""),
+        )
+        if cohort_key not in grouped:
+            cohort_order.append(cohort_key)
+        team_count_raw = str(row.get("team_count") or "0").strip() or "0"
+        advancement_raw = str(row.get("advancement") or "").strip()
+        grouped[cohort_key].append(
+            DivisionStructure(
+                name=str(row.get("division_name") or ""),
+                team_count=int(team_count_raw),
+                pool_sizes=_deserialize_pool_sizes(str(row.get("pool_sizes") or "")),
+                advancement=advancement_raw or None,
+            )
+        )
+
+    return [
+        CohortStructure(
+            age_group=cohort_key[0],
+            gender=cohort_key[1],
+            divisions=tuple(grouped[cohort_key]),
+        )
+        for cohort_key in cohort_order
+    ]
+
+
+def write_structure(
+    event_key: str,
+    scenario: str,
+    cohorts: list[CohortStructure],
+    *,
+    base_dir: Path | str = "reports",
+) -> None:
+    """Write cohorts to ``group_structure_summary.csv`` + sibling schema stamp."""
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    rows: list[dict[str, str]] = []
+    for cohort in cohorts:
+        for division in cohort.divisions:
+            rows.append(
+                {
+                    "cohort_age_group": cohort.age_group,
+                    "cohort_gender": cohort.gender,
+                    "division_name": division.name,
+                    "team_count": str(division.team_count),
+                    "pool_sizes": _serialize_pool_sizes(division.pool_sizes),
+                    "advancement": division.advancement or "",
+                }
+            )
+    write_csv(_csv_path(scenario_path), rows, fieldnames=FIELDNAMES)
+    write_json(
+        _schema_path(scenario_path),
+        stamp_schema_version({"fieldnames": list(FIELDNAMES)}),
+    )

--- a/tests/unit/test_storage__io.py
+++ b/tests/unit/test_storage__io.py
@@ -1,0 +1,177 @@
+"""Direct tests for ``src.tournaments.storage._io`` foundation primitives.
+
+The helpers are also exercised transitively through every reader/writer,
+but boundary cases (empty file, missing file, missing trailing newline,
+atomic-rename .tmp cleanup) deserve direct coverage so a regression in
+``_io`` doesn't show up first as a confusing failure four modules away.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage._io import (
+    append_jsonl,
+    read_csv,
+    read_json,
+    read_jsonl,
+    read_versioned_json,
+    utc_now_iso,
+    write_csv,
+    write_json,
+)
+from src.tournaments.storage.schema_version import SchemaVersionError
+
+# -------- write_json + read_json --------------------------------------
+
+
+def test_write_json_creates_parent_dirs(tmp_path: Path):
+    target = tmp_path / "deep" / "nested" / "out.json"
+    write_json(target, {"x": 1})
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_write_json_atomic_no_tmp_left_behind(tmp_path: Path):
+    target = tmp_path / "atomic.json"
+    write_json(target, {"x": 1})
+    assert target.exists()
+    assert not target.with_name(target.name + ".tmp").exists()
+
+
+def test_write_json_overwrites_existing(tmp_path: Path):
+    target = tmp_path / "atomic.json"
+    write_json(target, {"x": 1})
+    write_json(target, {"x": 2})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"x": 2}
+
+
+def test_read_json_does_not_validate_schema(tmp_path: Path):
+    """Read JSON does NOT enforce ``schema_version`` — safe for unstamped markers."""
+    target = tmp_path / "marker.json"
+    target.write_text(json.dumps({"schema_version": 999, "x": 1}), encoding="utf-8")
+    assert read_json(target) == {"schema_version": 999, "x": 1}
+
+
+def test_read_versioned_json_raises_on_newer(tmp_path: Path):
+    target = tmp_path / "stamped.json"
+    target.write_text(json.dumps({"schema_version": 2, "x": 1}), encoding="utf-8")
+    with pytest.raises(SchemaVersionError):
+        read_versioned_json(target)
+
+
+def test_read_versioned_json_accepts_v1(tmp_path: Path):
+    target = tmp_path / "stamped.json"
+    target.write_text(json.dumps({"schema_version": 1, "x": 1}), encoding="utf-8")
+    assert read_versioned_json(target) == {"schema_version": 1, "x": 1}
+
+
+# -------- write_csv + read_csv ---------------------------------------
+
+
+def test_write_csv_round_trip_with_explicit_fieldnames(tmp_path: Path):
+    target = tmp_path / "out.csv"
+    write_csv(target, [{"a": "1", "b": "x"}, {"a": "2", "b": "y"}], fieldnames=("a", "b"))
+    assert read_csv(target) == [{"a": "1", "b": "x"}, {"a": "2", "b": "y"}]
+
+
+def test_write_csv_defaults_missing_keys_to_empty_string(tmp_path: Path):
+    target = tmp_path / "out.csv"
+    write_csv(target, [{"a": "1"}], fieldnames=("a", "b"))
+    rows = read_csv(target)
+    assert rows == [{"a": "1", "b": ""}]
+
+
+def test_write_csv_drops_extras(tmp_path: Path):
+    """``extrasaction="ignore"`` — extra keys are silently dropped, not raised."""
+    target = tmp_path / "out.csv"
+    write_csv(target, [{"a": "1", "extra": "ignored"}], fieldnames=("a",))
+    assert read_csv(target) == [{"a": "1"}]
+
+
+def test_write_csv_empty_rows_writes_header_only(tmp_path: Path):
+    target = tmp_path / "empty.csv"
+    write_csv(target, [], fieldnames=("a", "b"))
+    assert target.read_text(encoding="utf-8").splitlines()[0] == "a,b"
+    assert read_csv(target) == []
+
+
+def test_write_csv_atomic_no_tmp_left_behind(tmp_path: Path):
+    target = tmp_path / "atomic.csv"
+    write_csv(target, [{"a": "1"}], fieldnames=("a",))
+    assert not target.with_name(target.name + ".tmp").exists()
+
+
+# -------- append_jsonl + read_jsonl ----------------------------------
+
+
+def test_append_jsonl_newline_first_protocol(tmp_path: Path):
+    """File must start with ``\\n`` so a partial-tail crash is detectable."""
+    target = tmp_path / "log.jsonl"
+    append_jsonl(target, {"x": 1})
+    raw = target.read_bytes()
+    assert raw.startswith(b"\n")
+    assert json.loads(raw.split(b"\n")[1]) == {"x": 1}
+
+
+def test_append_jsonl_multiple_records(tmp_path: Path):
+    target = tmp_path / "log.jsonl"
+    for i in range(3):
+        append_jsonl(target, {"i": i})
+    records = list(read_jsonl(target))
+    assert records == [{"i": 0}, {"i": 1}, {"i": 2}]
+
+
+def test_read_jsonl_missing_file_yields_empty(tmp_path: Path):
+    target = tmp_path / "missing.jsonl"
+    assert list(read_jsonl(target)) == []
+
+
+def test_read_jsonl_empty_file_yields_empty(tmp_path: Path):
+    """File exists but is zero bytes — the missing-trailing-newline edge."""
+    target = tmp_path / "empty.jsonl"
+    target.write_bytes(b"")
+    assert list(read_jsonl(target)) == []
+
+
+def test_read_jsonl_no_trailing_newline(tmp_path: Path):
+    """Newline-first protocol means the last record doesn't need a trailing \\n."""
+    target = tmp_path / "log.jsonl"
+    target.write_bytes(b'\n{"x": 1}\n{"x": 2}')  # second record, no trailing newline
+    records = list(read_jsonl(target))
+    assert records == [{"x": 1}, {"x": 2}]
+
+
+def test_append_jsonl_preserves_prior_records_after_partial_tail_simulation(
+    tmp_path: Path,
+):
+    """Simulate a partial-tail crash — prior records survive."""
+    target = tmp_path / "log.jsonl"
+    append_jsonl(target, {"x": 1})
+    append_jsonl(target, {"x": 2})
+    # Simulate a crash mid-append by truncating to mid-second-record.
+    raw = target.read_bytes()
+    # Lop off the final 3 bytes — partial JSON.
+    target.write_bytes(raw[:-3])
+    # The first record is still intact.
+    parts = target.read_bytes().split(b"\n")
+    assert json.loads(parts[1]) == {"x": 1}
+
+
+# -------- utc_now_iso ------------------------------------------------
+
+
+def test_utc_now_iso_is_timezone_aware():
+    stamp = utc_now_iso()
+    # Either ``+00:00`` or trailing ``Z`` is acceptable; ``isoformat`` emits ``+00:00``.
+    assert "+00:00" in stamp or stamp.endswith("Z")
+
+
+def test_utc_now_iso_round_trips_via_fromisoformat():
+    from datetime import datetime
+
+    parsed = datetime.fromisoformat(utc_now_iso())
+    assert parsed.tzinfo is not None

--- a/tests/unit/test_storage_constraints.py
+++ b/tests/unit/test_storage_constraints.py
@@ -1,0 +1,89 @@
+"""Unit tests for ``src.tournaments.storage.constraints``.
+
+Asserts the four spec §7 fields, their defaults, and ``Literal`` validation
+for ``rematch_avoidance_scope``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage.constraints import (
+    CohortConstraints,
+    read_constraints,
+    write_constraints,
+)
+from src.tournaments.storage.scenario import ensure_scenario
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def test_defaults_match_spec_section_7():
+    constraint = CohortConstraints(cohort_age_group="u14", cohort_gender="Female")
+    assert constraint.avoid_same_club_early is True
+    assert constraint.avoid_same_coach_early is True
+    assert constraint.avoid_same_state_pool is False
+    assert constraint.rematch_avoidance_scope == "same_event"
+    assert constraint.schema_version == 1
+
+
+def test_round_trip(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    constraints = [
+        CohortConstraints(
+            cohort_age_group="u14",
+            cohort_gender="Female",
+            avoid_same_state_pool=True,
+            rematch_avoidance_scope="prior_weekend",
+        ),
+        CohortConstraints(cohort_age_group="u15", cohort_gender="Male"),
+    ]
+    write_constraints(EVENT_KEY, SCENARIO, constraints, base_dir=tmp_path)
+    loaded = read_constraints(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded == constraints
+
+
+def test_rejects_out_of_vocabulary_rematch_scope():
+    with pytest.raises(ValueError, match="rematch_avoidance_scope"):
+        CohortConstraints(
+            cohort_age_group="u14",
+            cohort_gender="Female",
+            rematch_avoidance_scope="never",  # type: ignore[arg-type]
+        )
+
+
+def test_from_dict_defaults_missing_fields():
+    constraint = CohortConstraints.from_dict({"cohort_age_group": "u14", "cohort_gender": "Female"})
+    assert constraint.avoid_same_club_early is True
+    assert constraint.rematch_avoidance_scope == "same_event"
+
+
+def test_from_dict_rejects_invalid_scope():
+    with pytest.raises(ValueError, match="rematch_avoidance_scope"):
+        CohortConstraints.from_dict(
+            {
+                "cohort_age_group": "u14",
+                "cohort_gender": "Female",
+                "rematch_avoidance_scope": "yearly",
+            }
+        )
+
+
+def test_from_dict_does_not_validate_schema_version():
+    """Schema-version validation is the read boundary's job, not ``from_dict``'s.
+
+    Pinned in symmetry with ``EventMetadata.from_dict`` /
+    ``FrozenMedians.from_dict`` so a future re-introduction of validation
+    here would break a test.
+    """
+    constraint = CohortConstraints.from_dict(
+        {
+            "schema_version": 999,
+            "cohort_age_group": "u14",
+            "cohort_gender": "Female",
+        }
+    )
+    assert constraint.schema_version == 999

--- a/tests/unit/test_storage_event_key.py
+++ b/tests/unit/test_storage_event_key.py
@@ -1,0 +1,326 @@
+"""Unit tests for ``src.tournaments.storage.event_key``.
+
+Covers the optional-season-year contract, the parse round-trip including
+the legacy ``unknown`` segment, and the four-bucket aggregation behavior
+of ``rekey_unknown_directories`` (F5 / F18).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage.event_key import (
+    derive_season_year,
+    event_key,
+    parse_event_key,
+    rekey_unknown_directories,
+    run_dir,
+    scenario_dir,
+)
+
+# -------- event_key --------------------------------------------------
+
+
+def test_event_key_with_year():
+    assert event_key("gotsport", "45224", 2026) == "gotsport__45224__2026"
+
+
+def test_event_key_legacy_unknown_form_when_year_is_none():
+    assert event_key("gotsport", "45224") == "gotsport__45224__unknown"
+    assert event_key("gotsport", "45224", None) == "gotsport__45224__unknown"
+
+
+def test_event_key_rejects_empty_provider_code():
+    with pytest.raises(ValueError, match="provider_code"):
+        event_key("", "1", 2026)
+
+
+def test_event_key_rejects_double_underscore_in_provider_code():
+    with pytest.raises(ValueError, match="provider_code"):
+        event_key("got__sport", "1", 2026)
+
+
+def test_event_key_rejects_double_underscore_in_event_id():
+    with pytest.raises(ValueError, match="provider_event_id"):
+        event_key("gotsport", "12__34", 2026)
+
+
+def test_event_key_rejects_year_below_2000():
+    with pytest.raises(ValueError, match=">= 2000"):
+        event_key("gotsport", "1", 1999)
+
+
+def test_event_key_rejects_non_int_year():
+    with pytest.raises(ValueError, match="must be int"):
+        event_key("gotsport", "1", "2026")  # type: ignore[arg-type]
+
+
+def test_event_key_rejects_bool_year():
+    """``bool`` is a subclass of ``int`` — guard against accidental True/False."""
+    with pytest.raises(ValueError, match="must be int"):
+        event_key("gotsport", "1", True)  # type: ignore[arg-type]
+
+
+# -------- parse_event_key --------------------------------------------
+
+
+def test_parse_event_key_with_year():
+    assert parse_event_key("gotsport__45224__2026") == ("gotsport", "45224", 2026)
+
+
+def test_parse_event_key_legacy_unknown():
+    assert parse_event_key("gotsport__45224__unknown") == ("gotsport", "45224", None)
+
+
+def test_parse_event_key_rejects_non_int_season():
+    with pytest.raises(ValueError, match="season segment"):
+        parse_event_key("gotsport__45224__abcd")
+
+
+def test_parse_event_key_rejects_wrong_segment_count():
+    with pytest.raises(ValueError, match="three-segment|provider__eventid__season"):
+        parse_event_key("gotsport__45224")
+
+
+def test_parse_event_key_rejects_empty_segments():
+    with pytest.raises(ValueError):
+        parse_event_key("__45224__2026")
+
+
+def test_parse_event_key_rejects_year_below_2000():
+    """The floor on the parse path mirrors ``event_key()`` — symmetric contract."""
+    with pytest.raises(ValueError, match=">= 2000"):
+        parse_event_key("gotsport__45224__1999")
+
+
+# -------- derive_season_year ----------------------------------------
+
+
+def test_derive_season_year_iso_date():
+    assert derive_season_year("2026-04-15") == 2026
+
+
+def test_derive_season_year_none_input():
+    assert derive_season_year(None) is None
+
+
+def test_derive_season_year_unparseable_string():
+    assert derive_season_year("April 15, 2026") is None
+    assert derive_season_year("") is None
+    assert derive_season_year("xxxx-04-15") is None
+
+
+def test_derive_season_year_strict_iso_only():
+    """Year-only and invalid month/day fail the strict ``YYYY-MM-DD`` parse."""
+    assert derive_season_year("2026") is None
+    assert derive_season_year("2026-99-99") is None
+    assert derive_season_year("2026-13-01") is None
+    assert derive_season_year("2026-02-30") is None
+
+
+def test_derive_season_year_below_min():
+    assert derive_season_year("1999-04-15") is None
+
+
+# -------- rekey_unknown_directories ---------------------------------
+
+
+def _seed_event_dir(base: Path, old_key: str, *, metadata: dict | None) -> Path:
+    """Create ``<base>/<old_key>/intake/`` with optional ``event_metadata.json``."""
+    event_dir = base / old_key
+    intake = event_dir / "intake"
+    intake.mkdir(parents=True, exist_ok=True)
+    if metadata is not None:
+        (intake / "event_metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return event_dir
+
+
+def test_rekey_four_bucket_aggregation(tmp_path: Path):
+    """All four ``RekeyMigrationResult`` buckets exercised in one call (F18)."""
+    # (a) Success
+    _seed_event_dir(
+        tmp_path,
+        "gotsport__1__unknown",
+        metadata={
+            "schema_version": 1,
+            "provider_code": "gotsport",
+            "provider_event_id": "1",
+            "event_start_date": "2026-04-15",
+            "event_name": "Cup A",
+            "event_slug": "events/1",
+            "scrape_ts": "2026-04-25T12:00:00Z",
+        },
+    )
+    # (b) No intake/event_metadata.json
+    (tmp_path / "gotsport__2__unknown" / "intake").mkdir(parents=True)
+    # (c) Metadata exists but event_start_date None → no derivable year
+    _seed_event_dir(
+        tmp_path,
+        "gotsport__3__unknown",
+        metadata={
+            "schema_version": 1,
+            "provider_code": "gotsport",
+            "provider_event_id": "3",
+            "event_start_date": None,
+            "event_name": "Cup C",
+            "event_slug": "events/3",
+            "scrape_ts": "2026-04-25T12:00:00Z",
+        },
+    )
+    # (d) Destination already exists
+    _seed_event_dir(
+        tmp_path,
+        "gotsport__4__unknown",
+        metadata={
+            "schema_version": 1,
+            "provider_code": "gotsport",
+            "provider_event_id": "4",
+            "event_start_date": "2026-04-15",
+            "event_name": "Cup D",
+            "event_slug": "events/4",
+            "scrape_ts": "2026-04-25T12:00:00Z",
+        },
+    )
+    (tmp_path / "gotsport__4__2026").mkdir()  # destination collision
+
+    result = rekey_unknown_directories(tmp_path)
+
+    assert result.completed == (("gotsport__1__unknown", "gotsport__1__2026"),)
+    assert result.unmigrated == ("gotsport__2__unknown",)
+    failed_keys = {key for key, _ in result.failed}
+    assert failed_keys == {"gotsport__3__unknown", "gotsport__4__unknown"}
+    failed_reasons = {key: reason for key, reason in result.failed}
+    assert failed_reasons["gotsport__3__unknown"] == "no derivable season_year"
+    assert failed_reasons["gotsport__4__unknown"] == "destination already exists"
+
+    # Filesystem effects: only (a) renamed; (b)/(c)/(d) remain in place.
+    assert not (tmp_path / "gotsport__1__unknown").exists()
+    assert (tmp_path / "gotsport__1__2026").exists()
+    assert (tmp_path / "gotsport__2__unknown").exists()
+    assert (tmp_path / "gotsport__3__unknown").exists()
+    assert (tmp_path / "gotsport__4__unknown").exists()
+
+
+def test_rekey_idempotent(tmp_path: Path):
+    """A second call finds nothing to migrate."""
+    _seed_event_dir(
+        tmp_path,
+        "gotsport__1__unknown",
+        metadata={
+            "schema_version": 1,
+            "provider_code": "gotsport",
+            "provider_event_id": "1",
+            "event_start_date": "2026-04-15",
+            "event_name": "Cup A",
+            "event_slug": "events/1",
+            "scrape_ts": "2026-04-25T12:00:00Z",
+        },
+    )
+    first = rekey_unknown_directories(tmp_path)
+    assert len(first.completed) == 1
+
+    second = rekey_unknown_directories(tmp_path)
+    assert second.completed == ()
+    assert second.failed == ()
+    assert second.unmigrated == ()
+
+
+def test_rekey_skips_non_unknown_directories(tmp_path: Path):
+    (tmp_path / "gotsport__1__2026").mkdir()
+    (tmp_path / "some_other_dir").mkdir()
+
+    result = rekey_unknown_directories(tmp_path)
+    assert result.completed == ()
+    assert result.failed == ()
+    assert result.unmigrated == ()
+
+
+def test_rekey_returns_empty_when_base_missing(tmp_path: Path):
+    result = rekey_unknown_directories(tmp_path / "does_not_exist")
+    assert result.completed == ()
+    assert result.failed == ()
+    assert result.unmigrated == ()
+
+
+def test_rekey_handles_malformed_metadata_json(tmp_path: Path):
+    """Broad-except routes malformed metadata to ``failed`` without raising mid-loop."""
+    intake = tmp_path / "gotsport__99__unknown" / "intake"
+    intake.mkdir(parents=True)
+    (intake / "event_metadata.json").write_text("{not valid json", encoding="utf-8")
+
+    result = rekey_unknown_directories(tmp_path)
+    failed_keys = {key for key, _ in result.failed}
+    assert "gotsport__99__unknown" in failed_keys
+    assert (tmp_path / "gotsport__99__unknown").exists()  # still in place
+
+
+def test_rekey_handles_newer_schema_metadata(tmp_path: Path):
+    """A v2 metadata payload routes to ``failed`` instead of driving a rekey."""
+    intake = tmp_path / "gotsport__99__unknown" / "intake"
+    intake.mkdir(parents=True)
+    (intake / "event_metadata.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "provider_code": "gotsport",
+                "provider_event_id": "99",
+                "event_start_date": "2026-04-15",
+                "event_name": "Future",
+                "event_slug": "events/99",
+                "scrape_ts": "2026-04-25T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = rekey_unknown_directories(tmp_path)
+    failed_keys = {key for key, _ in result.failed}
+    assert "gotsport__99__unknown" in failed_keys
+    # No rekey happened — the __unknown dir is still in place.
+    assert (tmp_path / "gotsport__99__unknown").exists()
+    assert not (tmp_path / "gotsport__99__2026").exists()
+
+
+# -------- path-segment validation -----------------------------------
+
+
+def test_event_key_rejects_path_traversal():
+    with pytest.raises(ValueError, match="provider_code"):
+        event_key("..", "1", 2026)
+    with pytest.raises(ValueError, match="provider_event_id"):
+        event_key("gotsport", "..", 2026)
+    with pytest.raises(ValueError, match="provider_code"):
+        event_key("a/b", "1", 2026)
+    with pytest.raises(ValueError, match="provider_code"):
+        event_key("a\\b", "1", 2026)
+
+
+def test_scenario_dir_rejects_path_traversal():
+    with pytest.raises(ValueError, match="scenario name"):
+        scenario_dir("gotsport__45224__2026", "..")
+    with pytest.raises(ValueError, match="scenario name"):
+        scenario_dir("gotsport__45224__2026", "a/b")
+    with pytest.raises(ValueError, match="scenario name"):
+        scenario_dir("gotsport__45224__2026", "a\\b")
+
+
+def test_run_dir_rejects_path_traversal():
+    with pytest.raises(ValueError, match="run_id"):
+        run_dir("gotsport__45224__2026", "default", "..")
+    with pytest.raises(ValueError, match="run_id"):
+        run_dir("gotsport__45224__2026", "default", "a/b")
+    with pytest.raises(ValueError, match="run_id"):
+        run_dir("gotsport__45224__2026", "default", "a\\b")
+
+
+def test_event_dir_rejects_pre_formed_traversal_key():
+    """Pre-formed event_key strings are gated by ``_validate_segment`` too."""
+    from src.tournaments.storage.event_key import event_dir
+
+    with pytest.raises(ValueError, match="event_key"):
+        event_dir("..")
+    with pytest.raises(ValueError, match="event_key"):
+        event_dir("a/b")

--- a/tests/unit/test_storage_event_metadata.py
+++ b/tests/unit/test_storage_event_metadata.py
@@ -1,0 +1,128 @@
+"""Unit tests for ``src.tournaments.storage.event_metadata``.
+
+Round-trips JSON, asserts ``from_dict`` tolerates missing ``season_year``,
+and verifies the schema-version mismatch raises ``SchemaVersionError``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage.event_key import intake_dir
+from src.tournaments.storage.event_metadata import (
+    EventMetadata,
+    read_event_metadata,
+    write_event_metadata,
+)
+from src.tournaments.storage.schema_version import SchemaVersionError
+
+EVENT_KEY = "gotsport__45224__2026"
+
+
+def _meta(**overrides) -> EventMetadata:
+    payload = dict(
+        provider_code="gotsport",
+        provider_event_id="45224",
+        event_name="Phoenix Cup",
+        event_slug="events/45224",
+        event_start_date="2026-04-15",
+        scrape_ts="2026-04-25T12:00:00Z",
+        season_year=2026,
+        series_id=None,
+    )
+    payload.update(overrides)
+    return EventMetadata(**payload)
+
+
+def test_round_trip(tmp_path: Path):
+    meta = _meta()
+    write_event_metadata(EVENT_KEY, meta, base_dir=tmp_path)
+    loaded = read_event_metadata(EVENT_KEY, base_dir=tmp_path)
+    assert loaded == meta
+
+
+def test_round_trip_with_optional_season_year_missing(tmp_path: Path):
+    meta = _meta(season_year=None)
+    write_event_metadata(EVENT_KEY, meta, base_dir=tmp_path)
+    loaded = read_event_metadata(EVENT_KEY, base_dir=tmp_path)
+    assert loaded.season_year is None
+
+
+def test_from_dict_tolerates_missing_season_year():
+    payload = {
+        "schema_version": 1,
+        "provider_code": "gotsport",
+        "provider_event_id": "45224",
+        "event_name": "Phoenix Cup",
+        "event_slug": "events/45224",
+        "event_start_date": "2026-04-15",
+        "scrape_ts": "2026-04-25T12:00:00Z",
+    }
+    meta = EventMetadata.from_dict(payload)
+    assert meta.season_year is None
+
+
+def test_from_dict_tolerates_missing_schema_version():
+    """Lenient on read — Shell 01-era unstamped payloads still load."""
+    payload = {
+        "provider_code": "gotsport",
+        "provider_event_id": "45224",
+        "event_name": "Phoenix Cup",
+        "event_slug": "events/45224",
+        "event_start_date": "2026-04-15",
+        "scrape_ts": "2026-04-25T12:00:00Z",
+    }
+    meta = EventMetadata.from_dict(payload)
+    assert meta.schema_version == 1
+
+
+def test_read_raises_schema_version_error_on_newer(tmp_path: Path):
+    target = intake_dir(EVENT_KEY, base_dir=tmp_path) / "event_metadata.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "provider_code": "gotsport",
+                "provider_event_id": "45224",
+                "event_name": "Phoenix Cup",
+                "event_slug": "events/45224",
+                "event_start_date": "2026-04-15",
+                "scrape_ts": "2026-04-25T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SchemaVersionError, match="schema_version=2"):
+        read_event_metadata(EVENT_KEY, base_dir=tmp_path)
+
+
+def test_to_dict_includes_schema_version():
+    meta = _meta()
+    payload = meta.to_dict()
+    assert payload["schema_version"] == 1
+    assert payload["season_year"] == 2026
+    assert payload["provider_code"] == "gotsport"
+
+
+def test_from_dict_does_not_validate_schema_version():
+    """Validation belongs at the read boundary; ``from_dict`` is a pure constructor.
+
+    Matches ``CohortConstraints.from_dict`` / ``FrozenMedians.from_dict``.
+    A future "helpful" re-introduction of validation here would silently
+    break the symmetry — pin the contract.
+    """
+    payload = {
+        "schema_version": 999,
+        "provider_code": "gotsport",
+        "provider_event_id": "45224",
+        "event_name": "Phoenix Cup",
+        "event_slug": "events/45224",
+        "event_start_date": "2026-04-15",
+        "scrape_ts": "2026-04-25T12:00:00Z",
+    }
+    meta = EventMetadata.from_dict(payload)
+    assert meta.schema_version == 999

--- a/tests/unit/test_storage_frozen_medians.py
+++ b/tests/unit/test_storage_frozen_medians.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``src.tournaments.storage.frozen_medians``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments.storage.frozen_medians import (
+    FrozenMedians,
+    compute_frozen_medians,
+    read_frozen_medians,
+    write_frozen_medians,
+)
+from src.tournaments.storage.scenario import ensure_scenario
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def test_compute_medians_per_division():
+    result = compute_frozen_medians(
+        {
+            "Premier": [10.0, 20.0, 30.0],
+            "Champions": [5.0, 15.0],
+        }
+    )
+    assert result.medians_by_division == {"Premier": 20.0, "Champions": 10.0}
+    assert result.computed_at  # ISO timestamp set
+
+
+def test_compute_skips_empty_division():
+    result = compute_frozen_medians({"Premier": [10.0], "Empty": []})
+    assert result.medians_by_division == {"Premier": 10.0}
+
+
+def test_round_trip_preserves_values(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    medians = FrozenMedians(
+        medians_by_division={"Premier": 20.5, "Champions": 12.25},
+        computed_at="2026-04-25T12:00:00+00:00",
+    )
+    write_frozen_medians(EVENT_KEY, SCENARIO, medians, base_dir=tmp_path)
+    loaded = read_frozen_medians(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded == medians
+
+
+def test_from_dict_does_not_validate_schema_version():
+    """Schema-version validation is the read boundary's job, not ``from_dict``'s.
+
+    Pinned in symmetry with ``EventMetadata.from_dict`` /
+    ``CohortConstraints.from_dict``.
+    """
+    medians = FrozenMedians.from_dict(
+        {
+            "schema_version": 999,
+            "medians_by_division": {"Premier": 10.0},
+            "computed_at": "2026-04-25T12:00:00+00:00",
+        }
+    )
+    assert medians.schema_version == 999

--- a/tests/unit/test_storage_games_import.py
+++ b/tests/unit/test_storage_games_import.py
@@ -1,0 +1,140 @@
+"""Unit tests for ``src.tournaments.storage.games_import``.
+
+Uses the in-test fake-Supabase pattern from
+``tests/unit/test_alias_writer.py:21-101``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.tournaments.storage.games_import import check_games_import_status
+
+
+class _FakeQuery:
+    def __init__(self, table: "_FakeTable"):
+        self._table = table
+        self._filters: list[tuple[str, Any]] = []
+        self._select: str | None = None
+
+    def select(self, columns: str = "*") -> "_FakeQuery":
+        self._select = columns
+        return self
+
+    def eq(self, column: str, value: Any) -> "_FakeQuery":
+        self._filters.append((column, value))
+        return self
+
+    def execute(self) -> Any:
+        matched = [row for row in self._table._rows if all(row.get(c) == v for c, v in self._filters)]
+        return _FakeExecResult(matched)
+
+
+class _FakeExecResult:
+    def __init__(self, data: list[dict]):
+        self.data = data
+
+
+class _FakeTable:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def select(self, columns: str = "*") -> _FakeQuery:
+        return _FakeQuery(self).select(columns)
+
+
+class _FakeSupabase:
+    def __init__(self, games: list[dict[str, Any]]):
+        self._games = _FakeTable(games)
+
+    def table(self, name: str) -> _FakeTable:
+        assert name == "games"
+        return self._games
+
+
+def test_zero_rows_is_not_imported():
+    supabase = _FakeSupabase(games=[])
+    status = check_games_import_status(
+        "Phoenix Cup",
+        ["m1", "m2"],
+        supabase_client=supabase,
+    )
+    assert status == "not_imported"
+
+
+def test_full_team_coverage_is_complete():
+    games = [
+        {
+            "event_name": "Phoenix Cup",
+            "is_excluded": False,
+            "home_team_master_id": "m1",
+            "away_team_master_id": "m2",
+        },
+        {
+            "event_name": "Phoenix Cup",
+            "is_excluded": False,
+            "home_team_master_id": "m2",
+            "away_team_master_id": "m3",
+        },
+    ]
+    supabase = _FakeSupabase(games=games)
+    status = check_games_import_status(
+        "Phoenix Cup",
+        ["m1", "m2", "m3"],
+        supabase_client=supabase,
+    )
+    assert status == "complete"
+
+
+def test_partial_coverage_is_partial():
+    games = [
+        {
+            "event_name": "Phoenix Cup",
+            "is_excluded": False,
+            "home_team_master_id": "m1",
+            "away_team_master_id": "m2",
+        },
+    ]
+    supabase = _FakeSupabase(games=games)
+    status = check_games_import_status(
+        "Phoenix Cup",
+        ["m1", "m2", "m3"],
+        supabase_client=supabase,
+    )
+    assert status == "partial"
+
+
+def test_excluded_games_filtered_out():
+    games = [
+        {
+            "event_name": "Phoenix Cup",
+            "is_excluded": True,  # filtered
+            "home_team_master_id": "m1",
+            "away_team_master_id": "m2",
+        },
+    ]
+    supabase = _FakeSupabase(games=games)
+    status = check_games_import_status(
+        "Phoenix Cup",
+        ["m1", "m2"],
+        supabase_client=supabase,
+    )
+    assert status == "not_imported"
+
+
+def test_other_event_games_filtered_out():
+    games = [
+        {
+            "event_name": "Other Event",
+            "is_excluded": False,
+            "home_team_master_id": "m1",
+            "away_team_master_id": "m2",
+        },
+    ]
+    supabase = _FakeSupabase(games=games)
+    status = check_games_import_status(
+        "Phoenix Cup",
+        ["m1"],
+        supabase_client=supabase,
+    )
+    assert status == "not_imported"

--- a/tests/unit/test_storage_overrides.py
+++ b/tests/unit/test_storage_overrides.py
@@ -1,0 +1,54 @@
+"""Unit tests for ``src.tournaments.storage.overrides``.
+
+Append-only contract: 3 appends produce 3 records, insertion order is
+preserved, and every record carries ``schema_version: 1``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments.storage.overrides import append_override, load_overrides
+from src.tournaments.storage.scenario import ensure_scenario
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def test_append_three_records_preserves_order(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    for index in range(3):
+        append_override(
+            EVENT_KEY,
+            SCENARIO,
+            {"provider_team_id": f"t{index}", "ts": f"2026-04-25T12:0{index}:00Z"},
+            base_dir=tmp_path,
+        )
+    records = load_overrides(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert len(records) == 3
+    assert [r["provider_team_id"] for r in records] == ["t0", "t1", "t2"]
+
+
+def test_every_record_stamped_schema_version_one(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    append_override(EVENT_KEY, SCENARIO, {"provider_team_id": "t1"}, base_dir=tmp_path)
+    records = load_overrides(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert records[0]["schema_version"] == 1
+
+
+def test_load_returns_empty_when_no_overrides(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert load_overrides(EVENT_KEY, SCENARIO, base_dir=tmp_path) == []
+
+
+def test_user_supplied_schema_version_is_overridden_by_stamp(tmp_path: Path):
+    """Strict-on-write: callers can't slip in a stale stamp."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {"provider_team_id": "t1", "schema_version": 0},
+        base_dir=tmp_path,
+    )
+    records = load_overrides(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert records[0]["schema_version"] == 1

--- a/tests/unit/test_storage_raw_scrape.py
+++ b/tests/unit/test_storage_raw_scrape.py
@@ -1,0 +1,53 @@
+"""Unit tests for ``src.tournaments.storage.raw_scrape``.
+
+The module is mostly a re-export shim for ``src.scrapers.intake_journal``;
+the only added surface is ``load_raw_scrape``. Tests lock down the missing
+journal branch and the latest-run-wins ordering contract that Streamlit
+triage UIs rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.scrapers.intake_journal import IntakeJournal
+from src.tournaments.storage.raw_scrape import load_raw_scrape
+
+EVENT_KEY = "gotsport__45224__2026"
+
+
+def test_load_raw_scrape_missing_journal_returns_empty(tmp_path: Path):
+    assert load_raw_scrape(EVENT_KEY, base_dir=tmp_path) == []
+
+
+def test_load_raw_scrape_returns_latest_run_per_pid(tmp_path: Path):
+    """Latest-run-wins ordering — second record for the same pid replaces the first."""
+    journal = IntakeJournal(event_key=EVENT_KEY, base_dir=tmp_path)
+    with journal:
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:00:00+00:00",
+                "provider_team_id": "t1",
+                "alias_writer_action": "created",
+            }
+        )
+        journal.append(
+            {
+                "run_id": "2026-04-24T11:00:00+00:00",
+                "provider_team_id": "t1",
+                "alias_writer_action": "updated",
+            }
+        )
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:30:00+00:00",
+                "provider_team_id": "t2",
+                "alias_writer_action": "queued",
+            }
+        )
+
+    records = load_raw_scrape(EVENT_KEY, base_dir=tmp_path)
+    by_pid = {r["provider_team_id"]: r for r in records}
+    assert set(by_pid) == {"t1", "t2"}
+    assert by_pid["t1"]["alias_writer_action"] == "updated"
+    assert by_pid["t2"]["alias_writer_action"] == "queued"

--- a/tests/unit/test_storage_registry.py
+++ b/tests/unit/test_storage_registry.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``src.tournaments.storage.registry``.
+
+Asserts FIELDNAMES match the authoritative CLI column set at
+``scripts/backtest_tournament_event.py:145-153, 167-217``, that the CSV
+round-trips losslessly, and that the sibling ``event_team_registry.schema.json``
+is written + validated on read.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.registry import (
+    FIELDNAMES,
+    TeamRegistryEntry,
+    read_registry,
+    write_registry,
+)
+from src.tournaments.storage.scenario import ensure_scenario
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def test_fieldnames_cover_cli_input_set():
+    """F1: column set is locked to the CLI consumer."""
+    required_input = {
+        "event_team_name",
+        "event_age_group",
+        "display_age_group",
+        "event_gender",
+        "display_gender",
+        "event_club_name",
+        "search_age_group",
+        "resolved_gotsport_provider_team_id",
+        "canonical_resolution_status",
+        "in_scope_u10_u19",
+        "resolved_team_id_master",
+        "resolved_team_name",
+        "resolved_club_name",
+        "event_registration_id",
+    }
+    missing = required_input - set(FIELDNAMES)
+    assert missing == set(), f"missing required CLI input columns: {missing}"
+
+
+def test_fieldnames_cover_matcher_output_set():
+    required_matcher = {
+        "matcher_status",
+        "matcher_best_score",
+        "matcher_second_score",
+        "matcher_score_gap",
+        "matcher_resolved_team_id_master",
+        "matcher_resolved_team_name",
+        "matcher_resolved_club_name",
+        "matcher_resolved_provider_team_id",
+    }
+    missing = required_matcher - set(FIELDNAMES)
+    assert missing == set(), f"missing matcher-output columns: {missing}"
+
+
+def test_round_trip_stable_across_cycles(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    entries = [
+        TeamRegistryEntry(
+            event_registration_id="reg-1",
+            event_team_name="Team A",
+            event_age_group="u14",
+            event_gender="Female",
+            in_scope_u10_u19="True",
+            resolved_team_id_master="master-1",
+            matcher_status="strict_exact",
+            matcher_best_score="0.97",
+        ),
+        TeamRegistryEntry(
+            event_registration_id="reg-2",
+            event_team_name="Team B",
+            event_age_group="u15",
+            in_scope_u10_u19="False",
+        ),
+    ]
+    for _ in range(2):
+        write_registry(EVENT_KEY, SCENARIO, entries, base_dir=tmp_path)
+        loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+        assert loaded == entries
+
+
+def test_sibling_schema_json_written_and_validated(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    write_registry(EVENT_KEY, SCENARIO, [], base_dir=tmp_path)
+    schema_path = scenario_dir(EVENT_KEY, SCENARIO, base_dir=tmp_path) / "event_team_registry.schema.json"
+    assert schema_path.exists()
+    sidecar = json.loads(schema_path.read_text(encoding="utf-8"))
+    assert sidecar["schema_version"] == 1
+    assert tuple(sidecar["fieldnames"]) == FIELDNAMES
+
+
+def test_matcher_output_columns_default_to_empty(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    entry = TeamRegistryEntry(event_registration_id="reg-1")
+    write_registry(EVENT_KEY, SCENARIO, [entry], base_dir=tmp_path)
+    loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded[0].matcher_status == ""
+    assert loaded[0].matcher_best_score == ""
+
+
+def test_fieldnames_drift_logs_warning_not_raises(tmp_path: Path, caplog):
+    """F22: forward-compat — drift warns but read succeeds."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    entry = TeamRegistryEntry(event_registration_id="reg-1", event_team_name="Team A")
+    write_registry(EVENT_KEY, SCENARIO, [entry], base_dir=tmp_path)
+
+    schema_path = scenario_dir(EVENT_KEY, SCENARIO, base_dir=tmp_path) / "event_team_registry.schema.json"
+    schema_path.write_text(
+        json.dumps({"schema_version": 1, "fieldnames": ["event_team_name"]}),
+        encoding="utf-8",
+    )
+    with caplog.at_level("WARNING"):
+        loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded[0].event_team_name == "Team A"
+    assert any("FIELDNAMES drift" in record.message for record in caplog.records)

--- a/tests/unit/test_storage_rescrape.py
+++ b/tests/unit/test_storage_rescrape.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``src.tournaments.storage.rescrape.merge_rescrape``."""
+
+from __future__ import annotations
+
+from src.tournaments.storage.rescrape import merge_rescrape
+
+
+def _row(pid: str) -> dict:
+    return {"provider_team_id": pid}
+
+
+def _override(pid: str) -> dict:
+    return {"provider_team_id": pid, "kind": "manual_age_group"}
+
+
+def test_team_added():
+    report = merge_rescrape(
+        old_raw=[_row("t1")],
+        new_raw=[_row("t1"), _row("t2")],
+        overrides=[],
+    )
+    assert report.teams_added == ("t2",)
+
+
+def test_team_removed_with_override():
+    report = merge_rescrape(
+        old_raw=[_row("t1"), _row("t2")],
+        new_raw=[_row("t1")],
+        overrides=[_override("t2")],
+    )
+    assert report.teams_removed_but_overridden == ("t2",)
+
+
+def test_team_with_preserved_override():
+    report = merge_rescrape(
+        old_raw=[_row("t1")],
+        new_raw=[_row("t1")],
+        overrides=[_override("t1")],
+    )
+    assert report.teams_with_preserved_overrides == ("t1",)
+
+
+def test_orphan_override_in_no_bucket():
+    """An override for a pid never present in old or new is not surfaced."""
+    report = merge_rescrape(
+        old_raw=[_row("t1")],
+        new_raw=[_row("t1")],
+        overrides=[_override("ghost")],
+    )
+    assert report.teams_added == ()
+    assert report.teams_removed_but_overridden == ()
+    assert report.teams_with_preserved_overrides == ()
+
+
+def test_team_removed_without_override_not_surfaced():
+    report = merge_rescrape(
+        old_raw=[_row("t1"), _row("t2")],
+        new_raw=[_row("t1")],
+        overrides=[],
+    )
+    assert report.teams_removed_but_overridden == ()
+
+
+def test_combined_scenario():
+    """Mixed bucket exercise: added + removed-overridden + preserved + orphan."""
+    report = merge_rescrape(
+        old_raw=[_row("t1"), _row("t2"), _row("t3")],
+        new_raw=[_row("t1"), _row("t2"), _row("t4")],
+        overrides=[_override("t1"), _override("t3"), _override("ghost")],
+    )
+    assert report.teams_added == ("t4",)
+    assert report.teams_removed_but_overridden == ("t3",)
+    assert report.teams_with_preserved_overrides == ("t1",)

--- a/tests/unit/test_storage_run_layout.py
+++ b/tests/unit/test_storage_run_layout.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``src.tournaments.storage.run_layout``.
+
+Covers the full run state machine: stage → promote/fail/cancel, the F3
+stale-destination guard on promote, and ``list_runs(completed_only=True)``
+filtering.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.run_layout import (
+    RunStateError,
+    cancel_run,
+    create_staging_run,
+    fail_run,
+    list_runs,
+    promote_run,
+)
+from src.tournaments.storage.scenario import ensure_scenario
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def _runs_root(base: Path) -> Path:
+    return scenario_dir(EVENT_KEY, SCENARIO, base_dir=base) / "runs"
+
+
+def test_create_staging_run_creates_tmp(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    staging = create_staging_run(EVENT_KEY, SCENARIO, "run_001", base_dir=tmp_path)
+    assert staging.exists()
+    assert staging.name == "run_001.tmp"
+
+
+def test_create_staging_rejects_existing_tmp(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, "run_001", base_dir=tmp_path)
+    with pytest.raises(RunStateError, match="already exists"):
+        create_staging_run(EVENT_KEY, SCENARIO, "run_001", base_dir=tmp_path)
+
+
+def test_promote_writes_done_then_renames(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, "run_001", base_dir=tmp_path)
+
+    final_dir = promote_run(EVENT_KEY, SCENARIO, "run_001", base_dir=tmp_path)
+    assert final_dir.name == "run_001"
+    assert final_dir.exists()
+    assert not (_runs_root(tmp_path) / "run_001.tmp").exists()
+    done_payload = json.loads((final_dir / "done.json").read_text(encoding="utf-8"))
+    assert done_payload["run_id"] == "run_001"
+    assert done_payload["schema_version"] == 1
+    assert "promoted_at" in done_payload
+
+
+def test_fail_writes_error_and_renames(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, "run_002", base_dir=tmp_path)
+
+    failed_dir = fail_run(EVENT_KEY, SCENARIO, "run_002", "subprocess died", base_dir=tmp_path)
+    assert failed_dir.name == "run_002.failed"
+    assert failed_dir.exists()
+    error_payload = json.loads((failed_dir / "error.json").read_text(encoding="utf-8"))
+    assert error_payload["error"] == "subprocess died"
+    assert error_payload["schema_version"] == 1
+
+
+def test_cancel_writes_cancelled_and_renames(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, "run_003", base_dir=tmp_path)
+
+    cancelled_dir = cancel_run(EVENT_KEY, SCENARIO, "run_003", base_dir=tmp_path)
+    assert cancelled_dir.name == "run_003.cancelled"
+    payload = json.loads((cancelled_dir / "cancelled.json").read_text(encoding="utf-8"))
+    assert payload["run_id"] == "run_003"
+    assert payload["schema_version"] == 1
+
+
+def test_promote_missing_staging_raises(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    with pytest.raises(RunStateError, match="staging dir missing"):
+        promote_run(EVENT_KEY, SCENARIO, "ghost_run", base_dir=tmp_path)
+
+
+def test_promote_stale_destination_raises_before_writes(tmp_path: Path):
+    """F3: pre-existing ``runs/<run_id>/`` blocks promote BEFORE any write."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    staging = create_staging_run(EVENT_KEY, SCENARIO, "run_004", base_dir=tmp_path)
+    # Pre-create a stub final dir with content.
+    final_dir = _runs_root(tmp_path) / "run_004"
+    final_dir.mkdir()
+    (final_dir / "stale.txt").write_text("stale")
+
+    with pytest.raises(RunStateError, match="already exists"):
+        promote_run(EVENT_KEY, SCENARIO, "run_004", base_dir=tmp_path)
+
+    # Staging untouched, no done.json written.
+    assert staging.exists()
+    assert not (staging / "done.json").exists()
+    # Stale content untouched.
+    assert (final_dir / "stale.txt").read_text() == "stale"
+
+
+def test_list_runs_completed_only_filters(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, "run_a", base_dir=tmp_path)
+    promote_run(EVENT_KEY, SCENARIO, "run_a", base_dir=tmp_path)
+
+    create_staging_run(EVENT_KEY, SCENARIO, "run_b", base_dir=tmp_path)
+    fail_run(EVENT_KEY, SCENARIO, "run_b", "boom", base_dir=tmp_path)
+
+    create_staging_run(EVENT_KEY, SCENARIO, "run_c", base_dir=tmp_path)
+    cancel_run(EVENT_KEY, SCENARIO, "run_c", base_dir=tmp_path)
+
+    create_staging_run(EVENT_KEY, SCENARIO, "run_d", base_dir=tmp_path)  # left .tmp/
+
+    completed = list_runs(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert completed == ["run_a"]
+
+    everything = list_runs(EVENT_KEY, SCENARIO, completed_only=False, base_dir=tmp_path)
+    assert sorted(everything) == [
+        "run_a",
+        "run_b.failed",
+        "run_c.cancelled",
+        "run_d.tmp",
+    ]
+
+
+def test_list_runs_empty_when_no_runs_dir(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert list_runs(EVENT_KEY, SCENARIO, base_dir=tmp_path) == []

--- a/tests/unit/test_storage_scenario.py
+++ b/tests/unit/test_storage_scenario.py
@@ -1,0 +1,106 @@
+"""Unit tests for ``src.tournaments.storage.scenario``.
+
+Covers branch ``intake/`` exclusion, ``ScenarioExistsError`` on duplicate
+dst, ``src == dst`` rejection, and the per-scenario advisory lock
+acquire / release semantics (F12 / F16 / F19).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.storage.event_key import scenario_dir, scenarios_dir
+from src.tournaments.storage.scenario import (
+    ScenarioExistsError,
+    ScenarioLockError,
+    acquire_scenario_lock,
+    branch_scenario,
+    ensure_scenario,
+    list_scenarios,
+)
+
+EVENT_KEY = "gotsport__45224__2026"
+
+
+def test_ensure_scenario_creates_directory(tmp_path: Path):
+    path = ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    assert path.exists()
+    assert path == scenario_dir(EVENT_KEY, "default", base_dir=tmp_path)
+
+
+def test_ensure_scenario_idempotent(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+
+
+def test_branch_scenario_excludes_intake(tmp_path: Path):
+    src_path = ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    # Stray intake at the scenario tier — branch must NOT clone it.
+    (src_path / "intake").mkdir()
+    (src_path / "intake" / "should_not_exist_in_branch.txt").write_text("x")
+    (src_path / "overrides.jsonl").write_text("\n{}\n")
+
+    dst_path = branch_scenario(EVENT_KEY, "default", "experiment", base_dir=tmp_path)
+    assert dst_path.exists()
+    assert (dst_path / "overrides.jsonl").exists()
+    assert not (dst_path / "intake").exists()
+
+
+def test_branch_scenario_existing_dst_raises(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    ensure_scenario(EVENT_KEY, "experiment", base_dir=tmp_path)
+    with pytest.raises(ScenarioExistsError):
+        branch_scenario(EVENT_KEY, "default", "experiment", base_dir=tmp_path)
+
+
+def test_branch_scenario_same_name_raises(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    with pytest.raises(ValueError, match="must differ"):
+        branch_scenario(EVENT_KEY, "default", "default", base_dir=tmp_path)
+
+
+def test_list_scenarios_returns_sorted_names(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "zeta", base_dir=tmp_path)
+    ensure_scenario(EVENT_KEY, "alpha", base_dir=tmp_path)
+    assert list_scenarios(EVENT_KEY, base_dir=tmp_path) == ["alpha", "zeta"]
+
+
+def test_list_scenarios_empty_when_no_dir(tmp_path: Path):
+    assert list_scenarios(EVENT_KEY, base_dir=tmp_path) == []
+
+
+def test_acquire_lock_holds_within_context(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path):
+        # Lockfile exists for the duration of the context.
+        lock_path = scenarios_dir(EVENT_KEY, base_dir=tmp_path) / "default" / ".run.lock"
+        assert lock_path.exists()
+
+
+def test_double_acquire_raises_immediately_with_zero_timeout(tmp_path: Path):
+    """F16: ``timeout=0.0`` is once-and-raise."""
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path):
+        with pytest.raises(ScenarioLockError):
+            with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path, timeout=0.0):
+                pytest.fail("inner acquire should have raised")
+
+
+def test_release_then_reacquire(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path):
+        pass
+    # After context exit, a fresh acquire enters cleanly.
+    with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path):
+        pass
+
+
+def test_lockfile_persists_after_release(tmp_path: Path):
+    """F19 / spec §9 line 320: lockfile is presence/lock primitive — not deleted."""
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    with acquire_scenario_lock(EVENT_KEY, "default", base_dir=tmp_path):
+        pass
+    lock_path = scenarios_dir(EVENT_KEY, base_dir=tmp_path) / "default" / ".run.lock"
+    assert lock_path.exists()

--- a/tests/unit/test_storage_schema_version.py
+++ b/tests/unit/test_storage_schema_version.py
@@ -1,0 +1,71 @@
+"""Unit tests for ``src.tournaments.storage.schema_version``.
+
+Covers the v1 contract: lenient on read (missing field treated as v1),
+strict on write (every payload routed through ``stamp_schema_version``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tournaments.storage.schema_version import (
+    SCHEMA_VERSION,
+    SchemaVersionError,
+    assert_supported_version,
+    stamp_schema_version,
+)
+
+
+def test_schema_version_constant_is_one():
+    assert SCHEMA_VERSION == 1
+
+
+def test_assert_supported_version_accepts_v1():
+    assert_supported_version({"schema_version": 1, "x": 1}, source="test")
+
+
+def test_assert_supported_version_lenient_on_missing_field():
+    """Missing ``schema_version`` is treated as v1 — Shell 01 records survive."""
+    assert_supported_version({"x": 1}, source="test")
+
+
+def test_assert_supported_version_raises_on_newer():
+    with pytest.raises(SchemaVersionError, match="schema_version=2"):
+        assert_supported_version({"schema_version": 2}, source="event_metadata.json")
+
+
+def test_assert_supported_version_coerces_string_int():
+    """Hand-edited JSON that stamps ``"1"`` instead of ``1`` still passes."""
+    assert_supported_version({"schema_version": "1"}, source="test")
+
+
+def test_assert_supported_version_typed_error_on_garbage():
+    """Non-int / non-numeric values raise ``SchemaVersionError`` (not raw ``TypeError``)
+    so callers like ``rekey_unknown_directories`` can catch the typed exception."""
+    with pytest.raises(SchemaVersionError, match="malformed"):
+        assert_supported_version({"schema_version": None}, source="test")
+    with pytest.raises(SchemaVersionError, match="malformed"):
+        assert_supported_version({"schema_version": "abc"}, source="test")
+
+
+def test_stamp_schema_version_adds_field_when_absent():
+    stamped = stamp_schema_version({"x": 1})
+    assert stamped["schema_version"] == 1
+    assert stamped["x"] == 1
+
+
+def test_stamp_schema_version_overrides_existing():
+    stamped = stamp_schema_version({"schema_version": 0, "x": 1})
+    assert stamped["schema_version"] == 1
+
+
+def test_stamp_schema_version_does_not_mutate_input():
+    payload = {"x": 1}
+    stamped = stamp_schema_version(payload)
+    assert "schema_version" not in payload
+    assert stamped is not payload
+
+
+def test_stamp_schema_version_custom_version():
+    stamped = stamp_schema_version({"x": 1}, version=2)
+    assert stamped["schema_version"] == 2

--- a/tests/unit/test_storage_structure.py
+++ b/tests/unit/test_storage_structure.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``src.tournaments.storage.structure``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments.seeding_optimizer import DivisionSpec
+from src.tournaments.storage.scenario import ensure_scenario
+from src.tournaments.storage.structure import (
+    CohortStructure,
+    DivisionStructure,
+    read_structure,
+    write_structure,
+)
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def test_to_division_spec_field_match():
+    division = DivisionStructure(
+        name="Premier",
+        team_count=8,
+        pool_sizes=(4, 4),
+        advancement="cross_semis_final",
+    )
+    spec = division.to_division_spec()
+    assert isinstance(spec, DivisionSpec)
+    assert spec.name == "Premier"
+    assert spec.team_count == 8
+    assert spec.pool_sizes == (4, 4)
+    assert spec.advancement == "cross_semis_final"
+
+
+def test_pool_sizes_round_trip(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    cohorts = [
+        CohortStructure(
+            age_group="u14",
+            gender="Female",
+            divisions=(
+                DivisionStructure(
+                    name="Premier",
+                    team_count=12,
+                    pool_sizes=(4, 4, 4),
+                ),
+                DivisionStructure(
+                    name="Champions",
+                    team_count=8,
+                ),
+            ),
+        ),
+    ]
+    write_structure(EVENT_KEY, SCENARIO, cohorts, base_dir=tmp_path)
+    loaded = read_structure(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded == cohorts
+    # Empty tuple round-trips as empty string in CSV
+    assert loaded[0].divisions[1].pool_sizes == ()
+
+
+def test_advancement_none_round_trip(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    cohorts = [
+        CohortStructure(
+            age_group="u15",
+            gender="Male",
+            divisions=(DivisionStructure(name="A", team_count=4, pool_sizes=(4,)),),
+        ),
+    ]
+    write_structure(EVENT_KEY, SCENARIO, cohorts, base_dir=tmp_path)
+    loaded = read_structure(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded[0].divisions[0].advancement is None
+
+
+def test_grouping_by_cohort(tmp_path: Path):
+    """Multiple divisions per cohort group correctly on read."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    cohorts = [
+        CohortStructure(
+            age_group="u14",
+            gender="Female",
+            divisions=(
+                DivisionStructure(name="Premier", team_count=4),
+                DivisionStructure(name="Champions", team_count=4),
+            ),
+        ),
+        CohortStructure(
+            age_group="u15",
+            gender="Male",
+            divisions=(DivisionStructure(name="Premier", team_count=8),),
+        ),
+    ]
+    write_structure(EVENT_KEY, SCENARIO, cohorts, base_dir=tmp_path)
+    loaded = read_structure(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert len(loaded) == 2
+    assert len(loaded[0].divisions) == 2
+    assert len(loaded[1].divisions) == 1


### PR DESCRIPTION
## Summary

Shell 02 of 8 in the MatchBalance backtest intake build. Lands a pure-Python storage library at `src/tournaments/storage/` that owns every file I/O, schema-version, and scenario-locking primitive the Streamlit triage UI (Shell 03+) and the existing `backtest_tournament_event.py` CLI consume. No UI, no Supabase ownership in this PR.

## Scope

- **Event identity**: `(provider_code, provider_event_id, season_year)` keyed paths under `reports/<event_key>/`. Optional `season_year` keeps Shell 01 callers byte-equivalent through a legacy `__unknown` segment plus a one-shot non-destructive rekey migration.
- **Two-tier layout**: `intake/` (immutable, scenario-shared) + `scenarios/<name>/` (overlays). Branching copies the scenario dir but excludes `intake/`.
- **Per-scenario advisory lock** (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) at `scenarios/<name>/.run.lock` so two run subprocesses cannot race the same scenario. Strict no-IO contract on the lockfile body.
- **Run state machine**: staging `runs/<run_id>.tmp/` then atomic directory rename to `runs/<run_id>/`, `.failed/`, or `.cancelled/`. Marker JSON (`done.json` / `error.json` / `cancelled.json`) is written via atomic `<path>.tmp` + `os.replace` + `fsync` BEFORE the directory rename, so a power loss between marker write and directory rename leaves the marker durable.
- **Schema versioning**: lenient on read (missing field treated as v1), strict on write (every payload routed through `stamp_schema_version`). `assert_supported_version` coerces malformed types into typed `SchemaVersionError` so callers can rely on the exception in their except clauses.
- **Path-segment validation**: `_validate_segment` rejects empty, `.`, `..`, `/`, backslash, NUL on every path constructor (`event_key`, `event_dir`, `scenario_dir`, `run_dir`).

`EventMetadata` moves from `src/scrapers/provider.py` into `src/tournaments/storage/event_metadata.py` and is re-exported from the original location for back-compat. `provider.py`'s `_derive_event_key` and `_intake_path` become thin shims over the new helpers.

## State machine

```mermaid
stateDiagram-v2
  [*] --> Pending
  Pending --> Running: create_staging_run
  Running --> Completed: promote_run writes done.json then atomic rename
  Running --> Failed: fail_run writes error.json then rename to .failed
  Running --> Cancelled: cancel_run writes cancelled.json then rename to .cancelled
  Completed --> [*]
  Failed --> [*]
  Cancelled --> [*]
```

Only `runs/<run_id>/` directories with a `done.json` inside count as completed. Failed and cancelled runs are kept for diagnosis but excluded from the latest-run dropdown.

## Test plan

- [x] 122 storage unit tests (`tests/unit/test_storage_*.py`) pass
- [x] Shell 01 regression suite (`test_intake_journal`, `test_alias_writer`, `test_event_team_matcher`, `test_scrapers_http`) passes
- [x] Plan-defined integration boundary smokes (back-compat, FIELDNAMES match CLI consumer, rekey safe on existing `reports/` dirs)
- [x] Internal smoke checks (imports, `event_key` shapes, `EventMetadata.__module__`, `DivisionStructure.to_division_spec`)
- [x] Path-segment validation rejects `..`, `/`, backslash at every constructor
- [x] Strict `date.fromisoformat` rejects partial dates (`"2026"`, `"2026-99-99"`)
- [x] `assert_supported_version` coerces `"1"`, raises typed `SchemaVersionError` on `None` / `"abc"`
- [x] Two rounds of `/polish-code` (8 + 5 review findings applied)

## Notes

The `backtest_tournament_event.py` / `backtest_tournament_cohort.py` `_write_json` / `_write_csv` duplicates remain in place. Shell 06 (run orchestration) naturally swaps them when the CLI integration lands. CSV+sidecar reader/writer extraction for `registry.py` + `structure.py` is captured in `.turbo/improvements.md` for the rule-of-three trigger.

Generated with [Claude Code](https://claude.com/claude-code)
