### PR TITLE
fix(intake): load .env.local in config/settings.py

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -8,7 +8,10 @@ from dotenv import load_dotenv
 
 from src.rankings.constants import AGE_TO_ANCHOR
 
-# Load environment variables
+# Load environment variables. ``.env.local`` takes precedence (Vercel /
+# Next.js convention; this worktree carries Supabase creds there), then
+# fall back to ``.env`` for anything not overridden.
+load_dotenv(".env.local")
 load_dotenv()
 
 # Project Info

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,9 +10,11 @@ from src.rankings.constants import AGE_TO_ANCHOR
 
 # Load environment variables. ``.env.local`` takes precedence (Vercel /
 # Next.js convention; this worktree carries Supabase creds there), then
-# fall back to ``.env`` for anything not overridden.
-load_dotenv(".env.local")
-load_dotenv()
+# fall back to ``.env`` for anything not overridden. Anchor both paths to
+# the repo root so resolution is deterministic regardless of CWD.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+load_dotenv(_REPO_ROOT / ".env.local")
+load_dotenv(_REPO_ROOT / ".env")
 
 # Project Info
 PROJECT_NAME = "PitchRank"


### PR DESCRIPTION
`streamlit run tournament_intake.py` was failing locally because `config/settings.py` only called `load_dotenv()`, which picks up `.env` and skips `.env.local`. The tournament_beta worktree carries Supabase creds in `.env.local` (Vercel/Next.js convention), so the script couldn't initialize the client without manual env exports.

Prepend `load_dotenv(".env.local")` before the existing `load_dotenv()` so `.env.local` takes precedence and `.env` fills in anything not overridden.

Shipping this as a standalone before Shell 08 touches `tournament_intake.py` so the env fix doesn't get tangled up in the UI work.