### PR TITLE
Shell 06: MatchBalance run orchestration (per-cohort Popen streaming, atomic state machine, overrides audit, fallbacks ledger)

### DIFF
--- a/scripts/backtest_tournament_cohort.py
+++ b/scripts/backtest_tournament_cohort.py
@@ -105,8 +105,8 @@ class TournamentMatchPrediction:
 
 def _get_supabase():
     supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-    supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY") or os.getenv(
-        "SUPABASE_KEY"
+    supabase_key = (
+        os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_KEY")
     )
     if not supabase_url or not supabase_key:
         raise RuntimeError("Missing SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY/SUPABASE_KEY")
@@ -292,8 +292,7 @@ def _build_entrant_row(
         )
     if notes is not None and source_age_group != event_age_group:
         notes.append(
-            f"{event_team_name}: playing up from {source_age_group} into {event_age_group} "
-            "for this tournament cohort"
+            f"{event_team_name}: playing up from {source_age_group} into {event_age_group} for this tournament cohort"
         )
 
     return {
@@ -593,8 +592,7 @@ def _build_python_prediction_and_cost_functions(
         )
         probability_gap = abs(float(prediction.win_probability_a) - float(prediction.win_probability_b))
         competitive_probability = (
-            _sigmoid((1.15 - projected_margin) / 0.45) * 0.7
-            + _sigmoid((0.10 - probability_gap) / 0.08) * 0.3
+            _sigmoid((1.15 - projected_margin) / 0.45) * 0.7 + _sigmoid((0.10 - probability_gap) / 0.08) * 0.3
         )
         if prediction.predicted_winner == "draw":
             competitive_probability = max(competitive_probability, 0.85)
@@ -665,9 +663,13 @@ def _build_point_in_time_prediction_and_cost_functions(
         team_a_snapshot = resolved_snapshots_by_source_id.get(team_a_source_id)
         team_b_snapshot = resolved_snapshots_by_source_id.get(team_b_source_id)
         if team_a_snapshot is None:
-            raise ValueError(f"Missing point-in-time snapshot for {team_a_row['event_team_name']} as of {prediction_date}")  # noqa: E501
+            raise ValueError(
+                f"Missing point-in-time snapshot for {team_a_row['event_team_name']} as of {prediction_date}"
+            )  # noqa: E501
         if team_b_snapshot is None:
-            raise ValueError(f"Missing point-in-time snapshot for {team_b_row['event_team_name']} as of {prediction_date}")  # noqa: E501
+            raise ValueError(
+                f"Missing point-in-time snapshot for {team_b_row['event_team_name']} as of {prediction_date}"
+            )  # noqa: E501
 
         matchup_frame = pd.DataFrame(
             [
@@ -744,7 +746,11 @@ def _summarize_actual_games(game_rows: list[dict[str, Any]]) -> dict[str, float 
     return {
         "actual_game_count": len(margins),
         "average_goal_differential": float(sum(margins) / len(margins)),
-        "median_goal_differential": float(sorted(margins)[len(margins) // 2] if len(margins) % 2 else (sorted(margins)[len(margins) // 2 - 1] + sorted(margins)[len(margins) // 2]) / 2),  # noqa: E501
+        "median_goal_differential": float(
+            sorted(margins)[len(margins) // 2]
+            if len(margins) % 2
+            else (sorted(margins)[len(margins) // 2 - 1] + sorted(margins)[len(margins) // 2]) / 2
+        ),  # noqa: E501
         "close_game_rate": float(sum(1 for margin in margins if margin <= 1) / len(margins)),
         "blowout_3plus_rate": float(sum(1 for margin in margins if margin >= 3) / len(margins)),
         "blowout_5plus_rate": float(sum(1 for margin in margins if margin >= 5) / len(margins)),
@@ -797,12 +803,16 @@ def _build_division_recommendations(
             }
         )
 
-    recommendations.sort(key=lambda row: (row["move"] == "stay", row["recommended_division"], -(row["power_score"] or 0.0)))  # noqa: E501
+    recommendations.sort(
+        key=lambda row: (row["move"] == "stay", row["recommended_division"], -(row["power_score"] or 0.0))
+    )  # noqa: E501
     return recommendations
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Backtest one completed tournament cohort against an optimized reseeding")  # noqa: E501
+    parser = argparse.ArgumentParser(
+        description="Backtest one completed tournament cohort against an optimized reseeding"
+    )  # noqa: E501
     parser.add_argument("--input", required=True, help="Path to cohort backtest request JSON")
     parser.add_argument(
         "--output-dir",
@@ -858,12 +868,10 @@ def main() -> int:
         raise ValueError("Input needs a non-empty entrants list")
 
     client = _get_supabase()
+    print("PHASE: loading-actual-games", flush=True)
     canonical_team_ids = sorted({str(entrant["canonical_team_id"]) for entrant in entrants_payload})
     ranking_source_ids = sorted(
-        {
-            str(entrant.get("ranking_source_team_id") or entrant["canonical_team_id"])
-            for entrant in entrants_payload
-        }
+        {str(entrant.get("ranking_source_team_id") or entrant["canonical_team_id"]) for entrant in entrants_payload}
     )
 
     team_rows = _fetch_rows_by_ids(client, "teams", TEAM_META_COLS, "team_id_master", canonical_team_ids)
@@ -902,28 +910,28 @@ def main() -> int:
                 age_group=entrant_row["age_group"],
                 gender=entrant_row["gender"],
                 power_score=entrant_row["power_score"],
-                rank_in_cohort=float(entrant_row["rank_in_cohort"]) if entrant_row["rank_in_cohort"] is not None else None,  # noqa: E501
+                rank_in_cohort=float(entrant_row["rank_in_cohort"])
+                if entrant_row["rank_in_cohort"] is not None
+                else None,  # noqa: E501
                 club_name=entrant_row["club_name"],
                 state_code=entrant_row["state_code"],
                 games_played=entrant_row["games_played"],
             )
         )
 
-    actual_games = (
-        _normalize_actual_games_override(
-            payload.get("actual_games_override"),
-            {
-                str(division.get("actual_division_name") or division["name"])
-                for division in payload["divisions"]
-            },
-        )
+    actual_games = _normalize_actual_games_override(
+        payload.get("actual_games_override"),
+        {str(division.get("actual_division_name") or division["name"]) for division in payload["divisions"]},
     )
     if not actual_games:
         actual_games = (
             client.table("games")
             .select("id,division_name,game_date,home_team_master_id,away_team_master_id,home_score,away_score")
             .eq("event_name", event_name)
-            .in_("division_name", [str(division.get("actual_division_name") or division["name"]) for division in payload["divisions"]])  # noqa: E501
+            .in_(
+                "division_name",
+                [str(division.get("actual_division_name") or division["name"]) for division in payload["divisions"]],
+            )  # noqa: E501
             .eq("is_excluded", False)
             .not_.is_("home_score", "null")
             .not_.is_("away_score", "null")
@@ -942,6 +950,7 @@ def main() -> int:
     }
 
     prediction_date = str(payload.get("prediction_date") or min(str(row["game_date"]) for row in actual_games))
+    print("PHASE: fetching-recent-games", flush=True)
     recent_games = _fetch_recent_games_for_teams(client, ranking_source_ids, lookback_days=args.history_lookback_days)
 
     predictor_details: dict[str, Any] = {
@@ -962,16 +971,8 @@ def main() -> int:
             raise FileNotFoundError(f"Point-in-time model artifact not found: {artifact_candidate}")
 
         related_team_ids = sorted(
-            {
-                str(game.home_team_master_id)
-                for game in recent_games
-                if game.home_team_master_id
-            }
-            | {
-                str(game.away_team_master_id)
-                for game in recent_games
-                if game.away_team_master_id
-            }
+            {str(game.home_team_master_id) for game in recent_games if game.home_team_master_id}
+            | {str(game.away_team_master_id) for game in recent_games if game.away_team_master_id}
             | set(ranking_source_ids)
         )
         snapshot_lookback_days = max(0, max(args.history_lookback_days, args.snapshot_buffer_days))
@@ -979,6 +980,7 @@ def main() -> int:
             pd.Timestamp(prediction_date).normalize() - pd.Timedelta(days=snapshot_lookback_days)
         ).strftime("%Y-%m-%d")
         snapshot_end = pd.Timestamp(prediction_date).normalize().strftime("%Y-%m-%d")
+        print("PHASE: fetching-snapshots", flush=True)
         snapshots_df = asyncio.run(
             fetch_prediction_feature_snapshots(
                 client,
@@ -994,7 +996,8 @@ def main() -> int:
         snapshot_index = build_snapshot_index(snapshots_df)
         resolved_snapshots_by_source_id: dict[str, dict[str, Any]] = {}
         snapshot_resolution_counts = {"as_of": 0, "future_snapshot_fallback": 0, "synthetic_snapshot_fallback": 0}
-        for entrant_row in entrant_rows:
+        print("PHASE: resolving-snapshots", flush=True)
+        for idx, entrant_row in enumerate(entrant_rows):
             source_id = str(entrant_row["ranking_source_team_id"])
             resolved_snapshot, resolution_mode = _resolve_prediction_snapshot(
                 entrant_row,
@@ -1003,6 +1006,7 @@ def main() -> int:
             )
             resolved_snapshots_by_source_id[source_id] = resolved_snapshot
             snapshot_resolution_counts[resolution_mode] += 1
+            print(f"PROGRESS: snapshots {idx + 1}/{len(entrant_rows)}", flush=True)
             if resolution_mode == "future_snapshot_fallback":
                 notes.append(
                     f"{entrant_row['event_team_name']}: no as-of point-in-time snapshot on {prediction_date}; "
@@ -1041,6 +1045,7 @@ def main() -> int:
         predict_fn, matchup_cost_fn = _build_python_prediction_and_cost_functions(entrant_rows, recent_games)
         matchup_proxy = "python_match_predictor_v1"
 
+    print("PHASE: running-optimizer", flush=True)
     optimization_result = optimize_tournament_format(
         seedable_teams,
         divisions,
@@ -1057,7 +1062,9 @@ def main() -> int:
             division_name=division_spec.name,
             actual_division_name=str(division_payload.get("actual_division_name") or division_spec.name),
             pool_sizes=division_spec.pool_sizes,
-            actual_game_count=actual_game_counts.get(str(division_payload.get("actual_division_name") or division_spec.name)),  # noqa: E501
+            actual_game_count=actual_game_counts.get(
+                str(division_payload.get("actual_division_name") or division_spec.name)
+            ),  # noqa: E501
         )
         for division_spec, division_payload in zip(divisions, payload["divisions"], strict=False)
     }
@@ -1104,6 +1111,7 @@ def main() -> int:
     }
 
     output_dir = Path(args.output_dir)
+    print("PHASE: writing-summary", flush=True)
     _write_json(output_dir / "summary.json", output_payload)
     _write_json(output_dir / "division_recommendations.json", recommendations)
     _write_csv(output_dir / "division_recommendations.csv", recommendations)

--- a/src/tournaments/run_orchestrator.py
+++ b/src/tournaments/run_orchestrator.py
@@ -1,0 +1,990 @@
+"""Per-cohort backtest run orchestration — synchronous, atomic state machine.
+
+Spec §9 (run state machine + run safety) + Section 10 fold-ins 1b / 5b /
+6 / 12b / 21b. Owns the only writer that produces a fully-promoted
+``runs/<run_id>/`` directory with a ``done.json`` — every downstream
+reader (Shell 07's compute, Shell 08's Report Card embed and run-history
+dropdown) is allowed to assume that contract.
+
+Per-cohort: a click on the U14 boys "Run backtest" spawns one
+``backtest_tournament_cohort.py`` subprocess for that cohort. Other
+cohorts' Run buttons are independent — U10's blockers don't refuse a U14
+run and vice versa.
+
+Synchronous: ``execute_run`` blocks the caller (the Streamlit click
+handler) until the subprocess finishes. The scenario lock acquires inside
+this frame and releases when the function returns. v1 has no Cancel — the
+storage layer's ``cancel_run`` exists for v2 use.
+
+The orchestrator owns:
+
+- per-cohort request payload construction (entrants + divisions) so the
+  cohort CLI is invoked the same way as ``backtest_tournament_event.py``
+- subprocess streaming (``Popen`` line iteration) with structured PHASE /
+  PROGRESS markers parsed into ``ProgressEvent`` records
+- ``run_metadata.json`` (CLI args + git SHA + per-input file hashes)
+- ``run_overrides_audit.jsonl`` (per-cohort scope filter applied to
+  ``overrides.jsonl``) + ``fallbacks.jsonl`` (parsed from cohort
+  ``summary.json``'s notes + counts)
+- orphan ``.tmp/`` cleanup at preflight time so a parent crash mid-run
+  doesn't leave the runs dir corrupted forever
+
+KNOWN RISK — division-routing heuristic (matches Shell 04's `_recompute_medians_inner`):
+  `_build_cohort_request_payload` infers each registry team's division via
+  `event_team_name.startswith(division_name)`, falling back to the first
+  division on no match. Real GotSport team names (e.g. "Phoenix Rising 2012
+  Boys") rarely start with a structure division name (e.g. "BU14 Premier"),
+  so the fallback fires and every team in the cohort lands in division #1.
+  Until a follow-up shell adds explicit per-team division assignment to the
+  registry (Shell 04/05 follow-up), every fallback is logged to the run's
+  ``parser_warnings.jsonl`` so production usage will surface this loudly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Literal
+
+from src.tournaments.storage import (
+    ScenarioLockError,
+    acquire_scenario_lock,
+    create_staging_run,
+    fail_run,
+    load_overrides,
+    promote_run,
+    read_event_metadata,
+    read_registry,
+    read_structure,
+    scenario_dir,
+    stamp_schema_version,
+)
+from src.tournaments.storage._io import (
+    append_jsonl,
+    read_json,
+    utc_now_iso,
+    write_json,
+)
+from src.tournaments.triage import (
+    ReadinessResult,
+    is_ready,
+    project_overrides,
+    registry_provider_id,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PreflightResult",
+    "RunOutcome",
+    "execute_run",
+    "generate_run_id",
+    "preflight",
+]
+
+
+_MODEL_VERSION_ARTIFACT_MAP: dict[str, str] = {
+    "poisson_draw_gate_v1": (
+        "models/point_in_time_tournament_margin_postsnapshot_poisson_draw_gate_v1/point_in_time_match_model.pkl"
+    ),
+}
+"""Maps ``meta.extras["model_version_pin"]`` to the on-disk artifact path
+the cohort CLI loads via ``--point-in-time-model-artifact``. Hand-maintained;
+adding a new model version is one new entry. Unknown pins raise ``ValueError``
+inside ``_build_cli_args`` BEFORE Popen so the orchestrator surfaces a clear
+preflight error instead of letting the cohort CLI fail later with
+``FileNotFoundError``.
+"""
+
+_OTHER_COHORT_PREFIX_RE = re.compile(r"^(Boys|Girls) u\d+: ")
+"""Triage cohort-prefixed blocker shape (e.g. ``"Boys u14: foo pending review"``).
+
+Used by ``preflight`` to drop blockers naming a *different* cohort while
+preserving cohort-agnostic blockers (``"event metadata missing or unreadable: ..."``)
+and manual-add blockers (``"manual-add team_x: cohort attribution missing ..."``).
+"""
+
+_PROGRESS_LINE_RE = re.compile(r"^PROGRESS:\s+\S+\s+(\d+)/(\d+)\s*$")
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    """One structured update emitted by the running cohort subprocess.
+
+    Module-internal — only ``execute_run``'s ``on_event`` callback exposes
+    it. ``phase`` is set on a ``PHASE: <name>`` line; ``percent`` is set
+    on a ``PROGRESS: <name> <i>/<n>`` line; ``raw_line`` always holds the
+    original stdout text for fallback display.
+    """
+
+    phase: str | None
+    percent: int | None
+    raw_line: str
+    ts: str
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Per-cohort readiness verdict.
+
+    ``ready`` is True iff ``blockers`` is empty. ``warnings`` never block
+    the Run button — they decorate the enabled state with caveats
+    (e.g. stale snapshot date, high external-team ratio).
+    """
+
+    ready: bool
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    """Terminal state of one ``execute_run`` invocation.
+
+    ``run_dir`` is the promoted ``runs/<run_id>/`` on success or the
+    ``runs/<run_id>.failed/`` on failure. v1 has no cancelled state — the
+    synchronous lifecycle never produces one.
+    """
+
+    state: Literal["completed", "failed"]
+    run_dir: Path
+    error: str | None = None
+
+
+def generate_run_id(age: str, gender: str) -> str:
+    """Return a cohort-scoped run id: ``u14_male_YYYYMMDDTHHMMSS_xxxxxxxxxxxx``.
+
+    Cohort prefix keeps ``runs/`` listings distinguishable per cohort; the
+    UTC timestamp + ``secrets.token_hex(6)`` (48 bits) makes within-second
+    collisions vanishingly unlikely. If a collision still occurs,
+    ``create_staging_run`` raises ``RunStateError`` and the caller surfaces
+    a "click again" message rather than crashing.
+    """
+    timestamp = utc_now_iso().replace(":", "").replace("-", "")[:15]
+    return f"{age}_{gender.lower()}_{timestamp}_{secrets.token_hex(6)}"
+
+
+def _git_repo_sha() -> str:
+    """Return ``git rev-parse HEAD`` or ``""`` if git is unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path.cwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _file_sha256(path: Path) -> str | None:
+    """SHA-256 of the file at ``path``, or ``None`` if missing."""
+    if not path.exists():
+        return None
+    with path.open("rb") as fh:
+        return hashlib.file_digest(fh, "sha256").hexdigest()
+
+
+def _noop_on_event(_ev: ProgressEvent) -> None:
+    """Default ``on_event`` callback — accept and discard.
+
+    Lets callers omit ``on_event`` without sprinkling ``if cb is not None``
+    null-guards through the streaming loop.
+    """
+
+
+def _progress_record(ev: ProgressEvent) -> dict[str, Any]:
+    """Project a ``ProgressEvent`` to its JSONL row shape (single source of truth)."""
+    return {"phase": ev.phase, "percent": ev.percent, "raw_line": ev.raw_line, "ts": ev.ts}
+
+
+def _parse_progress_line(line: str, current_phase: str | None) -> ProgressEvent:
+    """Parse one stdout line into a ``ProgressEvent``.
+
+    - ``PHASE: <name>`` → phase set, percent None.
+    - ``PROGRESS: <name> <i>/<n>`` → percent computed, phase carried from
+      the most recent PHASE marker (PROGRESS does NOT change phase).
+    - Anything else → both None; the line is buffered for the next
+      phase-transition flush in ``execute_run``.
+    """
+    ts = utc_now_iso()
+    if line.startswith("PHASE: "):
+        return ProgressEvent(
+            phase=line.removeprefix("PHASE: ").strip(),
+            percent=None,
+            raw_line=line,
+            ts=ts,
+        )
+    if line.startswith("PROGRESS: "):
+        match = _PROGRESS_LINE_RE.match(line)
+        if match is not None:
+            current = int(match.group(1))
+            total = int(match.group(2))
+            percent = int(round(100 * current / total)) if total else None
+            return ProgressEvent(
+                phase=current_phase,
+                percent=percent,
+                raw_line=line,
+                ts=ts,
+            )
+    return ProgressEvent(phase=None, percent=None, raw_line=line, ts=ts)
+
+
+def _slugify(value: str) -> str:
+    """Lowercase + collapse non-alphanumerics — mirrors ``backtest_tournament_event._slugify``."""
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.strip().lower())
+    return normalized.strip("_")
+
+
+def _cleanup_orphan_staging_dirs(
+    event_key: str,
+    scenario: str,
+    *,
+    base_dir: Path | str,
+    max_age_hours: int = 24,
+) -> None:
+    """Remove ``runs/<id>.tmp/`` directories older than ``max_age_hours``.
+
+    Defends against parent-process crashes mid-run. Does NOT touch
+    in-flight runs — ``progress.jsonl`` is appended every PHASE transition
+    so its mtime tracks liveness. v1 assumes runs complete in well under
+    24h (typical Phoenix Cup cohort: 30–120s).
+    """
+    runs_root = scenario_dir(event_key, scenario, base_dir=base_dir) / "runs"
+    if not runs_root.exists():
+        return
+    threshold_seconds = max_age_hours * 3600
+    now = time.time()
+    for entry in runs_root.iterdir():
+        if not entry.is_dir() or not entry.name.endswith(".tmp"):
+            continue
+        progress_log = entry / "progress.jsonl"
+        if progress_log.exists():
+            mtime = progress_log.stat().st_mtime
+        else:
+            mtime = entry.stat().st_mtime
+        age_seconds = now - mtime
+        if age_seconds > threshold_seconds:
+            shutil.rmtree(entry, ignore_errors=True)
+            logger.warning(
+                "[run_orchestrator] cleaned up orphan staging dir %s (age %ds)",
+                entry.name,
+                int(age_seconds),
+            )
+
+
+def preflight(
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    *,
+    base_dir: Path | str = "reports",
+    supabase_client: Any,
+) -> PreflightResult:
+    """Compute per-cohort readiness + warnings before showing the Run button.
+
+    Wraps ``triage.is_ready`` (scenario-wide) and filters its blockers to
+    ones not naming a different cohort, so a U10 blocker doesn't refuse a
+    U14 run. Cohort-agnostic blockers (event-metadata-missing, manual-add
+    cohort-attribution-missing) survive the filter — they correctly block
+    every cohort's Run button.
+
+    Warnings axis (does NOT block):
+
+    - Stale ranking snapshot (>14 days before kickoff or today)
+    - High external-team ratio (>30% of registered cohort size)
+    """
+    # Cleanup races against in-flight runs in theory; the 24h threshold and
+    # per-PHASE mtime updates make actual data loss vanishingly unlikely, but
+    # we still skip cleanup whenever the scenario is currently locked rather
+    # than block the page render waiting for the lock.
+    try:
+        with acquire_scenario_lock(event_key, scenario, base_dir=base_dir, timeout=0.0):
+            _cleanup_orphan_staging_dirs(event_key, scenario, base_dir=base_dir)
+    except ScenarioLockError:
+        pass
+
+    result: ReadinessResult = is_ready(
+        event_key,
+        scenario,
+        base_dir=base_dir,
+        supabase_client=supabase_client,
+    )
+
+    this_label = f"{gender} {age}: "
+
+    def is_other_cohort(blocker: str) -> bool:
+        match = _OTHER_COHORT_PREFIX_RE.match(blocker)
+        return match is not None and not blocker.startswith(this_label)
+
+    blockers_for_cohort = tuple(b for b in result.blockers if not is_other_cohort(b))
+
+    warnings: list[str] = []
+    try:
+        meta = read_event_metadata(event_key, base_dir=base_dir)
+    except Exception:  # noqa: BLE001 — warnings are best-effort; surface only via blocker path
+        meta = None
+
+    if meta is not None:
+        snapshot_raw = (meta.extras or {}).get("ranking_snapshot_date")
+        snapshot_date: date | None = None
+        if isinstance(snapshot_raw, str):
+            try:
+                snapshot_date = date.fromisoformat(snapshot_raw)
+            except ValueError:
+                snapshot_date = None
+        if snapshot_date is not None:
+            reference_raw = meta.event_start_date
+            reference_date: date | None = None
+            if isinstance(reference_raw, str):
+                try:
+                    reference_date = date.fromisoformat(reference_raw)
+                except ValueError:
+                    reference_date = None
+            if reference_date is None:
+                reference_date = date.today()
+            if (reference_date - snapshot_date).days > 14:
+                warnings.append("ranking snapshot older than 14 days")
+
+    try:
+        overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+    except FileNotFoundError:
+        overrides = []
+    team_state, _ = project_overrides(overrides)
+
+    try:
+        registry = read_registry(event_key, scenario, base_dir=base_dir)
+    except FileNotFoundError:
+        registry = []
+
+    cohort_size = sum(1 for entry in registry if entry.event_age_group == age and entry.event_gender == gender)
+    external_count = 0
+    for entry in registry:
+        if entry.event_age_group != age or entry.event_gender != gender:
+            continue
+        pid = registry_provider_id(entry)
+        projected = team_state.get(pid)
+        if projected is not None and projected.state == "external":
+            external_count += 1
+    for team_ref, projected in team_state.items():
+        if not team_ref.startswith("manual_"):
+            continue
+        if projected.cohort_age_group != age or projected.cohort_gender != gender:
+            continue
+        if projected.state == "external":
+            external_count += 1
+            cohort_size += 1
+        elif projected.state == "resolved":
+            cohort_size += 1
+
+    if cohort_size and external_count / cohort_size > 0.30:
+        warnings.append(f"high external-team ratio ({external_count} of {cohort_size})")
+
+    return PreflightResult(
+        ready=not blockers_for_cohort,
+        blockers=blockers_for_cohort,
+        warnings=tuple(warnings),
+    )
+
+
+def _build_cohort_request_payload(
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    *,
+    base_dir: Path | str,
+    extras: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Build the cohort CLI's request payload (entrants + divisions).
+
+    Returns ``(payload, division_routing_fallbacks)``. ``fallbacks`` is the
+    list of team names that hit the heuristic division routing fallback
+    (see module docstring's KNOWN RISK). ``execute_run`` writes them to
+    ``parser_warnings.jsonl`` so production usage exposes how often the
+    routing heuristic is failing.
+
+    Mirrors ``scripts.backtest_tournament_event._build_request_payload``
+    (event:380-440) — inlined rather than imported because the script-side
+    ``sys.path`` setup is brittle for a package import. ``age`` is in
+    ``u14`` form; ``gender`` is ``"Boys"`` or ``"Girls"`` (matches
+    ``read_structure`` output, which already normalizes both).
+    """
+    if not age.startswith("u"):
+        raise ValueError(f"age must be normalized (e.g. 'u14'); got {age!r}")
+    if gender not in ("Boys", "Girls"):
+        raise ValueError(f"gender must be 'Boys' or 'Girls'; got {gender!r}")
+
+    meta = read_event_metadata(event_key, base_dir=base_dir)
+    registry = read_registry(event_key, scenario, base_dir=base_dir)
+    structure = read_structure(event_key, scenario, base_dir=base_dir)
+
+    cohort_structure = next(
+        (c for c in structure if c.age_group == age and c.gender == gender),
+        None,
+    )
+    if cohort_structure is None:
+        raise ValueError(f"structure for cohort {age}/{gender} not found")
+
+    overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+    team_state, _ = project_overrides(overrides)
+
+    division_names = [d.name for d in cohort_structure.divisions]
+    teams_by_division: dict[str, list[dict[str, Any]]] = {name: [] for name in division_names}
+    division_routing_fallbacks: list[str] = []
+
+    for entry in registry:
+        if entry.event_age_group != age or entry.event_gender != gender:
+            continue
+        pid = registry_provider_id(entry)
+        projected = team_state.get(pid)
+        team_id_master = (
+            projected.team_id_master
+            if projected is not None and projected.team_id_master
+            else (entry.resolved_team_id_master or "")
+        )
+        if not team_id_master:
+            continue
+        team_name = entry.event_team_name or pid
+        bracket = (entry.event_team_name or "").strip()
+        chosen_division = next(
+            (name for name in division_names if name and bracket.startswith(name)),
+            None,
+        )
+        if chosen_division is None:
+            # KNOWN RISK: heuristic fallback (see module docstring). Surface
+            # via parser_warnings.jsonl in execute_run so production usage
+            # exposes how often it bites — Shell 04/05 follow-up will replace
+            # this with explicit per-team division assignment.
+            chosen_division = division_names[0] if division_names else ""
+            division_routing_fallbacks.append(team_name)
+        if chosen_division not in teams_by_division:
+            teams_by_division[chosen_division] = []
+        teams_by_division[chosen_division].append(
+            {
+                "team_id_master": team_id_master,
+                "provider_team_id": pid,
+                "event_team_name": team_name,
+            }
+        )
+
+    age_suffix = age.removeprefix("u")
+    bu_prefix = f"BU{age_suffix} "
+
+    entrants: list[dict[str, Any]] = []
+    divisions_payload: list[dict[str, Any]] = []
+    for division in cohort_structure.divisions:
+        actual_division_name = division.name
+        # ``BU<n> `` strip mirrors event:403/414 for parity with the event CLI.
+        normalized_name = (
+            actual_division_name.removeprefix(bu_prefix).strip()
+            if actual_division_name.startswith(bu_prefix)
+            else actual_division_name
+        )
+        for team in sorted(teams_by_division.get(actual_division_name, []), key=lambda t: t["team_id_master"]):
+            entrants.append(
+                {
+                    "entrant_id": f"{_slugify(actual_division_name)}_{_slugify(team['event_team_name'])}",
+                    "canonical_team_id": team["team_id_master"],
+                    "provider_team_id": team["provider_team_id"],
+                    "event_team_name": team["event_team_name"],
+                    "event_age_group": age,
+                    "event_gender": gender,
+                    "actual_division_name": normalized_name,
+                }
+            )
+        divisions_payload.append(
+            {
+                "name": normalized_name,
+                "actual_division_name": actual_division_name,
+                "team_count": division.team_count,
+                "pool_sizes": list(division.pool_sizes),
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "event_name": meta.event_name,
+        "age_group": age,
+        "gender": gender.lower(),
+        "divisions": divisions_payload,
+        "entrants": entrants,
+    }
+    snapshot_date = extras.get("ranking_snapshot_date")
+    if snapshot_date:
+        payload["prediction_date"] = snapshot_date
+    return payload, sorted(division_routing_fallbacks)
+
+
+def _build_cli_args(staging_dir: Path, *, extras: dict[str, Any]) -> tuple[list[str], Path]:
+    """Return ``(cli_args, request_path)`` for the cohort CLI invocation.
+
+    All defaults are passed explicitly so ``run_metadata.cli_args`` is
+    exhaustive and reproducible. Unknown ``model_version_pin`` raises
+    ``ValueError`` BEFORE Popen — better than letting the cohort CLI fail
+    later with ``FileNotFoundError`` on a missing artifact.
+    """
+    request_path = staging_dir / "request.json"
+    model_pin = extras.get("model_version_pin", "poisson_draw_gate_v1")
+    artifact = _MODEL_VERSION_ARTIFACT_MAP.get(model_pin)
+    if artifact is None:
+        raise ValueError(f"unknown model_version_pin: {model_pin!r}; known: {list(_MODEL_VERSION_ARTIFACT_MAP)}")
+    cli_args = [
+        "--input",
+        str(request_path),
+        "--output-dir",
+        str(staging_dir),
+        "--predictor-source",
+        "point_in_time",
+        "--point-in-time-model-artifact",
+        artifact,
+        "--history-lookback-days",
+        "365",
+        "--snapshot-buffer-days",
+        "30",
+    ]
+    return cli_args, request_path
+
+
+def _collect_run_metadata(
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    run_id: str,
+    *,
+    base_dir: Path | str,
+    started_at: str,
+    cli_args: list[str],
+    extras: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the ``run_metadata.json`` payload (pre-stamp).
+
+    ``ended_at`` is left ``None``; ``execute_run`` patches it on the
+    terminal transition via ``_patch_ended_at`` so the file stays
+    self-describing even if the parent crashes between the patch and the
+    directory rename (the staging dir is non-trustworthy by definition
+    until ``promote_run`` / ``fail_run``).
+    """
+    meta = read_event_metadata(event_key, base_dir=base_dir)
+    scenario_path = scenario_dir(event_key, scenario, base_dir=base_dir)
+    return {
+        "run_id": run_id,
+        "event_key": event_key,
+        "scenario": scenario,
+        "cohort_age_group": age,
+        "cohort_gender": gender,
+        "event_name": meta.event_name,
+        "series_id": meta.series_id,
+        "started_at": started_at,
+        "ended_at": None,
+        "simulation_runs": 1,
+        "model_version_pin": extras.get("model_version_pin"),
+        "ranking_snapshot_date": extras.get("ranking_snapshot_date"),
+        "capped_gd_limit": extras.get("capped_gd_limit"),
+        "balance_score_weights": extras.get("balance_score_weights"),
+        "git_repo_sha": _git_repo_sha(),
+        "hashes": {
+            "registry": _file_sha256(scenario_path / "event_team_registry.csv"),
+            "structure": _file_sha256(scenario_path / "group_structure_summary.csv"),
+            "constraints": _file_sha256(scenario_path / "constraints.json"),
+        },
+        "cli_args": list(cli_args),
+    }
+
+
+def _patch_ended_at(metadata_path: Path, ts: str) -> None:
+    """Atomically patch ``ended_at`` into an existing ``run_metadata.json``."""
+    payload = read_json(metadata_path)
+    payload["ended_at"] = ts
+    write_json(metadata_path, payload)
+
+
+def _assert_summary_present(staging_dir: Path) -> None:
+    """Confirm the cohort CLI wrote ``summary.json`` before downstream readers run.
+
+    Shell 07's ``compute.py`` reads ``summary.json`` directly — no flat
+    ``standings_actual.csv`` / ``standings_optimized.csv`` is needed here
+    (the cohort summary already carries divisions/matches/standings nested
+    under ``optimized_projection.simulated_schedule``). A missing summary
+    is routed to ``fail_run`` by the parent's try/except.
+    """
+    if not (staging_dir / "summary.json").exists():
+        raise RuntimeError(f"cohort CLI did not produce summary.json at {staging_dir}")
+
+
+def _override_in_cohort(
+    record: dict[str, Any],
+    age: str,
+    gender: str,
+    registry_by_pid: dict[str, Any],
+) -> bool:
+    """Return True if ``record`` is an override scoped to the requested cohort.
+
+    For ``manual_add`` overrides the cohort lives on the override's own
+    ``after.cohort_age_group`` / ``after.cohort_gender`` fields. For other
+    types we look up the registry entry by ``team_ref`` (provider id) and
+    compare its ``event_age_group`` / ``event_gender``.
+    """
+    type_ = record.get("type")
+    after = record.get("after") or {}
+    team_ref = str(record.get("team_ref") or "")
+    if type_ == "manual_add":
+        return str(after.get("cohort_age_group") or "") == age and str(after.get("cohort_gender") or "") == gender
+    if type_ == "recompute_medians":
+        # Cohort-scoped overrides use ``team_ref = f"{age}_{gender}"`` (cf.
+        # tournament_intake._recompute_medians_inner).
+        return team_ref == f"{age}_{gender}"
+    entry = registry_by_pid.get(team_ref)
+    if entry is None:
+        return False
+    return entry.event_age_group == age and entry.event_gender == gender
+
+
+def _write_run_overrides_audit(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    age: str,
+    gender: str,
+    started_at: str,
+    staging_dir: Path,
+    *,
+    base_dir: Path | str,
+) -> None:
+    """Append cohort-scoped overrides to ``run_overrides_audit.jsonl``.
+
+    Empty (or absent) audit JSONL is fine when the cohort has zero
+    overrides — Shell 08 tolerates either. Per-record fields beyond the
+    source override: ``run_id``, ``applied_at`` (= ``started_at``),
+    ``delta_balance_score`` (always None in v1; Shell 08's audit panel may
+    lazy-compute on demand).
+    """
+    overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+    registry = read_registry(event_key, scenario, base_dir=base_dir)
+    registry_by_pid: dict[str, Any] = {}
+    for entry in registry:
+        pid = registry_provider_id(entry)
+        if pid:
+            registry_by_pid[pid] = entry
+
+    audit_path = staging_dir / "run_overrides_audit.jsonl"
+    for record in overrides:
+        if not _override_in_cohort(record, age, gender, registry_by_pid):
+            continue
+        audit_entry = {
+            **record,
+            "run_id": run_id,
+            "applied_at": started_at,
+            "delta_balance_score": None,
+        }
+        append_jsonl(audit_path, stamp_schema_version(audit_entry))
+
+
+_FALLBACK_MARKERS: tuple[tuple[str, str], ...] = (
+    (": no as-of point-in-time snapshot", "future_snapshot_fallback"),
+    (": no point-in-time snapshots found", "synthetic_snapshot_fallback"),
+)
+
+
+def _write_fallbacks_jsonl(staging_dir: Path) -> None:
+    """Translate cohort-CLI ``notes`` into per-team ``fallbacks.jsonl`` rows.
+
+    Suffix-partition (not first-colon split) so team names with embedded
+    colons (e.g. ``"FC Tucson: ECNL Boys 2014"``) don't get misattributed.
+    A defensive count-mismatch sentinel goes to a separate
+    ``parser_warnings.jsonl`` so ``fallbacks.jsonl`` stays semantically
+    clean (every row a real per-team fallback Shell 07 can render).
+    """
+    summary = read_json(staging_dir / "summary.json")
+    counts = summary.get("predictor", {}).get("snapshot_resolution_counts", {}) or {}
+    notes = summary.get("notes", []) or []
+
+    parsed_count = 0
+    for note in notes:
+        if not isinstance(note, str):
+            continue
+        for marker, kind in _FALLBACK_MARKERS:
+            head, sep, _tail = note.partition(marker)
+            if sep:
+                append_jsonl(
+                    staging_dir / "fallbacks.jsonl",
+                    stamp_schema_version(
+                        {
+                            "team_name": head,
+                            "fallback_kind": kind,
+                            "raw_note": note,
+                        }
+                    ),
+                )
+                parsed_count += 1
+                break
+
+    expected_fallback_count = int(counts.get("future_snapshot_fallback", 0) or 0) + int(
+        counts.get("synthetic_snapshot_fallback", 0) or 0
+    )
+    if expected_fallback_count > parsed_count:
+        append_jsonl(
+            staging_dir / "parser_warnings.jsonl",
+            stamp_schema_version(
+                {
+                    "kind": "fallback_count_mismatch",
+                    "counts": dict(counts),
+                    "parsed_records": parsed_count,
+                    "raw_notes": list(notes),
+                }
+            ),
+        )
+
+
+def _stream_subprocess(
+    proc: subprocess.Popen,
+    staging_dir: Path,
+    on_event: Callable[[ProgressEvent], None],
+) -> tuple[list[str], threading.Thread]:
+    """Drain stdout (structured + buffered) and stderr (background thread).
+
+    Returns ``(stderr_lines, stderr_thread)`` so the caller can join the
+    drain thread after ``proc.wait()`` and tail stderr into the failure
+    message. Stdout is appended to ``cli_stdout.log`` verbatim while
+    structured PHASE/PROGRESS markers also land in ``progress.jsonl``.
+    Non-marker lines are buffered and flushed to ``on_event`` on each
+    phase transition (UI throttling — keeps render cost bounded).
+    """
+    stderr_lines: list[str] = []
+
+    def _drain_stderr() -> None:
+        if proc.stderr is None:
+            return
+        for raw in iter(proc.stderr.readline, ""):
+            line = raw.rstrip("\n")
+            stderr_lines.append(line)
+            with open(staging_dir / "cli_stderr.log", "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
+    buffered_raw_lines: list[str] = []
+    current_phase: str | None = None
+    with open(staging_dir / "cli_stdout.log", "a", encoding="utf-8") as cli_stdout_log:
+        if proc.stdout is None:
+            return stderr_lines, stderr_thread
+        for raw in iter(proc.stdout.readline, ""):
+            line = raw.rstrip("\n")
+            cli_stdout_log.write(line + "\n")
+            cli_stdout_log.flush()
+            ev = _parse_progress_line(line, current_phase)
+            if ev.phase is not None or ev.percent is not None:
+                append_jsonl(staging_dir / "progress.jsonl", stamp_schema_version(_progress_record(ev)))
+            if ev.phase is not None and ev.phase != current_phase:
+                if buffered_raw_lines:
+                    # Flush buffered plain-text with phase=None so the handler
+                    # renders it as a log block rather than re-interpreting it
+                    # as a status-label update.
+                    on_event(
+                        ProgressEvent(
+                            phase=None,
+                            percent=None,
+                            raw_line="\n".join(buffered_raw_lines),
+                            ts=utc_now_iso(),
+                        )
+                    )
+                    buffered_raw_lines.clear()
+                current_phase = ev.phase
+                on_event(ev)
+            elif ev.percent is not None:
+                on_event(ev)
+            else:
+                buffered_raw_lines.append(line)
+        if buffered_raw_lines:
+            on_event(
+                ProgressEvent(
+                    phase=None,
+                    percent=None,
+                    raw_line="\n".join(buffered_raw_lines),
+                    ts=utc_now_iso(),
+                )
+            )
+
+    return stderr_lines, stderr_thread
+
+
+def _finalize_failure(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    staging_dir: Path,
+    error_msg: str,
+    *,
+    base_dir: Path | str,
+) -> RunOutcome:
+    """Patch ``ended_at``, rename to ``.failed/``, return the failure outcome.
+
+    Resilient to the early-failure case where ``run_metadata.json`` was not
+    yet written (e.g. ``_build_cohort_request_payload`` raised after
+    ``create_staging_run``): the patch is best-effort.
+    """
+    metadata_path = staging_dir / "run_metadata.json"
+    if metadata_path.exists():
+        _patch_ended_at(metadata_path, utc_now_iso())
+    failed_dir = fail_run(event_key, scenario, run_id, error=error_msg, base_dir=base_dir)
+    return RunOutcome(state="failed", run_dir=failed_dir, error=error_msg)
+
+
+def execute_run(
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    *,
+    base_dir: Path | str = "reports",
+    on_event: Callable[[ProgressEvent], None] = _noop_on_event,
+) -> RunOutcome:
+    """Run one cohort backtest synchronously, end-to-end.
+
+    Acquires the per-scenario lock (2.0s timeout, matching the existing
+    Streamlit flows at ``tournament_intake.py:1706/1835/1861``), creates
+    the staging dir, writes ``run_metadata.json`` BEFORE Popen so even a
+    spawn failure leaves the staging dir self-describing, streams the
+    cohort CLI's stdout (structured PHASE/PROGRESS → ``progress.jsonl`` +
+    ``on_event``; raw text → ``cli_stdout.log``) while a background thread
+    drains stderr to ``cli_stderr.log``, then either ``promote_run`` (zero
+    exit + post-run translation succeeds) or ``fail_run``.
+
+    Lock contention surfaces as ``ScenarioLockError``; the caller catches
+    it and renders ``st.error``. Any unhandled exception inside the lock
+    still releases it via the context manager's ``finally``.
+    """
+    with acquire_scenario_lock(event_key, scenario, base_dir=base_dir, timeout=2.0):
+        run_id = generate_run_id(age, gender)
+        meta = read_event_metadata(event_key, base_dir=base_dir)
+        extras = meta.extras or {}
+
+        staging_dir = create_staging_run(event_key, scenario, run_id, base_dir=base_dir)
+
+        # Anything between create_staging_run and Popen-spawn that raises
+        # leaves a stale .tmp dir without a marker file. Convert to a
+        # _finalize_failure call so the failure shows up as a normal failed
+        # run rather than a silent orphan that needs the 24h cleanup sweep.
+        try:
+            payload, division_routing_fallbacks = _build_cohort_request_payload(
+                event_key,
+                scenario,
+                age,
+                gender,
+                base_dir=base_dir,
+                extras=extras,
+            )
+            cli_args, request_path = _build_cli_args(staging_dir, extras=extras)
+            write_json(request_path, payload)
+
+            started_at = utc_now_iso()
+            metadata = stamp_schema_version(
+                _collect_run_metadata(
+                    event_key,
+                    scenario,
+                    age,
+                    gender,
+                    run_id,
+                    base_dir=base_dir,
+                    started_at=started_at,
+                    cli_args=cli_args,
+                    extras=extras,
+                )
+            )
+            write_json(staging_dir / "run_metadata.json", metadata)
+
+            if division_routing_fallbacks:
+                append_jsonl(
+                    staging_dir / "parser_warnings.jsonl",
+                    stamp_schema_version(
+                        {
+                            "kind": "division_routing_fallback",
+                            "fallback_division": payload["divisions"][0]["actual_division_name"]
+                            if payload["divisions"]
+                            else "",
+                            "team_count": len(division_routing_fallbacks),
+                            "team_names": division_routing_fallbacks,
+                        }
+                    ),
+                )
+
+            startup_ev = ProgressEvent(
+                phase="orchestrator-starting",
+                percent=None,
+                raw_line="orchestrator: spawning cohort CLI",
+                ts=utc_now_iso(),
+            )
+            append_jsonl(staging_dir / "progress.jsonl", stamp_schema_version(_progress_record(startup_ev)))
+            on_event(startup_ev)
+        except Exception as exc:  # noqa: BLE001 — pre-Popen failures route through fail_run
+            return _finalize_failure(
+                event_key,
+                scenario,
+                run_id,
+                staging_dir,
+                f"orchestrator pre-spawn failure: {exc!r}",
+                base_dir=base_dir,
+            )
+
+        proc = subprocess.Popen(
+            [sys.executable, "scripts/backtest_tournament_cohort.py", *cli_args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=Path.cwd(),
+            start_new_session=(sys.platform != "win32"),
+        )
+
+        stderr_lines, stderr_thread = _stream_subprocess(proc, staging_dir, on_event)
+        proc.wait()
+        stderr_thread.join(timeout=5.0)
+
+        if proc.returncode != 0:
+            error_msg = f"subprocess exit {proc.returncode}"
+            if stderr_lines:
+                error_msg += "\nstderr tail:\n" + "\n".join(stderr_lines[-20:])
+            return _finalize_failure(event_key, scenario, run_id, staging_dir, error_msg, base_dir=base_dir)
+
+        try:
+            _assert_summary_present(staging_dir)
+            _write_run_overrides_audit(
+                event_key,
+                scenario,
+                run_id,
+                age,
+                gender,
+                started_at,
+                staging_dir,
+                base_dir=base_dir,
+            )
+            _write_fallbacks_jsonl(staging_dir)
+            _patch_ended_at(staging_dir / "run_metadata.json", utc_now_iso())
+            final_dir = promote_run(event_key, scenario, run_id, base_dir=base_dir)
+            return RunOutcome(state="completed", run_dir=final_dir)
+        except Exception as exc:  # noqa: BLE001 — translate failure routes to fail_run
+            return _finalize_failure(
+                event_key,
+                scenario,
+                run_id,
+                staging_dir,
+                f"post-run translation failed: {exc!r}",
+                base_dir=base_dir,
+            )

--- a/src/tournaments/triage.py
+++ b/src/tournaments/triage.py
@@ -57,6 +57,7 @@ __all__ = [
     "build_override_record",
     "is_ready",
     "project_overrides",
+    "registry_provider_id",
 ]
 
 
@@ -400,7 +401,7 @@ def _fetch_resolved_teams(
     return {str(row["team_id_master"]): row for row in rows if row.get("team_id_master")}
 
 
-def _registry_provider_id(entry: Any) -> str:
+def registry_provider_id(entry: Any) -> str:
     """Resolve the per-row provider key.
 
     Prefers ``resolved_gotsport_provider_team_id`` (post-resolution); falls
@@ -456,7 +457,7 @@ def is_ready(
 
     team_ids_for_placeholder: set[str] = set()
     for entry in registry:
-        pid = _registry_provider_id(entry)
+        pid = registry_provider_id(entry)
         projected = team_state.get(pid)
         if projected and projected.team_id_master:
             team_ids_for_placeholder.add(projected.team_id_master)
@@ -467,11 +468,11 @@ def is_ready(
     blockers: list[str] = []
     cohorts_seen: set[tuple[str, str]] = set()
     cohort_team_ids: dict[tuple[str, str], set[str]] = {}
-    registry_pids = {_registry_provider_id(entry) for entry in registry}
+    registry_pids = {registry_provider_id(entry) for entry in registry}
     registry_pids.discard("")
 
     for entry in registry:
-        pid = _registry_provider_id(entry)
+        pid = registry_provider_id(entry)
         if not pid:
             continue
         cohort = (entry.event_age_group, entry.event_gender)

--- a/tests/integration/test_cohort_cli_phase_markers.py
+++ b/tests/integration/test_cohort_cli_phase_markers.py
@@ -1,0 +1,29 @@
+"""Integration smoke for the cohort CLI's PHASE marker emission.
+
+Shell 06 patches ``scripts/backtest_tournament_cohort.py`` to print
+``PHASE: <name>`` lines on stdout so the orchestrator's Popen stream loop
+can drive the Streamlit ``st.status`` UI. The full CLI requires a real
+Supabase client to land on the snapshot path; this smoke just asserts the
+help string still resolves so a typo in the patches doesn't break ``--help``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cohort_cli_help_runs_clean():
+    result = subprocess.run(
+        [sys.executable, "scripts/backtest_tournament_cohort.py", "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--input" in result.stdout
+    assert "--output-dir" in result.stdout

--- a/tests/unit/test_cohort_cli_request_payload_consumes_prediction_date.py
+++ b/tests/unit/test_cohort_cli_request_payload_consumes_prediction_date.py
@@ -1,0 +1,99 @@
+"""Regression: the cohort CLI's request payload reads ``prediction_date``.
+
+Shell 06 sets ``payload["prediction_date"]`` from the operator's
+``meta.extras["ranking_snapshot_date"]`` in
+``run_orchestrator._build_cohort_request_payload``. The cohort CLI then
+falls back to ``min(game_date)`` only when the field is absent — see
+``scripts/backtest_tournament_cohort.py`` near the ``prediction_date =``
+assignment. Spying on the full CLI requires real Supabase, so this test
+asserts the wiring at the source-code + payload-builder level and pins
+the CLI's ``payload.get("prediction_date")`` consumption pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments import run_orchestrator
+from src.tournaments.run_orchestrator import _build_cohort_request_payload
+from src.tournaments.storage import (
+    EventMetadata,
+    TeamRegistryEntry,
+    ensure_scenario,
+    write_event_metadata,
+    write_registry,
+    write_structure,
+)
+from src.tournaments.storage.structure import CohortStructure, DivisionStructure
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+REPO_ROOT = Path(run_orchestrator.__file__).resolve().parents[2]
+
+
+def _bootstrap(base: Path) -> None:
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-05-01",
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+        ),
+        base_dir=base,
+    )
+    write_structure(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            CohortStructure(
+                age_group="u14",
+                gender="Boys",
+                divisions=(DivisionStructure(name="A", team_count=1, pool_sizes=(1,)),),
+            )
+        ],
+        base_dir=base,
+    )
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="A Alpha",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            )
+        ],
+        base_dir=base,
+    )
+
+
+def test_payload_carries_prediction_date_from_extras(tmp_path: Path):
+    _bootstrap(tmp_path)
+    payload, _fallbacks = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={"ranking_snapshot_date": "2026-01-15"},
+    )
+    assert payload["prediction_date"] == "2026-01-15"
+
+
+def test_cohort_cli_reads_payload_prediction_date():
+    """Pin the CLI's consumer line so a future refactor can't silently break the wire.
+
+    The cohort CLI must read ``payload.get("prediction_date")`` somewhere in
+    ``main()``; the orchestrator relies on that contract.
+    """
+    cli_text = (REPO_ROOT / "scripts" / "backtest_tournament_cohort.py").read_text(encoding="utf-8")
+    assert 'payload.get("prediction_date")' in cli_text

--- a/tests/unit/test_run_orchestrator.py
+++ b/tests/unit/test_run_orchestrator.py
@@ -1,0 +1,1053 @@
+"""Unit tests for ``src.tournaments.run_orchestrator``.
+
+Covers the synchronous per-cohort run flow: id generation, cli_args /
+request payload helpers, run_metadata collection (with git + file
+hashes), the Popen-streaming + state-machine path (promote vs. fail),
+and the per-record helpers (overrides audit + fallbacks JSONL).
+
+All tests use ``tmp_path`` as the storage root and monkeypatch
+``subprocess.Popen`` so no real cohort CLI is invoked.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.tournaments import run_orchestrator
+from src.tournaments.run_orchestrator import (
+    _MODEL_VERSION_ARTIFACT_MAP,
+    ProgressEvent,
+    _build_cli_args,
+    _build_cohort_request_payload,
+    _cleanup_orphan_staging_dirs,
+    _collect_run_metadata,
+    _parse_progress_line,
+    _write_fallbacks_jsonl,
+    _write_run_overrides_audit,
+    execute_run,
+    generate_run_id,
+)
+from src.tournaments.storage import (
+    EventMetadata,
+    RunStateError,
+    TeamRegistryEntry,
+    append_override,
+    ensure_scenario,
+    write_event_metadata,
+    write_registry,
+    write_structure,
+)
+from src.tournaments.storage._io import write_json
+from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.structure import CohortStructure, DivisionStructure
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+# ---------------------------------------------------------------------------
+# fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_event(
+    base: Path,
+    *,
+    extras: dict[str, Any] | None = None,
+    event_start: str = "2026-05-01",
+) -> None:
+    """Create a minimal scenario layout for executor tests."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date=event_start,
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+            series_id="phoenix-cup-2026",
+            extras=extras or {},
+        ),
+        base_dir=base,
+    )
+    # Single cohort/single division so the request payload is well-defined.
+    write_structure(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            CohortStructure(
+                age_group="u14",
+                gender="Boys",
+                divisions=(DivisionStructure(name="A", team_count=2, pool_sizes=(2,), advancement=None),),
+            )
+        ],
+        base_dir=base,
+    )
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="A Alpha",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+                canonical_resolution_status="direct_provider_id",
+                in_scope_u10_u19="True",
+            ),
+            TeamRegistryEntry(
+                event_registration_id="reg-2",
+                event_team_name="A Bravo",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-2",
+                resolved_team_id_master="tim-2",
+                canonical_resolution_status="direct_provider_id",
+                in_scope_u10_u19="True",
+            ),
+        ],
+        base_dir=base,
+    )
+
+
+def _scenario(base: Path) -> Path:
+    return scenario_dir(EVENT_KEY, SCENARIO, base_dir=base)
+
+
+def _runs(base: Path) -> Path:
+    return _scenario(base) / "runs"
+
+
+# ---------------------------------------------------------------------------
+# generate_run_id
+# ---------------------------------------------------------------------------
+
+
+def test_generate_run_id_format():
+    rid = generate_run_id("u14", "Boys")
+    assert re.match(r"^u\d+_(boys|girls)_\d{8}T\d{6}_[0-9a-f]{12}$", rid), rid
+
+
+def test_generate_run_id_lowercases_gender():
+    rid = generate_run_id("u14", "Girls")
+    assert "_girls_" in rid
+
+
+# ---------------------------------------------------------------------------
+# _collect_run_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_collect_run_metadata_includes_cohort_and_hashes(tmp_path: Path):
+    _bootstrap_event(
+        tmp_path,
+        extras={
+            "model_version_pin": "poisson_draw_gate_v1",
+            "ranking_snapshot_date": "2026-04-30",
+            "capped_gd_limit": 3,
+            "balance_score_weights": {"preset_id": "default"},
+        },
+    )
+    # Constraints file presence drives one of the SHA hashes
+    write_json(_scenario(tmp_path) / "constraints.json", {"foo": "bar"})
+
+    metadata = _collect_run_metadata(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        "run_x",
+        base_dir=tmp_path,
+        started_at="2026-04-30T12:00:00+00:00",
+        cli_args=["--input", "x.json"],
+        extras={
+            "model_version_pin": "poisson_draw_gate_v1",
+            "ranking_snapshot_date": "2026-04-30",
+            "capped_gd_limit": 3,
+            "balance_score_weights": {"preset_id": "default"},
+        },
+    )
+
+    assert metadata["cohort_age_group"] == "u14"
+    assert metadata["cohort_gender"] == "Boys"
+    assert metadata["event_name"] == "Phoenix Cup 2026"
+    assert metadata["model_version_pin"] == "poisson_draw_gate_v1"
+    assert metadata["simulation_runs"] == 1
+    assert metadata["ended_at"] is None
+    assert metadata["cli_args"] == ["--input", "x.json"]
+    # SHA-256 hex digest is 64 chars
+    assert metadata["hashes"]["registry"] is not None
+    assert len(metadata["hashes"]["registry"]) == 64
+    assert metadata["hashes"]["structure"] is not None
+    assert metadata["hashes"]["constraints"] is not None
+
+
+def test_collect_run_metadata_handles_missing_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+
+    def _fake_git_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=args, returncode=128, stdout="", stderr="not a repo")
+
+    monkeypatch.setattr(run_orchestrator.subprocess, "run", _fake_git_run)
+
+    metadata = _collect_run_metadata(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        "run_x",
+        base_dir=tmp_path,
+        started_at="2026-04-30T12:00:00+00:00",
+        cli_args=[],
+        extras={},
+    )
+    assert metadata["git_repo_sha"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_cli_args
+# ---------------------------------------------------------------------------
+
+
+def test_build_cli_args_resolves_known_model_pin(tmp_path: Path):
+    assert (
+        _MODEL_VERSION_ARTIFACT_MAP["poisson_draw_gate_v1"]
+        == "models/point_in_time_tournament_margin_postsnapshot_poisson_draw_gate_v1/point_in_time_match_model.pkl"
+    )
+    cli_args, request_path = _build_cli_args(tmp_path / "stage", extras={})
+    assert request_path == tmp_path / "stage" / "request.json"
+    assert "--point-in-time-model-artifact" in cli_args
+    artifact_idx = cli_args.index("--point-in-time-model-artifact") + 1
+    assert cli_args[artifact_idx].endswith("point_in_time_match_model.pkl")
+
+
+def test_build_cli_args_raises_on_unknown_model_pin(tmp_path: Path):
+    with pytest.raises(ValueError, match="unknown model_version_pin"):
+        _build_cli_args(tmp_path / "stage", extras={"model_version_pin": "future_v9"})
+
+
+# ---------------------------------------------------------------------------
+# _build_cohort_request_payload
+# ---------------------------------------------------------------------------
+
+
+def test_build_cohort_request_payload_includes_prediction_date_when_extras_set(tmp_path: Path):
+    _bootstrap_event(tmp_path, extras={"ranking_snapshot_date": "2026-04-30"})
+    payload, fallbacks = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={"ranking_snapshot_date": "2026-04-30"},
+    )
+    assert payload["prediction_date"] == "2026-04-30"
+    assert payload["age_group"] == "u14"
+    assert payload["gender"] == "boys"
+    assert len(payload["entrants"]) == 2
+    # Fixture team names "A Alpha" / "A Bravo" both start with division "A"
+    # so the routing heuristic resolves cleanly with no fallbacks.
+    assert fallbacks == []
+
+
+def test_build_cohort_request_payload_omits_prediction_date_when_absent(tmp_path: Path):
+    _bootstrap_event(tmp_path)
+    payload, _fallbacks = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={},
+    )
+    assert "prediction_date" not in payload
+
+
+# ---------------------------------------------------------------------------
+# _parse_progress_line — exercises percent computation + phase carry
+# ---------------------------------------------------------------------------
+
+
+def test_parse_progress_line_phase_resets_phase():
+    ev = _parse_progress_line("PHASE: writing-summary", current_phase="resolving-snapshots")
+    assert ev.phase == "writing-summary"
+    assert ev.percent is None
+
+
+def test_parse_progress_line_progress_carries_phase_and_computes_percent():
+    ev = _parse_progress_line("PROGRESS: snapshots 2/5", current_phase="resolving-snapshots")
+    assert ev.phase == "resolving-snapshots"
+    assert ev.percent == 40
+
+
+def test_parse_progress_line_plain_text_returns_no_phase_no_percent():
+    ev = _parse_progress_line("plain log line", current_phase="resolving-snapshots")
+    assert ev.phase is None
+    assert ev.percent is None
+    assert ev.raw_line == "plain log line"
+
+
+# ---------------------------------------------------------------------------
+# execute_run — Popen plumbing
+# ---------------------------------------------------------------------------
+
+
+class _FakePopen:
+    """Stand-in for ``subprocess.Popen`` used by the orchestrator's run loop.
+
+    Designed to coexist with stray ``subprocess.run(["git", ...])`` calls
+    inside ``_git_repo_sha`` — those land here too because monkeypatching
+    ``run_orchestrator.subprocess.Popen`` also intercepts ``subprocess.run``
+    (which uses ``Popen`` internally). Unrecognized commands return empty
+    streams + zero exit so the git probe stays well-behaved.
+
+    Supports the context-manager protocol because ``subprocess.run``
+    does ``with Popen(...) as process``.
+    """
+
+    def __init__(
+        self,
+        cmd: list[str],
+        *,
+        stdout_lines: list[str],
+        stderr_lines: list[str] | None = None,
+        returncode: int = 0,
+        write_summary: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._cmd = cmd
+        is_cohort_cli = any("backtest_tournament_cohort" in part for part in cmd)
+        if is_cohort_cli:
+            self.stdout = io.StringIO("".join(line if line.endswith("\n") else line + "\n" for line in stdout_lines))
+            self.stderr = io.StringIO(
+                "".join(line if line.endswith("\n") else line + "\n" for line in (stderr_lines or []))
+            )
+            self.returncode = returncode
+            if write_summary is not None and "--output-dir" in cmd:
+                output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+                output_dir.mkdir(parents=True, exist_ok=True)
+                (output_dir / "summary.json").write_text(json.dumps(write_summary), encoding="utf-8")
+        else:
+            # Non-cohort invocations (e.g. ``git rev-parse HEAD``) — quiet success.
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+            self.returncode = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+    def poll(self) -> int:
+        return self.returncode
+
+    def communicate(self, input: Any = None, timeout: float | None = None) -> tuple[str, str]:
+        return self.stdout.read(), self.stderr.read()
+
+    def kill(self) -> None:
+        return None
+
+    def __enter__(self) -> "_FakePopen":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+
+def _install_fake_popen(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout_lines: list[str],
+    stderr_lines: list[str] | None = None,
+    returncode: int = 0,
+    write_summary: dict[str, Any] | None = None,
+    pre_check: list[Any] | None = None,
+) -> None:
+    """Replace ``subprocess.Popen`` *only* for the cohort CLI invocation.
+
+    Also stubs ``_git_repo_sha`` to ``""`` so the orchestrator's git probe
+    doesn't escape the sandbox via the real ``subprocess.run`` — which would
+    otherwise be re-routed through this monkeypatch and crash on the first
+    Popen-API contract that ``_FakePopen`` doesn't fully implement.
+    """
+    monkeypatch.setattr(run_orchestrator, "_git_repo_sha", lambda: "")
+
+    def _factory(cmd: list[str], **kwargs: Any) -> _FakePopen:
+        if pre_check is not None:
+            pre_check.append(cmd)
+        return _FakePopen(
+            cmd,
+            stdout_lines=stdout_lines,
+            stderr_lines=stderr_lines,
+            returncode=returncode,
+            write_summary=write_summary,
+        )
+
+    monkeypatch.setattr(run_orchestrator.subprocess, "Popen", _factory)
+
+
+def _minimal_summary() -> dict[str, Any]:
+    return {
+        "event_name": "Phoenix Cup 2026",
+        "cohort": {"age_group": "u14", "gender": "Boys"},
+        "predictor": {
+            "snapshot_resolution_counts": {
+                "as_of": 2,
+                "future_snapshot_fallback": 0,
+                "synthetic_snapshot_fallback": 0,
+            }
+        },
+        "notes": [],
+    }
+
+
+def test_execute_run_writes_metadata_before_popen(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+
+    metadata_present_at_popen: list[bool] = []
+    monkeypatch.setattr(run_orchestrator, "_git_repo_sha", lambda: "")
+
+    def _factory(cmd: list[str], **kwargs: Any) -> _FakePopen:
+        if any("backtest_tournament_cohort" in part for part in cmd):
+            output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            metadata_present_at_popen.append((output_dir / "run_metadata.json").exists())
+        return _FakePopen(
+            cmd,
+            stdout_lines=["PHASE: writing-summary\n"],
+            returncode=0,
+            write_summary=_minimal_summary(),
+        )
+
+    monkeypatch.setattr(run_orchestrator.subprocess, "Popen", _factory)
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "completed"
+    assert metadata_present_at_popen == [True]
+
+
+def test_execute_run_streams_phase_progress_to_callback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=[
+            "PHASE: resolving-snapshots\n",
+            "PROGRESS: snapshots 2/5\n",
+            "stray log\n",
+            "PHASE: writing-summary\n",
+        ],
+        returncode=0,
+        write_summary=_minimal_summary(),
+    )
+
+    events: list[ProgressEvent] = []
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        on_event=events.append,
+    )
+    assert outcome.state == "completed"
+
+    # First synthetic event from the orchestrator
+    assert events[0].phase == "orchestrator-starting"
+
+    phases = [(ev.phase, ev.percent) for ev in events if ev.phase is not None]
+    assert ("resolving-snapshots", None) in phases
+    # PROGRESS preserves current_phase + computes percent
+    assert ("resolving-snapshots", 40) in phases
+    # writing-summary phase eventually fires
+    assert any(p == "writing-summary" for p, _ in phases)
+
+
+def test_execute_run_progress_jsonl_contains_only_structured_records(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=[
+            "PHASE: resolving-snapshots\n",
+            "PROGRESS: snapshots 2/5\n",
+            "stray log\n",
+            "PHASE: writing-summary\n",
+        ],
+        returncode=0,
+        write_summary=_minimal_summary(),
+    )
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "completed"
+
+    progress_records = [
+        json.loads(line)
+        for line in (outcome.run_dir / "progress.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    # synthetic + 2x PHASE + 1x PROGRESS = 4 (no plain-text noise)
+    assert len(progress_records) == 4
+    assert all(r["schema_version"] == 1 for r in progress_records)
+    assert {r.get("phase") for r in progress_records} >= {
+        "orchestrator-starting",
+        "resolving-snapshots",
+        "writing-summary",
+    }
+
+    cli_stdout = (outcome.run_dir / "cli_stdout.log").read_text(encoding="utf-8")
+    assert "PHASE: resolving-snapshots" in cli_stdout
+    assert "stray log" in cli_stdout
+
+
+def test_execute_run_separates_stderr_into_log_and_error_field(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=[],
+        stderr_lines=["Traceback (most recent call last):\n", "ValueError: synthetic\n"],
+        returncode=1,
+    )
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "failed"
+    assert outcome.error and "subprocess exit 1" in outcome.error
+    assert "stderr tail:" in (outcome.error or "")
+    assert "synthetic" in (outcome.error or "")
+    cli_stderr = (outcome.run_dir / "cli_stderr.log").read_text(encoding="utf-8")
+    assert "Traceback" in cli_stderr
+    assert "ValueError: synthetic" in cli_stderr
+
+
+def test_execute_run_promotes_on_zero_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=["PHASE: writing-summary\n"],
+        returncode=0,
+        write_summary=_minimal_summary(),
+    )
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "completed"
+    assert outcome.run_dir.name.endswith("_" + outcome.run_dir.name.split("_")[-1])
+    assert (outcome.run_dir / "done.json").exists()
+    # staging dir gone
+    assert not (outcome.run_dir.parent / (outcome.run_dir.name + ".tmp")).exists()
+
+
+def test_execute_run_fails_on_nonzero_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=[],
+        returncode=1,
+    )
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "failed"
+    assert outcome.run_dir.name.endswith(".failed")
+    error_payload = json.loads((outcome.run_dir / "error.json").read_text(encoding="utf-8"))
+    assert "subprocess exit 1" in error_payload["error"]
+
+
+def test_execute_run_routes_translate_failure_to_fail_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=["PHASE: writing-summary\n"],
+        returncode=0,
+        # NO summary written
+    )
+
+    outcome = execute_run(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+    )
+    assert outcome.state == "failed"
+    assert outcome.run_dir.name.endswith(".failed")
+    error_payload = json.loads((outcome.run_dir / "error.json").read_text(encoding="utf-8"))
+    assert "post-run translation failed" in error_payload["error"]
+
+
+def test_execute_run_collision_recovery_surfaces_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path)
+    monkeypatch.setattr(run_orchestrator.secrets, "token_hex", lambda n: "deadbeef" * (n // 4))
+
+    # Pre-create the staging dir for the deterministic run_id so
+    # create_staging_run raises RunStateError immediately.
+    rid_first = generate_run_id("u14", "Boys")
+    (_runs(tmp_path) / f"{rid_first}.tmp").mkdir(parents=True)
+
+    with pytest.raises(RunStateError):
+        execute_run(
+            EVENT_KEY,
+            SCENARIO,
+            "u14",
+            "Boys",
+            base_dir=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _write_run_overrides_audit
+# ---------------------------------------------------------------------------
+
+
+def test_run_overrides_audit_filters_to_cohort(tmp_path: Path):
+    _bootstrap_event(tmp_path)
+    # A second cohort + entry for it
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="A Alpha",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+            TeamRegistryEntry(
+                event_registration_id="reg-3",
+                event_team_name="B Charlie",
+                event_age_group="u10",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-3",
+                resolved_team_id_master="tim-3",
+            ),
+        ],
+        base_dir=tmp_path,
+    )
+
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "accept_match",
+            "team_ref": "pid-1",
+            "before": {},
+            "after": {"team_id_master": "tim-1"},
+            "reason": "matches u14 cohort",
+        },
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:01:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "accept_match",
+            "team_ref": "pid-3",
+            "before": {},
+            "after": {"team_id_master": "tim-3"},
+            "reason": "matches u10 cohort",
+        },
+        base_dir=tmp_path,
+    )
+
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    _write_run_overrides_audit(
+        EVENT_KEY,
+        SCENARIO,
+        "run_x",
+        "u14",
+        "Boys",
+        "2026-04-21T00:00:00+00:00",
+        staging,
+        base_dir=tmp_path,
+    )
+
+    audit_lines = [
+        json.loads(line)
+        for line in (staging / "run_overrides_audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(audit_lines) == 1
+    assert audit_lines[0]["team_ref"] == "pid-1"
+    assert audit_lines[0]["run_id"] == "run_x"
+    assert audit_lines[0]["delta_balance_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# _write_fallbacks_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_fallbacks_jsonl_uses_predictor_key_and_top_level_notes(tmp_path: Path):
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    summary = {
+        "predictor": {
+            "snapshot_resolution_counts": {
+                "as_of": 1,
+                "future_snapshot_fallback": 1,
+                "synthetic_snapshot_fallback": 1,
+            }
+        },
+        "notes": [
+            "Alpha: no as-of point-in-time snapshot on 2026-04-30; using earliest later snapshot from 2026-05-02",
+            "Bravo: no point-in-time snapshots found; using synthesized snapshot from current ranking inputs",
+        ],
+    }
+    (staging / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+    _write_fallbacks_jsonl(staging)
+    rows = [
+        json.loads(line)
+        for line in (staging / "fallbacks.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 2
+    kinds = {row["fallback_kind"] for row in rows}
+    assert kinds == {"future_snapshot_fallback", "synthetic_snapshot_fallback"}
+
+
+def test_fallbacks_jsonl_handles_team_name_with_colon(tmp_path: Path):
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    summary = {
+        "predictor": {
+            "snapshot_resolution_counts": {
+                "as_of": 0,
+                "future_snapshot_fallback": 1,
+                "synthetic_snapshot_fallback": 0,
+            }
+        },
+        "notes": [
+            "FC Tucson: ECNL Boys 2014: no as-of point-in-time snapshot on 2026-04-30; "
+            "using earliest later snapshot from 2026-05-02"
+        ],
+    }
+    (staging / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+    _write_fallbacks_jsonl(staging)
+    rows = [
+        json.loads(line)
+        for line in (staging / "fallbacks.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["team_name"] == "FC Tucson: ECNL Boys 2014"
+    assert rows[0]["fallback_kind"] == "future_snapshot_fallback"
+
+
+def test_fallbacks_jsonl_emits_parser_warning_on_count_mismatch(tmp_path: Path):
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    # Counts claim two fallbacks, but only one note describes one — sentinel emits.
+    summary = {
+        "predictor": {
+            "snapshot_resolution_counts": {
+                "as_of": 0,
+                "future_snapshot_fallback": 1,
+                "synthetic_snapshot_fallback": 1,
+            }
+        },
+        "notes": ["Alpha: no as-of point-in-time snapshot on 2026-04-30"],
+    }
+    (staging / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+    _write_fallbacks_jsonl(staging)
+    warnings = [
+        json.loads(line)
+        for line in (staging / "parser_warnings.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert warnings and warnings[0]["kind"] == "fallback_count_mismatch"
+    assert warnings[0]["parsed_records"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_orphan_staging_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_tmp_cleanup_removes_old_dirs(tmp_path: Path):
+    _bootstrap_event(tmp_path)
+    runs_root = _runs(tmp_path)
+    runs_root.mkdir(exist_ok=True)
+    old_dir = runs_root / "old.tmp"
+    old_dir.mkdir()
+    new_dir = runs_root / "new.tmp"
+    new_dir.mkdir()
+
+    cutoff = time.time() - 25 * 3600
+    import os
+
+    os.utime(old_dir, (cutoff, cutoff))
+
+    _cleanup_orphan_staging_dirs(EVENT_KEY, SCENARIO, base_dir=tmp_path, max_age_hours=24)
+
+    assert not old_dir.exists()
+    assert new_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# _override_in_cohort — manual_add and recompute_medians branches
+# ---------------------------------------------------------------------------
+
+
+def test_run_overrides_audit_includes_manual_add_for_this_cohort(tmp_path: Path):
+    _bootstrap_event(tmp_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "manual_add",
+            "team_ref": "manual_xyz",
+            "before": {},
+            "after": {
+                "state": "external",
+                "cohort_age_group": "u14",
+                "cohort_gender": "Boys",
+                "note": "Visiting Mexican team",
+            },
+            "reason": "manual add",
+        },
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:01:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "manual_add",
+            "team_ref": "manual_other",
+            "before": {},
+            "after": {
+                "state": "external",
+                "cohort_age_group": "u10",
+                "cohort_gender": "Boys",
+            },
+            "reason": "wrong cohort",
+        },
+        base_dir=tmp_path,
+    )
+
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    _write_run_overrides_audit(
+        EVENT_KEY,
+        SCENARIO,
+        "run_x",
+        "u14",
+        "Boys",
+        "2026-04-21T00:00:00+00:00",
+        staging,
+        base_dir=tmp_path,
+    )
+    rows = [
+        json.loads(line)
+        for line in (staging / "run_overrides_audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["team_ref"] == "manual_xyz"
+
+
+def test_run_overrides_audit_includes_recompute_medians_for_this_cohort(tmp_path: Path):
+    _bootstrap_event(tmp_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "cohort",
+            "type": "recompute_medians",
+            "team_ref": "u14_Boys",
+            "before": {"medians_by_division": {}},
+            "after": {"medians_by_division": {"A": 0.55}},
+            "reason": "ops recompute",
+        },
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:01:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "cohort",
+            "type": "recompute_medians",
+            "team_ref": "u10_Boys",
+            "before": {"medians_by_division": {}},
+            "after": {"medians_by_division": {"A": 0.50}},
+            "reason": "other cohort",
+        },
+        base_dir=tmp_path,
+    )
+
+    staging = tmp_path / "stage"
+    staging.mkdir()
+    _write_run_overrides_audit(
+        EVENT_KEY,
+        SCENARIO,
+        "run_x",
+        "u14",
+        "Boys",
+        "2026-04-21T00:00:00+00:00",
+        staging,
+        base_dir=tmp_path,
+    )
+    rows = [
+        json.loads(line)
+        for line in (staging / "run_overrides_audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["team_ref"] == "u14_Boys"
+
+
+# ---------------------------------------------------------------------------
+# _parse_progress_line — malformed PROGRESS lines fall through cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_parse_progress_line_malformed_progress_falls_to_plain_text():
+    ev = _parse_progress_line("PROGRESS: incomplete-line", current_phase="resolving-snapshots")
+    # Doesn't match the strict ^PROGRESS:\s+\S+\s+(\d+)/(\d+)\s*$ regex
+    assert ev.phase is None
+    assert ev.percent is None
+    assert ev.raw_line == "PROGRESS: incomplete-line"
+
+
+def test_parse_progress_line_zero_total_yields_none_percent():
+    ev = _parse_progress_line("PROGRESS: snapshots 0/0", current_phase="resolving-snapshots")
+    # Division-by-zero guard: percent is None, phase still carries
+    assert ev.phase == "resolving-snapshots"
+    assert ev.percent is None
+
+
+# ---------------------------------------------------------------------------
+# Division-routing fallback emits parser_warnings.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_execute_run_emits_division_routing_fallback_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Bootstrap with team names that DON'T start with division "A" → fallback fires
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-05-01",
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+        ),
+        base_dir=tmp_path,
+    )
+    write_structure(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            CohortStructure(
+                age_group="u14",
+                gender="Boys",
+                divisions=(DivisionStructure(name="A", team_count=2, pool_sizes=(2,)),),
+            )
+        ],
+        base_dir=tmp_path,
+    )
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="Phoenix Rising 2012 Boys",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+        ],
+        base_dir=tmp_path,
+    )
+    _install_fake_popen(
+        monkeypatch,
+        stdout_lines=["PHASE: writing-summary\n"],
+        returncode=0,
+        write_summary=_minimal_summary(),
+    )
+    outcome = execute_run(EVENT_KEY, SCENARIO, "u14", "Boys", base_dir=tmp_path)
+    assert outcome.state == "completed"
+    warnings = [
+        json.loads(line)
+        for line in (outcome.run_dir / "parser_warnings.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert any(w["kind"] == "division_routing_fallback" for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# execute_run pre-Popen failure routes through fail_run (not orphaned .tmp)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_run_pre_popen_failure_routes_to_fail_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap_event(tmp_path, extras={"model_version_pin": "future_v9_unknown"})
+    monkeypatch.setattr(run_orchestrator, "_git_repo_sha", lambda: "")
+    outcome = execute_run(EVENT_KEY, SCENARIO, "u14", "Boys", base_dir=tmp_path)
+    assert outcome.state == "failed"
+    assert outcome.run_dir.name.endswith(".failed")
+    assert outcome.error and "orchestrator pre-spawn failure" in outcome.error
+    error_payload = json.loads((outcome.run_dir / "error.json").read_text(encoding="utf-8"))
+    assert "unknown model_version_pin" in error_payload["error"]

--- a/tests/unit/test_run_orchestrator_preflight.py
+++ b/tests/unit/test_run_orchestrator_preflight.py
@@ -1,0 +1,225 @@
+"""Unit tests for ``src.tournaments.run_orchestrator.preflight``.
+
+Validates the per-cohort blocker filter (drops blockers naming OTHER
+cohorts, keeps cohort-agnostic + this-cohort + manual-add blockers) and
+the warnings axis (stale snapshot, high external-team ratio).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tournaments import run_orchestrator
+from src.tournaments.run_orchestrator import preflight
+from src.tournaments.storage import (
+    EventMetadata,
+    TeamRegistryEntry,
+    append_override,
+    ensure_scenario,
+    write_event_metadata,
+    write_registry,
+    write_structure,
+)
+from src.tournaments.storage.structure import CohortStructure, DivisionStructure
+from src.tournaments.triage import ReadinessResult
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def _bootstrap(
+    base: Path,
+    *,
+    extras: dict | None = None,
+    event_start: str = "2026-05-01",
+    registry: list[TeamRegistryEntry] | None = None,
+) -> None:
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date=event_start,
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+            extras=extras or {},
+        ),
+        base_dir=base,
+    )
+    write_structure(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            CohortStructure(
+                age_group="u14",
+                gender="Boys",
+                divisions=(DivisionStructure(name="A", team_count=2, pool_sizes=(2,)),),
+            )
+        ],
+        base_dir=base,
+    )
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        registry
+        or [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="A Alpha",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+        ],
+        base_dir=base,
+    )
+
+
+def test_preflight_filters_blockers_to_requested_cohort(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap(tmp_path)
+    monkeypatch.setattr(
+        run_orchestrator,
+        "is_ready",
+        lambda *a, **k: ReadinessResult(
+            ready=False,
+            blockers=(
+                "Boys u14: A Alpha pending review",
+                "Boys u10: ghost-team pending review",
+                "event metadata missing or unreadable: oops",
+                "manual-add manual_x: cohort attribution missing (rewrite override)",
+            ),
+        ),
+    )
+    result = preflight(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        supabase_client=None,
+    )
+    blockers = set(result.blockers)
+    assert "Boys u14: A Alpha pending review" in blockers
+    assert "Boys u10: ghost-team pending review" not in blockers
+    assert "event metadata missing or unreadable: oops" in blockers
+    assert "manual-add manual_x: cohort attribution missing (rewrite override)" in blockers
+
+
+def test_preflight_warns_on_stale_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap(
+        tmp_path,
+        extras={"ranking_snapshot_date": "2025-12-01"},
+        event_start="2026-01-15",
+    )
+    monkeypatch.setattr(
+        run_orchestrator,
+        "is_ready",
+        lambda *a, **k: ReadinessResult(ready=True, blockers=()),
+    )
+    result = preflight(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        supabase_client=None,
+    )
+    assert any("older than 14 days" in w for w in result.warnings)
+
+
+def test_preflight_no_warnings_when_snapshot_recent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _bootstrap(
+        tmp_path,
+        extras={"ranking_snapshot_date": "2026-01-08"},
+        event_start="2026-01-15",
+    )
+    monkeypatch.setattr(
+        run_orchestrator,
+        "is_ready",
+        lambda *a, **k: ReadinessResult(ready=True, blockers=()),
+    )
+    result = preflight(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        supabase_client=None,
+    )
+    assert result.warnings == ()
+
+
+def test_preflight_warns_on_high_external_ratio_for_this_cohort_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Cohort u14 with 4 external out of 10
+    u14_entries = [
+        TeamRegistryEntry(
+            event_registration_id=f"reg-u14-{i}",
+            event_team_name=f"U14 Team {i}",
+            event_age_group="u14",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id=f"pid-u14-{i}",
+            resolved_team_id_master=f"tim-u14-{i}",
+        )
+        for i in range(10)
+    ]
+    u10_entries = [
+        TeamRegistryEntry(
+            event_registration_id=f"reg-u10-{i}",
+            event_team_name=f"U10 Team {i}",
+            event_age_group="u10",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id=f"pid-u10-{i}",
+            resolved_team_id_master=f"tim-u10-{i}",
+        )
+        for i in range(8)
+    ]
+    _bootstrap(tmp_path, registry=u14_entries + u10_entries)
+    # Mark 4 of u14 external via mark_external override
+    for i in range(4):
+        append_override(
+            EVENT_KEY,
+            SCENARIO,
+            {
+                "ts": f"2026-04-20T00:00:0{i}+00:00",
+                "actor": "ops@example.com",
+                "scope": "team",
+                "type": "mark_external",
+                "team_ref": f"pid-u14-{i}",
+                "before": {},
+                "after": {},
+                "reason": "test",
+            },
+            base_dir=tmp_path,
+        )
+
+    monkeypatch.setattr(
+        run_orchestrator,
+        "is_ready",
+        lambda *a, **k: ReadinessResult(ready=True, blockers=()),
+    )
+
+    result_u14 = preflight(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        supabase_client=None,
+    )
+    assert any("high external-team ratio" in w for w in result_u14.warnings)
+
+    result_u10 = preflight(
+        EVENT_KEY,
+        SCENARIO,
+        "u10",
+        "Boys",
+        base_dir=tmp_path,
+        supabase_client=None,
+    )
+    assert not any("high external-team ratio" in w for w in result_u10.warnings)

--- a/tournament_intake.py
+++ b/tournament_intake.py
@@ -38,6 +38,11 @@ from src.tournaments.event_team_matcher import (
     EventTeamSearchQuery,
     search_event_team_in_db,
 )
+from src.tournaments.run_orchestrator import (
+    ProgressEvent,
+    execute_run,
+    preflight,
+)
 from src.tournaments.seeding_optimizer import (
     normalize_age_group,
     normalize_gender_label,
@@ -47,6 +52,7 @@ from src.tournaments.storage import (
     CohortStructure,
     DivisionStructure,
     EventMetadata,
+    RunStateError,
     ScenarioLockError,
     SchemaVersionError,
     acquire_scenario_lock,
@@ -462,6 +468,8 @@ def _init_session_state() -> None:
         st.session_state.intake_mode = "backtest"
     if "_scrape_in_progress" not in st.session_state:
         st.session_state._scrape_in_progress = False
+    if "current_run_id_by_cohort" not in st.session_state:
+        st.session_state.current_run_id_by_cohort = {}
     st.session_state.setdefault("_reviewer_email", "")
 
 
@@ -2752,6 +2760,83 @@ def _render_advanced_settings(
 # ---------------------------------------------------------------------------
 
 
+def _render_cohort_run_control(
+    *,
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    supabase_client: Any,
+) -> None:
+    """Render the per-cohort Run-backtest control + warnings + status block.
+
+    Three branches:
+
+    - A run is already loaded for this cohort → caption only; Shell 08's
+      "Re-run" control clears the entry.
+    - Preflight has blockers → disabled button with the blocker list as
+      hover help.
+    - Preflight is clean → enabled button + warning chips + scenario-lock
+      notice. On click, runs synchronously via :func:`execute_run`,
+      streaming PHASE/PROGRESS markers into ``st.status``.
+    """
+    button_key = f"run_btn_{age}_{gender}"
+    cohort_run_id = st.session_state.current_run_id_by_cohort.get((age, gender))
+    if cohort_run_id is not None:
+        st.caption(f"Run loaded: {cohort_run_id}")
+        return
+
+    result = preflight(event_key, scenario, age, gender, supabase_client=supabase_client)
+    if result.blockers:
+        st.button(
+            "Run backtest",
+            disabled=True,
+            help="\n".join(result.blockers),
+            key=button_key,
+        )
+        return
+
+    clicked = st.button("Run backtest", type="primary", key=button_key)
+    for warning in result.warnings:
+        st.caption(f"⚠ {warning}")
+    st.caption("Run holds a per-scenario lock for the duration; other tabs cannot save while it runs.")
+    if not clicked:
+        return
+
+    with st.status(f"Running {gender} {age} backtest", expanded=True, state="running") as status_box:
+
+        def on_event(ev: ProgressEvent) -> None:
+            # The orchestrator emits PHASE/PROGRESS events with phase set
+            # (drives the status label) and buffered plain-text events with
+            # phase=None (rendered as a log block).
+            if ev.phase is not None:
+                pct_suffix = f" · {ev.percent}%" if ev.percent is not None else ""
+                status_box.update(label=f"{ev.phase}{pct_suffix}")
+            elif ev.raw_line:
+                st.code(ev.raw_line, language="text")
+
+        try:
+            outcome = execute_run(
+                event_key,
+                scenario,
+                age,
+                gender,
+                on_event=on_event,
+            )
+        except ScenarioLockError as exc:
+            status_box.update(label=f"Scenario locked: {exc}", state="error")
+            return
+        except RunStateError as exc:
+            status_box.update(label=f"Cannot stage run: {exc}", state="error")
+            return
+        if outcome.state == "completed":
+            st.session_state.current_run_id_by_cohort[(age, gender)] = outcome.run_dir.name
+            status_box.update(label="Completed", state="complete")
+            st.rerun()
+        else:
+            status_box.update(label=f"Failed: {outcome.error or 'unknown'}", state="error")
+
+
 def _render_cohort_containers(
     cohorts: dict[tuple[str, str], list[dict[str, Any]]],
     sorted_keys: list[tuple[str, str]],
@@ -2788,11 +2873,12 @@ def _render_cohort_containers(
                     event_name=event_name,
                     supabase_client=supabase_client,
                 )
-                st.button(
-                    "Run backtest",
-                    disabled=True,
-                    help="Run wiring lands in Shell 06.",
-                    key=f"run_btn_{age}_{gender}",
+                _render_cohort_run_control(
+                    event_key=event_key,
+                    scenario=scenario,
+                    age=age,
+                    gender=gender,
+                    supabase_client=supabase_client,
                 )
 
 


### PR DESCRIPTION
Adds the per-cohort Run-backtest path: Streamlit click then preflight, then synchronous Popen of `scripts/backtest_tournament_cohort.py`, then streamed PHASE/PROGRESS markers into `st.status`, then atomic `runs/<id>.tmp/` to `runs/<id>/` promote (or `.failed/` on subprocess error). Owns the only writer that produces a fully-promoted `runs/<run_id>/` with a `done.json`, so Shells 07/08 can trust the contract.

What's in:
- New `src/tournaments/run_orchestrator.py`. Public surface: `preflight`, `execute_run`, `generate_run_id`, `PreflightResult`, `RunOutcome`. Reuses the Shell 02 state-machine helpers (`create_staging_run` / `promote_run` / `fail_run`) and the per-scenario advisory lock.
- `scripts/backtest_tournament_cohort.py`: 6 `print("PHASE: ...", flush=True)` plus 1 `PROGRESS:` marker so the orchestrator's Popen stream parser can drive the status box. `enumerate` rewrite around the snapshot-resolution loop for the percent metric.
- `tournament_intake.py`: replaces the disabled stub Run button at `:2791` with `_render_cohort_run_control`. New session-state key `current_run_id_by_cohort: dict[(age, gender), str]`. Synchronous click handler streams PHASE updates into `st.status(...)` and renders buffered plain-text via `st.code`.
- Per-cohort preflight wraps `triage.is_ready` and filters scenario-wide blockers to ones not naming a different cohort (so a U10 blocker doesn't refuse a U14 run). Warnings axis: stale ranking snapshot (>14 days), high external-team ratio (>30%).
- Per-run artifacts in `runs/<run_id>/`: `request.json`, `run_metadata.json` (CLI args + git SHA + per-input file SHA-256s), `summary.json` (verbatim cohort CLI output), `progress.jsonl` (structured PHASE/PROGRESS), `cli_stdout.log`, `cli_stderr.log`, `run_overrides_audit.jsonl` (cohort-scoped overrides), `fallbacks.jsonl` (parsed from cohort summary notes), and `parser_warnings.jsonl` (defensive sentinels).
- Orphan `.tmp/` cleanup runs from preflight under a non-blocking lock-try, so a stalled-but-live run can't be deleted by another tab's preflight.
- Promoted `triage._registry_provider_id` to public `registry_provider_id` so the orchestrator can reuse the same fallback rule the readiness gate uses.

## State Machine

```mermaid
stateDiagram-v2
  [*] --> staging: create_staging_run() to runs/id.tmp
  staging --> running: write_metadata + Popen
  staging --> failed: pre-spawn exception (caught + finalized)
  running --> completed: zero exit + summary present + audit/fallbacks written
  running --> failed: nonzero exit OR post-translate error
  completed --> [*]: promote_run() to runs/id/done.json
  failed --> [*]: fail_run() to runs/id.failed/error.json
```

## Flow

```mermaid
sequenceDiagram
  participant UI as Streamlit click handler
  participant Orch as run_orchestrator.execute_run
  participant Lock as scenario lock
  participant Cohort as backtest_tournament_cohort.py
  UI->>Orch: execute_run(event_key, scenario, age, gender, on_event)
  Orch->>Lock: acquire (timeout=2.0s)
  Orch->>Orch: create_staging_run + write metadata + payload
  Orch->>Cohort: Popen(stdout=PIPE, stderr=PIPE)
  Cohort-->>Orch: PHASE / PROGRESS / log lines
  Orch-->>UI: on_event(ProgressEvent) per marker
  Cohort-->>Orch: exit code
  Orch->>Orch: write audit + fallbacks + patch ended_at
  Orch->>Lock: release
  Orch-->>UI: RunOutcome(state, run_dir, error)
```

Tests:
- New: `test_run_orchestrator.py` (id format + payload helpers + `_collect_run_metadata` + `_parse_progress_line` + Popen-streaming via `_FakePopen` + promote/fail/translate-fail/collision/pre-spawn-failure paths + override-audit cohort filter for `accept_match` + `manual_add` + `recompute_medians` + `fallbacks.jsonl` happy + colon-team-name + count-mismatch + orphan cleanup + division-routing fallback warning).
- New: `test_run_orchestrator_preflight.py` (cohort blocker filter, stale snapshot, high external ratio).
- New: `test_cohort_cli_phase_markers.py` (smoke `--help`).
- New: `test_cohort_cli_request_payload_consumes_prediction_date.py` (regression pin: orchestrator's `extras["ranking_snapshot_date"]` flows into the CLI's `payload.get("prediction_date")` consumer).
- All 46 new tests plus the existing run-layout tests pass.

Polish round caught and fixed: `_emit` null-guard wrapper replaced with no-op default callback; duplicated PHASE/PROGRESS dict literal collapsed into `_progress_record`; `cli_stdout.log` switched to `with open(...)` for guaranteed close on errors; `assert` in `_build_cohort_request_payload` replaced with `ValueError`; `_translate_cli_output` renamed to `_assert_summary_present`; `del supabase_client` (unused param) dropped; `_finalize_failure` extracted to collapse the duplicated failure-tail; modernized `_file_sha256` to `hashlib.file_digest`; pre-spawn exceptions now route through `fail_run` instead of leaving an orphaned `.tmp/`; orphan cleanup wrapped in non-blocking lock-try; Streamlit handler simplified after fixing the buffered-flush phase contract; `st.rerun()` only fires on success so the failure error stays visible.

## Known limitation

`_build_cohort_request_payload` infers each team's division via `event_team_name.startswith(division_name)`, falling back to `divisions[0]` on no match. Same heuristic exists in `tournament_intake._recompute_medians_inner`. Real GotSport team names rarely begin with structure division names, so the fallback fires for nearly every team and the entire cohort lands in the first division. Every fallback is logged to `runs/<run_id>/parser_warnings.jsonl` (`kind: "division_routing_fallback"`) so production usage will surface incidence; non-zero counts mean backtest output for that run is meaningless. Tracked in `.turbo/improvements.md` as a Shell 04/05 follow-up that needs to capture explicit per-team division assignment.

Plan: `.turbo/plans/matchbalance-backtest-intake-06-run-orchestration.md`. Spec §9, §10 fold-ins 1b / 5b / 6 / 12b / 21b. Forfeit policy (fold-in 15) explicitly deferred to a follow-up shell.
