### PR TITLE
fix(ci): add beautifulsoup4 to process-missing-games workflow

### DIFF
--- a/.github/workflows/process-missing-games.yml
+++ b/.github/workflows/process-missing-games.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Install core dependencies
-          pip install supabase python-dotenv pandas requests rich certifi numpy
+          pip install supabase python-dotenv pandas requests rich certifi numpy beautifulsoup4
       
       - name: Process missing games
         env:


### PR DESCRIPTION
## Summary
- Hourly **Process Missing Games** workflow has failed 11 consecutive runs since 2026-04-26T01:44Z with `ModuleNotFoundError: No module named 'bs4'`.
- Shell 01 (commit 66bedf7eb) added `from bs4 import BeautifulSoup` to `src/scrapers/gotsport.py`, which is imported at module load by `scripts/process_missing_games.py:32`.
- The workflow uses an inline pip list (not `requirements.txt`) — adding `beautifulsoup4` to that list unblocks the cron.

Verified the rest of the transitive import chain (gotsport → alias_writer → config.settings → rankings.constants → glicko_config) brings in no other third-party deps beyond what's already installed.

## Test plan
- [ ] Merge, then watch the next scheduled hourly run (cron `0 * * * *`) go green
- [ ] Or trigger manually via Actions → Process Missing Games → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)