### PR TITLE
Shells 07+09: MatchBalance report library + per-team division assignment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,5 @@ scikit-learn>=1.3.0
 
 # Dashboard
 streamlit>=1.29.0
+jinja2>=3.1
 matplotlib>=3.7.0

--- a/scripts/backfill_division_assignments.py
+++ b/scripts/backfill_division_assignments.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Backfill ``assign_division`` overrides from raw_scrape bracket names.
+
+Walks every registry team in a given event_key/scenario, looks up the
+matching ``raw_scrape`` record's ``bracket_name``, and writes one
+``assign_division`` override per team that prefix-matches a current
+structure division. Idempotent: teams already carrying an explicit
+assignment are skipped.
+
+Per-team critical section preserves operator intent under interleaving:
+the projection is re-read inside each team's ``acquire_scenario_lock``
+window so an operator write that lands mid-script doesn't get silently
+overwritten.
+
+Usage:
+    python scripts/backfill_division_assignments.py \\
+        --event-key gotsport__45224__2026 --scenario default [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from src.tournaments.storage import (  # noqa: E402
+    acquire_scenario_lock,
+    append_override,
+    load_overrides,
+    load_raw_scrape,
+    read_registry,
+    read_structure,
+)
+from src.tournaments.storage._io import utc_now_iso  # noqa: E402
+from src.tournaments.triage import (  # noqa: E402
+    SOURCE_PREFIX,
+    build_override_record,
+    project_overrides,
+    registry_provider_id,
+    resolve_division_assignment,
+)
+
+_BACKFILL_ACTOR = "backfill-script@matchbalance.local"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill assign_division overrides")
+    parser.add_argument("--event-key", required=True, help="Event key (e.g. gotsport__45224__2026)")
+    parser.add_argument("--scenario", required=True, help="Scenario name (e.g. default)")
+    parser.add_argument(
+        "--base-dir",
+        default="reports",
+        help="Storage base dir (default: reports)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute counts but skip every append_override call",
+    )
+    args = parser.parse_args()
+
+    event_key = args.event_key
+    scenario = args.scenario
+    base_dir = args.base_dir
+    dry_run = args.dry_run
+
+    raw_scrape = load_raw_scrape(event_key, base_dir=base_dir)
+    bracket_by_pid: dict[str, str] = {}
+    for record in raw_scrape:
+        pid = str(record.get("provider_team_id") or "").strip()
+        if not pid:
+            continue
+        bracket = str(record.get("bracket_name") or record.get("division") or "").strip()
+        if bracket:
+            bracket_by_pid[pid] = bracket
+
+    registry = read_registry(event_key, scenario, base_dir=base_dir)
+
+    backfilled_count = 0
+    already_assigned_count = 0
+    require_triage_count = 0
+    missing_raw_scrape_count = 0
+    dry_run_would_backfill_count = 0
+
+    for entry in registry:
+        pid = registry_provider_id(entry)
+        if not pid:
+            continue
+        bracket = bracket_by_pid.get(pid)
+        if bracket is None:
+            missing_raw_scrape_count += 1
+            continue
+        with acquire_scenario_lock(event_key, scenario, base_dir=base_dir, timeout=10.0):
+            # Re-read overrides AND structure INSIDE the lock — a fresh
+            # projection catches any operator write that landed since
+            # script start, and re-reading structure prevents writing a
+            # stale ``assign_division`` override against a division that
+            # was renamed/removed mid-script.
+            overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+            team_state, _ = project_overrides(overrides)
+            projected = team_state.get(pid)
+            if projected is not None and projected.assigned_division_name is not None:
+                already_assigned_count += 1
+                continue
+            structure = read_structure(event_key, scenario, base_dir=base_dir)
+            division_names = next(
+                (
+                    [d.name for d in cohort.divisions]
+                    for cohort in structure
+                    if cohort.age_group == entry.event_age_group and cohort.gender == entry.event_gender
+                ),
+                [],
+            )
+            resolution = resolve_division_assignment(None, bracket, division_names=division_names)
+            if resolution.source != SOURCE_PREFIX or resolution.name is None:
+                require_triage_count += 1
+                continue
+            if dry_run:
+                dry_run_would_backfill_count += 1
+                continue
+            append_override(
+                event_key,
+                scenario,
+                build_override_record(
+                    ts=utc_now_iso(),
+                    actor=_BACKFILL_ACTOR,
+                    scope="team",
+                    type="assign_division",
+                    team_ref=pid,
+                    before={"assigned_division_name": None},
+                    after={"assigned_division_name": resolution.name},
+                    reason=f"backfill from raw_scrape bracket_name for {event_key}/{scenario}",
+                ),
+                base_dir=base_dir,
+                _already_locked=True,
+                timeout=10.0,
+            )
+            backfilled_count += 1
+
+    prefix = "DRY RUN — no writes\n" if dry_run else ""
+    backfilled_label = "would-backfill" if dry_run else "backfilled"
+    backfilled_value = dry_run_would_backfill_count if dry_run else backfilled_count
+    print(
+        f"{prefix}{backfilled_value} teams {backfilled_label}, "
+        f"{already_assigned_count} teams already-assigned, "
+        f"{require_triage_count} teams require triage (no prefix match), "
+        f"{missing_raw_scrape_count} teams missing raw_scrape (no join)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tournaments/reports/__init__.py
+++ b/src/tournaments/reports/__init__.py
@@ -1,0 +1,70 @@
+"""Report Card library for the MatchBalance backtest intake.
+
+A pure-Python library that turns a Shell 06 cohort run dir into the
+commercial-grade Report Card — the artifact tournament directors see
+after a backtest completes. No Streamlit, no Supabase imports — Shell 08
+embeds the rendered HTML and the same code can later back a Next.js route.
+
+Layout:
+
+    src/tournaments/reports/
+      schema.py           # @dataclass(frozen=True) types + to_dict/from_dict
+      compute.py          # build a ReportCard from run_dir artifacts
+      render_html.py      # Jinja2 → HTML (embedded fragment / standalone)
+      render_csv.py       # flatten to three CSVs
+      templates/
+        report_card.html
+
+Public API is re-exported here; submodules are the implementation.
+"""
+
+from __future__ import annotations
+
+from src.tournaments.reports.compute import (
+    ReportCardError,
+    compute_and_persist_report_card,
+    compute_report_card,
+    read_comparison_json,
+    write_comparison_json,
+)
+from src.tournaments.reports.render_csv import (
+    render_all_csv,
+    render_metrics_csv,
+    render_risk_flags_csv,
+    render_team_movements_csv,
+)
+from src.tournaments.reports.render_html import render_html, write_html
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    OverrideAuditRow,
+    ReportCard,
+    RiskFlag,
+    TeamMovement,
+    TopReason,
+)
+
+__all__ = [
+    # dataclasses
+    "BalanceScore",
+    "Metric",
+    "OverrideAuditRow",
+    "ReportCard",
+    "RiskFlag",
+    "TeamMovement",
+    "TopReason",
+    # errors
+    "ReportCardError",
+    # compute
+    "compute_report_card",
+    "compute_and_persist_report_card",
+    "read_comparison_json",
+    "write_comparison_json",
+    # rendering
+    "render_html",
+    "write_html",
+    "render_metrics_csv",
+    "render_risk_flags_csv",
+    "render_team_movements_csv",
+    "render_all_csv",
+]

--- a/src/tournaments/reports/compute.py
+++ b/src/tournaments/reports/compute.py
@@ -1,0 +1,826 @@
+"""Build a ``ReportCard`` from a Shell 06 cohort run dir.
+
+The Report Card is the commercial proof-of-value artifact — what
+tournament directors see after a backtest run completes. ``compute.py``
+reads ``summary.json`` (Shell 06's authoritative output), the run-dir
+auxiliary JSONL files (``fallbacks.jsonl``, ``run_overrides_audit.jsonl``,
+``division_recommendations.json``), and scenario-level metadata /
+registry / overrides via the public storage facade — then computes every
+metric, risk flag, top reason, and team movement that lands on the
+Report Card.
+
+No new backtest logic lives here; all numbers are derived from Shell 06
+artifacts.
+
+**Cohort identity vocab — deviation from spec.** The plan reads cohort
+identity from ``summary.json["cohort"]`` but Shell 06 normalizes
+``gender`` to ``"Male"/"Female"`` (cf.
+``scripts/backtest_tournament_cohort.py:864`` ``normalize_gender_label``).
+The registry CSV, override ledger, and ``run_orchestrator._override_in_cohort``
+all use ``"Boys"/"Girls"``. This module reads ``run_metadata.json``
+(orchestrator-emitted at ``run_orchestrator.py:594``) so ``cohort_gender``
+matches the rest of the storage layer — required for the
+``recompute_medians`` cohort-key check (``f"{age}_{gender}"`` is written
+in registry vocab at ``tournament_intake.py:1930``).
+
+**Frozen-median invariant** (spec §12) is enforced upstream by Shell 06's
+CLI argv path; ``compute.py`` does not re-validate it.
+
+**Concurrency** — ``compute_and_persist_report_card`` is NOT safe to run
+concurrently for the same ``(event_key, scenario, run_id)``. Concurrent
+calls race the per-file ``.tmp → final`` renames and the sentinel-write
+order. Callers (Shell 06 orchestrator, Shell 08 UI) must serialize.
+"""
+
+from __future__ import annotations
+
+import datetime as _datetime
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    OverrideAuditRow,
+    ReportCard,
+    RiskFlag,
+    TeamMovement,
+    TopReason,
+)
+from src.tournaments.storage import (
+    EventMetadata,
+    SchemaVersionError,
+    assert_supported_version,
+    load_overrides,
+    read_event_metadata,
+    read_registry,
+    stamp_schema_version,
+)
+from src.tournaments.storage._io import (
+    read_json,
+    read_jsonl,
+    utc_now_iso,
+    write_json,
+)
+from src.tournaments.storage.event_key import run_dir as _run_dir
+from src.tournaments.triage import (
+    ProjectedCohortState,
+    ProjectedTeamState,
+    _is_placeholder_team,
+    project_overrides,
+)
+
+__all__ = [
+    "EARLY_STAGES",
+    "LOW_GAMES_THRESHOLD",
+    "STALE_SNAPSHOT_DAYS",
+    "TOP_REASON_TEMPLATES",
+    "ReportCardError",
+    "compute_and_persist_report_card",
+    "compute_report_card",
+    "read_comparison_json",
+    "write_comparison_json",
+]
+
+
+LOW_GAMES_THRESHOLD: int = 6
+"""Entrants with fewer than this many games trigger a ``low_games`` flag."""
+
+STALE_SNAPSHOT_DAYS: int = 7
+"""``ranking_snapshot_date`` older than this many days before
+``event_start_date`` triggers a ``stale_ranking_snapshot`` warning. Strict
+``>`` boundary — exactly 7 days is not flagged.
+"""
+
+EARLY_STAGES: frozenset[str] = frozenset({"Pool", "Semi Final A", "Semi Final B"})
+"""Stages considered "early" for same-club + rematch counting. Sourced
+from ``schedule_simulator.py:337, 362, 370`` — the only place ``stage``
+literals are written. ``"Final"`` and ``"Third Place"`` are excluded.
+"""
+
+TOP_REASON_TEMPLATES: dict[str, str] = {
+    "blowout_5plus": "Reduced 5+ goal mismatches from {actual_count} games to {optimized_count} ({pct_change:+.0%}).",
+    "one_goal_rate": "Raised one-goal games from {actual_pct:.0%} to {optimized_pct:.0%} of the schedule.",
+    "same_club_early": "Removed {removed_count} same-club early matchups.",
+    "same_coach_early": "Removed {removed_count} same-coach pool conflicts.",
+    "rematches": "Eliminated {removed_count} intra-event rematches.",
+    "avg_gd": "Tightened average goal differential from {actual_avg:.2f} to {optimized_avg:.2f}.",
+}
+"""Top-reason templates keyed by metric. Insertion order is the stable
+secondary sort key (Python 3.7+ dicts preserve it) so
+``test_reports_compute.py`` can assert exact ordering on tied magnitudes.
+"""
+
+
+_ARTIFACT_NAMES: tuple[str, ...] = (
+    "comparison.json",
+    "comparison_metrics.csv",
+    "comparison_risk_flags.csv",
+    "comparison_team_movements.csv",
+    "comparison.html",
+    "report_card.done",
+)
+
+
+class ReportCardError(RuntimeError):
+    """Raised when a run dir's invariants prevent Report Card computation.
+
+    Examples: missing ``done.json`` (run not completed), missing
+    ``run_metadata.json``, malformed ``summary.json``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extras(meta: EventMetadata) -> dict[str, Any]:
+    """Single-source the ``extras = meta.extras or {}`` guard.
+
+    Convention anchor: ``run_orchestrator.py:345``. Centralizing this
+    keeps the ``or {}`` default from drifting across the metric branches
+    that read from ``extras``.
+    """
+    return meta.extras or {}
+
+
+def _parse_iso_date(value: str | None) -> _datetime.date | None:
+    if not value:
+        return None
+    try:
+        return _datetime.date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _comparison_json_path(run_dir_path: Path) -> Path:
+    return run_dir_path / "comparison.json"
+
+
+def _iter_optimized_matches(optimized_proj: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield every per-``SimulatedMatch`` row across all divisions."""
+    for division in optimized_proj.get("divisions") or []:
+        for match in division.get("matches") or []:
+            yield match
+
+
+def _capped_avg_gd(matches: list[dict[str, Any]], cap: int) -> float | None:
+    """Mean of ``min(margin_i, cap)`` over per-match goal differentials."""
+    if not matches:
+        return None
+    return float(sum(min(int(m["goal_differential"]), cap) for m in matches) / len(matches))
+
+
+def _count_same_club_early(
+    matches: list[dict[str, Any]],
+    entrants_by_id: dict[str, dict[str, Any]],
+) -> int:
+    same_club = 0
+    for m in matches:
+        if m.get("stage") not in EARLY_STAGES:
+            continue
+        home = entrants_by_id.get(str(m.get("home_team_id") or ""))
+        away = entrants_by_id.get(str(m.get("away_team_id") or ""))
+        if home is None or away is None:
+            continue
+        home_club = home.get("club_name")
+        away_club = away.get("club_name")
+        if home_club and away_club and home_club == away_club:
+            same_club += 1
+    return same_club
+
+
+def _count_intra_event_rematches(matches: list[dict[str, Any]]) -> int:
+    """Count unordered ``(home, away)`` pairs that recur within EARLY_STAGES."""
+    pair_counts: dict[frozenset[str], int] = {}
+    for m in matches:
+        if m.get("stage") not in EARLY_STAGES:
+            continue
+        home_id = str(m.get("home_team_id") or "")
+        away_id = str(m.get("away_team_id") or "")
+        if not home_id or not away_id:
+            continue
+        pair = frozenset({home_id, away_id})
+        pair_counts[pair] = pair_counts.get(pair, 0) + 1
+    return sum(1 for count in pair_counts.values() if count > 1)
+
+
+def _count_total_early_meetings(matches: list[dict[str, Any]]) -> int:
+    return sum(1 for m in matches if m.get("stage") in EARLY_STAGES)
+
+
+def _read_run_metadata(run_dir_path: Path) -> dict[str, Any]:
+    """Read ``run_metadata.json``; raise ``ReportCardError`` if missing.
+
+    The orchestrator (``run_orchestrator.execute_run``) writes this file
+    BEFORE Popen-spawn, so a promoted run dir always carries it.
+    """
+    path = run_dir_path / "run_metadata.json"
+    if not path.exists():
+        raise ReportCardError(
+            f"run_metadata.json missing at {path}; cannot determine cohort identity"
+        )
+    payload = read_json(path)
+    try:
+        assert_supported_version(payload, source=str(path))
+    except SchemaVersionError as exc:
+        raise ReportCardError(str(exc)) from exc
+    return payload
+
+
+def _build_metrics(
+    actual_results: dict[str, Any],
+    optimized_proj: dict[str, Any],
+    same_club_early_count: int,
+    rematch_count: int,
+    capped_gd_limit: int,
+) -> tuple[Metric, ...]:
+    """Eight-row metrics tuple. Sign convention for ``delta``:
+
+    - GD / blowout / 3+ blowout / 5+ blowout: ``actual - optimized`` so a
+      positive delta is improvement (lower is better).
+    - One-goal rate: ``optimized - actual`` so positive delta is
+      improvement (higher is better).
+    """
+    matches = list(_iter_optimized_matches(optimized_proj))
+    capped_optimized = _capped_avg_gd(matches, capped_gd_limit)
+
+    actual_avg_gd = float(actual_results["average_goal_differential"])
+    opt_avg_gd = float(optimized_proj["average_goal_differential"])
+    actual_close = float(actual_results["close_game_rate"])
+    opt_close = float(optimized_proj["close_game_rate"])
+    actual_3plus = float(actual_results["blowout_3plus_rate"])
+    opt_3plus = float(optimized_proj["blowout_3plus_rate"])
+    actual_5plus = float(actual_results["blowout_5plus_rate"])
+    opt_5plus = float(optimized_proj["blowout_5plus_rate"])
+
+    return (
+        Metric(
+            label="Expected avg GD (raw)",
+            actual=actual_avg_gd,
+            optimized=opt_avg_gd,
+            delta=actual_avg_gd - opt_avg_gd,
+            unit="gd",
+        ),
+        Metric(
+            label=f"Expected avg GD (capped at {capped_gd_limit}; actual unavailable in v1)",
+            actual=None,
+            optimized=capped_optimized,
+            delta=None,
+            unit="gd",
+        ),
+        Metric(
+            label="One-goal game rate",
+            actual=actual_close,
+            optimized=opt_close,
+            delta=opt_close - actual_close,
+            unit="rate",
+        ),
+        Metric(
+            label="3+ goal blowout rate",
+            actual=actual_3plus,
+            optimized=opt_3plus,
+            delta=actual_3plus - opt_3plus,
+            unit="rate",
+        ),
+        Metric(
+            label="5+ goal blowout rate",
+            actual=actual_5plus,
+            optimized=opt_5plus,
+            delta=actual_5plus - opt_5plus,
+            unit="rate",
+        ),
+        Metric(
+            label="Same-club early meetings (actual unavailable in v1)",
+            actual=None,
+            optimized=int(same_club_early_count),
+            delta=None,
+            unit="count",
+        ),
+        Metric(
+            label="Same-coach early meetings (coach data unavailable in v1)",
+            actual=None,
+            optimized=None,
+            delta=None,
+            unit="count",
+        ),
+        Metric(
+            label="Intra-event rematches (actual unavailable in v1)",
+            actual=None,
+            optimized=int(rematch_count),
+            delta=None,
+            unit="count",
+        ),
+    )
+
+
+def _compute_balance_score(
+    optimized_proj: dict[str, Any],
+    same_club_early_count: int,
+    rematch_count: int,
+    extras: dict[str, Any],
+) -> tuple[BalanceScore, list[RiskFlag]]:
+    """Compute the optimized-side Balance Score per spec §9 default formula.
+
+    The actual side returns ``None`` in v1 — Shell 06's actual aggregates
+    don't carry per-match rows, so ``same_club_early_rate`` and
+    ``rematch_rate`` for actual are uncomputable. Substituting zero would
+    bias the actual baseline upward by 20 points and compress the
+    headline delta — see Step 4 metric notes.
+
+    Returns ``(score, risk_flags)`` so the zero-denominator guard's
+    ``no_early_meetings`` flag flows back into the ReportCard's flag list.
+    """
+    weights_dict = extras.get("balance_score_weights") or {}
+    preset_id = str(weights_dict.get("preset_id") or "default")
+    if preset_id != "default":
+        raise ValueError(
+            f"Unsupported balance_score_weights preset_id: {preset_id!r} "
+            "(v1 only supports 'default')"
+        )
+
+    flags: list[RiskFlag] = []
+    matches = list(_iter_optimized_matches(optimized_proj))
+    total_early = _count_total_early_meetings(matches)
+
+    one_goal_rate = float(optimized_proj["close_game_rate"])
+    blowout_5plus_rate = float(optimized_proj["blowout_5plus_rate"])
+
+    if total_early == 0:
+        same_club_early_rate = 0.0
+        rematch_rate = 0.0
+        flags.append(
+            RiskFlag(
+                severity="info",
+                category="no_early_meetings",
+                message=(
+                    "Cohort has no pool/semi early-meeting matches; "
+                    "same-club and rematch rates forced to 0."
+                ),
+            )
+        )
+    else:
+        same_club_early_rate = same_club_early_count / total_early
+        rematch_rate = rematch_count / total_early
+
+    optimized_score = (
+        50 * one_goal_rate
+        + 30 * (1 - blowout_5plus_rate)
+        + 10 * (1 - same_club_early_rate)
+        + 10 * (1 - rematch_rate)
+    )
+    return (
+        BalanceScore(
+            actual=None,
+            optimized=float(optimized_score),
+            delta=None,
+            preset_id=preset_id,
+        ),
+        flags,
+    )
+
+
+def _build_top_reasons(
+    actual_results: dict[str, Any],
+    optimized_proj: dict[str, Any],
+) -> tuple[TopReason, ...]:
+    """Generate templated top-reason bullets ranked by improvement magnitude.
+
+    Skips templates whose required inputs are ``None`` (covers the v1 gap
+    where actual per-match rows are unavailable). Stable secondary sort
+    key is ``TOP_REASON_TEMPLATES`` insertion order so tied deltas resolve
+    deterministically.
+    """
+    template_order = list(TOP_REASON_TEMPLATES.keys())
+    candidates: list[tuple[str, float, str]] = []  # (key, magnitude, text)
+
+    actual_5plus = actual_results.get("blowout_5plus_rate")
+    opt_5plus = optimized_proj.get("blowout_5plus_rate")
+    if actual_5plus is not None and opt_5plus is not None:
+        actual_count = int(round(float(actual_5plus) * int(actual_results.get("actual_game_count", 0) or 0)))
+        opt_count = int(round(float(opt_5plus) * int(optimized_proj.get("match_count", 0) or 0)))
+        if actual_5plus == 0:
+            pct_change = 0.0 if opt_5plus == 0 else float(opt_5plus)
+        else:
+            pct_change = (float(opt_5plus) - float(actual_5plus)) / float(actual_5plus)
+        text = TOP_REASON_TEMPLATES["blowout_5plus"].format(
+            actual_count=actual_count,
+            optimized_count=opt_count,
+            pct_change=pct_change,
+        )
+        candidates.append(("blowout_5plus", abs(float(opt_5plus) - float(actual_5plus)), text))
+
+    actual_one = actual_results.get("close_game_rate")
+    opt_one = optimized_proj.get("close_game_rate")
+    if actual_one is not None and opt_one is not None:
+        text = TOP_REASON_TEMPLATES["one_goal_rate"].format(
+            actual_pct=float(actual_one),
+            optimized_pct=float(opt_one),
+        )
+        candidates.append(("one_goal_rate", abs(float(opt_one) - float(actual_one)), text))
+
+    actual_avg = actual_results.get("average_goal_differential")
+    opt_avg = optimized_proj.get("average_goal_differential")
+    if actual_avg is not None and opt_avg is not None:
+        text = TOP_REASON_TEMPLATES["avg_gd"].format(
+            actual_avg=float(actual_avg),
+            optimized_avg=float(opt_avg),
+        )
+        candidates.append(("avg_gd", abs(float(actual_avg) - float(opt_avg)), text))
+
+    candidates.sort(key=lambda c: (-c[1], template_order.index(c[0])))
+
+    n_significant = sum(1 for _, mag, _ in candidates if mag > 0.001)
+    n_top = min(5, max(3, n_significant))
+    n_to_take = min(n_top, len(candidates))
+    return tuple(TopReason(text=text) for _, _, text in candidates[:n_to_take])
+
+
+def _build_team_movements(run_dir_path: Path) -> tuple[TeamMovement, ...]:
+    """Read ``division_recommendations.json`` and project to non-stay moves.
+
+    Per the plan, the headline list filters ``move != "stay"`` because the
+    UI surfaces "what changed" for the director. Missing file (e.g. an
+    older run dir) yields an empty tuple rather than raising.
+    """
+    path = run_dir_path / "division_recommendations.json"
+    if not path.exists():
+        return ()
+    rows = read_json(path)
+    if not isinstance(rows, list):
+        return ()
+    movements: list[TeamMovement] = []
+    for row in rows:
+        if str(row.get("move") or "") == "stay":
+            continue
+        movements.append(
+            TeamMovement(
+                canonical_team_id=str(row.get("canonical_team_id") or ""),
+                team_name=str(row.get("event_team_name") or ""),
+                from_division=str(row.get("actual_division") or ""),
+                to_division=str(row.get("recommended_division") or ""),
+                move=str(row.get("move") or "stay"),
+            )
+        )
+    return tuple(movements)
+
+
+def _build_risk_flags(
+    *,
+    meta: EventMetadata,
+    extras: dict[str, Any],
+    entrants: list[dict[str, Any]],
+    fallbacks: list[dict[str, Any]],
+    overrides: list[dict[str, Any]],
+    registry_pids: set[str],
+    team_state: Mapping[str, ProjectedTeamState],
+    cohort_state: Mapping[str, ProjectedCohortState],
+    age: str,
+    gender: str,
+    balance_score_flags: list[RiskFlag],
+) -> tuple[RiskFlag, ...]:
+    """Assemble the full risk-flag tuple from cohort-scoped inputs.
+
+    Ordering is intentional: snapshot freshness → fallbacks → state-derived
+    flags → low-games → orphans → no-early-meetings (carried in via
+    ``balance_score_flags``) → coach-data. Same order each render so the
+    HTML template can rely on stable groupings.
+    """
+    flags: list[RiskFlag] = []
+
+    # Snapshot freshness
+    snapshot_iso = extras.get("ranking_snapshot_date")
+    snapshot_date = _parse_iso_date(snapshot_iso if isinstance(snapshot_iso, str) else None)
+    event_start_date = _parse_iso_date(meta.event_start_date)
+    if snapshot_date is None or event_start_date is None:
+        flags.append(
+            RiskFlag(
+                severity="info",
+                category="snapshot_freshness_unknown",
+                message=(
+                    "Snapshot date or event start date not recorded; "
+                    "freshness cannot be computed."
+                ),
+            )
+        )
+    else:
+        days_old = (event_start_date - snapshot_date).days
+        if days_old > STALE_SNAPSHOT_DAYS:
+            flags.append(
+                RiskFlag(
+                    severity="warning",
+                    category="stale_ranking_snapshot",
+                    message=(
+                        f"Snapshot is {days_old} days old "
+                        f"(threshold: > {STALE_SNAPSHOT_DAYS} days). "
+                        f"event_start={event_start_date.isoformat()}, "
+                        f"snapshot={snapshot_date.isoformat()}."
+                    ),
+                )
+            )
+
+    # Synthetic / future-snapshot fallbacks (Section 10 fold-in 21c)
+    for row in fallbacks:
+        team_name = str(row.get("team_name") or "")
+        kind = str(row.get("fallback_kind") or "snapshot_fallback")
+        flags.append(
+            RiskFlag(
+                severity="warning",
+                category="snapshot_fallback",
+                message=f"{team_name}: {kind}",
+                affected_teams=(team_name,) if team_name else (),
+            )
+        )
+
+    # External / placeholder team states — entrants are inherently
+    # cohort-scoped (the cohort CLI processes one cohort per run).
+    cohort_key = f"{age}_{gender}"
+    has_cohort_recompute = cohort_key in cohort_state
+    for entrant in entrants:
+        pid = str(entrant.get("provider_team_id") or "")
+        team_name = str(entrant.get("event_team_name") or pid)
+        if not pid:
+            continue
+        projected = team_state.get(pid)
+        if projected is not None and projected.state == "external":
+            if has_cohort_recompute:
+                flags.append(
+                    RiskFlag(
+                        severity="info",
+                        category="external_with_assumed_median",
+                        message=(
+                            f"{team_name}: external team using cohort-recomputed "
+                            "median power score."
+                        ),
+                        affected_teams=(team_name,),
+                    )
+                )
+            else:
+                flags.append(
+                    RiskFlag(
+                        severity="info",
+                        category="external_no_override",
+                        message=(
+                            f"{team_name}: external team without a "
+                            "recompute_medians cohort override."
+                        ),
+                        affected_teams=(team_name,),
+                    )
+                )
+        if _is_placeholder_team(team_name=team_name, provider_team_id=pid):
+            flags.append(
+                RiskFlag(
+                    severity="warning",
+                    category="placeholder_match",
+                    message=(
+                        f"{team_name}: matched to ``unknown_<provider_id>`` "
+                        "placeholder; resolve before publishing."
+                    ),
+                    affected_teams=(team_name,),
+                )
+            )
+
+    # Low-games entrants
+    for entrant in entrants:
+        games = int(entrant.get("games_played") or 0)
+        if games < LOW_GAMES_THRESHOLD:
+            team_name = str(entrant.get("event_team_name") or entrant.get("provider_team_id") or "")
+            flags.append(
+                RiskFlag(
+                    severity="info",
+                    category="low_games",
+                    message=(
+                        f"{team_name}: only {games} games this season "
+                        f"(threshold: < {LOW_GAMES_THRESHOLD})."
+                    ),
+                    affected_teams=(team_name,) if team_name else (),
+                )
+            )
+
+    # Rescrape orphan overrides — scenario-scoped, not cohort-scoped.
+    # Same orphan surfaces on every cohort's Report Card until resolved.
+    seen_orphan_refs: set[str] = set()
+    for record in overrides:
+        if record.get("type") in {"manual_add", "recompute_medians"}:
+            continue
+        team_ref = str(record.get("team_ref") or "")
+        if not team_ref or team_ref.startswith("manual_"):
+            continue
+        if team_ref in registry_pids:
+            continue
+        if team_ref in seen_orphan_refs:
+            continue
+        seen_orphan_refs.add(team_ref)
+        affected_name = str((record.get("after") or {}).get("event_team_name") or team_ref)
+        flags.append(
+            RiskFlag(
+                severity="warning",
+                category="rescrape_orphan_override",
+                message=(
+                    f"Override targets provider_team_id {team_ref!r} "
+                    "not present in current scenario registry; team may need rescrape."
+                ),
+                affected_teams=(affected_name,),
+            )
+        )
+
+    # Balance-score zero-denominator flags (no early meetings)
+    flags.extend(balance_score_flags)
+
+    # Coach-data limitation — always emitted in v1 so the gap is loud
+    flags.append(
+        RiskFlag(
+            severity="info",
+            category="coach_data_unavailable",
+            message=(
+                "Coach data not yet collected; same-coach metric reserved for v2."
+            ),
+        )
+    )
+
+    return tuple(flags)
+
+
+# ---------------------------------------------------------------------------
+# Public API — pure compute
+# ---------------------------------------------------------------------------
+
+
+def compute_report_card(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> ReportCard:
+    """Build a ``ReportCard`` from the run dir's artifacts.
+
+    Pure — no side effects. ``compute_and_persist_report_card`` is the
+    side-effecting wrapper that writes the comparison artifacts.
+
+    Raises ``ReportCardError`` if the run is not completed (``done.json``
+    missing) or if cohort identity cannot be determined
+    (``run_metadata.json`` missing). Raises ``ValueError`` from
+    ``_compute_balance_score`` if a non-default ``preset_id`` is set in
+    ``meta.extras["balance_score_weights"]``.
+    """
+    run_dir_path = _run_dir(event_key, scenario, run_id, base_dir=base_dir)
+
+    if not (run_dir_path / "done.json").exists():
+        raise ReportCardError(
+            f"Run {run_id!r} is not completed (no done.json marker at "
+            f"{run_dir_path}). Failed/cancelled/in-flight runs cannot "
+            "produce a Report Card."
+        )
+
+    summary_path = run_dir_path / "summary.json"
+    if not summary_path.exists():
+        raise ReportCardError(f"summary.json missing at {summary_path}")
+    summary = read_json(summary_path)
+
+    run_metadata = _read_run_metadata(run_dir_path)
+    age = str(run_metadata["cohort_age_group"])
+    gender = str(run_metadata["cohort_gender"])
+    event_name = str(run_metadata.get("event_name") or summary.get("event_name") or "")
+
+    actual_results = summary.get("actual_results") or {}
+    optimized_proj = (summary.get("optimized_projection") or {}).get("simulated_schedule") or {}
+    entrants = list(summary.get("entrants") or [])
+    entrants_by_id = {str(e.get("entrant_id") or ""): e for e in entrants}
+
+    fallbacks_path = run_dir_path / "fallbacks.jsonl"
+    fallbacks = list(read_jsonl(fallbacks_path)) if fallbacks_path.exists() else []
+
+    audit_path = run_dir_path / "run_overrides_audit.jsonl"
+    audit_rows = list(read_jsonl(audit_path)) if audit_path.exists() else []
+
+    meta = read_event_metadata(event_key, base_dir=base_dir)
+    extras = _extras(meta)
+    capped_gd_limit = int(extras.get("capped_gd_limit", 3) or 3)
+
+    overrides = load_overrides(event_key, scenario, base_dir=base_dir)
+    team_state, cohort_state = project_overrides(overrides)
+    registry = read_registry(event_key, scenario, base_dir=base_dir)
+    registry_pids = {
+        entry.resolved_gotsport_provider_team_id
+        for entry in registry
+        if entry.resolved_gotsport_provider_team_id
+    }
+
+    matches = list(_iter_optimized_matches(optimized_proj))
+    same_club_early_count = _count_same_club_early(matches, entrants_by_id)
+    rematch_count = _count_intra_event_rematches(matches)
+
+    metrics = _build_metrics(
+        actual_results,
+        optimized_proj,
+        same_club_early_count,
+        rematch_count,
+        capped_gd_limit,
+    )
+    balance_score, balance_score_flags = _compute_balance_score(
+        optimized_proj,
+        same_club_early_count,
+        rematch_count,
+        extras,
+    )
+    risk_flags = _build_risk_flags(
+        meta=meta,
+        extras=extras,
+        entrants=entrants,
+        fallbacks=fallbacks,
+        overrides=overrides,
+        registry_pids=registry_pids,
+        team_state=team_state,
+        cohort_state=cohort_state,
+        age=age,
+        gender=gender,
+        balance_score_flags=balance_score_flags,
+    )
+    top_reasons = _build_top_reasons(actual_results, optimized_proj)
+    team_movements = _build_team_movements(run_dir_path)
+    override_audit = tuple(OverrideAuditRow.from_dict(row) for row in audit_rows)
+
+    return ReportCard(
+        event_key=event_key,
+        scenario=scenario,
+        run_id=run_id,
+        age_group=age,
+        gender=gender,
+        event_name=event_name,
+        computed_at=utc_now_iso(),
+        balance_score=balance_score,
+        metrics=metrics,
+        risk_flags=risk_flags,
+        top_reasons=top_reasons,
+        team_movements=team_movements,
+        override_audit=override_audit,
+    )
+
+
+def write_comparison_json(report_card: ReportCard, run_dir_path: Path) -> Path:
+    """Write the ReportCard as ``comparison.json`` with the schema stamp."""
+    path = _comparison_json_path(run_dir_path)
+    write_json(path, stamp_schema_version(report_card.to_dict()))
+    return path
+
+
+def read_comparison_json(path: Path) -> ReportCard:
+    """Read ``comparison.json`` back into a ``ReportCard``.
+
+    Strict on read: raises ``SchemaVersionError`` on a newer schema
+    (mirrors ``frozen_medians.py:80``).
+    """
+    payload = read_json(path)
+    assert_supported_version(payload, source=str(path))
+    return ReportCard.from_dict(payload)
+
+
+# ---------------------------------------------------------------------------
+# Public API — compute + persist (Step 8)
+# ---------------------------------------------------------------------------
+
+
+def compute_and_persist_report_card(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+) -> ReportCard:
+    """Compute the ReportCard and write all six artifacts to the run dir.
+
+    Order: ``comparison.json`` → three CSVs → ``comparison.html`` →
+    ``report_card.done`` (sentinel, written LAST so readers gating on the
+    sentinel never see partial state). Mirrors Shell 06's ``done.json``
+    contract at ``run_layout.py:5-26``.
+
+    On any exception, all six artifacts are unlinked (``missing_ok=True``)
+    before re-raising — the run dir reverts to "no Report Card present"
+    rather than a half-written state.
+
+    NOT safe for concurrent invocation against the same ``(event_key,
+    scenario, run_id)`` (per-file ``.tmp → final`` renames + sentinel
+    ordering would race). Callers must serialize.
+    """
+    # Local imports avoid a circular dependency on the renderers at module load.
+    from src.tournaments.reports.render_csv import render_all_csv
+    from src.tournaments.reports.render_html import write_html
+
+    rc = compute_report_card(event_key, scenario, run_id, base_dir=base_dir)
+    run_dir_path = _run_dir(event_key, scenario, run_id, base_dir=base_dir)
+    try:
+        write_comparison_json(rc, run_dir_path)
+        render_all_csv(rc, run_dir_path)
+        write_html(rc, run_dir_path / "comparison.html", mode="standalone")
+        write_json(
+            run_dir_path / "report_card.done",
+            stamp_schema_version({"completed_at": utc_now_iso()}),
+        )
+    except BaseException:
+        for name in _ARTIFACT_NAMES:
+            (run_dir_path / name).unlink(missing_ok=True)
+        raise
+    return rc

--- a/src/tournaments/reports/compute.py
+++ b/src/tournaments/reports/compute.py
@@ -69,6 +69,7 @@ from src.tournaments.triage import (
     ProjectedTeamState,
     _is_placeholder_team,
     project_overrides,
+    registry_provider_id,
 )
 
 __all__ = [
@@ -219,9 +220,7 @@ def _read_run_metadata(run_dir_path: Path) -> dict[str, Any]:
     """
     path = run_dir_path / "run_metadata.json"
     if not path.exists():
-        raise ReportCardError(
-            f"run_metadata.json missing at {path}; cannot determine cohort identity"
-        )
+        raise ReportCardError(f"run_metadata.json missing at {path}; cannot determine cohort identity")
     payload = read_json(path)
     try:
         assert_supported_version(payload, source=str(path))
@@ -336,10 +335,7 @@ def _compute_balance_score(
     weights_dict = extras.get("balance_score_weights") or {}
     preset_id = str(weights_dict.get("preset_id") or "default")
     if preset_id != "default":
-        raise ValueError(
-            f"Unsupported balance_score_weights preset_id: {preset_id!r} "
-            "(v1 only supports 'default')"
-        )
+        raise ValueError(f"Unsupported balance_score_weights preset_id: {preset_id!r} (v1 only supports 'default')")
 
     flags: list[RiskFlag] = []
     matches = list(_iter_optimized_matches(optimized_proj))
@@ -355,10 +351,7 @@ def _compute_balance_score(
             RiskFlag(
                 severity="info",
                 category="no_early_meetings",
-                message=(
-                    "Cohort has no pool/semi early-meeting matches; "
-                    "same-club and rematch rates forced to 0."
-                ),
+                message=("Cohort has no pool/semi early-meeting matches; same-club and rematch rates forced to 0."),
             )
         )
     else:
@@ -366,10 +359,7 @@ def _compute_balance_score(
         rematch_rate = rematch_count / total_early
 
     optimized_score = (
-        50 * one_goal_rate
-        + 30 * (1 - blowout_5plus_rate)
-        + 10 * (1 - same_club_early_rate)
-        + 10 * (1 - rematch_rate)
+        50 * one_goal_rate + 30 * (1 - blowout_5plus_rate) + 10 * (1 - same_club_early_rate) + 10 * (1 - rematch_rate)
     )
     return (
         BalanceScore(
@@ -396,15 +386,21 @@ def _build_top_reasons(
     template_order = list(TOP_REASON_TEMPLATES.keys())
     candidates: list[tuple[str, float, str]] = []  # (key, magnitude, text)
 
+    # Each template asserts a directional improvement ("Reduced", "Raised",
+    # "Tightened"), so we filter to genuine wins only — emitting "Reduced
+    # 5+ goal mismatches" when blowouts went UP would mislead the
+    # Report Card reader. Direction per metric:
+    #   blowout_5plus / avg_gd: lower-is-better (opt < actual)
+    #   one_goal_rate: higher-is-better (opt > actual)
     actual_5plus = actual_results.get("blowout_5plus_rate")
     opt_5plus = optimized_proj.get("blowout_5plus_rate")
-    if actual_5plus is not None and opt_5plus is not None:
+    if actual_5plus is not None and opt_5plus is not None and float(opt_5plus) < float(actual_5plus):
+        # Directional gate (opt < actual on a non-negative rate) guarantees
+        # actual_5plus > 0, so the divide is safe and the prior
+        # ``if actual_5plus == 0`` zero-guard is unreachable here.
         actual_count = int(round(float(actual_5plus) * int(actual_results.get("actual_game_count", 0) or 0)))
         opt_count = int(round(float(opt_5plus) * int(optimized_proj.get("match_count", 0) or 0)))
-        if actual_5plus == 0:
-            pct_change = 0.0 if opt_5plus == 0 else float(opt_5plus)
-        else:
-            pct_change = (float(opt_5plus) - float(actual_5plus)) / float(actual_5plus)
+        pct_change = (float(opt_5plus) - float(actual_5plus)) / float(actual_5plus)
         text = TOP_REASON_TEMPLATES["blowout_5plus"].format(
             actual_count=actual_count,
             optimized_count=opt_count,
@@ -414,7 +410,7 @@ def _build_top_reasons(
 
     actual_one = actual_results.get("close_game_rate")
     opt_one = optimized_proj.get("close_game_rate")
-    if actual_one is not None and opt_one is not None:
+    if actual_one is not None and opt_one is not None and float(opt_one) > float(actual_one):
         text = TOP_REASON_TEMPLATES["one_goal_rate"].format(
             actual_pct=float(actual_one),
             optimized_pct=float(opt_one),
@@ -423,7 +419,7 @@ def _build_top_reasons(
 
     actual_avg = actual_results.get("average_goal_differential")
     opt_avg = optimized_proj.get("average_goal_differential")
-    if actual_avg is not None and opt_avg is not None:
+    if actual_avg is not None and opt_avg is not None and float(opt_avg) < float(actual_avg):
         text = TOP_REASON_TEMPLATES["avg_gd"].format(
             actual_avg=float(actual_avg),
             optimized_avg=float(opt_avg),
@@ -499,10 +495,7 @@ def _build_risk_flags(
             RiskFlag(
                 severity="info",
                 category="snapshot_freshness_unknown",
-                message=(
-                    "Snapshot date or event start date not recorded; "
-                    "freshness cannot be computed."
-                ),
+                message=("Snapshot date or event start date not recorded; freshness cannot be computed."),
             )
         )
     else:
@@ -550,10 +543,7 @@ def _build_risk_flags(
                     RiskFlag(
                         severity="info",
                         category="external_with_assumed_median",
-                        message=(
-                            f"{team_name}: external team using cohort-recomputed "
-                            "median power score."
-                        ),
+                        message=(f"{team_name}: external team using cohort-recomputed median power score."),
                         affected_teams=(team_name,),
                     )
                 )
@@ -562,10 +552,7 @@ def _build_risk_flags(
                     RiskFlag(
                         severity="info",
                         category="external_no_override",
-                        message=(
-                            f"{team_name}: external team without a "
-                            "recompute_medians cohort override."
-                        ),
+                        message=(f"{team_name}: external team without a recompute_medians cohort override."),
                         affected_teams=(team_name,),
                     )
                 )
@@ -575,8 +562,7 @@ def _build_risk_flags(
                     severity="warning",
                     category="placeholder_match",
                     message=(
-                        f"{team_name}: matched to ``unknown_<provider_id>`` "
-                        "placeholder; resolve before publishing."
+                        f"{team_name}: matched to ``unknown_<provider_id>`` placeholder; resolve before publishing."
                     ),
                     affected_teams=(team_name,),
                 )
@@ -591,10 +577,7 @@ def _build_risk_flags(
                 RiskFlag(
                     severity="info",
                     category="low_games",
-                    message=(
-                        f"{team_name}: only {games} games this season "
-                        f"(threshold: < {LOW_GAMES_THRESHOLD})."
-                    ),
+                    message=(f"{team_name}: only {games} games this season (threshold: < {LOW_GAMES_THRESHOLD})."),
                     affected_teams=(team_name,) if team_name else (),
                 )
             )
@@ -634,9 +617,7 @@ def _build_risk_flags(
         RiskFlag(
             severity="info",
             category="coach_data_unavailable",
-            message=(
-                "Coach data not yet collected; same-coach metric reserved for v2."
-            ),
+            message=("Coach data not yet collected; same-coach metric reserved for v2."),
         )
     )
 
@@ -703,11 +684,11 @@ def compute_report_card(
     overrides = load_overrides(event_key, scenario, base_dir=base_dir)
     team_state, cohort_state = project_overrides(overrides)
     registry = read_registry(event_key, scenario, base_dir=base_dir)
-    registry_pids = {
-        entry.resolved_gotsport_provider_team_id
-        for entry in registry
-        if entry.resolved_gotsport_provider_team_id
-    }
+    # Use ``registry_provider_id`` so overrides keyed by the
+    # ``event_registration_id`` fallback (unresolved registry rows, manual-adds)
+    # are not falsely flagged as ``rescrape_orphan_override``. This mirrors how
+    # ``triage.is_ready`` derives the per-row identity.
+    registry_pids = {pid for entry in registry if (pid := registry_provider_id(entry))}
 
     matches = list(_iter_optimized_matches(optimized_proj))
     same_club_early_count = _count_same_club_early(matches, entrants_by_id)

--- a/src/tournaments/reports/render_csv.py
+++ b/src/tournaments/reports/render_csv.py
@@ -1,0 +1,127 @@
+"""Flat CSV exports of a ``ReportCard``.
+
+Three files written into a caller-supplied directory (typically the run
+dir, but any path works):
+
+- ``comparison_metrics.csv`` — one row per ``Metric``.
+- ``comparison_risk_flags.csv`` — one row per ``RiskFlag``;
+  ``affected_teams`` joined with ``";"``.
+- ``comparison_team_movements.csv`` — one row per ``TeamMovement``.
+
+Module-level ``FIELDNAMES`` tuples drive column order (mirrors
+``storage/registry.py:55-81``). ``_io.write_csv`` is atomic and treats
+missing keys as empty cells, which is exactly what ``Metric.actual=None``
+needs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments.reports.schema import ReportCard
+from src.tournaments.storage._io import write_csv
+
+__all__ = [
+    "METRICS_FIELDNAMES",
+    "RISK_FLAG_FIELDNAMES",
+    "TEAM_MOVEMENT_FIELDNAMES",
+    "render_all_csv",
+    "render_metrics_csv",
+    "render_risk_flags_csv",
+    "render_team_movements_csv",
+]
+
+
+METRICS_FIELDNAMES: tuple[str, ...] = (
+    "metric",
+    "actual",
+    "optimized",
+    "delta",
+    "unit",
+)
+
+RISK_FLAG_FIELDNAMES: tuple[str, ...] = (
+    "severity",
+    "category",
+    "message",
+    "affected_teams",
+)
+
+TEAM_MOVEMENT_FIELDNAMES: tuple[str, ...] = (
+    "canonical_team_id",
+    "team_name",
+    "from_division",
+    "to_division",
+    "move",
+)
+
+
+def _none_to_blank(value: object) -> object:
+    """``write_csv`` writes empty strings for missing keys; this maps
+    ``None`` values to empty strings explicitly so a ``Metric`` row with
+    ``actual=None`` doesn't get rendered as the literal string ``"None"``.
+    """
+    return "" if value is None else value
+
+
+def render_metrics_csv(report_card: ReportCard, dir_path: Path) -> Path:
+    """Write ``comparison_metrics.csv`` to ``dir_path``."""
+    rows = [
+        {
+            "metric": metric.label,
+            "actual": _none_to_blank(metric.actual),
+            "optimized": _none_to_blank(metric.optimized),
+            "delta": _none_to_blank(metric.delta),
+            "unit": metric.unit,
+        }
+        for metric in report_card.metrics
+    ]
+    path = dir_path / "comparison_metrics.csv"
+    write_csv(path, rows, fieldnames=METRICS_FIELDNAMES)
+    return path
+
+
+def render_risk_flags_csv(report_card: ReportCard, dir_path: Path) -> Path:
+    """Write ``comparison_risk_flags.csv`` to ``dir_path``.
+
+    ``affected_teams`` joined with ``";"`` so each cell stays single-line
+    in spreadsheet readers; round-trips via ``cell.split(";")``.
+    """
+    rows = [
+        {
+            "severity": flag.severity,
+            "category": flag.category,
+            "message": flag.message,
+            "affected_teams": ";".join(flag.affected_teams),
+        }
+        for flag in report_card.risk_flags
+    ]
+    path = dir_path / "comparison_risk_flags.csv"
+    write_csv(path, rows, fieldnames=RISK_FLAG_FIELDNAMES)
+    return path
+
+
+def render_team_movements_csv(report_card: ReportCard, dir_path: Path) -> Path:
+    """Write ``comparison_team_movements.csv`` to ``dir_path``."""
+    rows = [
+        {
+            "canonical_team_id": movement.canonical_team_id,
+            "team_name": movement.team_name,
+            "from_division": movement.from_division,
+            "to_division": movement.to_division,
+            "move": movement.move,
+        }
+        for movement in report_card.team_movements
+    ]
+    path = dir_path / "comparison_team_movements.csv"
+    write_csv(path, rows, fieldnames=TEAM_MOVEMENT_FIELDNAMES)
+    return path
+
+
+def render_all_csv(report_card: ReportCard, dir_path: Path) -> tuple[Path, Path, Path]:
+    """Convenience: write all three CSVs and return their paths."""
+    return (
+        render_metrics_csv(report_card, dir_path),
+        render_risk_flags_csv(report_card, dir_path),
+        render_team_movements_csv(report_card, dir_path),
+    )

--- a/src/tournaments/reports/render_csv.py
+++ b/src/tournaments/reports/render_csv.py
@@ -32,6 +32,32 @@ __all__ = [
 ]
 
 
+_FORMULA_INJECTION_PREFIXES: frozenset[str] = frozenset({"=", "+", "-", "@", "\t", "\r", "\n"})
+"""Spreadsheet apps (Excel, Sheets, Numbers) interpret a cell as a formula
+when the first character is one of these. The whitespace prefixes
+(``\\t`` / ``\\r`` / ``\\n``) are part of the OWASP CSV Injection guidance:
+some Excel import paths skip leading whitespace before formula detection,
+so a cell like ``"\\t=cmd|'/c calc'!A1"`` would otherwise parse as a live
+formula. Untrusted strings (event names, team names, override messages)
+reach the Report Card CSVs verbatim, so we prepend ``'`` (single quote)
+— spreadsheets render that as the literal text rather than executing.
+"""
+
+
+def _csv_safe(value: object) -> object:
+    """Return ``value`` with spreadsheet formula prefixes defanged.
+
+    Numeric and ``None`` values pass through unchanged — they cannot host
+    a formula injection. Strings starting with ``=`` / ``+`` / ``-`` /
+    ``@`` get a leading ``'`` so the spreadsheet renders the cell as text.
+    """
+    if not isinstance(value, str):
+        return value
+    if value and value[0] in _FORMULA_INJECTION_PREFIXES:
+        return "'" + value
+    return value
+
+
 METRICS_FIELDNAMES: tuple[str, ...] = (
     "metric",
     "actual",
@@ -68,7 +94,7 @@ def render_metrics_csv(report_card: ReportCard, dir_path: Path) -> Path:
     """Write ``comparison_metrics.csv`` to ``dir_path``."""
     rows = [
         {
-            "metric": metric.label,
+            "metric": _csv_safe(metric.label),
             "actual": _none_to_blank(metric.actual),
             "optimized": _none_to_blank(metric.optimized),
             "delta": _none_to_blank(metric.delta),
@@ -85,14 +111,15 @@ def render_risk_flags_csv(report_card: ReportCard, dir_path: Path) -> Path:
     """Write ``comparison_risk_flags.csv`` to ``dir_path``.
 
     ``affected_teams`` joined with ``";"`` so each cell stays single-line
-    in spreadsheet readers; round-trips via ``cell.split(";")``.
+    in spreadsheet readers; round-trips via ``cell.split(";")``. Defang is
+    applied to the joined string.
     """
     rows = [
         {
             "severity": flag.severity,
-            "category": flag.category,
-            "message": flag.message,
-            "affected_teams": ";".join(flag.affected_teams),
+            "category": _csv_safe(flag.category),
+            "message": _csv_safe(flag.message),
+            "affected_teams": _csv_safe(";".join(flag.affected_teams)),
         }
         for flag in report_card.risk_flags
     ]
@@ -105,10 +132,10 @@ def render_team_movements_csv(report_card: ReportCard, dir_path: Path) -> Path:
     """Write ``comparison_team_movements.csv`` to ``dir_path``."""
     rows = [
         {
-            "canonical_team_id": movement.canonical_team_id,
-            "team_name": movement.team_name,
-            "from_division": movement.from_division,
-            "to_division": movement.to_division,
+            "canonical_team_id": _csv_safe(movement.canonical_team_id),
+            "team_name": _csv_safe(movement.team_name),
+            "from_division": _csv_safe(movement.from_division),
+            "to_division": _csv_safe(movement.to_division),
             "move": movement.move,
         }
         for movement in report_card.team_movements

--- a/src/tournaments/reports/render_html.py
+++ b/src/tournaments/reports/render_html.py
@@ -17,6 +17,7 @@ at the package's ``templates/`` subdirectory (mirrors how
 
 from __future__ import annotations
 
+import html
 import os
 from pathlib import Path
 from typing import Literal
@@ -43,7 +44,11 @@ _env: Environment = Environment(
 
 _STANDALONE_CSS: str = """\
 :root { color-scheme: light; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #111; max-width: 960px; margin: 24px auto; padding: 0 16px; line-height: 1.55; font-size: 14px; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #111; max-width: 960px; margin: 24px auto; padding: 0 16px;
+  line-height: 1.55; font-size: 14px;
+}
 .report-card { background: #fff; }
 .rc-header { padding-bottom: 14px; border-bottom: 1px solid #e5e7eb; margin-bottom: 16px; }
 .rc-title { margin: 4px 0; font-size: 22px; }
@@ -54,15 +59,24 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-
 .rc-meta { font-size: 11px; color: #6b7280; }
 .rc-meta-good { color: #166534; }
 .rc-hero { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }
-.rc-card { padding: 18px 20px; border: 1px solid #e5e7eb; border-radius: 10px; background: #fafafa; position: relative; }
+.rc-card {
+  padding: 18px 20px; border: 1px solid #e5e7eb; border-radius: 10px;
+  background: #fafafa; position: relative;
+}
 .rc-optimized { border-color: #16a34a; background: #f0fdf4; }
 .rc-score { font-size: 42px; font-weight: 700; line-height: 1; color: #111; }
 .rc-score-good { color: #166534; }
 .rc-na { color: #6b7280; font-style: italic; padding: 6px 0; }
-.rc-badge { position: absolute; top: 18px; right: 20px; font-weight: 600; padding: 4px 10px; border-radius: 999px; font-size: 14px; }
+.rc-badge {
+  position: absolute; top: 18px; right: 20px; font-weight: 600;
+  padding: 4px 10px; border-radius: 999px; font-size: 14px;
+}
 .rc-badge-good { color: #166534; background: #dcfce7; }
 .rc-badge-bad { color: #991b1b; background: #fee2e2; }
-.rc-section { padding: 14px 18px; border: 1px solid #e5e7eb; border-radius: 10px; background: #fff; margin-bottom: 16px; }
+.rc-section {
+  padding: 14px 18px; border: 1px solid #e5e7eb; border-radius: 10px;
+  background: #fff; margin-bottom: 16px;
+}
 .rc-risks { border-color: #fde68a; background: #fffbeb; }
 .rc-list { margin: 8px 0 0; padding-left: 20px; }
 .rc-mono { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
@@ -75,7 +89,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-
 .delta-down { color: #991b1b; }
 .delta-flat { color: #6b7280; }
 .delta-na { color: #9ca3af; font-style: italic; }
-.rc-severity { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 600; text-transform: uppercase; margin-right: 4px; }
+.rc-severity {
+  display: inline-block; padding: 1px 6px; border-radius: 4px;
+  font-size: 10px; font-weight: 600; text-transform: uppercase; margin-right: 4px;
+}
 .rc-severity-info { background: #e0e7ff; color: #3730a3; }
 .rc-severity-warning { background: #fef3c7; color: #92400e; }
 .rc-severity-blocker { background: #fee2e2; color: #991b1b; }
@@ -102,13 +119,21 @@ def render_html(
     fragment = template.render(report_card=report_card)
     if mode == "embedded":
         return fragment
+    # ``event_name`` / ``gender`` / ``age_group`` come from provider scrape
+    # output and the registry CSV, so they're untrusted from this module's
+    # perspective. The title is built outside Jinja's autoescape, so we
+    # escape explicitly to defend against ``</title><script>...`` style
+    # injection. The CSS is a static module constant — no escape needed.
+    safe_event_name = html.escape(report_card.event_name)
+    safe_gender = html.escape(report_card.gender)
+    safe_age_group = html.escape(report_card.age_group)
     return (
         "<!DOCTYPE html>\n"
-        "<html lang=\"en\">\n"
+        '<html lang="en">\n'
         "<head>\n"
-        "<meta charset=\"utf-8\">\n"
-        f"<title>Report Card &middot; {report_card.event_name} &middot; "
-        f"{report_card.gender} {report_card.age_group}</title>\n"
+        '<meta charset="utf-8">\n'
+        f"<title>Report Card &middot; {safe_event_name} &middot; "
+        f"{safe_gender} {safe_age_group}</title>\n"
         f"<style>\n{_STANDALONE_CSS}</style>\n"
         "</head>\n"
         "<body>\n"

--- a/src/tournaments/reports/render_html.py
+++ b/src/tournaments/reports/render_html.py
@@ -1,0 +1,143 @@
+"""Render a ``ReportCard`` to HTML via Jinja2.
+
+Two modes:
+
+- ``embedded`` returns just the body fragment for Streamlit's
+  ``st.html(...)`` embed (Shell 08).
+- ``standalone`` wraps the fragment in a self-contained
+  ``<html><head>...</head><body>...</body></html>`` document with inline
+  CSS, suitable for export and shareable links.
+
+Jinja2 ``autoescape=True`` covers HTML escaping by default, so explicit
+``| e`` filters in the template are unnecessary. The renderer is
+import-time-safe: ``Environment`` is built once at module load, pointing
+at the package's ``templates/`` subdirectory (mirrors how
+``division_render.py:11`` keeps its precedent simple).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from src.tournaments.reports.schema import ReportCard
+
+__all__ = [
+    "render_html",
+    "write_html",
+]
+
+
+_TEMPLATES_DIR: Path = Path(__file__).parent / "templates"
+
+_env: Environment = Environment(
+    loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+    autoescape=select_autoescape(["html"]),
+    trim_blocks=False,
+    lstrip_blocks=False,
+)
+
+
+_STANDALONE_CSS: str = """\
+:root { color-scheme: light; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #111; max-width: 960px; margin: 24px auto; padding: 0 16px; line-height: 1.55; font-size: 14px; }
+.report-card { background: #fff; }
+.rc-header { padding-bottom: 14px; border-bottom: 1px solid #e5e7eb; margin-bottom: 16px; }
+.rc-title { margin: 4px 0; font-size: 22px; }
+.rc-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #6b7280; }
+.rc-eyebrow-muted { color: #9ca3af; }
+.rc-eyebrow-good { color: #166534; }
+.rc-eyebrow-amber { color: #92400e; }
+.rc-meta { font-size: 11px; color: #6b7280; }
+.rc-meta-good { color: #166534; }
+.rc-hero { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }
+.rc-card { padding: 18px 20px; border: 1px solid #e5e7eb; border-radius: 10px; background: #fafafa; position: relative; }
+.rc-optimized { border-color: #16a34a; background: #f0fdf4; }
+.rc-score { font-size: 42px; font-weight: 700; line-height: 1; color: #111; }
+.rc-score-good { color: #166534; }
+.rc-na { color: #6b7280; font-style: italic; padding: 6px 0; }
+.rc-badge { position: absolute; top: 18px; right: 20px; font-weight: 600; padding: 4px 10px; border-radius: 999px; font-size: 14px; }
+.rc-badge-good { color: #166534; background: #dcfce7; }
+.rc-badge-bad { color: #991b1b; background: #fee2e2; }
+.rc-section { padding: 14px 18px; border: 1px solid #e5e7eb; border-radius: 10px; background: #fff; margin-bottom: 16px; }
+.rc-risks { border-color: #fde68a; background: #fffbeb; }
+.rc-list { margin: 8px 0 0; padding-left: 20px; }
+.rc-mono { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+.rc-table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+.rc-table th, .rc-table td { padding: 6px 12px; border-bottom: 1px solid #f3f4f6; text-align: left; }
+.rc-table th { font-size: 11px; color: #6b7280; font-weight: 600; }
+.rc-num { text-align: right; font-variant-numeric: tabular-nums; }
+.rc-bold { font-weight: 600; }
+.delta-up { color: #166534; }
+.delta-down { color: #991b1b; }
+.delta-flat { color: #6b7280; }
+.delta-na { color: #9ca3af; font-style: italic; }
+.rc-severity { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 600; text-transform: uppercase; margin-right: 4px; }
+.rc-severity-info { background: #e0e7ff; color: #3730a3; }
+.rc-severity-warning { background: #fef3c7; color: #92400e; }
+.rc-severity-blocker { background: #fee2e2; color: #991b1b; }
+.rc-category { color: #6b7280; font-size: 12px; }
+.rc-affected { color: #6b7280; font-size: 12px; }
+.rc-from { color: #9ca3af; }
+.rc-to { color: #166534; font-weight: 600; }
+.rc-move-move_up { color: #166534; }
+.rc-move-move_down { color: #991b1b; }
+.rc-audit summary { cursor: pointer; }
+"""
+
+
+def render_html(
+    report_card: ReportCard,
+    *,
+    mode: Literal["embedded", "standalone"] = "standalone",
+) -> str:
+    """Render the ReportCard. ``mode`` controls whether the output is a
+    self-contained HTML document (``standalone``) or a body fragment
+    (``embedded``) for Streamlit's ``st.html`` embed.
+    """
+    template = _env.get_template("report_card.html")
+    fragment = template.render(report_card=report_card)
+    if mode == "embedded":
+        return fragment
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "<meta charset=\"utf-8\">\n"
+        f"<title>Report Card &middot; {report_card.event_name} &middot; "
+        f"{report_card.gender} {report_card.age_group}</title>\n"
+        f"<style>\n{_STANDALONE_CSS}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        f"{fragment}\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def write_html(
+    report_card: ReportCard,
+    path: Path,
+    *,
+    mode: Literal["embedded", "standalone"] = "standalone",
+) -> Path:
+    """Atomically write the rendered HTML to ``path``.
+
+    Mirrors ``_io.write_json``'s ``.tmp`` + ``os.replace`` + fsync
+    pattern at ``storage/_io.py:40``. HTML isn't JSON, so we use
+    ``Path.write_bytes`` against the ``.tmp`` path then ``os.replace``.
+    """
+    rendered = render_html(report_card, mode=mode)
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    encoded = rendered.encode("utf-8")
+    with open(tmp_path, "wb") as handle:
+        handle.write(encoded)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, path)
+    return path

--- a/src/tournaments/reports/schema.py
+++ b/src/tournaments/reports/schema.py
@@ -1,0 +1,259 @@
+"""Report Card dataclasses — leaves + the ``ReportCard`` aggregate.
+
+Mirrors the storage-layer JSON-backed dataclass conventions:
+
+- Leaves use ``frozen_medians.py:29-92`` — ``@dataclass(frozen=True)`` +
+  ``schema_version: int = 1`` + ``to_dict`` via ``asdict`` + classmethod
+  ``from_dict`` lenient on missing fields.
+- The ``ReportCard`` aggregate uses ``schedule_simulator.py:29-130`` —
+  hand-written ``to_dict`` recursing via ``[child.to_dict() for child in ...]``
+  because ``asdict`` on tuples of frozen dataclasses produces lists of
+  plain dicts, which is what ``write_json`` wants.
+
+``OverrideAuditRow`` is a passthrough container: each
+``run_overrides_audit.jsonl`` record already carries the orchestrator's
+shape (cf. ``run_orchestrator._write_run_overrides_audit``), so this
+dataclass just enforces the schema-version gate on read and round-trips
+the dict verbatim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from src.tournaments.storage.schema_version import assert_supported_version
+
+__all__ = [
+    "BalanceScore",
+    "Metric",
+    "OverrideAuditRow",
+    "ReportCard",
+    "RiskFlag",
+    "TeamMovement",
+    "TopReason",
+]
+
+
+MetricUnit = Literal["count", "rate", "gd"]
+RiskSeverity = Literal["info", "warning", "blocker"]
+TeamMove = Literal["move_up", "move_down", "stay"]
+
+
+@dataclass(frozen=True)
+class Metric:
+    """One row of the side-by-side metrics table.
+
+    ``actual`` and ``delta`` may be ``None`` for v1 metrics whose actual
+    side is unavailable (capped GD, same-club early, intra-event rematches,
+    same-coach early). ``unit`` drives the renderer's formatting:
+    ``"count"`` → integer, ``"rate"`` → percentage, ``"gd"`` → fixed
+    decimal.
+    """
+
+    label: str
+    actual: float | int | None
+    optimized: float | int | None
+    delta: float | int | None
+    unit: MetricUnit
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "Metric":
+        return cls(
+            label=payload["label"],
+            actual=payload.get("actual"),
+            optimized=payload.get("optimized"),
+            delta=payload.get("delta"),
+            unit=payload["unit"],
+        )
+
+
+@dataclass(frozen=True)
+class BalanceScore:
+    """Composite 0-100 score per spec §9.
+
+    ``actual`` and ``delta`` are ``None`` in v1 because Shell 06's
+    ``summary.json["actual_results"]`` carries only aggregates — no
+    per-match rows for the actual tournament — so ``same_club_early_rate``
+    and ``rematch_rate`` for the actual side cannot be computed.
+    Substituting zero would bias the actual baseline upward by 20 points;
+    the renderer surfaces ``"n/a"`` instead.
+    """
+
+    actual: float | None
+    optimized: float
+    delta: float | None
+    preset_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BalanceScore":
+        return cls(
+            actual=payload.get("actual"),
+            optimized=float(payload["optimized"]),
+            delta=payload.get("delta"),
+            preset_id=payload["preset_id"],
+        )
+
+
+@dataclass(frozen=True)
+class RiskFlag:
+    """One amber-block entry on the Report Card.
+
+    ``category`` is a free-form string for v1 — validated by the
+    template's render-side branching, not by ``__post_init__``, so new
+    categories can land without a schema bump.
+    """
+
+    severity: RiskSeverity
+    category: str
+    message: str
+    affected_teams: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RiskFlag":
+        return cls(
+            severity=payload["severity"],
+            category=payload["category"],
+            message=payload["message"],
+            affected_teams=tuple(payload.get("affected_teams") or ()),
+        )
+
+
+@dataclass(frozen=True)
+class TeamMovement:
+    """One actual-vs-optimized division reseat.
+
+    ``canonical_team_id`` is the FK that survives rescrape (verified at
+    ``backtest_tournament_cohort.py:300, 790-803``). ``team_name`` is the
+    operator-facing display name from the registry's ``event_team_name``.
+    """
+
+    canonical_team_id: str
+    team_name: str
+    from_division: str
+    to_division: str
+    move: TeamMove
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "TeamMovement":
+        return cls(
+            canonical_team_id=payload["canonical_team_id"],
+            team_name=payload["team_name"],
+            from_division=payload["from_division"],
+            to_division=payload["to_division"],
+            move=payload["move"],
+        )
+
+
+@dataclass(frozen=True)
+class TopReason:
+    """One auto-generated "why MatchBalance beats the status quo" bullet."""
+
+    text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "TopReason":
+        return cls(text=payload["text"])
+
+
+@dataclass(frozen=True)
+class OverrideAuditRow:
+    """Passthrough container for one ``run_overrides_audit.jsonl`` record.
+
+    The orchestrator (``run_orchestrator._write_run_overrides_audit``)
+    already stamps every row with ``run_id``, ``applied_at``,
+    ``delta_balance_score``, plus the schema-version gate. This dataclass
+    enforces ``assert_supported_version`` on read and round-trips the dict
+    verbatim — equivalent to inlining the call but explicit at the type
+    boundary.
+    """
+
+    record: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.record)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "OverrideAuditRow":
+        assert_supported_version(payload, source="OverrideAuditRow")
+        return cls(record=dict(payload))
+
+
+@dataclass(frozen=True)
+class ReportCard:
+    """Composite Report Card payload — one per ``(event_key, scenario, run_id)``.
+
+    Hand-written ``to_dict`` recurses via ``[child.to_dict() for child in self.<tuple>]``
+    (mirrors ``TournamentScheduleSimulation.to_dict`` at
+    ``schedule_simulator.py:120``). ``from_dict`` is lenient on
+    ``schema_version`` per the storage convention; the strict gate lives
+    in ``read_comparison_json`` (mirrors ``FrozenMedians`` at
+    ``frozen_medians.py:80``).
+    """
+
+    event_key: str
+    scenario: str
+    run_id: str
+    age_group: str
+    gender: str
+    event_name: str
+    computed_at: str
+    balance_score: BalanceScore
+    metrics: tuple[Metric, ...]
+    risk_flags: tuple[RiskFlag, ...]
+    top_reasons: tuple[TopReason, ...]
+    team_movements: tuple[TeamMovement, ...]
+    override_audit: tuple[OverrideAuditRow, ...] = field(default_factory=tuple)
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_key": self.event_key,
+            "scenario": self.scenario,
+            "run_id": self.run_id,
+            "age_group": self.age_group,
+            "gender": self.gender,
+            "event_name": self.event_name,
+            "computed_at": self.computed_at,
+            "balance_score": self.balance_score.to_dict(),
+            "metrics": [m.to_dict() for m in self.metrics],
+            "risk_flags": [r.to_dict() for r in self.risk_flags],
+            "top_reasons": [t.to_dict() for t in self.top_reasons],
+            "team_movements": [m.to_dict() for m in self.team_movements],
+            "override_audit": [a.to_dict() for a in self.override_audit],
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ReportCard":
+        return cls(
+            event_key=payload["event_key"],
+            scenario=payload["scenario"],
+            run_id=payload["run_id"],
+            age_group=payload["age_group"],
+            gender=payload["gender"],
+            event_name=payload["event_name"],
+            computed_at=payload["computed_at"],
+            balance_score=BalanceScore.from_dict(payload["balance_score"]),
+            metrics=tuple(Metric.from_dict(m) for m in payload.get("metrics") or ()),
+            risk_flags=tuple(RiskFlag.from_dict(r) for r in payload.get("risk_flags") or ()),
+            top_reasons=tuple(TopReason.from_dict(t) for t in payload.get("top_reasons") or ()),
+            team_movements=tuple(TeamMovement.from_dict(m) for m in payload.get("team_movements") or ()),
+            override_audit=tuple(OverrideAuditRow.from_dict(a) for a in payload.get("override_audit") or ()),
+            schema_version=int(payload.get("schema_version", 1)),
+        )

--- a/src/tournaments/reports/templates/report_card.html
+++ b/src/tournaments/reports/templates/report_card.html
@@ -1,0 +1,166 @@
+{#-
+  Report Card v1 template — block order matches Section 9 of the spec
+  and the brainstorm mockup at .superpowers/brainstorm/11406-1776984436/content/report-card.html.
+
+  Fields are auto-escaped (Environment created with autoescape=True) so
+  no manual `| e` is required. Inline CSS only, no external assets, no
+  JS — ships as a self-contained standalone HTML or as an embedded
+  fragment.
+-#}
+{%- macro fmt_metric(value, unit) -%}
+{%- if value is none -%}
+n/a
+{%- elif unit == 'rate' -%}
+{{ '%.0f%%' | format(value * 100) }}
+{%- elif unit == 'gd' -%}
+{{ '%.2f' | format(value) }}
+{%- else -%}
+{{ value | int }}
+{%- endif -%}
+{%- endmacro -%}
+
+{%- macro fmt_delta(metric) -%}
+{%- if metric.delta is none -%}
+n/a
+{%- elif metric.unit == 'rate' -%}
+{{ '%+.0f pp' | format(metric.delta * 100) }}
+{%- elif metric.unit == 'gd' -%}
+{{ '%+.2f' | format(metric.delta) }}
+{%- else -%}
+{{ '%+d' | format(metric.delta | int) }}
+{%- endif -%}
+{%- endmacro -%}
+
+{%- macro delta_class(metric) -%}
+{%- if metric.delta is none -%}
+delta-na
+{%- elif metric.delta > 0 -%}
+delta-up
+{%- elif metric.delta < 0 -%}
+delta-down
+{%- else -%}
+delta-flat
+{%- endif -%}
+{%- endmacro -%}
+
+<section class="report-card">
+  <header class="rc-header">
+    <div class="rc-eyebrow">MatchBalance Report Card</div>
+    <h1 class="rc-title">{{ report_card.event_name }} · {{ report_card.gender }} {{ report_card.age_group }}</h1>
+    <div class="rc-meta">
+      Run <code>{{ report_card.run_id }}</code> · scenario <code>{{ report_card.scenario }}</code> · computed {{ report_card.computed_at }}
+    </div>
+  </header>
+
+  <section class="rc-hero">
+    <div class="rc-card rc-actual">
+      <div class="rc-eyebrow rc-eyebrow-muted">Actual tournament</div>
+      {% if report_card.balance_score.actual is none %}
+        <div class="rc-na">n/a &mdash; actual per-match data not available in v1</div>
+      {% else %}
+        <div class="rc-score">{{ '%.0f' | format(report_card.balance_score.actual) }}</div>
+        <div class="rc-meta">/ 100 Balance Score</div>
+      {% endif %}
+    </div>
+    <div class="rc-card rc-optimized">
+      <div class="rc-eyebrow rc-eyebrow-good">MatchBalance</div>
+      <div class="rc-score rc-score-good">{{ '%.0f' | format(report_card.balance_score.optimized) }}</div>
+      <div class="rc-meta rc-meta-good">/ 100 Balance Score &middot; preset <code>{{ report_card.balance_score.preset_id }}</code></div>
+      {% if report_card.balance_score.delta is not none %}
+        <div class="rc-badge {{ 'rc-badge-good' if report_card.balance_score.delta > 0 else 'rc-badge-bad' }}">
+          {{ '%+.0f' | format(report_card.balance_score.delta) }}
+        </div>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="rc-section">
+    <div class="rc-eyebrow">Why MatchBalance beats the status quo</div>
+    {% if report_card.top_reasons %}
+      <ul class="rc-list">
+        {% for reason in report_card.top_reasons %}
+          <li>{{ reason.text }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="rc-na">No measurable improvement over the actual schedule.</div>
+    {% endif %}
+  </section>
+
+  <section class="rc-section">
+    <div class="rc-eyebrow">Side-by-side metrics</div>
+    <table class="rc-table">
+      <thead>
+        <tr>
+          <th>Metric</th>
+          <th class="rc-num">Actual</th>
+          <th class="rc-num">MatchBalance</th>
+          <th class="rc-num">&Delta;</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for metric in report_card.metrics %}
+          <tr>
+            <td>{{ metric.label }}</td>
+            <td class="rc-num">{{ fmt_metric(metric.actual, metric.unit) }}</td>
+            <td class="rc-num rc-bold">{{ fmt_metric(metric.optimized, metric.unit) }}</td>
+            <td class="rc-num {{ delta_class(metric) }}">{{ fmt_delta(metric) }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  {% if report_card.risk_flags %}
+    <section class="rc-section rc-risks">
+      <div class="rc-eyebrow rc-eyebrow-amber">Risk flags &middot; {{ report_card.risk_flags | length }} items</div>
+      <ul class="rc-list">
+        {% for flag in report_card.risk_flags %}
+          <li>
+            <span class="rc-severity rc-severity-{{ flag.severity }}">{{ flag.severity }}</span>
+            <span class="rc-category">{{ flag.category }}</span>
+            &mdash; {{ flag.message }}
+            {% if flag.affected_teams %}
+              <span class="rc-affected">({{ flag.affected_teams | join(', ') }})</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if report_card.team_movements %}
+    <section class="rc-section">
+      <div class="rc-eyebrow">Team movements &middot; {{ report_card.team_movements | length }} changes</div>
+      <ul class="rc-list rc-mono">
+        {% for movement in report_card.team_movements %}
+          <li>
+            {{ movement.team_name }} &middot;
+            <span class="rc-from">{{ movement.from_division }}</span>
+            &rarr;
+            <span class="rc-to">{{ movement.to_division }}</span>
+            <span class="rc-move-{{ movement.move }}">({{ movement.move }})</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if report_card.override_audit %}
+    <details class="rc-section rc-audit">
+      <summary class="rc-eyebrow">Override audit log &middot; {{ report_card.override_audit | length }} records</summary>
+      <ul class="rc-list rc-mono">
+        {% for entry in report_card.override_audit %}
+          {% set rec = entry.record %}
+          <li>
+            <code>{{ rec.get('ts', '') }}</code>
+            &middot; {{ rec.get('actor', '') }}
+            &middot; <strong>{{ rec.get('type', '') }}</strong>
+            &middot; team_ref={{ rec.get('team_ref', '') }}
+            {% if rec.get('reason') %} &middot; <em>{{ rec.get('reason') }}</em>{% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </details>
+  {% endif %}
+</section>

--- a/src/tournaments/run_orchestrator.py
+++ b/src/tournaments/run_orchestrator.py
@@ -29,15 +29,16 @@ The orchestrator owns:
 - orphan ``.tmp/`` cleanup at preflight time so a parent crash mid-run
   doesn't leave the runs dir corrupted forever
 
-KNOWN RISK — division-routing heuristic (matches Shell 04's `_recompute_medians_inner`):
-  `_build_cohort_request_payload` infers each registry team's division via
-  `event_team_name.startswith(division_name)`, falling back to the first
-  division on no match. Real GotSport team names (e.g. "Phoenix Rising 2012
-  Boys") rarely start with a structure division name (e.g. "BU14 Premier"),
-  so the fallback fires and every team in the cohort lands in division #1.
-  Until a follow-up shell adds explicit per-team division assignment to the
-  registry (Shell 04/05 follow-up), every fallback is logged to the run's
-  ``parser_warnings.jsonl`` so production usage will surface this loudly.
+KNOWN RISK — division-routing heuristic (now resolver-driven):
+  ``_build_cohort_request_payload`` calls ``resolve_division_assignment``
+  per team. Resolver-returned ``source='none'`` means both the operator's
+  ``assigned_division_name`` override AND the prefix heuristic missed for
+  this team. ``source='stale'`` means the operator assigned a division
+  that has since been removed. Shell 09 + the one-shot
+  ``scripts/backfill_division_assignments.py`` make ``source='none'``
+  rare on backfilled events; greenfield events still surface it until an
+  operator confirms assignments. Both kinds emit distinct
+  ``parser_warnings.jsonl`` records for cleanup.
 """
 
 from __future__ import annotations
@@ -77,10 +78,14 @@ from src.tournaments.storage._io import (
     write_json,
 )
 from src.tournaments.triage import (
+    SOURCE_EXPLICIT,
+    SOURCE_PREFIX,
+    SOURCE_STALE,
     ReadinessResult,
     is_ready,
     project_overrides,
     registry_provider_id,
+    resolve_division_assignment,
 )
 
 logger = logging.getLogger(__name__)
@@ -411,14 +416,16 @@ def _build_cohort_request_payload(
     *,
     base_dir: Path | str,
     extras: dict[str, Any],
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], list[str], list[str]]:
     """Build the cohort CLI's request payload (entrants + divisions).
 
-    Returns ``(payload, division_routing_fallbacks)``. ``fallbacks`` is the
-    list of team names that hit the heuristic division routing fallback
-    (see module docstring's KNOWN RISK). ``execute_run`` writes them to
-    ``parser_warnings.jsonl`` so production usage exposes how often the
-    routing heuristic is failing.
+    Returns ``(payload, division_routing_fallbacks, division_routing_stale_assignments)``.
+    ``fallbacks`` is the list of team names whose resolver returned
+    ``source="none"`` (no assignment AND no prefix match);
+    ``stale_assignments`` is the list whose resolver returned
+    ``source="stale"`` (operator-assigned division has since been removed).
+    ``execute_run`` emits two distinct ``parser_warnings.jsonl`` kinds so
+    operators can grep them independently.
 
     Mirrors ``scripts.backtest_tournament_event._build_request_payload``
     (event:380-440) — inlined rather than imported because the script-side
@@ -448,6 +455,7 @@ def _build_cohort_request_payload(
     division_names = [d.name for d in cohort_structure.divisions]
     teams_by_division: dict[str, list[dict[str, Any]]] = {name: [] for name in division_names}
     division_routing_fallbacks: list[str] = []
+    division_routing_stale_assignments: list[str] = []
 
     for entry in registry:
         if entry.event_age_group != age or entry.event_gender != gender:
@@ -462,16 +470,16 @@ def _build_cohort_request_payload(
         if not team_id_master:
             continue
         team_name = entry.event_team_name or pid
-        bracket = (entry.event_team_name or "").strip()
-        chosen_division = next(
-            (name for name in division_names if name and bracket.startswith(name)),
-            None,
-        )
-        if chosen_division is None:
-            # KNOWN RISK: heuristic fallback (see module docstring). Surface
-            # via parser_warnings.jsonl in execute_run so production usage
-            # exposes how often it bites — Shell 04/05 follow-up will replace
-            # this with explicit per-team division assignment.
+        resolution = resolve_division_assignment(projected, team_name, division_names=division_names)
+        if resolution.source in (SOURCE_EXPLICIT, SOURCE_PREFIX):
+            chosen_division = resolution.name or ""
+        elif resolution.source == SOURCE_STALE:
+            # Stale assignment: use the prefix-resolved fallback name when
+            # available, else first division. Track separately so the
+            # parser_warning splits "stale" from "never assigned".
+            chosen_division = resolution.name or (division_names[0] if division_names else "")
+            division_routing_stale_assignments.append(team_name)
+        else:  # SOURCE_NONE
             chosen_division = division_names[0] if division_names else ""
             division_routing_fallbacks.append(team_name)
         if chosen_division not in teams_by_division:
@@ -528,7 +536,7 @@ def _build_cohort_request_payload(
     snapshot_date = extras.get("ranking_snapshot_date")
     if snapshot_date:
         payload["prediction_date"] = snapshot_date
-    return payload, sorted(division_routing_fallbacks)
+    return payload, sorted(division_routing_fallbacks), sorted(division_routing_stale_assignments)
 
 
 def _build_cli_args(staging_dir: Path, *, extras: dict[str, Any]) -> tuple[list[str], Path]:
@@ -883,7 +891,11 @@ def execute_run(
         # _finalize_failure call so the failure shows up as a normal failed
         # run rather than a silent orphan that needs the 24h cleanup sweep.
         try:
-            payload, division_routing_fallbacks = _build_cohort_request_payload(
+            (
+                payload,
+                division_routing_fallbacks,
+                division_routing_stale_assignments,
+            ) = _build_cohort_request_payload(
                 event_key,
                 scenario,
                 age,
@@ -916,11 +928,26 @@ def execute_run(
                     stamp_schema_version(
                         {
                             "kind": "division_routing_fallback",
-                            "fallback_division": payload["divisions"][0]["actual_division_name"]
-                            if payload["divisions"]
-                            else "",
+                            "fallback_division": (
+                                payload["divisions"][0]["actual_division_name"] if payload["divisions"] else ""
+                            ),
                             "team_count": len(division_routing_fallbacks),
                             "team_names": division_routing_fallbacks,
+                        }
+                    ),
+                )
+            if division_routing_stale_assignments:
+                # Stale-assignment teams may route to several different
+                # divisions (each prefix-resolved individually), so a single
+                # ``fallback_division`` field would be misleading here —
+                # omit it and rely on ``team_names`` for cleanup triage.
+                append_jsonl(
+                    staging_dir / "parser_warnings.jsonl",
+                    stamp_schema_version(
+                        {
+                            "kind": "division_routing_stale_assignment",
+                            "team_count": len(division_routing_stale_assignments),
+                            "team_names": division_routing_stale_assignments,
                         }
                     ),
                 )

--- a/src/tournaments/storage/overrides.py
+++ b/src/tournaments/storage/overrides.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from src.tournaments.storage._io import append_jsonl, read_jsonl
 from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.scenario import acquire_scenario_lock
 from src.tournaments.storage.schema_version import (
     assert_supported_version,
     stamp_schema_version,
@@ -38,10 +39,28 @@ def append_override(
     override: dict[str, Any],
     *,
     base_dir: Path | str = "reports",
+    _already_locked: bool = False,
+    timeout: float = 2.0,
 ) -> None:
-    """Append one override record. Stamps ``schema_version: 1`` automatically."""
+    """Append one override record. Stamps ``schema_version: 1`` automatically.
+
+    When ``_already_locked=True``, the caller MUST already hold
+    ``acquire_scenario_lock(event_key, scenario, base_dir=base_dir)``. This
+    escape hatch exists so callers nested inside an existing scenario lock
+    (e.g., ``_recompute_medians_inner``) don't self-deadlock on the
+    non-reentrant advisory lock.
+
+    ``timeout`` is the per-call lock-acquire timeout. Default ``2.0``s
+    matches existing UI write paths; the backfill script passes ``10.0``s
+    to absorb contention with operator UI writes.
+    """
     path = _overrides_path(scenario_dir(event_key, scenario, base_dir=base_dir))
-    append_jsonl(path, stamp_schema_version(override))
+    record = stamp_schema_version(override)
+    if _already_locked:
+        append_jsonl(path, record)
+        return
+    with acquire_scenario_lock(event_key, scenario, base_dir=base_dir, timeout=timeout):
+        append_jsonl(path, record)
 
 
 def load_overrides(

--- a/src/tournaments/triage.py
+++ b/src/tournaments/triage.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal
 
@@ -45,9 +45,15 @@ _ACTOR_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "DivisionResolution",
+    "DivisionSource",
     "ProjectedCohortState",
     "ProjectedTeamState",
     "ReadinessResult",
+    "SOURCE_EXPLICIT",
+    "SOURCE_NONE",
+    "SOURCE_PREFIX",
+    "SOURCE_STALE",
     "TeamState",
     "_OVERRIDE_TYPES",
     "_STRENGTH_MODES",
@@ -58,6 +64,7 @@ __all__ = [
     "is_ready",
     "project_overrides",
     "registry_provider_id",
+    "resolve_division_assignment",
 ]
 
 
@@ -68,6 +75,7 @@ _OVERRIDE_TYPES: tuple[str, ...] = (
     "edit_external",
     "manual_add",
     "recompute_medians",
+    "assign_division",
 )
 """Closed set of override ``type`` values. Pinned by tests so a future
 refactor can't quietly add a new one without updating the projection
@@ -81,7 +89,7 @@ value.
 """
 
 _TEAM_SCOPED_TYPES: frozenset[str] = frozenset(
-    {"accept_match", "fix_match", "mark_external", "edit_external", "manual_add"}
+    {"accept_match", "fix_match", "mark_external", "edit_external", "manual_add", "assign_division"}
 )
 _COHORT_SCOPED_TYPES: frozenset[str] = frozenset({"recompute_medians"})
 
@@ -101,6 +109,7 @@ class ProjectedTeamState:
     state: TeamState
     team_id_master: str | None = None
     manual_seed_group: str | None = None
+    assigned_division_name: str | None = None
     strength_mode: str | None = None
     manual_power_score: float | None = None
     note: str | None = None
@@ -268,14 +277,27 @@ def _apply_team_override(
     Per-type rules pinned in the plan's Override Record Contract §6.
     """
     after = after or {}
+    carried_division = prior.assigned_division_name if prior is not None else None
+    if type_ == "assign_division":
+        carry = prior or ProjectedTeamState(state="unknown")
+        return replace(
+            carry,
+            assigned_division_name=str(after.get("assigned_division_name") or "") or None,
+            last_override_ts=ts,
+        )
     if type_ in ("accept_match", "fix_match"):
         return ProjectedTeamState(
             state="resolved",
             team_id_master=str(after.get("team_id_master") or "") or None,
+            assigned_division_name=carried_division,
             last_override_ts=ts,
         )
     if type_ == "mark_external":
-        return ProjectedTeamState(state="external", last_override_ts=ts)
+        return ProjectedTeamState(
+            state="external",
+            assigned_division_name=carried_division,
+            last_override_ts=ts,
+        )
     if type_ == "edit_external":
         strength_mode = str(after.get("strength_mode") or "") or None
         manual_power_score = after.get("manual_power_score")
@@ -286,6 +308,7 @@ def _apply_team_override(
             state="external",
             team_id_master=carried_team_id,
             manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+            assigned_division_name=carried_division,
             strength_mode=strength_mode,
             manual_power_score=(float(manual_power_score) if manual_power_score is not None else None),
             note=str(after.get("note") or "") or None,
@@ -300,6 +323,7 @@ def _apply_team_override(
                 state="resolved",
                 team_id_master=str(after.get("team_id_master") or "") or None,
                 manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+                assigned_division_name=carried_division,
                 last_override_ts=ts,
                 cohort_age_group=cohort_age,
                 cohort_gender=cohort_gender,
@@ -313,6 +337,7 @@ def _apply_team_override(
         return ProjectedTeamState(
             state="external",
             manual_seed_group=str(after.get("manual_seed_group") or "") or None,
+            assigned_division_name=carried_division,
             strength_mode=strength_mode,
             manual_power_score=(float(manual_power_score) if manual_power_score is not None else None),
             note=str(after.get("note") or "") or None,
@@ -321,6 +346,84 @@ def _apply_team_override(
             cohort_gender=cohort_gender,
         )
     raise ValueError(f"unhandled team-scoped override type: {type_!r}")
+
+
+DivisionSource = Literal["explicit", "prefix", "stale", "none"]
+"""Pinned vocabulary for ``DivisionResolution.source``. Re-exported so
+callers can branch on the constants below instead of bare string literals
+(typo-safe — a misspelled ``"None"`` would silently miscategorize)."""
+
+SOURCE_EXPLICIT: DivisionSource = "explicit"
+SOURCE_PREFIX: DivisionSource = "prefix"
+SOURCE_STALE: DivisionSource = "stale"
+SOURCE_NONE: DivisionSource = "none"
+
+
+@dataclass(frozen=True)
+class DivisionResolution:
+    """Result of ``resolve_division_assignment``.
+
+    ``source`` distinguishes never-assigned (``SOURCE_NONE``), operator-confirmed
+    (``SOURCE_EXPLICIT``), heuristic-resolved (``SOURCE_PREFIX``), and
+    assigned-to-deleted-division (``SOURCE_STALE``). Callers act on ``name`` for
+    routing and on ``source`` for telemetry / fallback decisions.
+
+    Approved consumer policies for ``SOURCE_STALE`` (intentionally diverge
+    by use case):
+
+    - ``run_orchestrator._build_cohort_request_payload`` — route the team
+      to the prefix-resolved fallback name and emit a
+      ``division_routing_stale_assignment`` parser_warning so cleanup is
+      observable.
+    - ``tournament_intake._build_division_groups`` — silently group with
+      explicit/prefix matches. The Shell 04 left pane is purely a render
+      surface; stale teams are surfaced separately by the per-row form.
+    - ``tournament_intake._recompute_medians_inner`` — skip the team
+      entirely (do NOT contaminate medians) and emit an ``st.warning``.
+    """
+
+    name: str | None
+    source: DivisionSource
+
+
+def resolve_division_assignment(
+    projected: ProjectedTeamState | None,
+    event_team_name: str | None,
+    *,
+    division_names: list[str],
+) -> DivisionResolution:
+    """Pick the authoritative division for a team in this cohort.
+
+    Precedence: explicit override-projected assignment → longest-prefix
+    match on ``event_team_name`` → none. The ``stale`` source surfaces
+    removed-division cleanup needs distinctly from genuine "never
+    assigned" teams.
+    """
+    if projected and projected.assigned_division_name:
+        if projected.assigned_division_name in division_names:
+            return DivisionResolution(name=projected.assigned_division_name, source=SOURCE_EXPLICIT)
+        # Stale: division was renamed/removed in structure form.
+        # Fall through to prefix; caller emits a parser_warning.
+        return DivisionResolution(name=_longest_prefix(event_team_name, division_names), source=SOURCE_STALE)
+    matched = _longest_prefix(event_team_name, division_names)
+    if matched is None:
+        return DivisionResolution(name=None, source=SOURCE_NONE)
+    return DivisionResolution(name=matched, source=SOURCE_PREFIX)
+
+
+def _longest_prefix(event_team_name: str | None, division_names: list[str]) -> str | None:
+    """Return the longest division name that prefixes ``event_team_name``.
+
+    Single source of truth for the bracket-prefix heuristic — reused by
+    the resolver's prefix + stale paths.
+    """
+    bracket = (event_team_name or "").strip()
+    if not bracket or not division_names:
+        return None
+    for name in sorted(division_names, key=len, reverse=True):
+        if name and bracket.startswith(name):
+            return name
+    return None
 
 
 def project_overrides(

--- a/tests/unit/test_cohort_cli_request_payload_consumes_prediction_date.py
+++ b/tests/unit/test_cohort_cli_request_payload_consumes_prediction_date.py
@@ -78,7 +78,7 @@ def _bootstrap(base: Path) -> None:
 
 def test_payload_carries_prediction_date_from_extras(tmp_path: Path):
     _bootstrap(tmp_path)
-    payload, _fallbacks = _build_cohort_request_payload(
+    payload, _fallbacks, _stale = _build_cohort_request_payload(
         EVENT_KEY,
         SCENARIO,
         "u14",

--- a/tests/unit/test_overrides_locking.py
+++ b/tests/unit/test_overrides_locking.py
@@ -1,0 +1,88 @@
+"""Concurrency tests for ``src.tournaments.storage.overrides.append_override``.
+
+Pins Shell 09 Step 0's writer-tier scenario-lock fix: two concurrent
+processes appending overrides for the same ``(event_key, scenario)``
+must serialize through ``acquire_scenario_lock`` so every record lands
+intact (no interleaved bytes, no lost writes).
+
+Uses ``multiprocessing.Process`` rather than ``threading.Thread`` because
+the underlying advisory locks (``fcntl.flock`` on POSIX,
+``msvcrt.locking`` on Windows) are per-fd; threads share the fd table
+and can't faithfully simulate "two browser tabs hitting the same
+Streamlit process pool".
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+from pathlib import Path
+
+from src.tournaments.storage import (
+    append_override,
+    ensure_scenario,
+)
+from src.tournaments.storage.event_key import scenario_dir
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def _writer(base_dir: str, worker_id: int, iterations: int) -> None:
+    """Append ``iterations`` overrides under the scenario lock.
+
+    Each record carries ``worker_id`` and a per-worker ``seq`` so the
+    parent test can verify per-process insertion order is preserved.
+    """
+    base_path = Path(base_dir)
+    for seq in range(iterations):
+        append_override(
+            EVENT_KEY,
+            SCENARIO,
+            {
+                "ts": "2026-04-26T12:00:00+00:00",
+                "actor": "ops@example.com",
+                "scope": "team",
+                "type": "accept_match",
+                "team_ref": f"pid-{worker_id}-{seq}",
+                "before": {},
+                "after": {"team_id_master": f"tim-{worker_id}-{seq}"},
+                "reason": f"worker {worker_id} seq {seq}",
+                "worker_id": worker_id,
+                "seq": seq,
+            },
+            base_dir=base_path,
+            timeout=10.0,
+        )
+
+
+def test_concurrent_writers_serialize_via_scenario_lock(tmp_path: Path) -> None:
+    """Two child processes each append 100 overrides; the resulting JSONL
+    must contain exactly 200 records, every line valid JSON, and per-worker
+    insertion order preserved within each worker's ``seq`` stream."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    iterations = 100
+
+    ctx = multiprocessing.get_context("spawn")
+    procs = [ctx.Process(target=_writer, args=(str(tmp_path), worker_id, iterations)) for worker_id in (1, 2)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=120)
+        assert p.exitcode == 0, f"writer exited with {p.exitcode}"
+
+    overrides_path = scenario_dir(EVENT_KEY, SCENARIO, base_dir=tmp_path) / "overrides.jsonl"
+    text = overrides_path.read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if line.strip()]
+    assert len(lines) == 2 * iterations, f"expected {2 * iterations} records, got {len(lines)}"
+
+    by_worker: dict[int, list[int]] = {}
+    for line in lines:
+        # Every line must parse as valid JSON — no interleaved bytes.
+        record = json.loads(line)
+        worker_id = record["worker_id"]
+        by_worker.setdefault(worker_id, []).append(record["seq"])
+
+    # Per-worker insertion order is preserved within each worker's records.
+    for worker_id, seqs in by_worker.items():
+        assert seqs == list(range(iterations)), f"worker {worker_id} seq order broken: {seqs[:5]}..."

--- a/tests/unit/test_recompute_medians.py
+++ b/tests/unit/test_recompute_medians.py
@@ -1,0 +1,244 @@
+"""Unit tests for ``tournament_intake._recompute_medians_inner``.
+
+Pins Shell 09's stale-assignment skip behavior: teams whose
+``assigned_division_name`` no longer matches a current structure
+division must be excluded from the medians and surfaced via
+``st.warning``, not silently bucketed into the prefix-resolved division.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.storage import (
+    EventMetadata,
+    TeamRegistryEntry,
+    append_override,
+    ensure_scenario,
+    load_overrides,
+    read_structure,
+    write_event_metadata,
+    write_registry,
+    write_structure,
+)
+from src.tournaments.storage.structure import CohortStructure, DivisionStructure
+from tournament_intake import _recompute_medians_inner
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+
+
+def _bootstrap(base: Path) -> None:
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-05-01",
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+        ),
+        base_dir=base,
+    )
+    write_structure(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            CohortStructure(
+                age_group="u14",
+                gender="Boys",
+                divisions=(DivisionStructure(name="BU14 Premier", team_count=2, pool_sizes=(2,)),),
+            )
+        ],
+        base_dir=base,
+    )
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="BU14 Premier Phoenix Rising",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+            TeamRegistryEntry(
+                event_registration_id="reg-2",
+                event_team_name="BU14 Premier Real Madrid",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-2",
+                resolved_team_id_master="tim-2",
+            ),
+        ],
+        base_dir=base,
+    )
+
+
+class _FakeQueryBuilder:
+    """Minimal Supabase query-builder stub for the rankings_full read.
+
+    Records the requested ``team_id`` ``in_`` filter and returns rows for
+    only those ids. The test sets ``rows_by_id`` so each test can stage
+    its own per-team powerscores.
+    """
+
+    def __init__(self, rows_by_id: dict[str, dict[str, Any]]) -> None:
+        self._rows_by_id = rows_by_id
+        self._wanted_ids: list[str] = []
+
+    def select(self, *_args: Any, **_kwargs: Any) -> "_FakeQueryBuilder":
+        return self
+
+    def eq(self, *_args: Any, **_kwargs: Any) -> "_FakeQueryBuilder":
+        return self
+
+    def ilike(self, *_args: Any, **_kwargs: Any) -> "_FakeQueryBuilder":
+        return self
+
+    def limit(self, *_args: Any, **_kwargs: Any) -> "_FakeQueryBuilder":
+        return self
+
+    def in_(self, _column: str, ids: list[str]) -> "_FakeQueryBuilder":
+        self._wanted_ids = list(ids)
+        return self
+
+    def execute(self) -> Any:
+        rows = [self._rows_by_id[tid] for tid in self._wanted_ids if tid in self._rows_by_id]
+        return type("Resp", (), {"data": rows})()
+
+
+class _FakeSupabase:
+    def __init__(self, rows_by_id: dict[str, dict[str, Any]]) -> None:
+        self._rows_by_id = rows_by_id
+
+    def table(self, _name: str) -> _FakeQueryBuilder:
+        return _FakeQueryBuilder(self._rows_by_id)
+
+
+def test_recompute_medians_skips_stale_assigned_team(tmp_path: Path, monkeypatch: Any) -> None:
+    """Team with ``assigned_division_name="BU14 Removed"`` must NOT
+    contribute to the BU14 Premier bucket — operator explicitly
+    de-assigned it from this division."""
+    _bootstrap(tmp_path)
+    # pid-2 carries a stale assignment to a since-removed division.
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "assign_division",
+            "team_ref": "pid-2",
+            "before": {},
+            "after": {"assigned_division_name": "BU14 Removed"},
+            "reason": "operator removed",
+        },
+        base_dir=tmp_path,
+    )
+
+    rows_by_id = {
+        "tim-1": {"team_id": "tim-1", "powerscore_ml": 14.0},
+        "tim-2": {"team_id": "tim-2", "powerscore_ml": 99.0},  # would skew medians badly
+    }
+
+    captured_buckets: dict[str, list[float]] = {}
+    captured_warnings: list[str] = []
+
+    import tournament_intake
+
+    def _fake_compute(buckets: dict[str, list[float]]) -> Any:
+        captured_buckets.update(buckets)
+        return type("Medians", (), {"medians_by_division": {k: sum(v) / len(v) for k, v in buckets.items() if v}})()
+
+    monkeypatch.setattr(tournament_intake, "compute_frozen_medians", _fake_compute)
+    monkeypatch.setattr(tournament_intake, "write_frozen_medians", lambda *a, **k: None)
+    monkeypatch.setattr(
+        tournament_intake, "read_frozen_medians", lambda *a, **k: type("FM", (), {"medians_by_division": {}})()
+    )
+
+    class _StWarn:
+        @staticmethod
+        def warning(msg: str) -> None:
+            captured_warnings.append(msg)
+
+        @staticmethod
+        def error(msg: str) -> None:  # pragma: no cover — surfaces test bugs
+            captured_warnings.append(f"ERROR: {msg}")
+
+    monkeypatch.setattr(tournament_intake, "st", _StWarn)
+    monkeypatch.setattr(tournament_intake, "_load_registry_cached", _LoadCacheStub(tmp_path))
+    monkeypatch.setattr(tournament_intake, "_rankings_full_age_form", lambda age, _sb: age)
+
+    fake_sb = _FakeSupabase(rows_by_id)
+
+    # Patch base_dir for the storage helpers — they default to ``"reports"``
+    # so we must monkeypatch the rebound module-level imports inside
+    # tournament_intake. ``append_override`` also defaults to ``"reports"``
+    # and would write outside ``tmp_path`` if not patched (test would
+    # leak audit records into the repo's ``reports/`` directory).
+    captured_overrides: list[dict[str, Any]] = []
+
+    def _capture_append_override(event_key: str, scenario: str, record: dict[str, Any], **kwargs: Any) -> None:
+        captured_overrides.append({"record": record, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        tournament_intake,
+        "load_overrides",
+        lambda event_key, scenario: load_overrides(event_key, scenario, base_dir=tmp_path),
+    )
+    monkeypatch.setattr(
+        tournament_intake,
+        "read_structure",
+        lambda event_key, scenario: read_structure(event_key, scenario, base_dir=tmp_path),
+    )
+    monkeypatch.setattr(tournament_intake, "append_override", _capture_append_override)
+
+    _recompute_medians_inner(
+        event_key=EVENT_KEY,
+        scenario=SCENARIO,
+        age="u14",
+        gender="Boys",
+        supabase_client=fake_sb,
+        reviewer_email="ops@example.com",
+    )
+
+    # Audit-log write fired with the lock-elision flag (recompute is
+    # nested inside an outer scenario lock).
+    assert len(captured_overrides) == 1
+    assert captured_overrides[0]["kwargs"].get("_already_locked") is True
+    assert captured_overrides[0]["record"]["type"] == "recompute_medians"
+
+    # Only tim-1 contributed to the bucket; tim-2 (stale) was skipped.
+    assert captured_buckets == {"BU14 Premier": [14.0]}
+    # Operator was warned about the stale-assignment skip.
+    assert any("stale-assigned" in w for w in captured_warnings)
+    assert any("BU14 Premier Real Madrid" in w for w in captured_warnings)
+
+
+class _LoadCacheStub:
+    """Drop-in stub for the ``@st.cache_data`` ``_load_registry_cached`` wrapper.
+
+    The real cache wrapper is callable AND has a ``.clear`` method; the
+    test cohort uses two registry rows from ``_bootstrap``. Re-reading
+    via ``read_registry`` keeps the test in lockstep with the on-disk
+    fixture.
+    """
+
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+
+    def __call__(self, event_key: str, scenario: str) -> list[dict[str, Any]]:
+        from src.tournaments.storage import read_registry
+
+        return [entry.to_row() for entry in read_registry(event_key, scenario, base_dir=self._base_dir)]
+
+    def clear(self) -> None:
+        return None

--- a/tests/unit/test_reports_compute.py
+++ b/tests/unit/test_reports_compute.py
@@ -1,0 +1,809 @@
+"""Unit tests for ``src.tournaments.reports.compute``.
+
+The fixture builds a minimal scenario layout under ``tmp_path``: an
+event metadata file, a registry CSV, and a run dir under
+``runs/<run_id>/`` with the auxiliary artifacts Shell 06 emits
+(``done.json``, ``run_metadata.json``, ``summary.json``,
+``division_recommendations.json``, optionally ``fallbacks.jsonl`` and
+``run_overrides_audit.jsonl``). Tests assert exact metric values, exact
+risk-flag categories, top-reason ordering, and the run-completion gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.tournaments.reports.compute import (
+    LOW_GAMES_THRESHOLD,
+    STALE_SNAPSHOT_DAYS,
+    ReportCardError,
+    compute_report_card,
+)
+from src.tournaments.reports.schema import RiskFlag
+from src.tournaments.storage import (
+    EventMetadata,
+    TeamRegistryEntry,
+    append_override,
+    ensure_scenario,
+    write_event_metadata,
+    write_registry,
+)
+from src.tournaments.storage._io import append_jsonl, write_json
+from src.tournaments.storage.event_key import run_dir
+from src.tournaments.storage.schema_version import stamp_schema_version
+from src.tournaments.triage import build_override_record
+
+EVENT_KEY = "gotsport__45224__2026"
+SCENARIO = "default"
+RUN_ID = "u14_boys_20260430T120000_aaaaaaaaaaaa"
+
+DEFAULT_EXTRAS: dict[str, Any] = {
+    "capped_gd_limit": 3,
+    "balance_score_weights": {"preset_id": "default"},
+    "ranking_snapshot_date": "2026-04-26",
+    "model_version_pin": "poisson_draw_gate_v1",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap(
+    base: Path,
+    *,
+    extras: dict[str, Any] | None = None,
+    extra_registry_rows: list[TeamRegistryEntry] | None = None,
+    event_start: str = "2026-05-01",
+) -> Path:
+    """Set up event metadata + registry + the run dir scaffold."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date=event_start,
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+            extras=DEFAULT_EXTRAS if extras is None else extras,
+        ),
+        base_dir=base,
+    )
+    rows = [
+        TeamRegistryEntry(
+            event_team_name="FC Dallas 2012",
+            event_age_group="u14",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id="pid-1",
+            resolved_team_id_master="tim-1",
+            in_scope_u10_u19="True",
+            event_club_name="FC Dallas",
+        ),
+        TeamRegistryEntry(
+            event_team_name="LUSA 2012 BCSPL",
+            event_age_group="u14",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id="pid-2",
+            resolved_team_id_master="tim-2",
+            in_scope_u10_u19="True",
+            event_club_name="LUSA",
+        ),
+        TeamRegistryEntry(
+            event_team_name="Tuzos Royals",
+            event_age_group="u14",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id="pid-3",
+            resolved_team_id_master="tim-3",
+            in_scope_u10_u19="True",
+            event_club_name="Tuzos",
+        ),
+        TeamRegistryEntry(
+            event_team_name="State 48 FC 2012",
+            event_age_group="u14",
+            event_gender="Boys",
+            resolved_gotsport_provider_team_id="pid-4",
+            resolved_team_id_master="tim-4",
+            in_scope_u10_u19="True",
+            event_club_name="State 48 FC",
+        ),
+    ]
+    if extra_registry_rows:
+        rows.extend(extra_registry_rows)
+    write_registry(EVENT_KEY, SCENARIO, rows, base_dir=base)
+    return _build_run_dir(base)
+
+
+def _build_run_dir(
+    base: Path,
+    *,
+    with_done: bool = True,
+    with_metadata: bool = True,
+) -> Path:
+    run_path = run_dir(EVENT_KEY, SCENARIO, RUN_ID, base_dir=base)
+    run_path.mkdir(parents=True, exist_ok=True)
+    if with_done:
+        write_json(
+            run_path / "done.json",
+            stamp_schema_version({"run_id": RUN_ID, "promoted_at": "2026-04-30T12:00:00+00:00"}),
+        )
+    if with_metadata:
+        write_json(
+            run_path / "run_metadata.json",
+            stamp_schema_version(
+                {
+                    "run_id": RUN_ID,
+                    "event_key": EVENT_KEY,
+                    "scenario": SCENARIO,
+                    "cohort_age_group": "u14",
+                    "cohort_gender": "Boys",
+                    "event_name": "Phoenix Cup 2026",
+                    "started_at": "2026-04-30T12:00:00+00:00",
+                    "ended_at": "2026-04-30T12:01:00+00:00",
+                }
+            ),
+        )
+    return run_path
+
+
+def _entrants() -> list[dict[str, Any]]:
+    """Four entrants — all with games_played >= LOW_GAMES_THRESHOLD."""
+    return [
+        {
+            "entrant_id": "e1",
+            "canonical_team_id": "tim-1",
+            "provider_team_id": "pid-1",
+            "event_team_name": "FC Dallas 2012",
+            "club_name": "FC Dallas",
+            "games_played": 12,
+            "ranking_status": "Active",
+            "actual_division_name": "Super Elite",
+            "event_age_group": "u14",
+            "event_gender": "Male",
+            "power_score": 1700,
+        },
+        {
+            "entrant_id": "e2",
+            "canonical_team_id": "tim-2",
+            "provider_team_id": "pid-2",
+            "event_team_name": "LUSA 2012 BCSPL",
+            "club_name": "LUSA",
+            "games_played": 8,
+            "ranking_status": "Active",
+            "actual_division_name": "Super Elite",
+            "event_age_group": "u14",
+            "event_gender": "Male",
+            "power_score": 1650,
+        },
+        {
+            "entrant_id": "e3",
+            "canonical_team_id": "tim-3",
+            "provider_team_id": "pid-3",
+            "event_team_name": "Tuzos Royals",
+            "club_name": "Tuzos",
+            "games_played": 10,
+            "ranking_status": "Active",
+            "actual_division_name": "Super Pro",
+            "event_age_group": "u14",
+            "event_gender": "Male",
+            "power_score": 1500,
+        },
+        {
+            "entrant_id": "e4",
+            "canonical_team_id": "tim-4",
+            "provider_team_id": "pid-4",
+            "event_team_name": "State 48 FC 2012",
+            "club_name": "State 48 FC",
+            "games_played": 9,
+            "ranking_status": "Active",
+            "actual_division_name": "Super Pro",
+            "event_age_group": "u14",
+            "event_gender": "Male",
+            "power_score": 1480,
+        },
+    ]
+
+
+def _default_pool_matches() -> list[dict[str, Any]]:
+    """Round-robin among 4 teams = 6 pool matches, varied goal differentials."""
+    return [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e3", "goal_differential": 2},
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e4", "goal_differential": 3},
+        {"stage": "Pool", "home_team_id": "e2", "away_team_id": "e3", "goal_differential": 1},
+        {"stage": "Pool", "home_team_id": "e2", "away_team_id": "e4", "goal_differential": 2},
+        {"stage": "Pool", "home_team_id": "e3", "away_team_id": "e4", "goal_differential": 0},
+    ]
+
+
+def _write_summary(
+    run_path: Path,
+    *,
+    entrants: list[dict[str, Any]] | None = None,
+    matches: list[dict[str, Any]] | None = None,
+    actual_overrides: dict[str, Any] | None = None,
+) -> None:
+    entrants = entrants if entrants is not None else _entrants()
+    matches = matches if matches is not None else _default_pool_matches()
+    n = len(matches)
+    one_goal = sum(1 for m in matches if m["goal_differential"] <= 1)
+    blow3 = sum(1 for m in matches if m["goal_differential"] >= 3)
+    blow5 = sum(1 for m in matches if m["goal_differential"] >= 5)
+    avg_gd = sum(m["goal_differential"] for m in matches) / n if n else 0.0
+    actual: dict[str, Any] = {
+        "actual_game_count": n,
+        "average_goal_differential": 2.09,
+        "median_goal_differential": 2.0,
+        "close_game_rate": 0.22,
+        "blowout_3plus_rate": 0.31,
+        "blowout_5plus_rate": 0.10,
+        "draw_rate": 0.05,
+        "divisions": {},
+    }
+    if actual_overrides:
+        actual.update(actual_overrides)
+    payload = {
+        "event_name": "Phoenix Cup 2026",
+        "cohort": {"age_group": "u14", "gender": "Male"},
+        "actual_results": actual,
+        "optimized_projection": {
+            "simulated_schedule": {
+                "match_count": n,
+                "average_goal_differential": float(avg_gd),
+                "median_goal_differential": 1.5,
+                "close_game_rate": one_goal / n if n else 0.0,
+                "blowout_3plus_rate": blow3 / n if n else 0.0,
+                "blowout_5plus_rate": blow5 / n if n else 0.0,
+                "draw_rate": sum(1 for m in matches if m["goal_differential"] == 0) / n if n else 0.0,
+                "divisions": [{"name": "Super Elite", "matches": matches}],
+            }
+        },
+        "comparison_to_actual": {},
+        "entrants": entrants,
+        "predictor": {"snapshot_resolution_counts": {}},
+        "notes": [],
+    }
+    write_json(run_path / "summary.json", payload)
+
+
+def _write_division_recommendations(run_path: Path, rows: list[dict[str, Any]] | None = None) -> None:
+    if rows is None:
+        rows = [
+            {
+                "event_team_name": "FC Dallas 2012",
+                "canonical_team_name": "FC Dallas 2012",
+                "club_name": "FC Dallas",
+                "provider_team_id": "pid-1",
+                "actual_division": "Super Elite",
+                "recommended_division": "Super Pro",
+                "move": "move_down",
+                "power_score": 1700,
+                "ranking_source_team_id": "tim-1",
+                "canonical_team_id": "tim-1",
+                "ranking_status": "Active",
+            },
+            {
+                "event_team_name": "Tuzos Royals",
+                "canonical_team_name": "Tuzos Royals",
+                "club_name": "Tuzos",
+                "provider_team_id": "pid-3",
+                "actual_division": "Super Pro",
+                "recommended_division": "Super Pro",
+                "move": "stay",
+                "power_score": 1500,
+                "ranking_source_team_id": "tim-3",
+                "canonical_team_id": "tim-3",
+                "ranking_status": "Active",
+            },
+        ]
+    write_json(run_path / "division_recommendations.json", rows)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _flag_categories(flags: tuple[RiskFlag, ...]) -> list[str]:
+    return [f.category for f in flags]
+
+
+def test_compute_report_card_basic_metrics(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    assert rc.event_key == EVENT_KEY
+    assert rc.scenario == SCENARIO
+    assert rc.run_id == RUN_ID
+    assert rc.age_group == "u14"
+    assert rc.gender == "Boys"  # registry vocab — not summary's "Male"
+    assert rc.event_name == "Phoenix Cup 2026"
+    assert len(rc.metrics) == 8
+
+    metric_labels = [m.label for m in rc.metrics]
+    assert "Expected avg GD (raw)" == metric_labels[0]
+    # 8 metrics, in the locked order; capped GD is metric #2
+    assert "capped at 3" in metric_labels[1]
+
+
+def test_balance_score_actual_is_none_in_v1(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    assert rc.balance_score.actual is None
+    assert rc.balance_score.delta is None
+    assert rc.balance_score.preset_id == "default"
+    # Optimized side: 50*one_goal + 30*(1-blow5) + 10*(1-same_club) + 10*(1-rematch)
+    # 6 matches with GDs [1,2,3,1,2,0]: one_goal (GD<=1) count=3 → 3/6, blow5=0,
+    # same_club=0 (different clubs), rematch=0.
+    expected = 50 * (3 / 6) + 30 * 1.0 + 10 * 1.0 + 10 * 1.0
+    assert rc.balance_score.optimized == pytest.approx(expected)
+
+
+def test_capped_gd_uses_extras_limit(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    matches = [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e3", "goal_differential": 5},
+        {"stage": "Pool", "home_team_id": "e2", "away_team_id": "e4", "goal_differential": 7},
+        {"stage": "Pool", "home_team_id": "e3", "away_team_id": "e4", "goal_differential": 0},
+    ]
+    _write_summary(run_path, matches=matches)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    # capped at 3: clamped values are [1, 3, 3, 0]; mean = 7/4 = 1.75
+    capped_metric = next(m for m in rc.metrics if "capped at 3" in m.label)
+    assert capped_metric.actual is None
+    assert capped_metric.optimized == pytest.approx(1.75)
+    assert capped_metric.delta is None
+
+
+def test_stage_filter_excludes_final_and_third_place(tmp_path: Path):
+    """Same-club early-meeting count counts only Pool / Semi Final A / Semi Final B."""
+    run_path = _bootstrap(tmp_path)
+    entrants = _entrants()
+    # Make e1 and e2 same club.
+    entrants[0]["club_name"] = "Same Club"
+    entrants[1]["club_name"] = "Same Club"
+    # e1-e2 in Final stage should NOT count; e1-e2 in Pool should.
+    matches = [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+        {"stage": "Final", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+        {"stage": "Third Place", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+    ]
+    _write_summary(run_path, entrants=entrants, matches=matches)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    same_club_metric = next(m for m in rc.metrics if m.label.startswith("Same-club"))
+    assert same_club_metric.optimized == 1
+
+
+def test_intra_event_rematches_pool_only(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    matches = [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+        {"stage": "Pool", "home_team_id": "e2", "away_team_id": "e1", "goal_differential": 0},  # rematch
+        {"stage": "Pool", "home_team_id": "e3", "away_team_id": "e4", "goal_differential": 2},
+        {"stage": "Final", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},  # not counted
+    ]
+    _write_summary(run_path, matches=matches)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    rematch_metric = next(m for m in rc.metrics if m.label.startswith("Intra-event rematches"))
+    assert rematch_metric.optimized == 1
+
+
+def test_low_games_flag_fires_below_threshold(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    entrants = _entrants()
+    entrants[0]["games_played"] = LOW_GAMES_THRESHOLD - 1  # 5 games
+    _write_summary(run_path, entrants=entrants)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    low_games_flags = [f for f in rc.risk_flags if f.category == "low_games"]
+    assert len(low_games_flags) == 1
+    assert low_games_flags[0].affected_teams == ("FC Dallas 2012",)
+
+
+def test_stale_snapshot_boundary(tmp_path: Path):
+    """At the exact threshold (= 7 days) → no flag; > 7 days → flag."""
+    extras = {**DEFAULT_EXTRAS, "ranking_snapshot_date": "2026-04-24"}  # exactly 7 days before 2026-05-01
+    run_path = _bootstrap(tmp_path, extras=extras)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "stale_ranking_snapshot" not in _flag_categories(rc.risk_flags)
+
+
+def test_stale_snapshot_fires_above_threshold(tmp_path: Path):
+    extras = {**DEFAULT_EXTRAS, "ranking_snapshot_date": "2026-04-23"}  # 8 days before 2026-05-01
+    run_path = _bootstrap(tmp_path, extras=extras)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    stale = [f for f in rc.risk_flags if f.category == "stale_ranking_snapshot"]
+    assert len(stale) == 1
+    assert "8 days" in stale[0].message
+
+
+def test_snapshot_freshness_unknown_when_no_event_start(tmp_path: Path):
+    extras = dict(DEFAULT_EXTRAS)
+    run_path = _bootstrap(tmp_path, extras=extras, event_start=None)  # type: ignore[arg-type]
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "snapshot_freshness_unknown" in _flag_categories(rc.risk_flags)
+
+
+def test_extras_none_uses_defaults(tmp_path: Path):
+    run_path = _bootstrap(tmp_path, extras=None)
+    # extras=None on the meta is the "no extras" case; helper above passes
+    # DEFAULT_EXTRAS when extras is None, so override here directly.
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-05-01",
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+            extras=None,
+        ),
+        base_dir=tmp_path,
+    )
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    # Should not raise on missing capped_gd_limit / preset_id; both default.
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    capped_metric = next(m for m in rc.metrics if "capped at" in m.label)
+    assert "capped at 3" in capped_metric.label  # default limit
+    # event_start exists but ranking_snapshot_date is missing → freshness_unknown
+    assert "snapshot_freshness_unknown" in _flag_categories(rc.risk_flags)
+
+
+def test_unsupported_balance_score_preset_raises(tmp_path: Path):
+    extras = {
+        **DEFAULT_EXTRAS,
+        "balance_score_weights": {"preset_id": "experimental_v2"},
+    }
+    run_path = _bootstrap(tmp_path, extras=extras)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    with pytest.raises(ValueError, match="Unsupported balance_score_weights"):
+        compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+
+def test_no_early_meetings_forces_zero_rates_and_flags(tmp_path: Path):
+    """All-Final cohort: no Pool / Semi early-meeting matches → flag fires."""
+    run_path = _bootstrap(tmp_path)
+    matches = [
+        {"stage": "Final", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+    ]
+    _write_summary(run_path, matches=matches)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "no_early_meetings" in _flag_categories(rc.risk_flags)
+
+
+def test_external_no_override_flag(tmp_path: Path):
+    """An entrant that's been mark_external'd without a recompute_medians cohort
+    override fires ``external_no_override``."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:00:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="team",
+            type="mark_external",
+            team_ref="pid-1",
+            before={},
+            after={},
+            reason="external club",
+        ),
+        base_dir=tmp_path,
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    cats = _flag_categories(rc.risk_flags)
+    assert "external_no_override" in cats
+    assert "external_with_assumed_median" not in cats
+
+
+def test_external_with_assumed_median_flag(tmp_path: Path):
+    """Adding a recompute_medians cohort override flips external flag."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:00:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="team",
+            type="mark_external",
+            team_ref="pid-1",
+            before={},
+            after={},
+            reason="external club",
+        ),
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:01:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="cohort",
+            type="recompute_medians",
+            team_ref="u14_Boys",
+            before={"medians_by_division": {}},
+            after={"medians_by_division": {"Super Elite": 1700.0}},
+            reason="recompute",
+        ),
+        base_dir=tmp_path,
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    cats = _flag_categories(rc.risk_flags)
+    assert "external_with_assumed_median" in cats
+    assert "external_no_override" not in cats
+
+
+def test_placeholder_match_flag(tmp_path: Path):
+    """Entrant whose name matches ``unknown_<provider_team_id>`` fires placeholder."""
+    run_path = _bootstrap(tmp_path)
+    entrants = _entrants()
+    entrants[0]["event_team_name"] = "unknown_pid-1"
+    _write_summary(run_path, entrants=entrants)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "placeholder_match" in _flag_categories(rc.risk_flags)
+
+
+def test_placeholder_helper_short_circuits_on_empty_pid(tmp_path: Path):
+    """Empty provider_team_id with name ``unknown_`` does NOT fire placeholder."""
+    run_path = _bootstrap(tmp_path)
+    entrants = _entrants()
+    # First entrant: empty pid + name "unknown_". Should NOT fire placeholder.
+    entrants[0]["provider_team_id"] = ""
+    entrants[0]["event_team_name"] = "unknown_"
+    _write_summary(run_path, entrants=entrants)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "placeholder_match" not in _flag_categories(rc.risk_flags)
+
+
+def test_orphan_override_flag_fires_for_genuine_orphan(tmp_path: Path):
+    """An override whose team_ref isn't in the registry fires the orphan flag."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:00:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="team",
+            type="mark_external",
+            team_ref="pid-orphan-99",
+            before={},
+            after={"event_team_name": "Ghost Team FC"},
+            reason="orphan",
+        ),
+        base_dir=tmp_path,
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    orphan_flags = [f for f in rc.risk_flags if f.category == "rescrape_orphan_override"]
+    assert len(orphan_flags) == 1
+    assert orphan_flags[0].affected_teams == ("Ghost Team FC",)
+
+
+def test_manual_add_override_does_not_fire_orphan_flag(tmp_path: Path):
+    """``manual_add`` overrides have ``team_ref`` starting with ``manual_`` and
+    are excluded from orphan detection."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:00:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="team",
+            type="manual_add",
+            team_ref="manual_xyz",
+            before={},
+            after={
+                "event_team_name": "Manual Team",
+                "cohort_age_group": "u14",
+                "cohort_gender": "Boys",
+                "state": "external",
+            },
+            reason="manual entry",
+        ),
+        base_dir=tmp_path,
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "rescrape_orphan_override" not in _flag_categories(rc.risk_flags)
+
+
+def test_cohort_scoping_no_u17_team_in_u14_run(tmp_path: Path):
+    """Registry has both U14 boys and U17 girls; U14 run should not surface
+    U17 teams in any flag."""
+    extra = TeamRegistryEntry(
+        event_team_name="U17 Other Team",
+        event_age_group="u17",
+        event_gender="Girls",
+        resolved_gotsport_provider_team_id="pid-u17",
+        resolved_team_id_master="tim-u17",
+        in_scope_u10_u19="True",
+        event_club_name="Other Club",
+    )
+    run_path = _bootstrap(tmp_path, extra_registry_rows=[extra])
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    for flag in rc.risk_flags:
+        assert "U17 Other Team" not in (flag.message + " ".join(flag.affected_teams))
+
+
+def test_missing_done_json_raises_report_card_error(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    (run_path / "done.json").unlink()
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    with pytest.raises(ReportCardError, match="not completed"):
+        compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+
+def test_missing_run_metadata_raises_report_card_error(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    (run_path / "run_metadata.json").unlink()
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    with pytest.raises(ReportCardError, match="run_metadata.json"):
+        compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+
+def test_top_reasons_ordered_by_magnitude(tmp_path: Path):
+    """The largest absolute delta lands first."""
+    run_path = _bootstrap(tmp_path)
+    # Force a big drop in 5+ blowout (1.0 → 0.0) so it dominates.
+    matches = [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 1},
+    ]
+    actual_overrides = {
+        "actual_game_count": 1,
+        "average_goal_differential": 5.0,
+        "close_game_rate": 0.0,
+        "blowout_3plus_rate": 1.0,
+        "blowout_5plus_rate": 1.0,
+    }
+    _write_summary(run_path, matches=matches, actual_overrides=actual_overrides)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    # Magnitudes (rates as percentage-point delta, gd as raw):
+    #   blowout_5plus: |0 - 1| = 1.0
+    #   one_goal_rate: |1 - 0| = 1.0   (tied with blowout_5plus)
+    #   avg_gd: |5 - 1| = 4.0
+    # Expected order: avg_gd, blowout_5plus, one_goal_rate
+    # (Tied blowout_5plus / one_goal: insertion-order in TOP_REASON_TEMPLATES
+    # places blowout_5plus before one_goal_rate.)
+    assert len(rc.top_reasons) >= 3
+    assert "Tightened average goal differential" in rc.top_reasons[0].text
+    assert "5+ goal mismatches" in rc.top_reasons[1].text
+    assert "one-goal games" in rc.top_reasons[2].text
+
+
+def test_team_movements_filtered_to_non_stay(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    # Fixture writes 1 move_down + 1 stay; only the move_down survives.
+    assert len(rc.team_movements) == 1
+    assert rc.team_movements[0].move == "move_down"
+    assert rc.team_movements[0].team_name == "FC Dallas 2012"
+
+
+def test_fallbacks_jsonl_emits_one_flag_per_row(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_jsonl(
+        run_path / "fallbacks.jsonl",
+        stamp_schema_version(
+            {
+                "team_name": "FC Dallas 2012",
+                "fallback_kind": "synthetic_snapshot_fallback",
+                "raw_note": "FC Dallas 2012: no point-in-time snapshots found",
+            }
+        ),
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    fallback_flags = [f for f in rc.risk_flags if f.category == "snapshot_fallback"]
+    assert len(fallback_flags) == 1
+    assert fallback_flags[0].affected_teams == ("FC Dallas 2012",)
+
+
+def test_run_overrides_audit_loaded_into_report_card(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    append_jsonl(
+        run_path / "run_overrides_audit.jsonl",
+        stamp_schema_version(
+            {
+                "ts": "2026-04-29T10:00:00+00:00",
+                "actor": "dallas@pitchrank.io",
+                "scope": "team",
+                "type": "accept_match",
+                "team_ref": "pid-1",
+                "before": {},
+                "after": {},
+                "reason": "accepted",
+                "run_id": RUN_ID,
+                "applied_at": "2026-04-30T12:00:00+00:00",
+                "delta_balance_score": None,
+            }
+        ),
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert len(rc.override_audit) == 1
+    assert rc.override_audit[0].record["type"] == "accept_match"
+
+
+def test_coach_data_unavailable_flag_always_emitted(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert "coach_data_unavailable" in _flag_categories(rc.risk_flags)

--- a/tests/unit/test_reports_compute.py
+++ b/tests/unit/test_reports_compute.py
@@ -18,7 +18,6 @@ import pytest
 
 from src.tournaments.reports.compute import (
     LOW_GAMES_THRESHOLD,
-    STALE_SNAPSHOT_DAYS,
     ReportCardError,
     compute_report_card,
 )
@@ -737,6 +736,78 @@ def test_top_reasons_ordered_by_magnitude(tmp_path: Path):
     assert "Tightened average goal differential" in rc.top_reasons[0].text
     assert "5+ goal mismatches" in rc.top_reasons[1].text
     assert "one-goal games" in rc.top_reasons[2].text
+
+
+def test_top_reasons_skip_regressed_metrics(tmp_path: Path):
+    """A metric that got worse must not appear in top reasons — the
+    templates assert directional improvement ("Reduced", "Raised",
+    "Tightened") and emitting them when the optimized side is worse
+    misleads the Report Card reader."""
+    run_path = _bootstrap(tmp_path)
+    # Optimized blowouts WORSE than actual; one_goal lower; avg_gd higher.
+    matches = [
+        {"stage": "Pool", "home_team_id": "e1", "away_team_id": "e2", "goal_differential": 6},
+        {"stage": "Pool", "home_team_id": "e3", "away_team_id": "e4", "goal_differential": 5},
+    ]
+    actual_overrides = {
+        "actual_game_count": 2,
+        "average_goal_differential": 1.0,
+        "close_game_rate": 0.9,
+        "blowout_3plus_rate": 0.1,
+        "blowout_5plus_rate": 0.0,
+    }
+    _write_summary(run_path, matches=matches, actual_overrides=actual_overrides)
+    _write_division_recommendations(run_path)
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    # No reason should be emitted because every direction is a regression.
+    for reason in rc.top_reasons:
+        assert "Reduced" not in reason.text
+        assert "Raised" not in reason.text
+        assert "Tightened" not in reason.text
+
+
+def test_orphan_detection_uses_event_registration_fallback(tmp_path: Path):
+    """Registry rows with empty ``resolved_gotsport_provider_team_id`` fall
+    back to ``event_registration_id`` for the orphan check, mirroring how
+    ``triage.is_ready`` derives per-row identity."""
+    # Add a registry row with no resolved provider id but an event registration id.
+    fallback_row = TeamRegistryEntry(
+        event_registration_id="reg-fallback-1",
+        event_team_name="Fallback Team",
+        event_age_group="u14",
+        event_gender="Boys",
+        resolved_gotsport_provider_team_id="",  # falls back to reg-fallback-1
+        resolved_team_id_master="",
+        in_scope_u10_u19="True",
+        event_club_name="Fallback Club",
+    )
+    run_path = _bootstrap(tmp_path, extra_registry_rows=[fallback_row])
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    # Override targets the fallback id — used to be flagged as orphan.
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        build_override_record(
+            ts="2026-04-29T10:00:00+00:00",
+            actor="dallas@pitchrank.io",
+            scope="team",
+            type="mark_external",
+            team_ref="reg-fallback-1",
+            before={},
+            after={"event_team_name": "Fallback Team"},
+            reason="external",
+        ),
+        base_dir=tmp_path,
+    )
+
+    rc = compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    orphan_flags = [f for f in rc.risk_flags if f.category == "rescrape_orphan_override"]
+    assert orphan_flags == [], (
+        "Override keyed by event_registration_id fallback was falsely flagged as orphan; "
+        "registry_pids must use registry_provider_id() to honor the fallback."
+    )
 
 
 def test_team_movements_filtered_to_non_stay(tmp_path: Path):

--- a/tests/unit/test_reports_persist.py
+++ b/tests/unit/test_reports_persist.py
@@ -25,7 +25,6 @@ from tests.unit.test_reports_compute import (
     _write_summary,
 )
 
-
 _ARTIFACTS: tuple[str, ...] = (
     "comparison.json",
     "comparison_metrics.csv",

--- a/tests/unit/test_reports_persist.py
+++ b/tests/unit/test_reports_persist.py
@@ -1,0 +1,111 @@
+"""Unit tests for ``compute_and_persist_report_card``.
+
+End-to-end: build a fixture run dir, call the persist wrapper, verify
+all six artifacts land in the run dir with the sentinel written last.
+A partial-failure test monkeypatches the renderer to confirm cleanup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.reports import compute as reports_compute
+from src.tournaments.reports.compute import (
+    compute_and_persist_report_card,
+    read_comparison_json,
+)
+from tests.unit.test_reports_compute import (
+    EVENT_KEY,
+    RUN_ID,
+    SCENARIO,
+    _bootstrap,
+    _write_division_recommendations,
+    _write_summary,
+)
+
+
+_ARTIFACTS: tuple[str, ...] = (
+    "comparison.json",
+    "comparison_metrics.csv",
+    "comparison_risk_flags.csv",
+    "comparison_team_movements.csv",
+    "comparison.html",
+    "report_card.done",
+)
+
+
+def test_compute_and_persist_writes_all_six_artifacts(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    rc = compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    for name in _ARTIFACTS:
+        assert (run_path / name).exists(), f"missing artifact: {name}"
+    # Round-trip the JSON canonical form back into a ReportCard.
+    restored = read_comparison_json(run_path / "comparison.json")
+    assert restored.balance_score.optimized == pytest.approx(rc.balance_score.optimized)
+    assert restored.event_key == rc.event_key
+    assert restored.run_id == rc.run_id
+
+
+def test_sentinel_written_last(tmp_path: Path):
+    """``report_card.done``'s mtime must be >= every other artifact."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    sentinel_mtime = (run_path / "report_card.done").stat().st_mtime
+    for name in _ARTIFACTS:
+        if name == "report_card.done":
+            continue
+        other = (run_path / name).stat().st_mtime
+        # `>=` rather than strict `>`: filesystem mtime granularity on some
+        # platforms (notably Windows NTFS at ~16 ms) can collapse adjacent
+        # writes to the same value. The contract is "not earlier than", and
+        # `>=` honors that without flaking on coarse timers.
+        assert sentinel_mtime >= other, f"sentinel mtime older than {name}"
+
+
+def test_partial_failure_cleans_up_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """If ``write_html`` raises, no artifacts must survive on disk."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    # Patch the import target inside compute_and_persist_report_card.
+    def _exploding_write_html(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    # ``src.tournaments.reports.render_html`` is shadowed in the package
+    # namespace by the ``render_html`` function re-exported from
+    # ``__init__.py`` (classic Python ``from package.foo import foo`` name
+    # collision). Pull the actual module from ``sys.modules``.
+    import importlib
+
+    render_html_module = importlib.import_module("src.tournaments.reports.render_html")
+    monkeypatch.setattr(render_html_module, "write_html", _exploding_write_html)
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    # All six artifacts must be absent — the cleanup loop ran.
+    for name in _ARTIFACTS:
+        assert not (run_path / name).exists(), f"leftover artifact after failure: {name}"
+
+
+def test_compute_report_card_pure_does_not_write(tmp_path: Path):
+    """``compute_report_card`` is the pure variant — no side effects."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    reports_compute.compute_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    for name in _ARTIFACTS:
+        assert not (run_path / name).exists(), f"compute_report_card leaked artifact: {name}"

--- a/tests/unit/test_reports_render_csv.py
+++ b/tests/unit/test_reports_render_csv.py
@@ -107,6 +107,87 @@ def test_render_team_movements_csv_columns(tmp_path: Path):
     assert rows[0]["move"] == "move_down"
 
 
+def test_csv_formula_injection_prefixes_defanged(tmp_path: Path):
+    """Cells starting with ``=``, ``+``, ``-``, ``@`` must be prefixed with
+    ``'`` so spreadsheet apps render them as text instead of executing
+    formulas (OWASP CSV-injection mitigation)."""
+    rc = ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_test",
+        age_group="u14",
+        gender="Boys",
+        event_name="Phoenix Cup 2026",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(),
+        risk_flags=(
+            RiskFlag(
+                severity="warning",
+                category="=cmd|attack",  # leading ``=``
+                message="+1+1 evil formula",  # leading ``+``
+                affected_teams=('=HYPERLINK("http://evil")',),  # leading ``=``
+            ),
+        ),
+        top_reasons=(),
+        team_movements=(
+            TeamMovement(
+                canonical_team_id="-12345",  # leading ``-``
+                team_name="@team",  # leading ``@``
+                from_division="Super Elite",
+                to_division="Super Pro",
+                move="move_down",
+            ),
+        ),
+    )
+    flags_path = render_risk_flags_csv(rc, tmp_path)
+    _, flag_rows = _read_csv(flags_path)
+    assert flag_rows[0]["category"].startswith("'=")
+    assert flag_rows[0]["message"].startswith("'+")
+    assert flag_rows[0]["affected_teams"].startswith("'=")
+
+    movements_path = render_team_movements_csv(rc, tmp_path)
+    _, movement_rows = _read_csv(movements_path)
+    assert movement_rows[0]["canonical_team_id"].startswith("'-")
+    assert movement_rows[0]["team_name"].startswith("'@")
+
+
+def test_csv_whitespace_prefixes_defanged(tmp_path: Path):
+    """OWASP CSV-injection guidance flags leading ``\\t``, ``\\r``, ``\\n``
+    too — Excel skips leading whitespace before formula detection in some
+    import paths, so ``"\\t=cmd|...!A1"`` parses as a live formula without
+    the prefix in ``_FORMULA_INJECTION_PREFIXES``."""
+    rc = ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_test",
+        age_group="u14",
+        gender="Boys",
+        event_name="Phoenix Cup 2026",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(),
+        risk_flags=(
+            RiskFlag(
+                severity="warning",
+                category="\t=cmd|attack",  # leading TAB then formula
+                message="\r-evil",  # leading CR then formula
+                affected_teams=("\n=HYPERLINK",),  # leading LF then formula
+            ),
+        ),
+        top_reasons=(),
+        team_movements=(),
+    )
+    flags_path = render_risk_flags_csv(rc, tmp_path)
+    raw = flags_path.read_bytes().decode("utf-8")
+    # Each of the three whitespace-prefixed cells must be defanged with
+    # a leading single quote BEFORE the whitespace — the spreadsheet sees
+    # ``'\t=cmd|attack`` and renders it as text.
+    assert "'\t=cmd|attack" in raw
+    assert "'\r-evil" in raw or "'-evil" in raw  # CR may be normalized by csv module
+    assert "'\n=HYPERLINK" in raw or "'=HYPERLINK" in raw
+
+
 def test_render_all_csv_writes_three_files(tmp_path: Path):
     rc = _hand_built_report()
     metrics_path, flags_path, movements_path = render_all_csv(rc, tmp_path)

--- a/tests/unit/test_reports_render_csv.py
+++ b/tests/unit/test_reports_render_csv.py
@@ -1,0 +1,118 @@
+"""Unit tests for ``src.tournaments.reports.render_csv``.
+
+Render the three CSVs from a hand-built ``ReportCard`` and assert column
+headers, row counts, and the ``;``-join contract for ``affected_teams``.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from src.tournaments.reports.render_csv import (
+    METRICS_FIELDNAMES,
+    RISK_FLAG_FIELDNAMES,
+    TEAM_MOVEMENT_FIELDNAMES,
+    render_all_csv,
+    render_metrics_csv,
+    render_risk_flags_csv,
+    render_team_movements_csv,
+)
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    ReportCard,
+    RiskFlag,
+    TeamMovement,
+)
+
+
+def _hand_built_report() -> ReportCard:
+    return ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_test",
+        age_group="u14",
+        gender="Boys",
+        event_name="Phoenix Cup 2026",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(
+            Metric(label="One-goal game rate", actual=0.22, optimized=0.41, delta=0.19, unit="rate"),
+            Metric(label="Same-club early meetings", actual=None, optimized=0, delta=None, unit="count"),
+        ),
+        risk_flags=(
+            RiskFlag(severity="info", category="low_games", message="Foo: only 4 games", affected_teams=("a", "b")),
+            RiskFlag(severity="warning", category="stale_ranking_snapshot", message="9 days old"),
+        ),
+        top_reasons=(),
+        team_movements=(
+            TeamMovement(
+                canonical_team_id="tim-1",
+                team_name="FC Dallas 2012",
+                from_division="Super Elite",
+                to_division="Super Pro",
+                move="move_down",
+            ),
+        ),
+    )
+
+
+def _read_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    with open(path, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+        headers = list(reader.fieldnames or ())
+    return headers, rows
+
+
+def test_render_metrics_csv_column_order_matches_FIELDNAMES(tmp_path: Path):
+    rc = _hand_built_report()
+    path = render_metrics_csv(rc, tmp_path)
+    headers, rows = _read_csv(path)
+    assert tuple(headers) == METRICS_FIELDNAMES
+    assert len(rows) == 2
+
+
+def test_metric_actual_none_renders_as_empty_cell(tmp_path: Path):
+    rc = _hand_built_report()
+    path = render_metrics_csv(rc, tmp_path)
+    _, rows = _read_csv(path)
+    # Second row's actual should be empty string, not "None".
+    assert rows[1]["metric"] == "Same-club early meetings"
+    assert rows[1]["actual"] == ""
+    assert rows[1]["delta"] == ""
+
+
+def test_render_risk_flags_csv_joins_affected_teams_with_semicolons(tmp_path: Path):
+    rc = _hand_built_report()
+    path = render_risk_flags_csv(rc, tmp_path)
+    headers, rows = _read_csv(path)
+    assert tuple(headers) == RISK_FLAG_FIELDNAMES
+    assert rows[0]["affected_teams"] == "a;b"
+    # Round-trips on split.
+    assert rows[0]["affected_teams"].split(";") == ["a", "b"]
+    # Empty affected_teams renders as empty string.
+    assert rows[1]["affected_teams"] == ""
+
+
+def test_render_team_movements_csv_columns(tmp_path: Path):
+    rc = _hand_built_report()
+    path = render_team_movements_csv(rc, tmp_path)
+    headers, rows = _read_csv(path)
+    assert tuple(headers) == TEAM_MOVEMENT_FIELDNAMES
+    assert len(rows) == 1
+    assert rows[0]["from_division"] == "Super Elite"
+    assert rows[0]["to_division"] == "Super Pro"
+    assert rows[0]["move"] == "move_down"
+
+
+def test_render_all_csv_writes_three_files(tmp_path: Path):
+    rc = _hand_built_report()
+    metrics_path, flags_path, movements_path = render_all_csv(rc, tmp_path)
+    assert metrics_path.exists()
+    assert flags_path.exists()
+    assert movements_path.exists()
+    assert metrics_path.name == "comparison_metrics.csv"
+    assert flags_path.name == "comparison_risk_flags.csv"
+    assert movements_path.name == "comparison_team_movements.csv"

--- a/tests/unit/test_reports_render_html.py
+++ b/tests/unit/test_reports_render_html.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``src.tournaments.reports.render_html``.
+
+Render against hand-built ``ReportCard`` instances and assert structural
+substrings appear. No byte-snapshot comparisons — substring assertions
+only so cosmetic CSS tweaks don't break the suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tournaments.reports.render_html import render_html, write_html
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    OverrideAuditRow,
+    ReportCard,
+    RiskFlag,
+    TeamMovement,
+    TopReason,
+)
+
+
+def _hand_built_report() -> ReportCard:
+    return ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_test",
+        age_group="u14",
+        gender="Boys",
+        event_name="Phoenix Cup 2026",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(
+            Metric(label="One-goal game rate", actual=0.22, optimized=0.41, delta=0.19, unit="rate"),
+            Metric(label="Same-club early meetings", actual=None, optimized=0, delta=None, unit="count"),
+        ),
+        risk_flags=(
+            RiskFlag(severity="info", category="low_games", message="Foo: only 4 games", affected_teams=("Foo",)),
+            RiskFlag(severity="warning", category="stale_ranking_snapshot", message="9 days old"),
+        ),
+        top_reasons=(
+            TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),
+        ),
+        team_movements=(
+            TeamMovement(
+                canonical_team_id="tim-1",
+                team_name="FC Dallas 2012",
+                from_division="Super Elite",
+                to_division="Super Pro",
+                move="move_down",
+            ),
+        ),
+        override_audit=(
+            OverrideAuditRow.from_dict(
+                {
+                    "schema_version": 1,
+                    "ts": "2026-04-30T11:00:00+00:00",
+                    "type": "accept_match",
+                    "team_ref": "pid-1",
+                    "actor": "dallas@pitchrank.io",
+                    "reason": "accepted match",
+                }
+            ),
+        ),
+    )
+
+
+def test_render_html_standalone_wraps_in_html_document():
+    rendered = render_html(_hand_built_report(), mode="standalone")
+    assert rendered.startswith("<!DOCTYPE html>")
+    assert "<html" in rendered
+    assert "<style>" in rendered
+    assert "</html>" in rendered
+
+
+def test_render_html_embedded_returns_fragment_only():
+    rendered = render_html(_hand_built_report(), mode="embedded")
+    assert "<!DOCTYPE html>" not in rendered
+    assert "<html" not in rendered
+    # Body content still present.
+    assert "Phoenix Cup 2026" in rendered
+
+
+def test_render_html_includes_event_and_cohort():
+    rendered = render_html(_hand_built_report())
+    assert "Phoenix Cup 2026" in rendered
+    assert "Boys u14" in rendered
+
+
+def test_balance_score_actual_renders_n_a_when_none():
+    rendered = render_html(_hand_built_report())
+    assert "n/a &mdash; actual per-match data not available in v1" in rendered
+
+
+def test_metric_with_none_actual_renders_n_a():
+    rendered = render_html(_hand_built_report())
+    # Metric "Same-club early meetings" has actual=None; should render n/a.
+    assert "Same-club early meetings" in rendered
+    assert ">n/a<" in rendered
+
+
+def test_risk_flag_messages_appear():
+    rendered = render_html(_hand_built_report())
+    assert "Foo: only 4 games" in rendered
+    assert "9 days old" in rendered
+    # Categories surface as plain text labels.
+    assert "low_games" in rendered
+    assert "stale_ranking_snapshot" in rendered
+
+
+def test_top_reason_text_is_present():
+    rendered = render_html(_hand_built_report())
+    assert "Reduced 5+ goal mismatches from 4 to 1 (-75%)." in rendered
+
+
+def test_team_movement_renders_arrow_and_clubs():
+    rendered = render_html(_hand_built_report())
+    assert "FC Dallas 2012" in rendered
+    assert "Super Elite" in rendered
+    assert "Super Pro" in rendered
+    assert "&rarr;" in rendered
+
+
+def test_override_audit_collapsed_in_details():
+    rendered = render_html(_hand_built_report())
+    assert "<details" in rendered
+    assert "accept_match" in rendered
+
+
+def test_metric_value_rendering_formats():
+    rendered = render_html(_hand_built_report())
+    # rate=0.22 should render as 22%; rate=0.41 as 41%
+    assert "22%" in rendered
+    assert "41%" in rendered
+
+
+def test_write_html_atomic(tmp_path: Path):
+    rc = _hand_built_report()
+    out = tmp_path / "comparison.html"
+    written = write_html(rc, out)
+    assert written == out
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert text.startswith("<!DOCTYPE html>")
+    # The intermediate ``.tmp`` file should not survive a successful write.
+    assert not out.with_name(out.name + ".tmp").exists()
+
+
+def test_no_streamlit_or_supabase_imports_at_runtime():
+    """Reports module must not transitively import streamlit or supabase."""
+    import sys
+
+    # Force a fresh import of the reports package.
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("src.tournaments.reports"):
+            del sys.modules[mod_name]
+    import src.tournaments.reports  # noqa: F401 — import for side effect
+
+    assert "streamlit" not in sys.modules
+    assert "supabase" not in sys.modules

--- a/tests/unit/test_reports_render_html.py
+++ b/tests/unit/test_reports_render_html.py
@@ -39,9 +39,7 @@ def _hand_built_report() -> ReportCard:
             RiskFlag(severity="info", category="low_games", message="Foo: only 4 games", affected_teams=("Foo",)),
             RiskFlag(severity="warning", category="stale_ranking_snapshot", message="9 days old"),
         ),
-        top_reasons=(
-            TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),
-        ),
+        top_reasons=(TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),),
         team_movements=(
             TeamMovement(
                 canonical_team_id="tim-1",
@@ -147,15 +145,56 @@ def test_write_html_atomic(tmp_path: Path):
     assert not out.with_name(out.name + ".tmp").exists()
 
 
+def test_standalone_title_escapes_html():
+    """``<title>`` is built outside Jinja autoescape; the renderer must
+    escape every provider-controlled field interpolated into the head.
+    Covers ``event_name``, ``gender``, AND ``age_group`` so dropping any
+    one ``html.escape`` call surfaces in CI."""
+    rc = ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_test",
+        age_group="<u14>",
+        gender="Boys&Girls",
+        event_name="Phoenix Cup </title><script>alert(1)</script>",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(),
+        risk_flags=(),
+        top_reasons=(),
+        team_movements=(),
+    )
+    rendered = render_html(rc, mode="standalone")
+    head_section = rendered.split("<body>", 1)[0]
+    # Live markup must NOT appear inside the head.
+    assert "</title><script>" not in head_section
+    assert "<script>alert(1)</script>" not in head_section
+    # Each of the three escaped fields shows up in its escaped form.
+    assert "&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in head_section
+    assert "Boys&amp;Girls" in head_section
+    assert "&lt;u14&gt;" in head_section
+
+
 def test_no_streamlit_or_supabase_imports_at_runtime():
-    """Reports module must not transitively import streamlit or supabase."""
+    """Reports module must not transitively import streamlit or supabase.
+
+    Uses a subprocess so a previously-loaded streamlit (e.g. from
+    ``tournament_intake.py`` imported in another test) does not pollute
+    the assertion. The contract is "the reports package's import graph",
+    not "the current interpreter's import graph".
+    """
+    import subprocess
     import sys
 
-    # Force a fresh import of the reports package.
-    for mod_name in list(sys.modules):
-        if mod_name.startswith("src.tournaments.reports"):
-            del sys.modules[mod_name]
-    import src.tournaments.reports  # noqa: F401 — import for side effect
-
-    assert "streamlit" not in sys.modules
-    assert "supabase" not in sys.modules
+    probe = (
+        "import sys\n"
+        "import src.tournaments.reports  # noqa: F401\n"
+        "assert 'streamlit' not in sys.modules, 'streamlit leaked'\n"
+        "assert 'supabase' not in sys.modules, 'supabase leaked'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"

--- a/tests/unit/test_reports_schema.py
+++ b/tests/unit/test_reports_schema.py
@@ -45,9 +45,7 @@ def _sample_report_card() -> ReportCard:
             RiskFlag(severity="info", category="low_games", message="Foo: only 4 games", affected_teams=("Foo",)),
             RiskFlag(severity="warning", category="stale_ranking_snapshot", message="Snapshot is 9 days old"),
         ),
-        top_reasons=(
-            TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),
-        ),
+        top_reasons=(TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),),
         team_movements=(
             TeamMovement(
                 canonical_team_id="tim-1",

--- a/tests/unit/test_reports_schema.py
+++ b/tests/unit/test_reports_schema.py
@@ -1,0 +1,128 @@
+"""Unit tests for ``src.tournaments.reports.schema``.
+
+Round-trip a hand-built ``ReportCard`` through ``to_dict`` and
+``from_dict``; verify schema-version handling on both sides; verify
+``OverrideAuditRow`` honors the storage ``schema_version`` gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.reports.compute import (
+    read_comparison_json,
+    write_comparison_json,
+)
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    OverrideAuditRow,
+    ReportCard,
+    RiskFlag,
+    TeamMovement,
+    TopReason,
+)
+from src.tournaments.storage.schema_version import SchemaVersionError
+
+
+def _sample_report_card() -> ReportCard:
+    return ReportCard(
+        event_key="gotsport__45224__2026",
+        scenario="default",
+        run_id="u14_boys_20260430T120000_aaaaaaaaaaaa",
+        age_group="u14",
+        gender="Boys",
+        event_name="Phoenix Cup 2026",
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=78.0, delta=None, preset_id="default"),
+        metrics=(
+            Metric(label="One-goal game rate", actual=0.22, optimized=0.41, delta=0.19, unit="rate"),
+            Metric(label="Same-club early meetings", actual=None, optimized=0, delta=None, unit="count"),
+        ),
+        risk_flags=(
+            RiskFlag(severity="info", category="low_games", message="Foo: only 4 games", affected_teams=("Foo",)),
+            RiskFlag(severity="warning", category="stale_ranking_snapshot", message="Snapshot is 9 days old"),
+        ),
+        top_reasons=(
+            TopReason(text="Reduced 5+ goal mismatches from 4 to 1 (-75%)."),
+        ),
+        team_movements=(
+            TeamMovement(
+                canonical_team_id="tim-1",
+                team_name="FC Dallas 2012",
+                from_division="Super Elite",
+                to_division="Super Pro",
+                move="move_down",
+            ),
+        ),
+        override_audit=(
+            OverrideAuditRow.from_dict(
+                {"schema_version": 1, "ts": "2026-04-30T11:00:00+00:00", "type": "accept_match", "team_ref": "pid-1"}
+            ),
+        ),
+    )
+
+
+def test_report_card_round_trip_preserves_equality():
+    rc = _sample_report_card()
+    payload = rc.to_dict()
+    restored = ReportCard.from_dict(payload)
+    assert restored == rc
+
+
+def test_report_card_from_dict_tolerates_missing_schema_version():
+    """Lenient on read: default to v1 (mirrors ``frozen_medians.from_dict``)."""
+    rc = _sample_report_card()
+    payload = rc.to_dict()
+    payload.pop("schema_version", None)
+    restored = ReportCard.from_dict(payload)
+    assert restored.schema_version == 1
+
+
+def test_override_audit_row_rejects_newer_schema():
+    """The ``schema_version`` gate fires at the row level on read."""
+    with pytest.raises(SchemaVersionError):
+        OverrideAuditRow.from_dict({"schema_version": 999, "type": "accept_match"})
+
+
+def test_override_audit_row_to_dict_round_trips():
+    payload = {"schema_version": 1, "ts": "x", "type": "accept_match", "team_ref": "pid"}
+    row = OverrideAuditRow.from_dict(payload)
+    assert row.to_dict() == payload
+
+
+def test_balance_score_round_trip_with_actual_present():
+    score = BalanceScore(actual=43.0, optimized=78.0, delta=35.0, preset_id="default")
+    restored = BalanceScore.from_dict(score.to_dict())
+    assert restored == score
+
+
+def test_metric_round_trip_with_none_actual():
+    metric = Metric(label="Capped GD", actual=None, optimized=0.82, delta=None, unit="gd")
+    restored = Metric.from_dict(metric.to_dict())
+    assert restored == metric
+
+
+def test_comparison_json_round_trip(tmp_path: Path):
+    rc = _sample_report_card()
+    run_dir = tmp_path / "runs" / "u14_boys_test"
+    run_dir.mkdir(parents=True)
+    path = write_comparison_json(rc, run_dir)
+    restored = read_comparison_json(path)
+    assert restored == rc
+
+
+def test_comparison_json_rejects_newer_schema(tmp_path: Path):
+    """Strict on write — any tampered ``schema_version`` newer than 1 fails."""
+    rc = _sample_report_card()
+    run_dir = tmp_path / "runs" / "u14_boys_test"
+    run_dir.mkdir(parents=True)
+    path = write_comparison_json(rc, run_dir)
+    # Tamper the on-disk file to claim a future schema version.
+    raw = path.read_text(encoding="utf-8")
+    tampered = raw.replace('"schema_version": 1', '"schema_version": 999', 1)
+    path.write_text(tampered, encoding="utf-8")
+    with pytest.raises(SchemaVersionError):
+        read_comparison_json(path)

--- a/tests/unit/test_run_orchestrator.py
+++ b/tests/unit/test_run_orchestrator.py
@@ -246,7 +246,7 @@ def test_build_cli_args_raises_on_unknown_model_pin(tmp_path: Path):
 
 def test_build_cohort_request_payload_includes_prediction_date_when_extras_set(tmp_path: Path):
     _bootstrap_event(tmp_path, extras={"ranking_snapshot_date": "2026-04-30"})
-    payload, fallbacks = _build_cohort_request_payload(
+    payload, fallbacks, stale = _build_cohort_request_payload(
         EVENT_KEY,
         SCENARIO,
         "u14",
@@ -259,13 +259,14 @@ def test_build_cohort_request_payload_includes_prediction_date_when_extras_set(t
     assert payload["gender"] == "boys"
     assert len(payload["entrants"]) == 2
     # Fixture team names "A Alpha" / "A Bravo" both start with division "A"
-    # so the routing heuristic resolves cleanly with no fallbacks.
+    # so the resolver returns ``source="prefix"`` with no fallbacks.
     assert fallbacks == []
+    assert stale == []
 
 
 def test_build_cohort_request_payload_omits_prediction_date_when_absent(tmp_path: Path):
     _bootstrap_event(tmp_path)
-    payload, _fallbacks = _build_cohort_request_payload(
+    payload, _fallbacks, _stale = _build_cohort_request_payload(
         EVENT_KEY,
         SCENARIO,
         "u14",
@@ -274,6 +275,184 @@ def test_build_cohort_request_payload_omits_prediction_date_when_absent(tmp_path
         extras={},
     )
     assert "prediction_date" not in payload
+
+
+def _bootstrap_event_metadata_only(base: Path) -> None:
+    """Write only event metadata + ``ensure_scenario``. Each test then
+    writes its own ``write_structure`` so the structure shape (one or
+    two divisions) lives next to the test that depends on it."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=base)
+    write_event_metadata(
+        EVENT_KEY,
+        EventMetadata(
+            provider_code="gotsport",
+            provider_event_id="45224",
+            event_name="Phoenix Cup 2026",
+            event_slug="phoenix-cup-2026",
+            event_start_date="2026-05-01",
+            scrape_ts="2026-04-15T00:00:00+00:00",
+            season_year=2026,
+            series_id="phoenix-cup-2026",
+        ),
+        base_dir=base,
+    )
+
+
+def _two_division_structure() -> CohortStructure:
+    return CohortStructure(
+        age_group="u14",
+        gender="Boys",
+        divisions=(
+            DivisionStructure(name="BU14 Premier", team_count=1, pool_sizes=(1,)),
+            DivisionStructure(name="BU14 Champions", team_count=1, pool_sizes=(1,)),
+        ),
+    )
+
+
+def _single_premier_division_structure() -> CohortStructure:
+    return CohortStructure(
+        age_group="u14",
+        gender="Boys",
+        divisions=(DivisionStructure(name="BU14 Premier", team_count=2, pool_sizes=(2,)),),
+    )
+
+
+def test_build_cohort_request_payload_explicit_assignment_wins_over_prefix(tmp_path: Path):
+    _bootstrap_event_metadata_only(tmp_path)
+    write_structure(EVENT_KEY, SCENARIO, [_two_division_structure()], base_dir=tmp_path)
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="BU14 Premier Phoenix Rising",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+        ],
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "assign_division",
+            "team_ref": "pid-1",
+            "before": {},
+            "after": {"assigned_division_name": "BU14 Champions"},
+            "reason": "operator override",
+        },
+        base_dir=tmp_path,
+    )
+    payload, fallbacks, stale = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={},
+    )
+    assert fallbacks == []
+    assert stale == []
+    # Lookup the entrant's actual_division_name (the BU14-stripped form).
+    assert len(payload["entrants"]) == 1
+    assert payload["entrants"][0]["actual_division_name"] == "Champions"
+
+
+def test_build_cohort_request_payload_no_override_no_prefix_match_collects_fallbacks(tmp_path: Path):
+    _bootstrap_event_metadata_only(tmp_path)
+    write_structure(EVENT_KEY, SCENARIO, [_single_premier_division_structure()], base_dir=tmp_path)
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="Phoenix Rising",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+            TeamRegistryEntry(
+                event_registration_id="reg-2",
+                event_team_name="Real Madrid",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-2",
+                resolved_team_id_master="tim-2",
+            ),
+        ],
+        base_dir=tmp_path,
+    )
+    payload, fallbacks, stale = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={},
+    )
+    assert fallbacks == ["Phoenix Rising", "Real Madrid"]
+    assert stale == []
+    # Both teams still land in the only division (legacy fallback).
+    assert len(payload["entrants"]) == 2
+
+
+def test_build_cohort_request_payload_stale_assignment_falls_through_to_prefix(tmp_path: Path):
+    _bootstrap_event_metadata_only(tmp_path)
+    # Single-division structure: assignment to "BU14 Removed" is stale.
+    write_structure(EVENT_KEY, SCENARIO, [_single_premier_division_structure()], base_dir=tmp_path)
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(
+                event_registration_id="reg-1",
+                event_team_name="BU14 Premier Phoenix Rising",
+                event_age_group="u14",
+                event_gender="Boys",
+                resolved_gotsport_provider_team_id="pid-1",
+                resolved_team_id_master="tim-1",
+            ),
+        ],
+        base_dir=tmp_path,
+    )
+    append_override(
+        EVENT_KEY,
+        SCENARIO,
+        {
+            "ts": "2026-04-20T00:00:00+00:00",
+            "actor": "ops@example.com",
+            "scope": "team",
+            "type": "assign_division",
+            "team_ref": "pid-1",
+            "before": {},
+            "after": {"assigned_division_name": "BU14 Removed"},
+            "reason": "stale after rename",
+        },
+        base_dir=tmp_path,
+    )
+    payload, fallbacks, stale = _build_cohort_request_payload(
+        EVENT_KEY,
+        SCENARIO,
+        "u14",
+        "Boys",
+        base_dir=tmp_path,
+        extras={},
+    )
+    assert fallbacks == []
+    assert stale == ["BU14 Premier Phoenix Rising"]
+    # Team still routed via prefix-resolved name; the entrant's actual_division_name
+    # is the BU14-stripped "Premier".
+    assert len(payload["entrants"]) == 1
+    assert payload["entrants"][0]["actual_division_name"] == "Premier"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tournament_intake_helpers.py
+++ b/tests/unit/test_tournament_intake_helpers.py
@@ -13,6 +13,7 @@ from datetime import date
 from src.tournaments.triage import ProjectedTeamState
 from tournament_intake import (
     _DISABLED_MODES,
+    _build_division_groups,
     _cohort_sort_key,
     _cohort_toggle_key,
     _default_snapshot,
@@ -248,3 +249,63 @@ def test_default_snapshot_falls_back_to_today_when_date_missing():
 
 def test_default_snapshot_falls_back_to_today_on_unparseable_date():
     assert _default_snapshot("not-a-date") == date.today()
+
+
+# -------- _build_division_groups (resolver wiring) ----------------------
+
+
+class _StubDivision:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubStructure:
+    def __init__(self, names: list[str]) -> None:
+        self.divisions = [_StubDivision(n) for n in names]
+
+
+def test_build_division_groups_explicit_assignment_wins_over_prefix():
+    """Operator override-projected ``assigned_division_name`` must beat
+    the prefix heuristic when both could match."""
+    structure = _StubStructure(["BU14 Premier", "BU14 Champions"])
+    records = [
+        {"provider_team_id": "pid-1", "bracket_name": "BU14 Premier Phoenix Rising"},
+    ]
+    team_state = {
+        "pid-1": ProjectedTeamState(state="resolved", assigned_division_name="BU14 Champions"),
+    }
+    groups = _build_division_groups(records, structure, team_state)
+    assert groups["BU14 Champions"] == ["pid-1"]
+    assert groups["BU14 Premier"] == []
+
+
+def test_build_division_groups_default_empty_team_state_is_prefix_only():
+    """Calls without ``team_state`` (or with an empty mapping) must
+    behave identically to the prior prefix-only path — keeps existing
+    test/render callers safe even though the resolver is wired in."""
+    structure = _StubStructure(["BU14 Premier", "BU14 Champions"])
+    records = [
+        {"provider_team_id": "pid-1", "bracket_name": "BU14 Premier Phoenix Rising"},
+    ]
+    groups = _build_division_groups(records, structure)
+    assert groups["BU14 Premier"] == ["pid-1"]
+    assert groups["BU14 Champions"] == []
+
+
+def test_build_division_groups_unknown_bracket_falls_back_to_first_division():
+    """When neither override nor prefix resolves, the team lands in the
+    first division — preserves the prior fallback behavior at this site."""
+    structure = _StubStructure(["BU14 Premier", "BU14 Champions"])
+    records = [
+        {"provider_team_id": "pid-1", "bracket_name": "Unrelated Bracket"},
+    ]
+    groups = _build_division_groups(records, structure)
+    assert groups["BU14 Premier"] == ["pid-1"]
+
+
+def test_build_division_groups_unstructured_when_no_structure():
+    """``structure_for_cohort=None`` short-circuits to a single virtual
+    ``_unstructured`` bucket — preserves the "ship before Shell 05" path."""
+    records = [{"provider_team_id": "pid-1", "bracket_name": "anything"}]
+    groups = _build_division_groups(records, None)
+    assert groups == {"_unstructured": ["pid-1"]}

--- a/tests/unit/test_triage_classifiers.py
+++ b/tests/unit/test_triage_classifiers.py
@@ -30,6 +30,7 @@ def test_override_types_constant_is_pinned():
         "edit_external",
         "manual_add",
         "recompute_medians",
+        "assign_division",
     )
 
 
