### PR TITLE
Shell 04: MatchBalance triage UI (projection contract, readiness gate, four-state classifier)

### DIFF
--- a/src/tournaments/division_render.py
+++ b/src/tournaments/division_render.py
@@ -1,0 +1,28 @@
+"""Shell 04 ↔ Shell 05 division-container rendering contract.
+
+Shell 04 (triage UI) calls ``render_division_container`` for each division
+inside a cohort to draw the division card + invoke the per-division body.
+Shell 05 (structure input forms) replaces the stub with the real
+implementation — until then, the stub raises ``NotImplementedError`` and
+the triage UI catches it to render an "enter structure first" hint.
+
+Both shells agree on this signature today so Shell 04 can ship before
+Shell 05 lands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = ["render_division_container"]
+
+
+def render_division_container(division_name: str, body: Callable[[], None]) -> None:
+    """Render a single division card with its body.
+
+    Stub implementation — Shell 05 ships the real surface (a Streamlit
+    container + structure-input header above the body). Until then, Shell
+    04 catches the ``NotImplementedError`` once per cohort and surfaces a
+    placeholder.
+    """
+    raise NotImplementedError("Shell 05 owns the division container surface.")

--- a/src/tournaments/triage.py
+++ b/src/tournaments/triage.py
@@ -1,0 +1,560 @@
+"""Per-team triage projection + readiness predicate.
+
+Single source of truth for the four-state team classification model
+(``resolved`` / ``candidates`` / ``placeholder`` / ``external``) plus the
+``unknown`` blocker state. The projection collapses an append-only
+``overrides.jsonl`` ledger into the latest per-team / per-cohort state.
+
+Three shells consume this module:
+
+- Shell 04 (triage UI) — renders rows tinted by ``_classify_team_state``,
+  writes overrides via ``build_override_record`` + ``append_override``.
+- Shell 06 (run gate) — calls ``is_ready`` to refuse a run when any team is
+  not resolved or any cohort lacks structure / games-coverage.
+- Shell 07 (Report Card) — re-uses ``project_overrides`` so the post-run
+  metrics see the same per-team state the operator triaged.
+
+Pure-Python — no Streamlit, no Supabase imports. The caller injects a
+Supabase client into ``is_ready`` when the placeholder + games-coverage
+checks need DB access.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from src.tournaments.storage import (
+    SchemaVersionError,
+    check_games_import_status,
+    load_overrides,
+    load_raw_scrape,
+    read_event_metadata,
+    read_registry,
+    read_structure,
+)
+
+# Sanity-gate format for ``actor`` emails. Not RFC 5322 — just enough to
+# refuse "x" / "asdf" / "   " from contaminating the audit ledger.
+_ACTOR_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ProjectedCohortState",
+    "ProjectedTeamState",
+    "ReadinessResult",
+    "TeamState",
+    "_OVERRIDE_TYPES",
+    "_STRENGTH_MODES",
+    "_classify_team_state",
+    "_is_placeholder_team",
+    "_is_play_up",
+    "build_override_record",
+    "is_ready",
+    "project_overrides",
+]
+
+
+_OVERRIDE_TYPES: tuple[str, ...] = (
+    "accept_match",
+    "fix_match",
+    "mark_external",
+    "edit_external",
+    "manual_add",
+    "recompute_medians",
+)
+"""Closed set of override ``type`` values. Pinned by tests so a future
+refactor can't quietly add a new one without updating the projection
+table.
+"""
+
+_STRENGTH_MODES: tuple[str, ...] = ("median", "manual", "exclude")
+"""Strength-mode vocabulary for external teams. ``exclude`` semantics for
+the Report Card are deferred to Shell 07 — this shell only persists the
+value.
+"""
+
+_TEAM_SCOPED_TYPES: frozenset[str] = frozenset(
+    {"accept_match", "fix_match", "mark_external", "edit_external", "manual_add"}
+)
+_COHORT_SCOPED_TYPES: frozenset[str] = frozenset({"recompute_medians"})
+
+
+TeamState = Literal["resolved", "candidates", "placeholder", "external", "unknown"]
+
+
+@dataclass(frozen=True)
+class ProjectedTeamState:
+    """Latest projected per-team override state.
+
+    ``last_override_ts`` is the ``ts`` of the record that produced this
+    projection — useful for audit and debounce, never reads the prior
+    projection's ts.
+    """
+
+    state: TeamState
+    team_id_master: str | None = None
+    manual_seed_group: str | None = None
+    strength_mode: str | None = None
+    manual_power_score: float | None = None
+    note: str | None = None
+    last_override_ts: str | None = None
+    # ``cohort_age_group`` + ``cohort_gender`` are populated for ``manual_add``
+    # overrides only. The registry CSV doesn't carry manual-add rows, so
+    # these fields are how ``is_ready`` discovers them. Other override types
+    # leave them ``None`` — the cohort comes from the registry entry instead.
+    cohort_age_group: str | None = None
+    cohort_gender: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectedCohortState:
+    """Latest projected per-cohort override state (medians only for v1)."""
+
+    medians_by_division: Mapping[str, float] = field(default_factory=dict)
+    last_override_ts: str | None = None
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    """Output of ``is_ready``. ``blockers`` is empty iff ``ready`` is True."""
+
+    ready: bool
+    blockers: tuple[str, ...]
+
+
+def _is_placeholder_team(team_name: str | None, provider_team_id: str) -> bool:
+    """Return True if ``team_name`` is the canonical ``unknown_<pid>`` placeholder.
+
+    Authoritative predicate at ``scripts/scrape_games.py:50-58``. Inlined
+    here rather than imported to keep this module independent of the
+    scripts package (script-side ``sys.path`` setup is brittle for a
+    storage-tier import).
+    """
+    name = (team_name or "").strip()
+    pid = (provider_team_id or "").strip()
+    if not name or not pid:
+        return False
+    return name.lower() == f"unknown_{pid}".lower()
+
+
+def _is_play_up(resolved_age: str | None, cohort_age: str) -> bool:
+    """Return True if the resolved team's age cohort is younger than its registered cohort.
+
+    "Play-up" in youth soccer = a team competing in an older age cohort
+    than its rostered birth-year cohort. ``u12`` team in ``u14`` cohort →
+    True. Same age → False. Missing inputs → False (not enough info to
+    judge).
+    """
+    if not resolved_age or not cohort_age:
+        return False
+    try:
+        resolved_n = int(str(resolved_age).removeprefix("u").removeprefix("U"))
+        cohort_n = int(str(cohort_age).removeprefix("u").removeprefix("U"))
+    except (TypeError, ValueError):
+        return False
+    return resolved_n < cohort_n
+
+
+def _classify_team_state(
+    record: dict,
+    *,
+    resolved_team: dict | None,
+    projected: ProjectedTeamState | None,
+) -> TeamState:
+    """Project (raw_scrape record + override) → one of five UI states.
+
+    Priority order:
+
+    1. Override-projected ``external`` wins outright — the operator
+       explicitly externalized the team.
+    2. Override-projected ``resolved`` becomes ``placeholder`` only when
+       the resolved team's name matches ``unknown_<provider_team_id>``.
+       Otherwise it's a real ``resolved``.
+    3. Fall through to the scraper's ``canonical.scraper_state``:
+
+       - ``review_queued`` → ``candidates`` (operator must triage).
+       - ``alias_written`` → ``placeholder`` if the linked DB team is the
+         ``unknown_<pid>`` row, else ``resolved``.
+       - ``unresolved`` → ``external`` (no DB candidate; operator can edit
+         or accept the externalization).
+
+    4. Anything else (missing ``canonical``, novel state) → ``unknown``.
+       Returning ``unknown`` instead of silently labelling the team
+       ``external`` keeps a corrupted scrape journal from passing
+       readiness — ``is_ready`` lists ``unknown`` as a blocker.
+    """
+    pid = str(record.get("provider_team_id") or "").strip()
+
+    if projected is not None:
+        if projected.state == "external":
+            return "external"
+        if projected.state == "resolved":
+            if resolved_team and _is_placeholder_team(resolved_team.get("team_name"), pid):
+                return "placeholder"
+            return "resolved"
+
+    canonical = record.get("canonical") or {}
+    scraper_state = canonical.get("scraper_state")
+
+    if scraper_state == "review_queued":
+        return "candidates"
+    if scraper_state == "alias_written":
+        if resolved_team is None:
+            return "unknown"
+        if _is_placeholder_team(resolved_team.get("team_name"), pid):
+            return "placeholder"
+        return "resolved"
+    if scraper_state == "unresolved":
+        return "external"
+
+    return "unknown"
+
+
+def build_override_record(
+    *,
+    ts: str,
+    actor: str,
+    scope: str,
+    type: str,
+    team_ref: str,
+    before: dict,
+    after: dict,
+    reason: str,
+) -> dict:
+    """Build an override envelope dict ready for ``append_override``.
+
+    Refuses empty ``actor`` (page-level reviewer-email gate must produce a
+    non-empty value). Refuses ``type`` outside ``_OVERRIDE_TYPES`` and
+    ``scope`` outside ``("team", "cohort")``. Schema-version stamping is
+    the storage layer's job — this builder leaves it off.
+    """
+    actor_clean = (actor or "").strip()
+    if not actor_clean:
+        raise ValueError("override actor must be a non-empty reviewer email")
+    if not _ACTOR_EMAIL_RE.fullmatch(actor_clean):
+        raise ValueError(f"override actor must be a valid reviewer email; got {actor!r}")
+    if type not in _OVERRIDE_TYPES:
+        raise ValueError(f"override type {type!r} not in {_OVERRIDE_TYPES!r}")
+    if scope not in ("team", "cohort"):
+        raise ValueError(f"override scope must be 'team' or 'cohort'; got {scope!r}")
+    return {
+        "ts": ts,
+        "actor": actor,
+        "scope": scope,
+        "type": type,
+        "team_ref": team_ref,
+        "before": dict(before or {}),
+        "after": dict(after or {}),
+        "reason": reason,
+    }
+
+
+def _apply_team_override(
+    type_: str,
+    after: Mapping[str, Any],
+    prior: ProjectedTeamState | None,
+    *,
+    ts: str | None,
+) -> ProjectedTeamState:
+    """Apply a single team-scoped override to the prior projection.
+
+    Per-type rules pinned in the plan's Override Record Contract §6.
+    """
+    after = after or {}
+    if type_ in ("accept_match", "fix_match"):
+        return ProjectedTeamState(
+            state="resolved",
+            team_id_master=str(after.get("team_id_master") or "") or None,
+            last_override_ts=ts,
+        )
+    if type_ == "mark_external":
+        return ProjectedTeamState(state="external", last_override_ts=ts)
+    if type_ == "edit_external":
+        strength_mode = str(after.get("strength_mode") or "") or None
+        manual_power_score = after.get("manual_power_score")
+        if strength_mode != "manual":
+            manual_power_score = None
+        carried_team_id = prior.team_id_master if prior is not None else None
+        return ProjectedTeamState(
+            state="external",
+            team_id_master=carried_team_id,
+            manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+            strength_mode=strength_mode,
+            manual_power_score=(float(manual_power_score) if manual_power_score is not None else None),
+            note=str(after.get("note") or "") or None,
+            last_override_ts=ts,
+        )
+    if type_ == "manual_add":
+        state = str(after.get("state") or "")
+        cohort_age = str(after.get("cohort_age_group") or "") or None
+        cohort_gender = str(after.get("cohort_gender") or "") or None
+        if state == "resolved":
+            return ProjectedTeamState(
+                state="resolved",
+                team_id_master=str(after.get("team_id_master") or "") or None,
+                manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+                last_override_ts=ts,
+                cohort_age_group=cohort_age,
+                cohort_gender=cohort_gender,
+            )
+        # Default to external for any non-"resolved" manual_add — keeps
+        # the projection deterministic if the writer ever omits the field.
+        strength_mode = str(after.get("strength_mode") or "") or None
+        manual_power_score = after.get("manual_power_score")
+        if strength_mode != "manual":
+            manual_power_score = None
+        return ProjectedTeamState(
+            state="external",
+            manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+            strength_mode=strength_mode,
+            manual_power_score=(float(manual_power_score) if manual_power_score is not None else None),
+            note=str(after.get("note") or "") or None,
+            last_override_ts=ts,
+            cohort_age_group=cohort_age,
+            cohort_gender=cohort_gender,
+        )
+    raise ValueError(f"unhandled team-scoped override type: {type_!r}")
+
+
+def project_overrides(
+    records: list[dict],
+) -> tuple[Mapping[str, ProjectedTeamState], Mapping[str, ProjectedCohortState]]:
+    """Walk overrides in append order; latest record per ``(scope, team_ref)`` wins.
+
+    Records whose ``type`` is not in ``_OVERRIDE_TYPES`` are skipped with
+    a single ``logging.warning`` (forward-compat — old code reading newer
+    ledgers should not crash on unrecognized types).
+
+    The append-only contract means there is no revert type — later writes
+    simply replace the projected state for the same ``team_ref``.
+    """
+    team_state: dict[str, ProjectedTeamState] = {}
+    cohort_state: dict[str, ProjectedCohortState] = {}
+
+    for record in records or []:
+        type_ = record.get("type")
+        if type_ not in _OVERRIDE_TYPES:
+            logger.warning("[triage] skipping override with unknown type=%r", type_)
+            continue
+        scope = record.get("scope")
+        team_ref = str(record.get("team_ref") or "")
+        ts = record.get("ts")
+        after = record.get("after") or {}
+
+        if scope == "team" and type_ in _TEAM_SCOPED_TYPES:
+            prior = team_state.get(team_ref)
+            team_state[team_ref] = _apply_team_override(type_, after, prior, ts=ts)
+        elif scope == "cohort" and type_ in _COHORT_SCOPED_TYPES:
+            cohort_state[team_ref] = ProjectedCohortState(
+                medians_by_division=dict(after.get("medians_by_division") or {}),
+                last_override_ts=ts,
+            )
+        else:
+            logger.warning(
+                "[triage] skipping override with mismatched scope=%r type=%r",
+                scope,
+                type_,
+            )
+
+    return team_state, cohort_state
+
+
+def _scraper_state_from_status(status: str | None) -> str:
+    """Map a registry ``canonical_resolution_status`` to the JSONL ``scraper_state``.
+
+    Used by ``is_ready`` when raw_scrape is incomplete — falling back on
+    the registry's snapshot is still better than ``unknown`` for every
+    team that didn't appear in the journal.
+    """
+    if not status:
+        return "unresolved"
+    if status in ("direct_provider_id", "strict_exact", "high_confidence"):
+        return "alias_written"
+    if status == "review":
+        return "review_queued"
+    return "unresolved"
+
+
+def _fetch_resolved_teams(
+    supabase_client: Any,
+    team_id_masters: Iterable[str],
+) -> dict[str, dict]:
+    """Fetch ``team_id_master → {team_id_master, team_name}`` for placeholder detection.
+
+    Empty iterable or ``supabase_client is None`` returns ``{}`` — the
+    caller skips the placeholder branch.
+    """
+    if supabase_client is None:
+        return {}
+    ids = sorted({str(tid) for tid in team_id_masters if tid})
+    if not ids:
+        return {}
+    response = supabase_client.table("teams").select("team_id_master, team_name").in_("team_id_master", ids).execute()
+    rows = response.data or []
+    return {str(row["team_id_master"]): row for row in rows if row.get("team_id_master")}
+
+
+def _registry_provider_id(entry: Any) -> str:
+    """Resolve the per-row provider key.
+
+    Prefers ``resolved_gotsport_provider_team_id`` (post-resolution); falls
+    back to ``event_registration_id`` for unresolved rows and manual-adds.
+    """
+    primary = str(getattr(entry, "resolved_gotsport_provider_team_id", "") or "").strip()
+    if primary:
+        return primary
+    return str(getattr(entry, "event_registration_id", "") or "").strip()
+
+
+def is_ready(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str = "reports",
+    supabase_client: Any = None,
+) -> ReadinessResult:
+    """Return whether the scenario can hand off to a backtest run.
+
+    Blockers are calibrated to the spec §7 validation rules:
+
+    - Per team — any ``candidates`` / ``placeholder`` / ``unknown`` state.
+    - Per cohort — missing structure, or ``check_games_import_status`` !=
+      ``"complete"``.
+
+    ``supabase_client`` is required for the placeholder + games-coverage
+    checks. Without it, those branches are skipped and the result is a
+    weaker "no scraper-state blockers" check — fine for unit-test
+    construction but never accepted by Shell 06's gate.
+    """
+    registry = read_registry(event_key, scenario, base_dir=base_dir)
+    overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+    structure = read_structure(event_key, scenario, base_dir=base_dir)
+    try:
+        meta = read_event_metadata(event_key, base_dir=base_dir)
+    except (FileNotFoundError, SchemaVersionError) as exc:
+        return ReadinessResult(
+            ready=False,
+            blockers=(f"event metadata missing or unreadable: {exc}",),
+        )
+    raw_scrape = list(load_raw_scrape(event_key, base_dir=base_dir))
+
+    team_state, _cohort_state = project_overrides(overrides)
+
+    raw_by_pid: dict[str, dict] = {}
+    for record in raw_scrape:
+        pid = str(record.get("provider_team_id") or "").strip()
+        if pid:
+            raw_by_pid[pid] = record
+
+    structure_by_cohort = {(c.age_group, c.gender): c for c in structure}
+
+    team_ids_for_placeholder: set[str] = set()
+    for entry in registry:
+        pid = _registry_provider_id(entry)
+        projected = team_state.get(pid)
+        if projected and projected.team_id_master:
+            team_ids_for_placeholder.add(projected.team_id_master)
+        elif entry.resolved_team_id_master:
+            team_ids_for_placeholder.add(entry.resolved_team_id_master)
+    resolved_team_by_id = _fetch_resolved_teams(supabase_client, team_ids_for_placeholder)
+
+    blockers: list[str] = []
+    cohorts_seen: set[tuple[str, str]] = set()
+    cohort_team_ids: dict[tuple[str, str], set[str]] = {}
+    registry_pids = {_registry_provider_id(entry) for entry in registry}
+    registry_pids.discard("")
+
+    for entry in registry:
+        pid = _registry_provider_id(entry)
+        if not pid:
+            continue
+        cohort = (entry.event_age_group, entry.event_gender)
+        cohorts_seen.add(cohort)
+
+        record = raw_by_pid.get(pid)
+        if record is None:
+            record = {
+                "provider_team_id": pid,
+                "canonical": {
+                    "scraper_state": _scraper_state_from_status(entry.canonical_resolution_status),
+                },
+            }
+        projected = team_state.get(pid)
+
+        team_id_master: str | None = None
+        if projected and projected.team_id_master:
+            team_id_master = projected.team_id_master
+        elif entry.resolved_team_id_master:
+            team_id_master = entry.resolved_team_id_master
+        resolved_team = resolved_team_by_id.get(team_id_master) if team_id_master else None
+
+        state = _classify_team_state(record, resolved_team=resolved_team, projected=projected)
+
+        cohort_label = f"{cohort[1]} {cohort[0]}"
+        team_label = entry.event_team_name or pid
+        if state == "candidates":
+            blockers.append(f"{cohort_label}: {team_label} pending review")
+        elif state == "placeholder":
+            blockers.append(f"{cohort_label}: {team_label} matched to placeholder")
+        elif state == "unknown":
+            blockers.append(f"{cohort_label}: {team_label} state unknown — re-scrape or triage")
+
+        if state in ("resolved", "placeholder") and team_id_master:
+            cohort_team_ids.setdefault(cohort, set()).add(team_id_master)
+
+    # Second pass: manual-add teams. They live only in ``team_state`` (never
+    # in the registry CSV) and carry their cohort attribution in
+    # ``ProjectedTeamState.cohort_age_group`` / ``cohort_gender``. Without
+    # this walk, a manual-add team with zero games would slip past the
+    # readiness gate.
+    for team_ref, projected in team_state.items():
+        if team_ref in registry_pids:
+            continue
+        if not team_ref.startswith("manual_"):
+            continue
+        cohort_age = projected.cohort_age_group
+        cohort_gender = projected.cohort_gender
+        if not cohort_age or not cohort_gender:
+            blockers.append(f"manual-add {team_ref}: cohort attribution missing (rewrite override)")
+            continue
+        cohort = (cohort_age, cohort_gender)
+        cohorts_seen.add(cohort)
+        cohort_label = f"{cohort_gender} {cohort_age}"
+        team_label = projected.note or team_ref
+        if projected.state == "external":
+            # External manual-adds aren't blockers; they pass through to the
+            # ranking pane via frozen medians. Don't enforce games coverage
+            # for them either.
+            continue
+        if projected.state == "resolved":
+            if not projected.team_id_master:
+                blockers.append(f"{cohort_label}: manual-add {team_label} missing team_id_master")
+                continue
+            cohort_team_ids.setdefault(cohort, set()).add(projected.team_id_master)
+            continue
+        # Any other state on a manual_add row is a misconfigured writer.
+        blockers.append(f"{cohort_label}: manual-add {team_label} state {projected.state!r}")
+
+    for cohort in sorted(cohorts_seen):
+        cohort_label = f"{cohort[1]} {cohort[0]}"
+        if cohort not in structure_by_cohort:
+            blockers.append(f"{cohort_label}: structure not entered")
+            continue
+        if supabase_client is None:
+            continue
+        team_ids = cohort_team_ids.get(cohort, set())
+        try:
+            status = check_games_import_status(meta.event_name, sorted(team_ids), supabase_client=supabase_client)
+        except Exception as exc:  # noqa: BLE001 — Supabase failure surfaces as blocker, not crash
+            blockers.append(f"{cohort_label}: games coverage check failed ({exc})")
+            continue
+        if status != "complete":
+            blockers.append(f"{cohort_label}: games coverage {status}")
+
+    return ReadinessResult(ready=not blockers, blockers=tuple(blockers))