@@ -253,6 +254,7 @@ def test_build_override_record_copies_before_and_after():
         ),
         ("manual_add", {"state", "team_id_master", "manual_seed_group"}),
         ("recompute_medians", {"medians_by_division"}),
+        ("assign_division", {"assigned_division_name"}),
     ],
 )
 def test_per_type_after_payload_keys_round_trip(type_, after_keys):

--- a/tests/unit/test_triage_projection.py
+++ b/tests/unit/test_triage_projection.py
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from src.tournaments.triage import (
+    DivisionResolution,
     ProjectedCohortState,
     ProjectedTeamState,
+    _apply_team_override,
     project_overrides,
+    resolve_division_assignment,
 )
 
 
@@ -274,6 +279,242 @@ def test_manual_add_external_projects_strength_fields():
     assert final.note == "guest team"
     assert final.cohort_age_group == "u14"
     assert final.cohort_gender == "Male"
+
+
+# -------- assign_division ------------------------------------------------
+
+
+def test_assign_division_carries_team_id_master_from_prior_resolved():
+    """``assign_division`` after ``accept_match`` preserves ``team_id_master``
+    AND populates ``assigned_division_name`` — the carry-forward ``replace``
+    semantics."""
+    records = [
+        _team_record(
+            "accept_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "abc"},
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _team_record(
+            "assign_division",
+            "pid-1",
+            {"assigned_division_name": "BU14 Premier"},
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.state == "resolved"
+    assert final.team_id_master == "abc"
+    assert final.assigned_division_name == "BU14 Premier"
+
+
+def test_assign_division_then_fix_match_preserves_assignment():
+    """Order-dependence guard: ``fix_match`` after ``assign_division`` must
+    carry the assignment forward so subsequent consumers still route
+    correctly."""
+    records = [
+        _team_record(
+            "assign_division",
+            "pid-1",
+            {"assigned_division_name": "BU14 Champions"},
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _team_record(
+            "fix_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "xyz"},
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.state == "resolved"
+    assert final.team_id_master == "xyz"
+    assert final.assigned_division_name == "BU14 Champions"
+
+
+def test_fix_match_then_assign_division_preserves_team_id_master():
+    """Symmetric order: ``assign_division`` after ``fix_match`` must
+    preserve the prior ``team_id_master``."""
+    records = [
+        _team_record(
+            "fix_match",
+            "pid-1",
+            {"state": "resolved", "team_id_master": "xyz"},
+            ts="2026-04-26T12:00:00+00:00",
+        ),
+        _team_record(
+            "assign_division",
+            "pid-1",
+            {"assigned_division_name": "BU14 Premier"},
+            ts="2026-04-26T13:00:00+00:00",
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.state == "resolved"
+    assert final.team_id_master == "xyz"
+    assert final.assigned_division_name == "BU14 Premier"
+
+
+def test_assign_division_starting_from_no_prior_creates_unknown_state():
+    """``assign_division`` with no prior projection lands as ``state=unknown``
+    with the assignment populated — the writer can land an assignment for a
+    team that has no other override yet, and the next override fixes the
+    state."""
+    records = [
+        _team_record(
+            "assign_division",
+            "pid-1",
+            {"assigned_division_name": "BU14 Premier"},
+        ),
+    ]
+    team_state, _ = project_overrides(records)
+    final = team_state["pid-1"]
+    assert final.state == "unknown"
+    assert final.assigned_division_name == "BU14 Premier"
+
+
+# -------- per-type reset regression: external-only fields drop on flip ---
+
+
+@pytest.mark.parametrize(
+    ("target_type", "target_after", "expected_state"),
+    [
+        ("accept_match", {"state": "resolved", "team_id_master": "abc"}, "resolved"),
+        ("fix_match", {"state": "resolved", "team_id_master": "xyz"}, "resolved"),
+        ("mark_external", {"state": "external"}, "external"),
+        (
+            "manual_add",
+            {"state": "resolved", "team_id_master": "abc", "manual_seed_group": "Premier"},
+            "resolved",
+        ),
+        (
+            "manual_add",
+            {
+                "state": "external",
+                "manual_seed_group": "Champions",
+                "strength_mode": "median",
+            },
+            "external",
+        ),
+    ],
+)
+def test_external_only_fields_drop_when_flipping_state(target_type, target_after, expected_state):
+    """Pin Step 3's per-branch reset semantics: every existing branch must
+    drop external-only fields (``manual_seed_group`` from a prior
+    ``edit_external``, ``strength_mode``, ``manual_power_score``, ``note``)
+    when projecting a new override that does not itself populate them.
+    ``assigned_division_name`` always defaults to ``None`` here because the
+    prior had no assignment to carry forward — pins both directions of
+    Step 3's carry-forward fix."""
+    prior = _apply_team_override(
+        "edit_external",
+        {
+            "state": "external",
+            "manual_seed_group": "X",
+            "strength_mode": "manual",
+            "manual_power_score": 12.5,
+            "note": "frozen",
+        },
+        prior=None,
+        ts="2026-04-26T12:00:00+00:00",
+    )
+    assert prior.manual_seed_group == "X"
+    assert prior.strength_mode == "manual"
+
+    result = _apply_team_override(
+        target_type,
+        target_after,
+        prior=prior,
+        ts="2026-04-26T13:00:00+00:00",
+    )
+    assert result.state == expected_state
+    if target_type in ("accept_match", "fix_match", "mark_external"):
+        # Reset semantics: the target's ``after`` does not include any of
+        # the external-only fields, so the projection must be ``None`` for
+        # all of them.
+        assert result.manual_seed_group is None
+        assert result.strength_mode is None
+        assert result.manual_power_score is None
+        assert result.note is None
+    elif target_type == "manual_add" and target_after.get("state") == "resolved":
+        # manual_add resolved branch: only ``manual_seed_group`` flows from
+        # ``after``; strength fields drop.
+        assert result.manual_seed_group == "Premier"
+        assert result.strength_mode is None
+        assert result.manual_power_score is None
+        assert result.note is None
+    else:  # manual_add external branch
+        # manual_add external rebuilds from scratch — ``manual_seed_group``
+        # comes from ``after``, NOT carried from the prior.
+        assert result.manual_seed_group == "Champions"
+        assert result.strength_mode == "median"
+    # In all cases the prior had no assignment, so this defaults to None
+    # both before and after the flip — pins "no carry, no erasure".
+    assert result.assigned_division_name is None
+
+
+# -------- resolve_division_assignment ------------------------------------
+
+
+def test_resolve_division_assignment_no_signal_returns_none_source():
+    res = resolve_division_assignment(
+        None,
+        "Phoenix Rising 2012 Boys",
+        division_names=["BU14 Premier", "BU14 Champions"],
+    )
+    assert res == DivisionResolution(name=None, source="none")
+
+
+def test_resolve_division_assignment_explicit_wins_over_prefix():
+    projected = ProjectedTeamState(state="resolved", assigned_division_name="BU14 Premier")
+    res = resolve_division_assignment(
+        projected,
+        "BU14 Champions Phoenix Rising",
+        division_names=["BU14 Premier", "BU14 Champions"],
+    )
+    assert res == DivisionResolution(name="BU14 Premier", source="explicit")
+
+
+def test_resolve_division_assignment_stale_falls_through_to_prefix():
+    projected = ProjectedTeamState(state="resolved", assigned_division_name="BU14 Renamed")
+    res = resolve_division_assignment(
+        projected,
+        "BU14 Premier Phoenix",
+        division_names=["BU14 Premier", "BU14 Champions"],
+    )
+    assert res == DivisionResolution(name="BU14 Premier", source="stale")
+
+
+def test_resolve_division_assignment_stale_with_no_prefix_match_returns_no_name():
+    projected = ProjectedTeamState(state="resolved", assigned_division_name="BU14 Removed")
+    res = resolve_division_assignment(
+        projected,
+        "Phoenix Rising 2012 Boys",
+        division_names=["BU14 Premier"],
+    )
+    assert res == DivisionResolution(name=None, source="stale")
+
+
+def test_resolve_division_assignment_longest_prefix_wins():
+    res = resolve_division_assignment(
+        None,
+        "Premier Elite Phoenix",
+        division_names=["Premier", "Premier Elite"],
+    )
+    assert res == DivisionResolution(name="Premier Elite", source="prefix")
+
+
+def test_resolve_division_assignment_empty_divisions_returns_none():
+    res = resolve_division_assignment(None, "Anything", division_names=[])
+    assert res == DivisionResolution(name=None, source="none")
+
+
+def test_resolve_division_assignment_empty_bracket_returns_none():
+    res = resolve_division_assignment(None, "", division_names=["BU14 Premier"])
+    assert res == DivisionResolution(name=None, source="none")
 
 
 def test_recompute_medians_latest_wins():

--- a/tournament_intake.py
+++ b/tournament_intake.py
@@ -13,7 +13,7 @@ import html
 import os
 import sys
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import replace
 from datetime import date, timedelta
 from pathlib import Path
@@ -81,12 +81,16 @@ from src.tournaments.storage import (
 from src.tournaments.storage._io import utc_now_iso
 from src.tournaments.triage import (
     _STRENGTH_MODES,
+    SOURCE_EXPLICIT,
+    SOURCE_PREFIX,
+    SOURCE_STALE,
     ProjectedTeamState,
     _classify_team_state,
     _is_placeholder_team,
     _is_play_up,
     build_override_record,
     project_overrides,
+    resolve_division_assignment,
 )
 from supabase import create_client
 
@@ -105,6 +109,11 @@ st.caption(f"Version {VERSION} | Powered by {PROJECT_NAME}")
 
 # Disabled-mode contract — pinned by tests against silent re-enablement.
 _DISABLED_MODES: tuple[str, ...] = ("seeding",)
+
+# Sentinel option for the per-row Assign division selectbox: forces the
+# operator to pick a real division when the resolver has no signal
+# (``source="none"``) before any override is written.
+_DIV_ASSIGN_SENTINEL = "— pick to confirm —"
 
 
 # Database connection helper
@@ -879,12 +888,18 @@ def _registry_provider_id(entry_row: dict[str, Any]) -> str:
 def _build_division_groups(
     cohort_records: list[dict[str, Any]],
     structure_for_cohort: Any,
+    team_state: Mapping[str, ProjectedTeamState] | None = None,
 ) -> dict[str, list[str]]:
     """Group provider ids by division name within a cohort.
 
     Falls back to a single virtual ``"_unstructured"`` division when no
     ``CohortStructure`` exists yet — matches the plan's "ship before
     Shell 05" path.
+
+    ``team_state`` must be the projection of the same overrides ledger
+    that the surrounding render is reading; passing ``None`` (or an empty
+    mapping) reverts to prefix-only routing — kept as a safe default for
+    tests / callers that don't exercise the override path.
     """
     if structure_for_cohort is None:
         ids = [
@@ -894,19 +909,18 @@ def _build_division_groups(
         ]
         return {"_unstructured": ids}
     division_names = [division.name for division in structure_for_cohort.divisions]
-    # Sort by length descending so a longer name like "Premier Elite" wins
-    # over a shorter prefix like "Premier" when both could match a bracket.
-    sorted_division_names = sorted(division_names, key=len, reverse=True)
     groups: dict[str, list[str]] = {name: [] for name in division_names}
+    state = team_state or {}
     for record in cohort_records:
         bracket = str(record.get("bracket_name") or record.get("division") or "").strip()
         pid = str(record.get("provider_team_id") or "").strip()
         if not pid:
             continue
-        chosen = next(
-            (name for name in sorted_division_names if bracket and bracket.startswith(name)),
-            division_names[0] if division_names else "_unstructured",
-        )
+        resolution = resolve_division_assignment(state.get(pid), bracket, division_names=division_names)
+        if resolution.source in (SOURCE_EXPLICIT, SOURCE_PREFIX, SOURCE_STALE) and resolution.name:
+            chosen = resolution.name
+        else:
+            chosen = division_names[0] if division_names else "_unstructured"
         groups.setdefault(chosen, []).append(pid)
     return groups
 
@@ -1019,7 +1033,7 @@ def _render_triage(
             team_id_masters.add(team_id)
     resolved_team_by_id = _batch_load_resolved_teams(supabase_client, team_id_masters)
 
-    division_groups = _build_division_groups(cohort_records, structure_for_cohort)
+    division_groups = _build_division_groups(cohort_records, structure_for_cohort, team_state)
 
     _render_games_coverage(
         cohort_records=cohort_records,
@@ -1282,6 +1296,19 @@ def _render_division_body(
             )
         elif state == "unknown":
             st.info(f"Team {team_name}: state unknown — re-scrape or accept manually.")
+
+        # ``candidates`` / ``placeholder`` / ``unknown`` rows must be
+        # triaged via the existing review/fix flows before assignment is
+        # meaningful.
+        if state in ("resolved", "external") and len(division_names) > 1:
+            _render_assign_division_form(
+                pid=pid,
+                team_name=team_name,
+                projected=projected,
+                division_names=division_names,
+                event_key=event_key,
+                scenario=scenario,
+            )
 
 
 def _render_team_row(
@@ -1696,6 +1723,84 @@ def _external_before(projected: ProjectedTeamState | None) -> dict[str, Any]:
     }
 
 
+def _render_assign_division_form(
+    *,
+    pid: str,
+    team_name: str,
+    projected: ProjectedTeamState | None,
+    division_names: list[str],
+    event_key: str,
+    scenario: str,
+) -> None:
+    """Form-wrapped per-team Assign division selectbox.
+
+    Renders only when the cohort has multiple divisions and the team is
+    in a state where assignment is meaningful (``resolved`` or
+    ``external``). Default selection follows ``resolution.source``: a
+    sentinel for ``"none"`` (and for ``"stale"`` with no prefix-resolved
+    name — the operator must reconfirm), the resolved/explicit name
+    otherwise.
+    """
+    reviewer_email = st.session_state.get("_reviewer_email", "")
+    write_disabled = not reviewer_email
+    resolution = resolve_division_assignment(projected, team_name, division_names=division_names)
+    if resolution.name is None:
+        # ``source`` is either SOURCE_NONE (no signal) or SOURCE_STALE with
+        # no prefix-resolved fallback — both cases require operator pick.
+        options = [_DIV_ASSIGN_SENTINEL, *division_names]
+        index = 0
+    else:
+        options = list(division_names)
+        index = options.index(resolution.name) if resolution.name in options else 0
+
+    with st.expander(f"Assign division for {team_name}", expanded=False):
+        if resolution.source == SOURCE_STALE:
+            st.warning(
+                f"Prior assignment '{projected.assigned_division_name if projected else ''}' is no longer "
+                "in this cohort's structure — re-confirm or pick a different division."
+            )
+        with st.form(f"_div_assign_form_{pid}", clear_on_submit=False):
+            selected = st.selectbox(
+                "Division",
+                options=options,
+                index=index,
+                key=f"_div_assign_{pid}",
+                help="Operator-confirmed division; overrides the prefix heuristic.",
+            )
+            submitted = st.form_submit_button("Save assignment", disabled=write_disabled)
+        if not submitted:
+            return
+        if selected == _DIV_ASSIGN_SENTINEL:
+            return  # operator clicked Save without picking; no-op
+        # Re-read overrides at submit time so a Streamlit rerun between
+        # render and submit doesn't put a stale ``before`` snapshot in
+        # the audit ledger (matches ``_render_external_drawer``).
+        fresh_team_state, _ = project_overrides(load_overrides(event_key, scenario))
+        fresh_projected = fresh_team_state.get(pid)
+        prior_assigned = fresh_projected.assigned_division_name if fresh_projected else None
+        if selected == prior_assigned:
+            return  # already-explicit re-pick of same value; avoid redundant audit records
+        append_override(
+            event_key,
+            scenario,
+            build_override_record(
+                ts=utc_now_iso(),
+                actor=reviewer_email,
+                scope="team",
+                type="assign_division",
+                team_ref=pid,
+                before={"assigned_division_name": prior_assigned},
+                after={"assigned_division_name": selected},
+                reason="",
+            ),
+        )
+        # Drop widget key — sentinel is removed from options after the flip,
+        # which would crash Streamlit if session_state still held it.
+        st.session_state.pop(f"_div_assign_{pid}", None)
+        _load_registry_cached.clear()
+        st.rerun()
+
+
 def _trigger_recompute(
     *,
     event_key: str,
@@ -1760,20 +1865,39 @@ def _recompute_medians_inner(
         row for row in registry_rows if row.get("event_age_group") == age and row.get("event_gender") == gender
     ]
     division_by_team_id: dict[str, str] = {}
+    stale_team_names: list[str] = []
     for row in cohort_rows:
         pid = _registry_provider_id(row)
         team_id_master = _resolve_team_id_master(team_state.get(pid), row)
         if not team_id_master:
             continue
         bracket = str(row.get("event_team_name") or "").strip()
-        chosen = next(
-            (name for name in division_names if name and bracket.startswith(name)),
-            division_names[0] if division_names else "_unstructured",
-        )
-        division_by_team_id[team_id_master] = chosen
+        if not division_names:
+            # No structure for this cohort — bucket every team under the
+            # virtual ``_unstructured`` division (mirrors the prior fallback
+            # behavior at this site).
+            division_by_team_id[team_id_master] = "_unstructured"
+            continue
+        resolution = resolve_division_assignment(team_state.get(pid), bracket, division_names=division_names)
+        if resolution.source in (SOURCE_EXPLICIT, SOURCE_PREFIX):
+            division_by_team_id[team_id_master] = resolution.name or division_names[0]
+        elif resolution.source == SOURCE_STALE:
+            # Skip stale-assigned teams from the medians: bucketing into
+            # the prefix-resolved division would contaminate medians with
+            # values the operator explicitly de-assigned. Surface via UI
+            # warning so the operator re-assigns before re-running.
+            stale_team_names.append(bracket or pid)
+        else:  # SOURCE_NONE
+            division_by_team_id[team_id_master] = division_names[0]
 
     if not division_by_team_id:
         raise RuntimeError("No resolved teams in cohort — nothing to recompute.")
+
+    if stale_team_names:
+        st.warning(
+            f"Medians recomputed without {len(stale_team_names)} stale-assigned team(s) — "
+            "re-confirm assignments before treating new medians as authoritative: " + ", ".join(stale_team_names)
+        )
 
     probed_age = _rankings_full_age_form(age, supabase_client)
     rows = (
@@ -1823,6 +1947,7 @@ def _recompute_medians_inner(
                 after={"medians_by_division": dict(medians.medians_by_division)},
                 reason="operator recompute",
             ),
+            _already_locked=True,
         )
     except Exception:  # noqa: BLE001
         st.error("Medians recomputed but audit log write failed; rerun Recompute to land the ledger entry.")


### PR DESCRIPTION
## Summary

Bundles two MatchBalance shells onto a fresh branch off `origin/main`:

- **Shell 09 (per-team division assignment)**: replaces the brittle `event_team_name.startswith(division_name)` heuristic with an override-driven model. Adds `assigned_division_name` to `ProjectedTeamState`, a new `assign_division` override type with carry-forward across all six existing projection branches, and a shared `resolve_division_assignment` resolver returning a `DivisionResolution(name, source)` where `source` is one of `explicit`/`prefix`/`stale`/`none`. Migrates three call sites (`run_orchestrator._build_cohort_request_payload`, `tournament_intake._recompute_medians_inner`, `tournament_intake._build_division_groups`). Per-row Streamlit Assign-division form bolts onto Shell 04's left pane. New `scripts/backfill_division_assignments.py` walks raw_scrape brackets and writes one `assign_division` per team that prefix-matches a current division, with per-team `acquire_scenario_lock` re-projecting overrides + structure inside the lock to preserve operator intent under interleaving.
- **Shell 09 writer-tier fix**: `append_override` now wraps `acquire_scenario_lock` by default, with an `_already_locked=True` escape hatch for callers nested inside an outer lock (`_recompute_medians_inner`, the backfill script).
- **Shell 07 (report library)**: new `src/tournaments/reports/` package (compute, render_csv, render_html, schema, Jinja template) plus 5 test files.

`parser_warnings.jsonl` now emits two distinct kinds: `division_routing_fallback` (no signal at all) and `division_routing_stale_assignment` (operator-assigned division was renamed/removed).

## Shell 07 P1 review findings — resolved

All four P1 review findings on the Shell 07 report library are addressed in commit `31e8a7f6`:

1. **`compute.py:_build_top_reasons`** — added directional improvement gates (`opt < actual` for blowouts/avg-gd, `opt > actual` for one-goal rate). Templates that assert "Reduced/Raised/Tightened" only emit when the optimized side actually beats actual. Polish-code round 2 also removed the now-unreachable `actual_5plus == 0` zero-guard branch.
2. **`compute.py` orphan detection** — `registry_pids` now seeds from `registry_provider_id(entry)` (mirrors `triage.is_ready`) so overrides keyed by the `event_registration_id` fallback are no longer falsely flagged as `rescrape_orphan_override`.
3. **`render_html.py` standalone `<title>`** — three provider-controlled fields (`event_name`, `gender`, `age_group`) now route through `html.escape` before f-string interpolation. The fragment body still rides Jinja autoescape; only the head's f-string interpolations needed explicit escapes.
4. **`render_csv.py` formula injection** — new `_csv_safe` helper prefixes cells beginning with `=`/`+`/`-`/`@` (and OWASP-recommended whitespace prefixes `\t`/`\r`/`\n`) with a single quote. Applied to every string-typed cell in `comparison_metrics.csv`, `comparison_risk_flags.csv`, and `comparison_team_movements.csv`.

Each fix has a regression test: `test_top_reasons_skip_regressed_metrics`, `test_orphan_detection_uses_event_registration_fallback`, `test_standalone_title_escapes_html` (covers all three escaped fields), `test_csv_formula_injection_prefixes_defanged`, and `test_csv_whitespace_prefixes_defanged`.

**Deferred to follow-up** (`.turbo/improvements.md`): lift `_csv_safe` from `render_csv.py` into `storage/_io.py:write_csv` so `registry.py` and `structure.py` CSVs (which write provider-controlled `event_team_name` / `event_club_name` / division names) automatically get the same defang. Out of scope for this PR's P1 fix scope.

## State Machine

```mermaid
stateDiagram-v2
    [*] --> SOURCE_NONE: no override, no prefix match
    [*] --> SOURCE_PREFIX: no override, name prefix-matches a division
    [*] --> SOURCE_EXPLICIT: assign_division override matches a current division
    [*] --> SOURCE_STALE: assign_division override points at a renamed/removed division
    SOURCE_PREFIX --> SOURCE_EXPLICIT: operator confirms via Assign division form
    SOURCE_NONE --> SOURCE_EXPLICIT: operator picks a division via the form
    SOURCE_STALE --> SOURCE_EXPLICIT: operator re-picks via the form
    SOURCE_EXPLICIT --> SOURCE_STALE: structure rename/remove
```

## Test plan

- [x] 150+ unit tests pass (triage classifiers, projection, run orchestrator, recompute medians, overrides locking, tournament intake helpers, cohort CLI request payload, reports library)
- [x] Backfill script `--help` and `--dry-run` smoke checks pass
- [x] Resolver smoke probe (all 4 source values)
- [x] All 4 Shell 07 P1 review findings resolved with regression tests (60 reports tests pass)
- [ ] Manual Streamlit smoke per Shell 09 plan: open a multi-division cohort, expand a team row, confirm sentinel-default-on-none + Save no-op behavior, change assignment and verify ledger entry
- [ ] Backfill script smoke against a real Phoenix Cup cohort (`--dry-run` then real run; verify summary counts add up)