--- a/tests/unit/test_division_render_contract.py
+++ b/tests/unit/test_division_render_contract.py
@@ -1,0 +1,34 @@
+"""Pin the Shell 04 ↔ Shell 05 ``render_division_container`` contract.
+
+Until Shell 05 lands, ``render_division_container`` raises
+``NotImplementedError`` and the triage UI falls back to a placeholder
+hint. The xfail-marked test below flips to xpass once Shell 05 commits a
+real implementation that invokes ``body`` exactly once — that flip is
+the signal Shell 04 needs to drop the fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tournaments.division_render import render_division_container
+
+
+def test_stub_raises_not_implemented_until_shell_05_lands():
+    with pytest.raises(NotImplementedError, match="Shell 05"):
+        render_division_container("Premier", lambda: None)
+
+
+@pytest.mark.xfail(
+    reason="Shell 05 ships the real implementation",
+    raises=NotImplementedError,
+    strict=True,
+)
+def test_render_division_container_invokes_body_once():
+    call_count = {"n": 0}
+
+    def body() -> None:
+        call_count["n"] += 1
+
+    render_division_container("Super Elite", body)
+    assert call_count["n"] == 1

--- a/tests/unit/test_tournament_intake_helpers.py
+++ b/tests/unit/test_tournament_intake_helpers.py
@@ -8,6 +8,7 @@ Streamlit runtime is required.
 
 from __future__ import annotations
 
+from src.tournaments.triage import ProjectedTeamState
 from tournament_intake import (
     _DISABLED_MODES,
     _cohort_sort_key,
@@ -15,8 +16,11 @@ from tournament_intake import (
     _display_gender,
     _group_cohorts,
     _resolve_intake_mode,
+    _resolve_team_id_master,
+    _safe_float,
     _scrape_state_counts,
     _scraper_tint,
+    _state_tint_level,
 )
 
 # -------- _DISABLED_MODES + _resolve_intake_mode --------------------------
@@ -166,3 +170,63 @@ def test_cohort_sort_key_female_before_male_within_age():
 def test_cohort_toggle_key_format_is_stable():
     assert _cohort_toggle_key("u14", "Male") == "_cohort_expanded_u14_Male"
     assert _cohort_toggle_key("u19", "Female") == "_cohort_expanded_u19_Female"
+
+
+# -------- _resolve_team_id_master ----------------------------------------
+
+
+def test_resolve_team_id_master_prefers_projection():
+    projected = ProjectedTeamState(state="resolved", team_id_master="proj_abc")
+    registry_row = {"resolved_team_id_master": "reg_xyz"}
+    assert _resolve_team_id_master(projected, registry_row) == "proj_abc"
+
+
+def test_resolve_team_id_master_falls_back_to_registry():
+    projected = None
+    registry_row = {"resolved_team_id_master": "reg_xyz"}
+    assert _resolve_team_id_master(projected, registry_row) == "reg_xyz"
+
+
+def test_resolve_team_id_master_handles_empty_projection():
+    projected = ProjectedTeamState(state="external", team_id_master=None)
+    registry_row = {"resolved_team_id_master": "reg_xyz"}
+    assert _resolve_team_id_master(projected, registry_row) == "reg_xyz"
+
+
+def test_resolve_team_id_master_returns_none_when_both_empty():
+    assert _resolve_team_id_master(None, {}) is None
+    assert _resolve_team_id_master(None, None) is None
+
+
+# -------- _safe_float ----------------------------------------------------
+
+
+def test_safe_float_handles_normal_inputs():
+    assert _safe_float(1.5) == 1.5
+    assert _safe_float("2.0") == 2.0
+    assert _safe_float(3) == 3.0
+
+
+def test_safe_float_returns_none_for_empty_or_unparseable():
+    assert _safe_float(None) is None
+    assert _safe_float("") is None
+    assert _safe_float("not a number") is None
+    assert _safe_float([1, 2]) is None
+
+
+# -------- _state_tint_level ----------------------------------------------
+
+
+def test_state_tint_level_resolved_is_green():
+    assert _state_tint_level("resolved") == "green"
+
+
+def test_state_tint_level_external_is_amber():
+    assert _state_tint_level("external") == "amber"
+
+
+def test_state_tint_level_blockers_default_red():
+    assert _state_tint_level("candidates") == "red"
+    assert _state_tint_level("placeholder") == "red"
+    assert _state_tint_level("unknown") == "red"
+    assert _state_tint_level("not-a-state") == "red"

--- a/tests/unit/test_triage_classifiers.py
+++ b/tests/unit/test_triage_classifiers.py
@@ -1,0 +1,280 @@
+"""Unit tests for ``src.tournaments.triage`` classifier + builder helpers.
+
+Pins ``_classify_team_state``'s priority ladder, the placeholder/play-up
+predicates, the ``_OVERRIDE_TYPES`` / ``_STRENGTH_MODES`` constants, and
+``build_override_record``'s validation surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tournaments.triage import (
+    _OVERRIDE_TYPES,
+    _STRENGTH_MODES,
+    ProjectedTeamState,
+    _classify_team_state,
+    _is_placeholder_team,
+    _is_play_up,
+    build_override_record,
+)
+
+# -------- _OVERRIDE_TYPES + _STRENGTH_MODES constants --------------------
+
+
+def test_override_types_constant_is_pinned():
+    assert _OVERRIDE_TYPES == (
+        "accept_match",
+        "fix_match",
+        "mark_external",
+        "edit_external",
+        "manual_add",
+        "recompute_medians",
+    )
+
+
+def test_strength_modes_constant_is_pinned():
+    assert _STRENGTH_MODES == ("median", "manual", "exclude")
+
+
+# -------- _is_placeholder_team -------------------------------------------
+
+
+def test_is_placeholder_team_canonical_match():
+    assert _is_placeholder_team("unknown_12345", "12345") is True
+
+
+def test_is_placeholder_team_case_insensitive():
+    assert _is_placeholder_team("UNKNOWN_12345", "12345") is True
+    assert _is_placeholder_team("Unknown_12345", "12345") is True
+
+
+def test_is_placeholder_team_mismatched_id_is_false():
+    assert _is_placeholder_team("unknown_99999", "12345") is False
+
+
+def test_is_placeholder_team_empty_name_is_false():
+    assert _is_placeholder_team("", "12345") is False
+    assert _is_placeholder_team(None, "12345") is False
+
+
+def test_is_placeholder_team_empty_pid_is_false():
+    assert _is_placeholder_team("unknown_12345", "") is False
+
+
+def test_is_placeholder_team_real_team_name_is_false():
+    assert _is_placeholder_team("Phoenix Rising 2014", "12345") is False
+
+
+# -------- _is_play_up ----------------------------------------------------
+
+
+def test_is_play_up_younger_team_in_older_cohort():
+    assert _is_play_up("u12", "u14") is True
+
+
+def test_is_play_up_uppercase_inputs():
+    assert _is_play_up("U12", "U14") is True
+
+
+def test_is_play_up_same_age_is_false():
+    assert _is_play_up("u14", "u14") is False
+
+
+def test_is_play_up_older_team_in_younger_cohort_is_false():
+    assert _is_play_up("u15", "u14") is False
+
+
+def test_is_play_up_missing_resolved_age_is_false():
+    assert _is_play_up(None, "u14") is False
+    assert _is_play_up("", "u14") is False
+
+
+def test_is_play_up_unparseable_age_is_false():
+    assert _is_play_up("varsity", "u14") is False
+
+
+# -------- _classify_team_state -------------------------------------------
+
+
+def _record(scraper_state: str | None, *, pid: str = "12345") -> dict:
+    canonical = {"scraper_state": scraper_state} if scraper_state is not None else {}
+    return {"provider_team_id": pid, "canonical": canonical}
+
+
+def test_classify_projected_external_wins():
+    record = _record("alias_written")
+    projected = ProjectedTeamState(state="external")
+    assert _classify_team_state(record, resolved_team=None, projected=projected) == "external"
+
+
+def test_classify_projected_resolved_with_real_team():
+    record = _record("review_queued")
+    projected = ProjectedTeamState(state="resolved", team_id_master="abc")
+    resolved = {"team_id_master": "abc", "team_name": "Phoenix Rising 2014"}
+    assert _classify_team_state(record, resolved_team=resolved, projected=projected) == "resolved"
+
+
+def test_classify_projected_resolved_to_placeholder():
+    record = _record("review_queued", pid="12345")
+    projected = ProjectedTeamState(state="resolved", team_id_master="abc")
+    resolved = {"team_id_master": "abc", "team_name": "unknown_12345"}
+    assert _classify_team_state(record, resolved_team=resolved, projected=projected) == "placeholder"
+
+
+def test_classify_projected_resolved_with_no_resolved_team_returns_resolved():
+    """When the override projection says ``resolved`` but the placeholder
+    check has no DB row to inspect, the team should still classify as
+    ``resolved`` — the override is the authoritative source."""
+    record = _record("review_queued", pid="12345")
+    projected = ProjectedTeamState(state="resolved", team_id_master="abc")
+    assert _classify_team_state(record, resolved_team=None, projected=projected) == "resolved"
+
+
+def test_classify_review_queued_is_candidates():
+    record = _record("review_queued")
+    assert _classify_team_state(record, resolved_team=None, projected=None) == "candidates"
+
+
+def test_classify_alias_written_is_resolved_with_real_team():
+    record = _record("alias_written", pid="12345")
+    resolved = {"team_name": "Phoenix Rising 2014"}
+    assert _classify_team_state(record, resolved_team=resolved, projected=None) == "resolved"
+
+
+def test_classify_alias_written_is_placeholder_with_unknown_name():
+    record = _record("alias_written", pid="12345")
+    resolved = {"team_name": "unknown_12345"}
+    assert _classify_team_state(record, resolved_team=resolved, projected=None) == "placeholder"
+
+
+def test_classify_alias_written_without_resolved_team_is_unknown():
+    record = _record("alias_written")
+    assert _classify_team_state(record, resolved_team=None, projected=None) == "unknown"
+
+
+def test_classify_unresolved_is_external():
+    record = _record("unresolved")
+    assert _classify_team_state(record, resolved_team=None, projected=None) == "external"
+
+
+def test_classify_missing_canonical_is_unknown():
+    record = {"provider_team_id": "12345"}
+    assert _classify_team_state(record, resolved_team=None, projected=None) == "unknown"
+
+
+def test_classify_novel_scraper_state_is_unknown():
+    record = _record("not_a_real_state")
+    assert _classify_team_state(record, resolved_team=None, projected=None) == "unknown"
+
+
+# -------- build_override_record ------------------------------------------
+
+
+def _envelope(**overrides):
+    base = dict(
+        ts="2026-04-26T12:00:00+00:00",
+        actor="dallas@example.com",
+        scope="team",
+        type="accept_match",
+        team_ref="pid-1",
+        before={"state": "candidates"},
+        after={"state": "resolved", "team_id_master": "abc"},
+        reason="best match accepted",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_build_override_record_envelope_keys():
+    record = build_override_record(**_envelope())
+    # ``schema_version`` is stamped by ``append_override``, not the builder.
+    assert set(record.keys()) == {
+        "ts",
+        "actor",
+        "scope",
+        "type",
+        "team_ref",
+        "before",
+        "after",
+        "reason",
+    }
+
+
+def test_build_override_record_refuses_empty_actor():
+    with pytest.raises(ValueError, match="non-empty reviewer email"):
+        build_override_record(**_envelope(actor=""))
+    with pytest.raises(ValueError, match="non-empty reviewer email"):
+        build_override_record(**_envelope(actor="   "))
+
+
+def test_build_override_record_refuses_non_email_actor():
+    with pytest.raises(ValueError, match="valid reviewer email"):
+        build_override_record(**_envelope(actor="dallas"))
+    with pytest.raises(ValueError, match="valid reviewer email"):
+        build_override_record(**_envelope(actor="dallas@nodot"))
+
+
+def test_build_override_record_refuses_unknown_type():
+    with pytest.raises(ValueError, match="not in"):
+        build_override_record(**_envelope(type="invent_a_type"))
+
+
+def test_build_override_record_refuses_unknown_scope():
+    with pytest.raises(ValueError, match="scope must be"):
+        build_override_record(**_envelope(scope="event"))
+
+
+def test_build_override_record_copies_before_and_after():
+    """Builder must defensively copy mutable inputs so post-hoc mutation
+    by the caller cannot mutate the record after it's been queued for
+    append."""
+    before = {"state": "candidates"}
+    after = {"state": "resolved", "team_id_master": "abc"}
+    record = build_override_record(**_envelope(before=before, after=after))
+    before["state"] = "external"
+    after["state"] = "external"
+    assert record["before"] == {"state": "candidates"}
+    assert record["after"]["state"] == "resolved"
+
+
+# -------- per-type ``after`` payload contract (Override Record §3) --------
+
+
+@pytest.mark.parametrize(
+    ("type_", "after_keys"),
+    [
+        ("accept_match", {"state", "team_id_master", "match_rank"}),
+        ("fix_match", {"state", "team_id_master"}),
+        ("mark_external", {"state"}),
+        (
+            "edit_external",
+            {"state", "manual_seed_group", "strength_mode", "manual_power_score", "note"},
+        ),
+        ("manual_add", {"state", "team_id_master", "manual_seed_group"}),
+        ("recompute_medians", {"medians_by_division"}),
+    ],
+)
+def test_per_type_after_payload_keys_round_trip(type_, after_keys):
+    """Pin the per-type ``after`` payload key set documented in the
+    Override Record Contract §3. Builder accepts it; reader sees it back."""
+    after = {key: "x" for key in after_keys}
+    if "match_rank" in after:
+        after["match_rank"] = 1
+    if "manual_power_score" in after:
+        after["manual_power_score"] = 12.5
+    if "medians_by_division" in after:
+        after["medians_by_division"] = {"Premier": 14.2}
+    scope = "cohort" if type_ == "recompute_medians" else "team"
+    team_ref = "u14_Male" if scope == "cohort" else "pid-1"
+    record = build_override_record(
+        ts="2026-04-26T12:00:00+00:00",
+        actor="dallas@example.com",
+        scope=scope,
+        type=type_,
+        team_ref=team_ref,
+        before={},
+        after=after,
+        reason="test",
+    )
+    assert set(record["after"].keys()) == after_keys

--- a/tests/unit/test_triage_projection.py
+++ b/tests/unit/test_triage_projection.py
@@ -1,0 +1,298 @@
+"""Unit tests for ``src.tournaments.triage.project_overrides``.
+
+Pins latest-wins semantics, per-type field projections, the cohort-scoped
+``recompute_medians`` lane, and forward-compat skip-with-warning behavior
+for unrecognized override types.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.tournaments.triage import (
+    ProjectedCohortState,
+    ProjectedTeamState,
+    project_overrides,
+)
+
+
+def _team_record(type_: str, team_ref: str, after: dict, *, ts: str | None = None, before: dict | None = None) -> dict:
+    return {
+        "ts": ts or "2026-04-26T12:00:00+00:00",
+        "actor": "dallas@example.com",
+        "scope": "team",
+        "type": type_,
+        "team_ref": team_ref,
+        "before": before or {},
+        "after": after,
+        "reason": "test",
+    }
+
+
+def _cohort_record(type_: str, team_ref: str, after: dict, *, ts: str | None = None) -> dict:
+    return {
+        "ts": ts or "2026-04-26T12:00:00+00:00",
+        "actor": "dallas@example.com",
+        "scope": "cohort",
+        "type": type_,
+        "team_ref": team_ref,
+        "before": {},
+        "after": after,
+        "reason": "test",
+    }
+
+
+def test_empty_records_returns_two_empty_mappings():
+    team_state, cohort_state = project_overrides([])
+    assert team_state == {}
+    assert cohort_state == {}
+
+
+def test_accept_match_produces_resolved_team_state():
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc", "match_rank": 1},
+        )
+    ]
+    team_state, _ = project_overrides(records)
+    assert "pid-1" in team_state
+    assert team_state["pid-1"] == ProjectedTeamState(
+        state="resolved",
+        team_id_master="abc",
+        last_override_ts="2026-04-26T12:00:00+00:00",
+    )
+
+
+def test_accept_match_does_not_project_match_rank():
+    """``match_rank`` lives in the JSONL ``after`` payload but is NOT
+    projected — ``ProjectedTeamState`` has no ``match_rank`` attribute."""
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc", "match_rank": 1},
+        )
+    ]
+    team_state, _ = project_overrides(records)
+    assert not hasattr(team_state["pid-1"], "match_rank")
+
+
+def test_latest_record_wins_per_team_ref():
+    """``mark_external`` after ``accept_match`` flips the team to
+    external — by design (no revert type in the append-only contract)."""
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc"},
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _team_record(
+            "mark_external",
+            "pid-1",
+            {"state": "external"},
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    assert team_state["pid-1"].state == "external"
+    assert team_state["pid-1"].team_id_master is None
+
+
+def test_recompute_medians_appears_in_cohort_state_only():
+    records = [
+        _cohort_record(
+            "recompute_medians",
+            "u14_Male",
+            {"medians_by_division": {"Premier": 14.2, "Champions": 12.0}},
+        )
+    ]
+    team_state, cohort_state = project_overrides(records)
+    assert team_state == {}
+    assert "u14_Male" in cohort_state
+    assert cohort_state["u14_Male"] == ProjectedCohortState(
+        medians_by_division={"Premier": 14.2, "Champions": 12.0},
+        last_override_ts="2026-04-26T12:00:00+00:00",
+    )
+
+
+def test_manual_add_then_edit_external_reflects_edit():
+    records = [
+        _team_record(
+            "manual_add",
+            "manual_pid-1",
+            {
+                "state": "external",
+                "manual_seed_group": "Premier",
+                "strength_mode": "median",
+            },
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _team_record(
+            "edit_external",
+            "manual_pid-1",
+            {
+                "state": "external",
+                "manual_seed_group": "Champions",
+                "strength_mode": "manual",
+                "manual_power_score": 13.5,
+                "note": "operator-assigned",
+            },
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["manual_pid-1"]
+    assert final.state == "external"
+    assert final.manual_seed_group == "Champions"
+    assert final.strength_mode == "manual"
+    assert final.manual_power_score == 13.5
+    assert final.note == "operator-assigned"
+
+
+def test_edit_external_clears_manual_power_score_when_strength_not_manual():
+    records = [
+        _team_record(
+            "edit_external",
+            "pid-1",
+            {
+                "state": "external",
+                "manual_seed_group": "Premier",
+                "strength_mode": "median",
+                "manual_power_score": 99.0,
+            },
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.strength_mode == "median"
+    assert final.manual_power_score is None
+
+
+def test_edit_external_carries_team_id_master_from_prior():
+    """``edit_external`` carries ``team_id_master`` over from the prior
+    projection — relevant when an externalized team was previously
+    DB-resolved via manual_add."""
+    records = [
+        _team_record(
+            "manual_add",
+            "manual_pid-1",
+            {"state": "resolved", "team_id_master": "abc", "manual_seed_group": "Premier"},
+        ),
+        _team_record(
+            "edit_external",
+            "manual_pid-1",
+            {
+                "state": "external",
+                "manual_seed_group": "Champions",
+                "strength_mode": "median",
+            },
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["manual_pid-1"]
+    assert final.state == "external"
+    assert final.team_id_master == "abc"
+
+
+def test_mark_external_clears_team_id_master():
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc"},
+        ),
+        _team_record("mark_external", "pid-1", {"state": "external"}),
+    ]
+    team_state, _ = project_overrides(records)
+    assert team_state["pid-1"].team_id_master is None
+
+
+def test_unknown_type_is_skipped_with_warning(caplog):
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc"},
+        ),
+        {
+            "ts": "2026-04-26T13:00:00+00:00",
+            "actor": "dallas@example.com",
+            "scope": "team",
+            "type": "future_v2_action",
+            "team_ref": "pid-1",
+            "before": {},
+            "after": {},
+            "reason": "from a v2 ledger",
+        },
+    ]
+    with caplog.at_level(logging.WARNING, logger="src.tournaments.triage"):
+        team_state, _ = project_overrides(records)
+    # First record still projected; second skipped.
+    assert team_state["pid-1"].state == "resolved"
+    assert any("future_v2_action" in record.message for record in caplog.records)
+
+
+def test_fix_match_produces_resolved_state():
+    records = [
+        _team_record(
+            "fix_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "xyz"},
+        )
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.state == "resolved"
+    assert final.team_id_master == "xyz"
+
+
+def test_manual_add_external_projects_strength_fields():
+    records = [
+        _team_record(
+            "manual_add",
+            "manual_abc",
+            {
+                "state": "external",
+                "manual_seed_group": "Premier",
+                "strength_mode": "manual",
+                "manual_power_score": 14.5,
+                "note": "guest team",
+                "cohort_age_group": "u14",
+                "cohort_gender": "Male",
+            },
+        )
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["manual_abc"]
+    assert final.state == "external"
+    assert final.manual_seed_group == "Premier"
+    assert final.strength_mode == "manual"
+    assert final.manual_power_score == 14.5
+    assert final.note == "guest team"
+    assert final.cohort_age_group == "u14"
+    assert final.cohort_gender == "Male"
+
+
+def test_recompute_medians_latest_wins():
+    records = [
+        _cohort_record(
+            "recompute_medians",
+            "u14_Male",
+            {"medians_by_division": {"Premier": 10.0}},
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _cohort_record(
+            "recompute_medians",
+            "u14_Male",
+            {"medians_by_division": {"Premier": 14.2, "Champions": 12.0}},
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    _, cohort_state = project_overrides(records)
+    assert cohort_state["u14_Male"].medians_by_division == {
+        "Premier": 14.2,
+        "Champions": 12.0,
+    }

--- a/tests/unit/test_triage_readiness.py
+++ b/tests/unit/test_triage_readiness.py
@@ -1,0 +1,452 @@
+"""Unit tests for ``src.tournaments.triage.is_ready``.
+
+The readiness predicate is what Shell 06 calls before allowing a run to
+launch. This file pins the per-team blockers (candidates / placeholder /
+unknown) and per-cohort blockers (no structure / partial games coverage),
+plus the all-green ``ready=True`` happy path.
+
+FakeSupabase is colocated — no precedent for shared fakes in
+``tests/unit/`` and the inline shape mirrors
+``tests/unit/test_storage_games_import.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage._io import append_jsonl
+from src.tournaments.storage.event_key import intake_dir
+from src.tournaments.storage.event_metadata import (
+    EventMetadata,
+    write_event_metadata,
+)
+from src.tournaments.storage.overrides import append_override
+from src.tournaments.storage.registry import TeamRegistryEntry, write_registry
+from src.tournaments.storage.scenario import ensure_scenario
+from src.tournaments.storage.structure import (
+    CohortStructure,
+    DivisionStructure,
+    write_structure,
+)
+from src.tournaments.triage import is_ready
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+EVENT_NAME = "Phoenix Cup 2026"
+
+
+# -------- FakeSupabase ---------------------------------------------------
+
+
+class _FakeQuery:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+        self._eq: list[tuple[str, Any]] = []
+        self._in: list[tuple[str, list[Any]]] = []
+
+    def select(self, columns: str = "*") -> "_FakeQuery":
+        return self
+
+    def eq(self, column: str, value: Any) -> "_FakeQuery":
+        self._eq.append((column, value))
+        return self
+
+    def in_(self, column: str, values: list[Any]) -> "_FakeQuery":
+        self._in.append((column, list(values)))
+        return self
+
+    def execute(self) -> Any:
+        out = []
+        for row in self._rows:
+            if any(row.get(c) != v for c, v in self._eq):
+                continue
+            if any(row.get(c) not in vs for c, vs in self._in):
+                continue
+            out.append(row)
+        return _FakeExecResult(out)
+
+
+class _FakeExecResult:
+    def __init__(self, data: list[dict]):
+        self.data = data
+
+
+class _FakeSupabase:
+    def __init__(
+        self,
+        *,
+        teams: list[dict[str, Any]] | None = None,
+        games: list[dict[str, Any]] | None = None,
+    ):
+        self._teams = teams or []
+        self._games = games or []
+
+    def table(self, name: str) -> _FakeQuery:
+        if name == "teams":
+            return _FakeQuery(self._teams)
+        if name == "games":
+            return _FakeQuery(self._games)
+        raise AssertionError(f"unexpected table {name!r}")
+
+
+# -------- fixtures helpers ------------------------------------------------
+
+
+def _seed_event(
+    base: Path,
+    *,
+    raw_records: list[dict],
+    registry_entries: list[TeamRegistryEntry],
+    structure: list[CohortStructure],
+) -> None:
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name=EVENT_NAME,
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-04-01",
+            scrape_ts="2026-04-26T12:00:00+00:00",
+            season_year=2026,
+        ),
+        base_dir=base,
+    )
+    journal_path = intake_dir(EVENT_KEY, base_dir=base) / "raw_scrape.jsonl"
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    for record in raw_records:
+        append_jsonl(journal_path, record)
+    write_registry(EVENT_KEY, SCENARIO, registry_entries, base_dir=base)
+    write_structure(EVENT_KEY, SCENARIO, structure, base_dir=base)
+
+
+def _raw(pid: str, scraper_state: str, *, age: str = "u14", gender: str = "Male") -> dict:
+    return {
+        "run_id": "2026-04-26T12:00:00",
+        "provider_team_id": pid,
+        "team_name": f"Team {pid}",
+        "club_name": "Phoenix Rising",
+        "cohort_age_group": age,
+        "cohort_gender": gender,
+        "division": "Premier",
+        "bracket_name": "Premier A",
+        "playing_up": False,
+        "has_view_rankings_link": True,
+        "provider_id_resolution_status": "matched",
+        "also_appears_in_brackets": [],
+        "canonical": {
+            "team_id_master": f"m_{pid}" if scraper_state == "alias_written" else None,
+            "confidence": 1.0,
+            "resolved_status": "high_confidence",
+            "match_method": "direct_id" if scraper_state == "alias_written" else None,
+            "scraper_state": scraper_state,
+        },
+        "alias_writer_action": "created",
+        "scrape_ts": "2026-04-26T12:00:00",
+        "source_url": "https://example.com",
+        "provider_event_id": "45224",
+    }
+
+
+def _registry(
+    pid: str,
+    *,
+    age: str = "u14",
+    gender: str = "Male",
+    canonical_status: str = "high_confidence",
+    resolved_team_id: str | None = None,
+) -> TeamRegistryEntry:
+    return TeamRegistryEntry(
+        event_registration_id=f"reg_{pid}",
+        event_team_name=f"Team {pid}",
+        event_age_group=age,
+        display_age_group=age.upper(),
+        event_gender=gender,
+        display_gender="Boys" if gender == "Male" else "Girls",
+        event_club_name="Phoenix Rising",
+        resolved_gotsport_provider_team_id=pid,
+        canonical_resolution_status=canonical_status,
+        in_scope_u10_u19="True",
+        resolved_team_id_master=resolved_team_id or (f"m_{pid}" if canonical_status != "review" else ""),
+    )
+
+
+def _structure(age: str = "u14", gender: str = "Male") -> list[CohortStructure]:
+    return [
+        CohortStructure(
+            age_group=age,
+            gender=gender,
+            divisions=(DivisionStructure(name="Premier", team_count=2),),
+        )
+    ]
+
+
+# -------- tests -----------------------------------------------------------
+
+
+def test_ready_when_all_resolved_with_complete_games(tmp_path: Path):
+    raw = [_raw("p1", "alias_written"), _raw("p2", "alias_written")]
+    registry = [_registry("p1"), _registry("p2")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    supabase = _FakeSupabase(
+        teams=[
+            {"team_id_master": "m_p1", "team_name": "Real Team 1"},
+            {"team_id_master": "m_p2", "team_name": "Real Team 2"},
+        ],
+        games=[
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p1",
+                "away_team_master_id": "m_p2",
+            },
+        ],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is True
+    assert result.blockers == ()
+
+
+def test_blocked_by_candidates_state(tmp_path: Path):
+    raw = [_raw("p1", "review_queued"), _raw("p2", "alias_written")]
+    registry = [_registry("p1", canonical_status="review"), _registry("p2")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    supabase = _FakeSupabase(
+        teams=[{"team_id_master": "m_p2", "team_name": "Real Team 2"}],
+        games=[
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p2",
+                "away_team_master_id": "other",
+            },
+        ],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("pending review" in blocker for blocker in result.blockers)
+
+
+def test_blocked_by_placeholder_state(tmp_path: Path):
+    raw = [_raw("p1", "alias_written"), _raw("p2", "alias_written")]
+    registry = [_registry("p1"), _registry("p2")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    supabase = _FakeSupabase(
+        teams=[
+            {"team_id_master": "m_p1", "team_name": "unknown_p1"},  # placeholder
+            {"team_id_master": "m_p2", "team_name": "Real Team 2"},
+        ],
+        games=[
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p1",
+                "away_team_master_id": "m_p2",
+            },
+        ],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("placeholder" in blocker for blocker in result.blockers)
+
+
+def test_blocked_by_unknown_state(tmp_path: Path):
+    raw = [
+        # Missing canonical → unknown state
+        {
+            "run_id": "2026-04-26T12:00:00",
+            "provider_team_id": "p1",
+            "team_name": "Team p1",
+            "cohort_age_group": "u14",
+            "cohort_gender": "Male",
+        }
+    ]
+    registry = [_registry("p1", canonical_status="")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    supabase = _FakeSupabase(teams=[], games=[])
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("state unknown" in blocker for blocker in result.blockers)
+
+
+def test_blocked_by_missing_structure(tmp_path: Path):
+    raw = [_raw("p1", "alias_written")]
+    registry = [_registry("p1")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=[],  # no structure entered
+    )
+    supabase = _FakeSupabase(
+        teams=[{"team_id_master": "m_p1", "team_name": "Real Team 1"}],
+        games=[],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("structure not entered" in blocker for blocker in result.blockers)
+
+
+def test_blocked_by_partial_games_coverage(tmp_path: Path):
+    raw = [_raw("p1", "alias_written"), _raw("p2", "alias_written")]
+    registry = [_registry("p1"), _registry("p2")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    supabase = _FakeSupabase(
+        teams=[
+            {"team_id_master": "m_p1", "team_name": "Real Team 1"},
+            {"team_id_master": "m_p2", "team_name": "Real Team 2"},
+        ],
+        games=[
+            # Only p1 has a game; p2 has none → partial
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p1",
+                "away_team_master_id": "other_team",
+            },
+        ],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("games coverage partial" in blocker for blocker in result.blockers)
+
+
+def test_manual_add_resolved_blocks_when_games_partial(tmp_path: Path):
+    """Manual-add resolved teams must be visible to the games-coverage gate.
+    Before the manual_add visibility fix, ``is_ready`` could return ``True``
+    even when a manual-add team had zero games in the DB."""
+    raw = [_raw("p1", "alias_written")]
+    registry = [_registry("p1")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    # Operator manually added a second team via the +Add team form.
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-26T13:00:00+00:00",
+            "actor": "dallas@example.com",
+            "scope": "team",
+            "type": "manual_add",
+            "team_ref": "manual_abc123",
+            "before": {},
+            "after": {
+                "state": "resolved",
+                "team_id_master": "m_manual_abc",
+                "manual_seed_group": "Premier",
+                "cohort_age_group": "u14",
+                "cohort_gender": "Male",
+            },
+            "reason": "manual add — DB match",
+        },
+        base_dir=tmp_path,
+    )
+    supabase = _FakeSupabase(
+        teams=[
+            {"team_id_master": "m_p1", "team_name": "Real Team 1"},
+            {"team_id_master": "m_manual_abc", "team_name": "Manual Team"},
+        ],
+        # p1 has a game; the manual-add team does NOT — coverage should be
+        # partial.
+        games=[
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p1",
+                "away_team_master_id": "other",
+            },
+        ],
+    )
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is False
+    assert any("games coverage partial" in blocker for blocker in result.blockers)
+
+
+def test_is_ready_returns_blocker_when_event_metadata_missing(tmp_path: Path):
+    """When ``event_metadata.json`` is missing, ``is_ready`` returns a
+    blocker rather than crashing with ``FileNotFoundError``."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    write_registry(EVENT_KEY, SCENARIO, [], base_dir=tmp_path)
+    write_structure(EVENT_KEY, SCENARIO, [], base_dir=tmp_path)
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=None)
+    assert result.ready is False
+    assert any("event metadata missing" in blocker for blocker in result.blockers)
+
+
+def test_override_accept_match_unblocks_candidate(tmp_path: Path):
+    raw = [_raw("p1", "review_queued")]
+    registry = [_registry("p1", canonical_status="review")]
+    _seed_event(
+        tmp_path,
+        raw_records=raw,
+        registry_entries=registry,
+        structure=_structure(),
+    )
+    # Operator accepted the top match — projection should mark p1 resolved.
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-26T13:00:00+00:00",
+            "actor": "dallas@example.com",
+            "scope": "team",
+            "type": "accept_match",
+            "team_ref": "p1",
+            "before": {"state": "candidates"},
+            "after": {"state": "resolved", "team_id_master": "m_p1", "match_rank": 1},
+            "reason": "best match",
+        },
+        base_dir=tmp_path,
+    )
+    supabase = _FakeSupabase(
+        teams=[{"team_id_master": "m_p1", "team_name": "Real Team 1"}],
+        games=[
+            {
+                "event_name": EVENT_NAME,
+                "is_excluded": False,
+                "home_team_master_id": "m_p1",
+                "away_team_master_id": "other",
+            },
+        ],
+    )
+    structure = [
+        CohortStructure(
+            age_group="u14",
+            gender="Male",
+            divisions=(DivisionStructure(name="Premier", team_count=1),),
+        )
+    ]
+    write_structure(EVENT_KEY, SCENARIO, structure, base_dir=tmp_path)
+    result = is_ready(EVENT_KEY, SCENARIO, base_dir=tmp_path, supabase_client=supabase)
+    assert result.ready is True

--- a/tournament_intake.py
+++ b/tournament_intake.py
@@ -9,8 +9,10 @@ backtest runs.
 from __future__ import annotations
 
 import contextlib
+import html
 import os
 import sys
+import uuid
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -28,22 +30,47 @@ from src.scrapers.provider import (
     UnsupportedProviderError,
     get_provider_scraper,
 )
+from src.tournaments.division_render import render_division_container
+from src.tournaments.event_team_matcher import (
+    EventTeamSearchQuery,
+    search_event_team_in_db,
+)
 from src.tournaments.seeding_optimizer import (
     normalize_age_group,
     normalize_gender_label,
 )
 from src.tournaments.storage import (
+    ScenarioLockError,
     SchemaVersionError,
+    acquire_scenario_lock,
+    append_override,
     check_games_import_status,
+    compute_frozen_medians,
     ensure_scenario,
     event_key,
     intake_dir,
+    list_runs,
+    load_overrides,
     load_raw_scrape,
     parse_event_key,
     read_event_metadata,
+    read_frozen_medians,
+    read_registry,
+    read_structure,
     rekey_unknown_directories,
     reports_dir,
     write_event_metadata,
+    write_frozen_medians,
+)
+from src.tournaments.storage._io import utc_now_iso
+from src.tournaments.triage import (
+    _STRENGTH_MODES,
+    ProjectedTeamState,
+    _classify_team_state,
+    _is_placeholder_team,
+    _is_play_up,
+    build_override_record,
+    project_overrides,
 )
 from supabase import create_client
 
@@ -346,6 +373,7 @@ def _init_session_state() -> None:
         st.session_state.intake_mode = "backtest"
     if "_scrape_in_progress" not in st.session_state:
         st.session_state._scrape_in_progress = False
+    st.session_state.setdefault("_reviewer_email", "")
 
 
 def _render_rekey_banner() -> None:
@@ -549,7 +577,8 @@ def _render_cohort_summary(
         is_active = bool(st.session_state.get(_cohort_toggle_key(age, gender), False))
         active_border = "#2563eb" if is_active else border
         active_width = "2px" if is_active else "1px"
-        label = f"{_display_gender(gender)} {age.upper()}"
+        label = html.escape(f"{_display_gender(gender)} {age.upper()}")
+        safe_note = html.escape(note)
         col = cohort_cols[i % cols_per_row]
         with col:
             st.markdown(
@@ -558,7 +587,7 @@ def _render_cohort_summary(
                 f"background:{bg}'>"
                 f"<div style='font-weight:600;font-size:11px;color:#6b7280'>{label}</div>"
                 f"<div style='font-size:18px;font-weight:600;margin:2px 0'>{len(records)}</div>"
-                f"<div style='font-size:10px;color:{text}'>● {note}</div>"
+                f"<div style='font-size:10px;color:{text}'>● {safe_note}</div>"
                 f"</div>",
                 unsafe_allow_html=True,
             )
@@ -581,12 +610,1321 @@ def _render_cohort_summary(
     return tints
 
 
+# ---------------------------------------------------------------------------
+# Triage UI — left pane (team rows) + right pane (power ranking)
+# ---------------------------------------------------------------------------
+
+
+_RANK_COLS = (
+    "team_id, team_name, club_name, age_group, gender, state_code, "
+    "games_played, off_norm, def_norm, sos_norm, perf_centered, ml_norm, "
+    "powerscore_ml"
+)
+_TEAM_LOOKUP_COLS = "team_id_master, team_name, club_name, age_group, gender, state_code, provider_team_id"
+
+
+def _render_reviewer_email_input() -> None:
+    """Render the page-level reviewer-email gate.
+
+    All triage write actions read ``st.session_state._reviewer_email`` and
+    stay disabled until it's populated. Mirrors ``dashboard.py:699``
+    (``rq_reviewer_email``) and ``dashboard.py:5746`` (``dd_reviewer_email``).
+    """
+    st.text_input(
+        "Your email (required to save triage actions)",
+        key="_reviewer_email",
+        placeholder="dallas@example.com",
+        help="Triage write actions stay disabled until this is set.",
+    )
+
+
+@st.cache_data(ttl=10)
+def _load_registry_cached(event_key: str, scenario: str) -> list[dict[str, str]]:
+    """Cache the per-scenario registry as plain dicts for stable cache keys."""
+    entries = read_registry(event_key, scenario)
+    return [entry.to_row() for entry in entries]
+
+
+@st.cache_data(ttl=300)
+def _rankings_full_age_form(age: str, _supabase: Any) -> str:
+    """Probe the canonical ``age_group`` casing in ``rankings_full``.
+
+    Memory ``gotcha_age_group_format.md`` flags the lowercase/uppercase
+    divergence; sample five rows whose digits match ``age`` and pick the
+    majority casing. Returns ``age`` unchanged if no rows come back so the
+    right-pane caller can surface the empty-result warning loudly.
+    """
+    if _supabase is None:
+        return age
+    try:
+        rows = (
+            _supabase.table("rankings_full").select("age_group").ilike("age_group", age).limit(5).execute().data or []
+        )
+    except Exception:  # noqa: BLE001 — probe failure surfaces in caller
+        return age
+    if not rows:
+        return age
+    casings = [str(row.get("age_group") or "") for row in rows if row.get("age_group")]
+    if not casings:
+        return age
+    # Majority pick.
+    counts: dict[str, int] = {}
+    for casing in casings:
+        counts[casing] = counts.get(casing, 0) + 1
+    return max(counts, key=counts.get)
+
+
+def _query_from_registry_row(row: dict[str, Any]) -> EventTeamSearchQuery | None:
+    """Build an ``EventTeamSearchQuery`` from a registry row.
+
+    Returns ``None`` when neither ``event_age_group`` nor ``display_age_group``
+    is set — ``normalize_age_group("")`` would crash the matcher otherwise.
+    Mirrors ``scripts/backtest_tournament_event.py._matcher_query_from_registry_row``.
+    """
+    age = str(row.get("event_age_group") or row.get("display_age_group") or "").strip()
+    if not age:
+        return None
+    return EventTeamSearchQuery(
+        event_team_name=str(row.get("event_team_name") or "").strip(),
+        event_age_group=age,
+        event_gender=str(row.get("event_gender") or row.get("display_gender") or "").strip(),
+        event_club_name=str(row.get("event_club_name") or "").strip() or None,
+        search_age_group=str(row.get("search_age_group") or "").strip() or None,
+        provider_team_id=str(row.get("resolved_gotsport_provider_team_id") or "").strip() or None,
+    )
+
+
+def _registry_provider_id(entry_row: dict[str, Any]) -> str:
+    """Resolve the per-row provider key (resolved gotsport id or registration id)."""
+    primary = str(entry_row.get("resolved_gotsport_provider_team_id") or "").strip()
+    if primary:
+        return primary
+    return str(entry_row.get("event_registration_id") or "").strip()
+
+
+def _build_division_groups(
+    cohort_records: list[dict[str, Any]],
+    structure_for_cohort: Any,
+) -> dict[str, list[str]]:
+    """Group provider ids by division name within a cohort.
+
+    Falls back to a single virtual ``"_unstructured"`` division when no
+    ``CohortStructure`` exists yet — matches the plan's "ship before
+    Shell 05" path.
+    """
+    if structure_for_cohort is None:
+        ids = [
+            str(record.get("provider_team_id") or "").strip()
+            for record in cohort_records
+            if record.get("provider_team_id")
+        ]
+        return {"_unstructured": ids}
+    division_names = [division.name for division in structure_for_cohort.divisions]
+    # Sort by length descending so a longer name like "Premier Elite" wins
+    # over a shorter prefix like "Premier" when both could match a bracket.
+    sorted_division_names = sorted(division_names, key=len, reverse=True)
+    groups: dict[str, list[str]] = {name: [] for name in division_names}
+    for record in cohort_records:
+        bracket = str(record.get("bracket_name") or record.get("division") or "").strip()
+        pid = str(record.get("provider_team_id") or "").strip()
+        if not pid:
+            continue
+        chosen = next(
+            (name for name in sorted_division_names if bracket and bracket.startswith(name)),
+            division_names[0] if division_names else "_unstructured",
+        )
+        groups.setdefault(chosen, []).append(pid)
+    return groups
+
+
+def _batch_load_resolved_teams(
+    supabase_client: Any,
+    team_id_masters: set[str],
+) -> dict[str, dict[str, Any]]:
+    """One-shot batch fetch of resolved teams keyed by ``team_id_master``."""
+    if supabase_client is None or not team_id_masters:
+        return {}
+    try:
+        rows = (
+            supabase_client.table("teams")
+            .select(_TEAM_LOOKUP_COLS)
+            .in_("team_id_master", sorted(team_id_masters))
+            .execute()
+            .data
+            or []
+        )
+    except Exception as exc:  # noqa: BLE001 — Supabase failure shouldn't crash render
+        st.warning(f"Resolved-team lookup failed: {exc}")
+        return {}
+    return {str(row["team_id_master"]): row for row in rows if row.get("team_id_master")}
+
+
+# Triage-state → UI lookups. Module-level so the four states are defined
+# in one place and the lookup is a constant-time dict access.
+_STATE_DOT: dict[str, str] = {
+    "resolved": "✓",
+    "candidates": "⚠",
+    "placeholder": "⚠",
+    "external": "✗",
+    "unknown": "❓",
+}
+_STATE_ACTION_LABEL: dict[str, str] = {
+    "resolved": "view",
+    "candidates": "review",
+    "placeholder": "fix",
+    "external": "edit",
+    "unknown": "check",
+}
+_STATE_TINT_LEVEL: dict[str, str] = {
+    "resolved": "green",
+    "external": "amber",
+}
+
+
+def _state_tint_level(state: str) -> str:
+    """Resolve a triage state's tint level. Defaults to ``red`` for blockers."""
+    return _STATE_TINT_LEVEL.get(state, "red")
+
+
+def _resolve_team_id_master(
+    projected: ProjectedTeamState | None,
+    registry_row: dict[str, Any] | None,
+) -> str | None:
+    """Pick the authoritative ``team_id_master`` for a triaged team.
+
+    Override projection wins over the registry snapshot — the registry's
+    ``resolved_team_id_master`` reflects scrape-time matcher state, while
+    the projection reflects the operator's latest accept/fix override.
+    """
+    if projected and projected.team_id_master:
+        return projected.team_id_master
+    if registry_row and registry_row.get("resolved_team_id_master"):
+        return str(registry_row["resolved_team_id_master"])
+    return None
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _render_triage(
+    cohort_records: list[dict[str, Any]],
+    *,
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    event_name: str,
+    supabase_client: Any,
+) -> None:
+    """Top-level triage orchestrator for one expanded cohort."""
+    try:
+        registry_rows = _load_registry_cached(event_key, scenario)
+    except FileNotFoundError:
+        registry_rows = []
+    overrides = load_overrides(event_key, scenario)
+    team_state, _cohort_state = project_overrides(overrides)
+
+    structure_list = read_structure(event_key, scenario)
+    structure_for_cohort = next(
+        (c for c in structure_list if c.age_group == age and c.gender == gender),
+        None,
+    )
+
+    registry_by_pid = {_registry_provider_id(row): row for row in registry_rows if _registry_provider_id(row)}
+    cohort_provider_ids = {
+        str(record.get("provider_team_id") or "").strip() for record in cohort_records if record.get("provider_team_id")
+    }
+    cohort_registry_by_pid = {pid: row for pid, row in registry_by_pid.items() if pid in cohort_provider_ids}
+
+    team_id_masters: set[str] = set()
+    for pid in cohort_provider_ids:
+        team_id = _resolve_team_id_master(team_state.get(pid), cohort_registry_by_pid.get(pid))
+        if team_id:
+            team_id_masters.add(team_id)
+    resolved_team_by_id = _batch_load_resolved_teams(supabase_client, team_id_masters)
+
+    division_groups = _build_division_groups(cohort_records, structure_for_cohort)
+
+    _render_games_coverage(
+        cohort_records=cohort_records,
+        team_state=team_state,
+        cohort_registry_by_pid=cohort_registry_by_pid,
+        structure_for_cohort=structure_for_cohort,
+        event_name=event_name,
+        supabase_client=supabase_client,
+    )
+
+    left_col, right_col = st.columns([3, 2])
+    with left_col:
+        _render_triage_left_pane(
+            cohort_records=cohort_records,
+            registry_by_pid=cohort_registry_by_pid,
+            team_state=team_state,
+            resolved_team_by_id=resolved_team_by_id,
+            division_groups=division_groups,
+            age=age,
+            gender=gender,
+            event_key=event_key,
+            scenario=scenario,
+            supabase_client=supabase_client,
+        )
+    with right_col:
+        _render_triage_right_pane(
+            team_state=team_state,
+            resolved_team_by_id=resolved_team_by_id,
+            registry_by_pid=cohort_registry_by_pid,
+            division_groups=division_groups,
+            age=age,
+            gender=gender,
+            event_key=event_key,
+            scenario=scenario,
+            supabase_client=supabase_client,
+        )
+
+
+def _render_games_coverage(
+    *,
+    cohort_records: list[dict[str, Any]],
+    team_state: Any,
+    cohort_registry_by_pid: dict[str, dict[str, Any]],
+    structure_for_cohort: Any,
+    event_name: str,
+    supabase_client: Any,
+) -> None:
+    """Render the per-cohort games-coverage gauge above the triage split."""
+    if structure_for_cohort is None:
+        st.metric("Games coverage", "pending structure")
+        return
+    expected = sum(
+        getattr(division, "expected_game_count", division.team_count) for division in structure_for_cohort.divisions
+    )
+    team_ids: set[str] = set()
+    for record in cohort_records:
+        pid = str(record.get("provider_team_id") or "").strip()
+        if not pid:
+            continue
+        team_id = _resolve_team_id_master(team_state.get(pid), cohort_registry_by_pid.get(pid))
+        if team_id:
+            team_ids.add(team_id)
+    if not team_ids or supabase_client is None:
+        st.metric("Games coverage", f"unknown — 0 / {expected}")
+        return
+    try:
+        status = _check_games_import_cached(event_name, frozenset(team_ids), supabase_client)
+    except Exception as exc:  # noqa: BLE001
+        st.metric("Games coverage", f"check failed ({exc})")
+        return
+    st.metric("Games coverage", f"{status} — {len(team_ids)} / {expected}")
+    if status == "not_imported":
+        st.warning(
+            "Games not yet imported for this event — run `python scripts/scrape_specific_event.py <event_id>` first."
+        )
+    elif status == "partial":
+        st.info("Games-coverage partial; rerun the per-event scrape to fill gaps.")
+
+
+def _render_triage_left_pane(
+    *,
+    cohort_records: list[dict[str, Any]],
+    registry_by_pid: dict[str, dict[str, Any]],
+    team_state: Any,
+    resolved_team_by_id: dict[str, dict[str, Any]],
+    division_groups: dict[str, list[str]],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> None:
+    """Render the left pane: per-team rows grouped by division."""
+    record_by_pid = {
+        str(r.get("provider_team_id") or "").strip(): r for r in cohort_records if r.get("provider_team_id")
+    }
+    render_matcher_cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]] = {}
+    division_names = list(division_groups.keys())
+
+    fallback_rendered = False
+    for division_name, pids in division_groups.items():
+
+        def body(pids=pids, division_name=division_name) -> None:
+            _render_division_body(
+                pids=pids,
+                division_name=division_name,
+                division_names=division_names,
+                record_by_pid=record_by_pid,
+                registry_by_pid=registry_by_pid,
+                team_state=team_state,
+                resolved_team_by_id=resolved_team_by_id,
+                render_matcher_cache=render_matcher_cache,
+                age=age,
+                gender=gender,
+                event_key=event_key,
+                scenario=scenario,
+                supabase_client=supabase_client,
+            )
+
+        try:
+            render_division_container(division_name, body)
+        except NotImplementedError:
+            if not fallback_rendered:
+                st.info("Enter division structure first to triage teams")
+                fallback_rendered = True
+            # Render the body inline so the operator can still triage.
+            with st.container(border=True):
+                st.markdown(f"**{division_name}**")
+                body()
+
+
+def _render_division_body(
+    *,
+    pids: list[str],
+    division_name: str,
+    division_names: list[str],
+    record_by_pid: dict[str, dict[str, Any]],
+    registry_by_pid: dict[str, dict[str, Any]],
+    team_state: Any,
+    resolved_team_by_id: dict[str, dict[str, Any]],
+    render_matcher_cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> None:
+    """Render the team rows for one division plus the manual-add affordance."""
+    add_key = f"_add_open_{age}_{gender}_{division_name}"
+    st.session_state.setdefault(add_key, False)
+    if st.button(
+        "+ Add team",
+        key=f"_add_btn_{age}_{gender}_{division_name}",
+        help="Add a team that didn't appear in the scrape",
+    ):
+        st.session_state[add_key] = not st.session_state[add_key]
+    if st.session_state[add_key]:
+        _render_manual_add_form(
+            division_name=division_name,
+            division_names=division_names,
+            age=age,
+            gender=gender,
+            event_key=event_key,
+            scenario=scenario,
+            render_matcher_cache=render_matcher_cache,
+            supabase_client=supabase_client,
+        )
+
+    for pid in pids:
+        record = record_by_pid.get(pid, {"provider_team_id": pid, "canonical": {}})
+        registry_row = registry_by_pid.get(pid, {})
+        projected = team_state.get(pid)
+        team_id_master = _resolve_team_id_master(projected, registry_row)
+        resolved_team = resolved_team_by_id.get(team_id_master) if team_id_master else None
+        state = _classify_team_state(record, resolved_team=resolved_team, projected=projected)
+
+        team_name = registry_row.get("event_team_name") or record.get("team_name") or pid
+        play_up = _is_play_up((resolved_team or {}).get("age_group"), cohort_age=age)
+        _render_team_row(
+            pid=pid,
+            team_name=team_name,
+            state=state,
+            play_up=play_up,
+            level=_state_tint_level(state),
+        )
+
+        toggle_key = f"_triage_open_{pid}"
+        st.session_state.setdefault(toggle_key, False)
+        if not st.session_state[toggle_key]:
+            continue
+
+        if state == "candidates":
+            _render_review_expander(
+                pid=pid,
+                registry_row=registry_row,
+                event_key=event_key,
+                scenario=scenario,
+                render_matcher_cache=render_matcher_cache,
+                supabase_client=supabase_client,
+            )
+        elif state == "placeholder":
+            _render_fix_expander(
+                pid=pid,
+                registry_row=registry_row,
+                team_id_master=team_id_master,
+                event_key=event_key,
+                scenario=scenario,
+                supabase_client=supabase_client,
+            )
+        elif state == "external":
+            _render_external_drawer(
+                pid=pid,
+                registry_row=registry_row,
+                projected=projected,
+                division_names=division_names,
+                age=age,
+                gender=gender,
+                event_key=event_key,
+                scenario=scenario,
+                supabase_client=supabase_client,
+            )
+        elif state == "unknown":
+            st.info(f"Team {team_name}: state unknown — re-scrape or accept manually.")
+
+
+def _render_team_row(
+    *,
+    pid: str,
+    team_name: str,
+    state: str,
+    play_up: bool,
+    level: str,
+) -> None:
+    """Render one team row + action toggle."""
+    bg = _TINT_BG[level]
+    border = _TINT_BORDER[level]
+    text = _TINT_TEXT[level]
+    dot = _STATE_DOT.get(state, "•")
+    action_label = _STATE_ACTION_LABEL.get(state, "view")
+    play_up_badge = " 🆙 play-up" if play_up else ""
+    toggle_key = f"_triage_open_{pid}"
+    # ``team_name`` originates from scraped provider HTML; escape before
+    # interpolating into a markdown block with ``unsafe_allow_html=True``.
+    safe_team_name = html.escape(str(team_name))
+    safe_state = html.escape(state)
+    cols = st.columns([0.5, 4, 1, 1.4])
+    with cols[0]:
+        st.markdown(
+            f"<div style='font-size:18px;color:{text};text-align:center'>{dot}</div>",
+            unsafe_allow_html=True,
+        )
+    with cols[1]:
+        st.markdown(
+            f"<div style='padding:6px 8px;border:1px solid {border};border-radius:6px;"
+            f"background:{bg}'>"
+            f"<div style='font-weight:600;font-size:13px'>{safe_team_name}</div>"
+            f"<div style='font-size:11px;color:#6b7280'>{safe_state}{play_up_badge}</div>"
+            f"</div>",
+            unsafe_allow_html=True,
+        )
+    with cols[2]:
+        st.caption(state)
+    with cols[3]:
+        if state == "resolved":
+            st.caption(f"✓ {action_label}")
+        else:
+            if st.button(
+                action_label,
+                key=f"_triage_action_{pid}",
+                help=f"Open the {action_label} flow for this team",
+            ):
+                st.session_state[toggle_key] = not st.session_state.get(toggle_key, False)
+                st.rerun()
+
+
+def _render_review_expander(
+    *,
+    pid: str,
+    registry_row: dict[str, Any],
+    event_key: str,
+    scenario: str,
+    render_matcher_cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]],
+    supabase_client: Any,
+) -> None:
+    """Render the candidates → match-acceptance flow."""
+    name = registry_row.get("event_team_name") or pid
+    reviewer_email = st.session_state.get("_reviewer_email", "")
+    write_disabled = not reviewer_email
+    with st.expander(f"Review {name}", expanded=True):
+        if supabase_client is None:
+            st.warning("Database unavailable — cannot run live matcher.")
+            return
+        query = _query_from_registry_row(registry_row)
+        if query is None:
+            st.warning(
+                "Registry row is missing age group; cannot run live matcher. Re-scrape this event before triaging."
+            )
+            return
+        try:
+            result = search_event_team_in_db(
+                supabase_client,
+                query,
+                limit=3,
+                cache=render_matcher_cache,
+            )
+        except Exception as exc:  # noqa: BLE001
+            st.error(f"Matcher failed: {exc}")
+            return
+        if not result.matches:
+            st.info("No DB candidates — mark this team external if it doesn't exist.")
+        for rank, match in enumerate(result.matches, start=1):
+            cols = st.columns([3, 1, 1, 1])
+            with cols[0]:
+                st.markdown(
+                    f"**{match.get('team_name', '?')}** · {match.get('club_name') or '—'} · "
+                    f"{match.get('age_group', '')}/{match.get('gender', '')}"
+                )
+                st.caption(f"score={match.get('score', 0):.3f} · reason={match.get('score_reason', '?')}")
+            with cols[1]:
+                with st.popover("details"):
+                    st.json(match)
+            with cols[2]:
+                st.metric("score", f"{match.get('score', 0):.2f}")
+            with cols[3]:
+                if st.button(
+                    "Accept",
+                    key=f"_accept_{pid}_{rank}",
+                    disabled=write_disabled,
+                ):
+                    append_override(
+                        event_key,
+                        scenario,
+                        build_override_record(
+                            ts=utc_now_iso(),
+                            actor=reviewer_email,
+                            scope="team",
+                            type="accept_match",
+                            team_ref=pid,
+                            before={
+                                "state": "candidates",
+                                "best_score": result.best_score,
+                                "second_score": result.second_score,
+                            },
+                            after={
+                                "state": "resolved",
+                                "team_id_master": match.get("team_id_master"),
+                                "match_rank": rank,
+                            },
+                            reason=f"operator-accepted match #{rank}",
+                        ),
+                    )
+                    _load_registry_cached.clear()
+                    st.session_state[f"_triage_open_{pid}"] = False
+                    st.rerun()
+        if st.button(
+            "Mark external (reject all)",
+            key=f"_mark_ext_{pid}",
+            disabled=write_disabled,
+        ):
+            append_override(
+                event_key,
+                scenario,
+                build_override_record(
+                    ts=utc_now_iso(),
+                    actor=reviewer_email,
+                    scope="team",
+                    type="mark_external",
+                    team_ref=pid,
+                    before={"state": "candidates"},
+                    after={"state": "external"},
+                    reason="rejected all DB candidates",
+                ),
+            )
+            _load_registry_cached.clear()
+            st.session_state[f"_triage_open_{pid}"] = False
+            st.rerun()
+
+
+def _render_fix_expander(
+    *,
+    pid: str,
+    registry_row: dict[str, Any],
+    team_id_master: str | None,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> None:
+    """Render the placeholder → real-team search flow."""
+    name = registry_row.get("event_team_name") or pid
+    reviewer_email = st.session_state.get("_reviewer_email", "")
+    write_disabled = not reviewer_email
+    with st.expander(f"Fix placeholder {name}", expanded=True):
+        with st.form(f"_fix_{pid}"):
+            name_query = st.text_input("Team name", key=f"_fix_name_{pid}")
+            club_query = st.text_input("Club name", key=f"_fix_club_{pid}")
+            provider_id_query = st.text_input("Provider team id", key=f"_fix_pid_{pid}")
+            team_id_master_query = st.text_input("team_id_master", key=f"_fix_tim_{pid}")
+            submitted = st.form_submit_button("Search")
+        if submitted and supabase_client is not None:
+            results = _search_master_teams(
+                supabase_client,
+                name_query=name_query,
+                club_query=club_query,
+                provider_id_query=provider_id_query,
+                team_id_master_query=team_id_master_query,
+            )
+            if not results:
+                st.info("No matches.")
+            for hit in results:
+                cols = st.columns([4, 1])
+                with cols[0]:
+                    st.markdown(f"**{hit.get('team_name')}** · {hit.get('club_name') or '—'}")
+                    st.caption(
+                        f"{hit.get('age_group', '')} / {hit.get('gender', '')} · "
+                        f"team_id_master={hit.get('team_id_master')}"
+                    )
+                with cols[1]:
+                    if st.button(
+                        "Use this team",
+                        key=f"_fix_use_{pid}_{hit.get('team_id_master')}",
+                        disabled=write_disabled,
+                    ):
+                        append_override(
+                            event_key,
+                            scenario,
+                            build_override_record(
+                                ts=utc_now_iso(),
+                                actor=reviewer_email,
+                                scope="team",
+                                type="fix_match",
+                                team_ref=pid,
+                                before={
+                                    "state": "placeholder",
+                                    "team_id_master": team_id_master,
+                                },
+                                after={
+                                    "state": "resolved",
+                                    "team_id_master": hit.get("team_id_master"),
+                                },
+                                reason="operator picked DB team",
+                            ),
+                        )
+                        _load_registry_cached.clear()
+                        st.session_state[f"_triage_open_{pid}"] = False
+                        st.rerun()
+        if st.button(
+            "Mark external instead",
+            key=f"_fix_mark_ext_{pid}",
+            disabled=write_disabled,
+        ):
+            append_override(
+                event_key,
+                scenario,
+                build_override_record(
+                    ts=utc_now_iso(),
+                    actor=reviewer_email,
+                    scope="team",
+                    type="mark_external",
+                    team_ref=pid,
+                    before={
+                        "state": "placeholder",
+                        "team_id_master": team_id_master,
+                    },
+                    after={
+                        "state": "external",
+                        "manual_override_assume_resolved_without_db": True,
+                    },
+                    reason="placeholder — externalized",
+                ),
+            )
+            _load_registry_cached.clear()
+            st.session_state[f"_triage_open_{pid}"] = False
+            st.rerun()
+
+
+def _search_master_teams(
+    supabase_client: Any,
+    *,
+    name_query: str,
+    club_query: str,
+    provider_id_query: str,
+    team_id_master_query: str,
+) -> list[dict[str, Any]]:
+    """Look up master teams matching any of the supplied fields.
+
+    Mirrors ``dashboard.py:4596-4615``'s search structure. Filters
+    placeholder rows in Python — the cross-column predicate doesn't fit
+    PostgREST.
+    """
+    name_query = (name_query or "").strip()
+    club_query = (club_query or "").strip()
+    provider_id_query = (provider_id_query or "").strip()
+    team_id_master_query = (team_id_master_query or "").strip()
+    if not any([name_query, club_query, provider_id_query, team_id_master_query]):
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        builder = supabase_client.table("teams").select(_TEAM_LOOKUP_COLS)
+        if provider_id_query:
+            rows = builder.eq("provider_team_id", provider_id_query).limit(20).execute().data or []
+        elif team_id_master_query:
+            rows = builder.eq("team_id_master", team_id_master_query).limit(20).execute().data or []
+        elif name_query:
+            rows = builder.ilike("team_name", f"%{name_query}%").limit(20).execute().data or []
+        elif club_query:
+            rows = builder.ilike("club_name", f"%{club_query}%").limit(20).execute().data or []
+    except Exception as exc:  # noqa: BLE001
+        st.error(f"Search failed: {exc}")
+        return []
+    # Filter placeholders in Python via the canonical predicate. Prefix
+    # filtering would also drop legit teams whose name happens to start
+    # with ``unknown_`` (rare, but the canonical predicate is the source
+    # of truth and is essentially free to call).
+    return [
+        row for row in rows if not _is_placeholder_team(row.get("team_name"), str(row.get("provider_team_id") or ""))
+    ]
+
+
+def _render_external_drawer(
+    *,
+    pid: str,
+    registry_row: dict[str, Any],
+    projected: ProjectedTeamState | None,
+    division_names: list[str],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> None:
+    """Render the external-team edit drawer + recompute-medians action."""
+    name = registry_row.get("event_team_name") or pid
+    reviewer_email = st.session_state.get("_reviewer_email", "")
+    write_disabled = not reviewer_email
+    prior_seed = (projected.manual_seed_group if projected else None) or (
+        division_names[0] if division_names else "_unstructured"
+    )
+    prior_strength = (projected.strength_mode if projected else None) or "median"
+    prior_power = projected.manual_power_score if projected else None
+    prior_note = (projected.note if projected else None) or ""
+    with st.expander(f"External team: {name}", expanded=True):
+        with st.form(f"_external_{pid}"):
+            seed_options = division_names or ["_unstructured"]
+            seed_index = seed_options.index(prior_seed) if prior_seed in seed_options else 0
+            manual_seed_group = st.selectbox(
+                "Manual seed group",
+                options=seed_options,
+                index=seed_index,
+                key=f"_ext_seed_{pid}",
+            )
+            mode_index = _STRENGTH_MODES.index(prior_strength) if prior_strength in _STRENGTH_MODES else 0
+            strength_mode = st.radio(
+                "Strength mode",
+                options=_STRENGTH_MODES,
+                index=mode_index,
+                horizontal=True,
+                key=f"_ext_mode_{pid}",
+                help=(
+                    "median: derive from cohort medians · "
+                    "manual: enter a power_score · "
+                    "exclude: skip during ranking (Report Card semantics finalized in a later shell)"
+                ),
+            )
+            manual_power_score = st.number_input(
+                "Manual power_score",
+                value=float(prior_power) if prior_power is not None else 0.0,
+                step=0.1,
+                format="%.2f",
+                disabled=(strength_mode != "manual"),
+                key=f"_ext_score_{pid}",
+            )
+            note = st.text_area("Note", value=prior_note, key=f"_ext_note_{pid}")
+            submitted = st.form_submit_button("Save", disabled=write_disabled)
+        if submitted and reviewer_email:
+            after = {
+                "state": "external",
+                "manual_seed_group": manual_seed_group,
+                "strength_mode": strength_mode,
+                "note": note,
+            }
+            if strength_mode == "manual":
+                after["manual_power_score"] = float(manual_power_score)
+            # Re-load overrides at submit time so a Streamlit rerun between
+            # render and submit doesn't put a stale ``before`` snapshot in
+            # the audit ledger.
+            fresh_team_state, _ = project_overrides(load_overrides(event_key, scenario))
+            fresh_projected = fresh_team_state.get(pid)
+            append_override(
+                event_key,
+                scenario,
+                build_override_record(
+                    ts=utc_now_iso(),
+                    actor=reviewer_email,
+                    scope="team",
+                    type="edit_external",
+                    team_ref=pid,
+                    before=_external_before(fresh_projected),
+                    after=after,
+                    reason="operator edit external",
+                ),
+            )
+            _load_registry_cached.clear()
+            st.session_state[f"_triage_open_{pid}"] = False
+            st.rerun()
+        st.divider()
+        if st.button(
+            "Recompute medians",
+            key=f"_recompute_{pid}",
+            disabled=write_disabled,
+            help=(
+                "Affects every external team in this cohort, not just this one. "
+                "Re-derives medians from current resolved teams."
+            ),
+        ):
+            _trigger_recompute(
+                event_key=event_key,
+                scenario=scenario,
+                age=age,
+                gender=gender,
+                supabase_client=supabase_client,
+                reviewer_email=reviewer_email,
+            )
+
+
+def _external_before(projected: ProjectedTeamState | None) -> dict[str, Any]:
+    """Capture the prior external-team state for the override ``before``."""
+    if projected is None:
+        return {"state": "external"}
+    return {
+        "state": projected.state,
+        "manual_seed_group": projected.manual_seed_group,
+        "strength_mode": projected.strength_mode,
+        "manual_power_score": projected.manual_power_score,
+        "note": projected.note,
+    }
+
+
+def _trigger_recompute(
+    *,
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    supabase_client: Any,
+    reviewer_email: str,
+) -> None:
+    """Run the medians recompute with lock + audit-write ordering."""
+    if supabase_client is None:
+        st.error("Database unavailable — cannot recompute medians.")
+        return
+    with st.spinner("Recomputing medians..."):
+        try:
+            with acquire_scenario_lock(event_key, scenario, timeout=2.0):
+                staging = [
+                    name for name in list_runs(event_key, scenario, completed_only=False) if name.endswith(".tmp")
+                ]
+                if staging:
+                    raise RuntimeError("Recompute disabled while a run is active")
+                _recompute_medians_inner(
+                    event_key=event_key,
+                    scenario=scenario,
+                    age=age,
+                    gender=gender,
+                    supabase_client=supabase_client,
+                    reviewer_email=reviewer_email,
+                )
+        except ScenarioLockError:
+            st.error("Scenario is locked by another process — try again shortly.")
+            return
+        except RuntimeError as exc:
+            st.error(str(exc))
+            return
+    st.success("Medians recomputed.")
+    _load_registry_cached.clear()
+    st.rerun()
+
+
+def _recompute_medians_inner(
+    *,
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    supabase_client: Any,
+    reviewer_email: str,
+) -> None:
+    """Read rankings_full, bucket by division, persist medians + audit."""
+    overrides = load_overrides(event_key, scenario)
+    team_state, _cohort_state = project_overrides(overrides)
+    structure_list = read_structure(event_key, scenario)
+    structure_for_cohort = next(
+        (c for c in structure_list if c.age_group == age and c.gender == gender),
+        None,
+    )
+    division_names = [d.name for d in structure_for_cohort.divisions] if structure_for_cohort else []
+
+    registry_rows = _load_registry_cached(event_key, scenario)
+    cohort_rows = [
+        row for row in registry_rows if row.get("event_age_group") == age and row.get("event_gender") == gender
+    ]
+    division_by_team_id: dict[str, str] = {}
+    for row in cohort_rows:
+        pid = _registry_provider_id(row)
+        team_id_master = _resolve_team_id_master(team_state.get(pid), row)
+        if not team_id_master:
+            continue
+        bracket = str(row.get("event_team_name") or "").strip()
+        chosen = next(
+            (name for name in division_names if name and bracket.startswith(name)),
+            division_names[0] if division_names else "_unstructured",
+        )
+        division_by_team_id[team_id_master] = chosen
+
+    if not division_by_team_id:
+        raise RuntimeError("No resolved teams in cohort — nothing to recompute.")
+
+    probed_age = _rankings_full_age_form(age, supabase_client)
+    rows = (
+        supabase_client.table("rankings_full")
+        .select("team_id, powerscore_ml")
+        .eq("age_group", probed_age)
+        .eq("gender", normalize_gender_label(gender))
+        .in_("team_id", sorted(division_by_team_id.keys()))
+        .execute()
+        .data
+        or []
+    )
+    if not rows:
+        st.warning(f"rankings_full returned zero rows for {age}/{gender} — verify age_group casing.")
+        return
+    buckets: dict[str, list[float]] = {}
+    for row in rows:
+        team_id = str(row.get("team_id") or "")
+        score = _safe_float(row.get("powerscore_ml"))
+        division = division_by_team_id.get(team_id)
+        if score is None or not division:
+            continue
+        buckets.setdefault(division, []).append(score)
+
+    if not any(buckets.values()):
+        st.warning("Recompute produced no median samples — preserving prior medians.")
+        return
+
+    try:
+        prior = read_frozen_medians(event_key, scenario).medians_by_division
+    except FileNotFoundError:
+        prior = {}
+
+    medians = compute_frozen_medians(buckets)
+    write_frozen_medians(event_key, scenario, medians)
+    try:
+        append_override(
+            event_key,
+            scenario,
+            build_override_record(
+                ts=utc_now_iso(),
+                actor=reviewer_email,
+                scope="cohort",
+                type="recompute_medians",
+                team_ref=f"{age}_{gender}",
+                before={"medians_by_division": dict(prior)},
+                after={"medians_by_division": dict(medians.medians_by_division)},
+                reason="operator recompute",
+            ),
+        )
+    except Exception:  # noqa: BLE001
+        st.error("Medians recomputed but audit log write failed; rerun Recompute to land the ledger entry.")
+
+
+def _render_manual_add_form(
+    *,
+    division_name: str,
+    division_names: list[str],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    render_matcher_cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]],
+    supabase_client: Any,
+) -> None:
+    """Render the +Add team form for one division."""
+    reviewer_email = st.session_state.get("_reviewer_email", "")
+    write_disabled = not reviewer_email
+    form_key = f"_add_form_{age}_{gender}_{division_name}"
+    with st.form(form_key):
+        mode = st.radio(
+            "Mode",
+            options=("DB-match", "External"),
+            horizontal=True,
+            key=f"_add_mode_{age}_{gender}_{division_name}",
+        )
+        team_name = st.text_input("Team name", key=f"_add_name_{age}_{gender}_{division_name}")
+        club_name = st.text_input("Club name", key=f"_add_club_{age}_{gender}_{division_name}")
+        provider_team_id = st.text_input(
+            "Provider team id (optional)",
+            key=f"_add_pid_{age}_{gender}_{division_name}",
+        )
+        seed_options = division_names or [division_name]
+        seed_index = seed_options.index(division_name) if division_name in seed_options else 0
+        manual_seed_group = st.selectbox(
+            "Manual seed group",
+            options=seed_options,
+            index=seed_index,
+            help="Reassign before submit if you meant a different division",
+            key=f"_add_seed_{age}_{gender}_{division_name}",
+        )
+        note = st.text_area("Note (External mode)", key=f"_add_note_{age}_{gender}_{division_name}")
+        submitted = st.form_submit_button("Add", disabled=write_disabled)
+    if not (submitted and reviewer_email):
+        return
+    # UUID-derived ids avoid collision (two operators adding the same team)
+    # and key pollution (raw input flowing into widget keys / paths).
+    event_registration_id = uuid.uuid4().hex[:16]
+    team_ref = f"manual_{event_registration_id}"
+    if mode == "DB-match":
+        if supabase_client is None:
+            st.warning("Database unavailable — cannot run live matcher.")
+            return
+        result = search_event_team_in_db(
+            supabase_client,
+            EventTeamSearchQuery(
+                event_team_name=team_name,
+                event_age_group=age,
+                event_gender=gender,
+                event_club_name=club_name or None,
+                provider_team_id=provider_team_id or None,
+            ),
+            limit=3,
+            cache=render_matcher_cache,
+        )
+        if not result.matches:
+            st.info("No DB matches — switch to External mode if this team isn't in the DB.")
+            return
+        # First match is auto-accepted for v1; richer pick-list lands in a later shell.
+        best = result.matches[0]
+        append_override(
+            event_key,
+            scenario,
+            build_override_record(
+                ts=utc_now_iso(),
+                actor=reviewer_email,
+                scope="team",
+                type="manual_add",
+                team_ref=team_ref,
+                before={},
+                after={
+                    "state": "resolved",
+                    "team_id_master": best.get("team_id_master"),
+                    "manual_seed_group": manual_seed_group,
+                    "cohort_age_group": age,
+                    "cohort_gender": gender,
+                    "team_name": team_name,
+                    "club_name": club_name,
+                },
+                reason="manual add — DB match",
+            ),
+        )
+    else:  # External mode
+        append_override(
+            event_key,
+            scenario,
+            build_override_record(
+                ts=utc_now_iso(),
+                actor=reviewer_email,
+                scope="team",
+                type="manual_add",
+                team_ref=team_ref,
+                before={},
+                after={
+                    "state": "external",
+                    "manual_seed_group": manual_seed_group,
+                    "strength_mode": "median",
+                    "note": note,
+                    "cohort_age_group": age,
+                    "cohort_gender": gender,
+                    "team_name": team_name,
+                    "club_name": club_name,
+                },
+                reason="manual add — external",
+            ),
+        )
+    _load_registry_cached.clear()
+    st.session_state[f"_add_open_{age}_{gender}_{division_name}"] = False
+    st.rerun()
+
+
+def _render_triage_right_pane(
+    *,
+    team_state: Any,
+    resolved_team_by_id: dict[str, dict[str, Any]],
+    registry_by_pid: dict[str, dict[str, Any]],
+    division_groups: dict[str, list[str]],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> None:
+    """Render the right pane: power ranking with Grouped/Flat toggle."""
+    st.markdown("**Ranked by power_score**")
+    view_key = f"_rank_view_{age}_{gender}"
+    view = st.radio(
+        "View",
+        options=("Grouped", "Flat"),
+        index=0,
+        horizontal=True,
+        key=view_key,
+        label_visibility="collapsed",
+    )
+
+    division_by_pid: dict[str, str] = {}
+    for division_name, pids in division_groups.items():
+        for pid in pids:
+            division_by_pid[pid] = division_name
+
+    rank_rows = _build_rank_rows(
+        team_state=team_state,
+        registry_by_pid=registry_by_pid,
+        division_by_pid=division_by_pid,
+        age=age,
+        gender=gender,
+        event_key=event_key,
+        scenario=scenario,
+        supabase_client=supabase_client,
+    )
+
+    if not rank_rows:
+        st.info("No ranked teams yet.")
+        return
+
+    if view == "Grouped":
+        rank_rows.sort(key=lambda r: (r["division"], -(r["score"] or -1e9)))
+        prior_division: str | None = None
+        for index, row in enumerate(rank_rows, start=1):
+            if prior_division is not None and row["division"] != prior_division:
+                st.markdown("<hr style='border-style:dashed'/>", unsafe_allow_html=True)
+            _render_rank_row(index, row)
+            prior_division = row["division"]
+    else:
+        rank_rows.sort(key=lambda r: -(r["score"] if r["score"] is not None else -1e9))
+        for index, row in enumerate(rank_rows, start=1):
+            _render_rank_row(index, row)
+
+
+def _build_rank_rows(
+    *,
+    team_state: Any,
+    registry_by_pid: dict[str, dict[str, Any]],
+    division_by_pid: dict[str, str],
+    age: str,
+    gender: str,
+    event_key: str,
+    scenario: str,
+    supabase_client: Any,
+) -> list[dict[str, Any]]:
+    """Build rank rows for the cohort: resolved+placeholder from rankings_full,
+    externals from frozen medians or manual scores."""
+    rows: list[dict[str, Any]] = []
+    cohort_pids = set(division_by_pid.keys())
+
+    resolved_team_ids: set[str] = set()
+    pid_by_team_id: dict[str, str] = {}
+    for pid in cohort_pids:
+        projected = team_state.get(pid)
+        registry_row = registry_by_pid.get(pid, {})
+        # Externals don't show in rankings_full; their score comes from frozen medians.
+        if projected and projected.state == "external":
+            continue
+        team_id_master = _resolve_team_id_master(projected, registry_row)
+        if team_id_master:
+            resolved_team_ids.add(team_id_master)
+            pid_by_team_id[team_id_master] = pid
+
+    rankings_score_by_team_id: dict[str, float] = {}
+    if resolved_team_ids and supabase_client is not None:
+        probed_age = _rankings_full_age_form(age, supabase_client)
+        try:
+            rankings_rows = (
+                supabase_client.table("rankings_full")
+                .select("team_id, powerscore_ml")
+                .eq("age_group", probed_age)
+                .in_("team_id", sorted(resolved_team_ids))
+                .execute()
+                .data
+                or []
+            )
+        except Exception as exc:  # noqa: BLE001
+            st.warning(f"rankings_full lookup failed: {exc}")
+            rankings_rows = []
+        for row in rankings_rows:
+            team_id = str(row.get("team_id") or "")
+            score = _safe_float(row.get("powerscore_ml"))
+            if team_id and score is not None:
+                rankings_score_by_team_id[team_id] = score
+        if not rankings_rows and resolved_team_ids:
+            st.warning(f"rankings_full returned zero rows for {age}/{gender} — verify age_group casing.")
+
+    # Hoist frozen-medians read above the per-team loop. Each external
+    # team needs the medians map; reading per row would re-parse the JSON
+    # on every iteration.
+    try:
+        medians_by_division = read_frozen_medians(event_key, scenario).medians_by_division
+    except FileNotFoundError:
+        medians_by_division = {}
+
+    for pid in cohort_pids:
+        projected = team_state.get(pid)
+        registry_row = registry_by_pid.get(pid, {})
+        division = division_by_pid.get(pid, "_unstructured")
+        team_name = registry_row.get("event_team_name") or pid
+        marker = ""
+        score: float | None = None
+        if projected and projected.state == "external":
+            if projected.strength_mode == "exclude":
+                continue
+            if projected.strength_mode == "manual":
+                score = projected.manual_power_score
+                marker = "★"
+            else:  # median or None
+                seed_group = projected.manual_seed_group
+                score = medians_by_division.get(seed_group) if seed_group else None
+                marker = "★"
+        else:
+            team_id_master = _resolve_team_id_master(projected, registry_row)
+            if team_id_master:
+                score = rankings_score_by_team_id.get(team_id_master)
+            if projected and projected.state == "placeholder":
+                marker = "⚠"
+
+        rows.append(
+            {
+                "pid": pid,
+                "team_name": team_name,
+                "division": division,
+                "score": score,
+                "marker": marker,
+            }
+        )
+    return rows
+
+
+def _render_rank_row(index: int, row: dict[str, Any]) -> None:
+    """Render one ranked-team row in the right pane."""
+    cols = st.columns([0.5, 3, 1, 0.5])
+    with cols[0]:
+        st.caption(f"{index}.")
+    with cols[1]:
+        st.markdown(f"**{row['team_name']}**")
+        st.caption(row["division"])
+    with cols[2]:
+        score = row["score"]
+        if score is None:
+            st.caption("median pending — click Recompute")
+        else:
+            st.caption(f"{score:.2f}")
+    with cols[3]:
+        st.caption(row.get("marker") or "")
+
+
+# ---------------------------------------------------------------------------
+# Cohort containers
+# ---------------------------------------------------------------------------
+
+
 def _render_cohort_containers(
     cohorts: dict[tuple[str, str], list[dict[str, Any]]],
     sorted_keys: list[tuple[str, str]],
     tints: dict[tuple[str, str], tuple[str, str]],
+    *,
+    event_key: str,
+    scenario: str,
+    event_name: str,
+    supabase_client: Any,
 ) -> None:
-    """Render one collapsible container per cohort with placeholder bodies."""
+    """Render one collapsible container per cohort with the triage surface."""
     for cohort in sorted_keys:
         age, gender = cohort
         records = cohorts[cohort]
@@ -603,13 +1941,21 @@ def _render_cohort_containers(
         st.toggle(toggle_label, key=toggle_key)
         if st.session_state[toggle_key]:
             with st.container(border=True):
+                _render_triage(
+                    records,
+                    age=age,
+                    gender=gender,
+                    event_key=event_key,
+                    scenario=scenario,
+                    event_name=event_name,
+                    supabase_client=supabase_client,
+                )
                 st.button(
                     "Run backtest",
                     disabled=True,
-                    help="Run wiring not yet available.",
+                    help="Run wiring lands in Shell 06.",
                     key=f"run_btn_{age}_{gender}",
                 )
-                st.caption("(triage + structure inputs coming soon)")
 
 
 def main() -> None:
@@ -638,13 +1984,22 @@ def main() -> None:
 
     cohorts = _group_cohorts(records)
     sorted_keys = sorted(cohorts.keys(), key=_cohort_sort_key)
+    _render_reviewer_email_input()
     tints = _render_cohort_summary(
         cohorts,
         sorted_keys,
         event_name=meta.event_name,
         supabase_client=supabase_client,
     )
-    _render_cohort_containers(cohorts, sorted_keys, tints)
+    _render_cohort_containers(
+        cohorts,
+        sorted_keys,
+        tints,
+        event_key=key,
+        scenario=st.session_state.scenario_name,
+        event_name=meta.event_name,
+        supabase_client=supabase_client,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds the per-cohort triage surface that resolves every team to one of `resolved` / `candidates` / `placeholder` / `external` (plus `unknown` as a blocker) before a backtest can launch.
- New `src/tournaments/triage.py` is the single source of truth for override projection, the team-state classifier, and the `is_ready` predicate that Shell 06 will gate runs on.
- New `src/tournaments/division_render.py` pins the Shell 04 ↔ Shell 05 division-container contract; Shell 04 ships independently and the contract test flips from `xfail` to `xpass` once Shell 05 lands.
- Wires the Streamlit triage UI into `tournament_intake.py`: page-level reviewer-email gate, per-cohort left pane (review / fix / edit / +Add expanders), right-pane power ranking with Grouped / Flat toggle, recompute-medians flow with scenario lock, games-coverage gauge.
- 88 new unit tests; 240 passing in the storage + intake regression suite.

## State Machine

\`\`\`mermaid
stateDiagram-v2
  [*] --> candidates: scraper_state=review_queued
  [*] --> resolved: scraper_state=alias_written + DB row
  [*] --> placeholder: scraper_state=alias_written + unknown_pid row
  [*] --> external: scraper_state=unresolved
  [*] --> unknown: missing canonical
  candidates --> resolved: accept_match
  candidates --> external: mark_external
  placeholder --> resolved: fix_match
  placeholder --> external: mark_external
  external --> external: edit_external
  resolved --> external: mark_external
  unknown --> [*]: re-scrape or triage
\`\`\`

## Notes

- Override ledger now carries \`cohort_age_group\` + \`cohort_gender\` on \`manual_add\` payloads. Without those fields, \`is_ready\` couldn't see manual-add teams (registry CSV doesn't include them) and could approve a run with un-attributed teams. Shell 07 Report Card consumes the same projection.
- \`_recompute_medians_inner\` acquires the per-scenario lock before writing \`frozen_medians.json\` and refuses if a \`.tmp\` staging dir is active. Empty-bucket recomputes preserve prior medians instead of clobbering with \`{}\`.
- Stored-XSS hardening: every \`unsafe_allow_html=True\` markdown block escapes scraped values via \`html.escape()\`. Caught during review since \`team_name\` flows directly from provider HTML.
- Reviewer-email gate validates email shape (not full RFC, just \`<local>@<domain>.<tld>\`) before any override write.

## Test plan
- [x] \`python -m pytest tests/unit/test_triage_classifiers.py tests/unit/test_triage_projection.py tests/unit/test_triage_readiness.py tests/unit/test_division_render_contract.py tests/unit/test_tournament_intake_helpers.py -v\`
- [x] Storage + intake regression: \`python -m pytest tests/unit/test_storage_*.py tests/unit/test_intake_journal.py tests/unit/test_event_team_matcher.py -q\`
- [x] Smoke imports: \`python -c "import tournament_intake; from src.tournaments.triage import is_ready, project_overrides; from src.tournaments.division_render import render_division_container"\`
- [ ] Manual Streamlit smoke: \`streamlit run tournament_intake.py\`, expand a Phoenix Cup cohort, walk review / fix / edit / +Add flows, click Recompute, toggle Grouped / Flat