### PR TITLE
fix(matcher): retry transient httpx errors in fetch_db_candidates

### DIFF
--- a/src/tournaments/event_team_matcher.py
+++ b/src/tournaments/event_team_matcher.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from dataclasses import asdict, dataclass
 from difflib import SequenceMatcher
-from typing import Any
+from typing import Any, Callable, TypeVar
+
+import httpx
 
 from scripts.find_fuzzy_duplicate_teams import _should_skip_pair, score_team_pair
 from scripts.find_queue_matches import (
@@ -18,7 +22,47 @@ from scripts.find_queue_matches import (
 )
 from src.tournaments.seeding_optimizer import normalize_age_group, normalize_gender_label
 
+logger = logging.getLogger(__name__)
+
 TEAM_SELECT_COLS = "team_id_master,team_name,club_name,state_code,age_group,gender,provider_team_id,is_deprecated"
+
+_T = TypeVar("_T")
+
+_TRANSIENT_HTTPX_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.RemoteProtocolError,
+    httpx.ReadTimeout,
+    httpx.WriteError,
+    httpx.PoolTimeout,
+)
+
+
+def _execute_with_retry(
+    op: Callable[[], _T],
+    *,
+    description: str,
+    max_attempts: int = 3,
+    initial_backoff: float = 0.5,
+) -> _T:
+    backoff = initial_backoff
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return op()
+        except _TRANSIENT_HTTPX_ERRORS as exc:
+            if attempt >= max_attempts:
+                raise
+            logger.warning(
+                "Transient httpx error on %s (attempt %d/%d): %s. Retrying in %.1fs.",
+                description,
+                attempt,
+                max_attempts,
+                type(exc).__name__,
+                backoff,
+            )
+            time.sleep(backoff)
+            backoff *= 2
+    raise RuntimeError("unreachable")  # pragma: no cover
 
 
 @dataclass(frozen=True)
@@ -162,7 +206,11 @@ def fetch_db_candidates(
         query_builder = client.table("teams").select(TEAM_SELECT_COLS).ilike("gender", gender).or_(age_clause)
         if not include_deprecated:
             query_builder = query_builder.eq("is_deprecated", False)
-        response = query_builder.range(offset, offset + page_size - 1).execute()
+        paginated = query_builder.range(offset, offset + page_size - 1)
+        response = _execute_with_retry(
+            paginated.execute,
+            description=f"teams page offset={offset} gender={gender}",
+        )
         batch = response.data or []
         if not batch:
             break

--- a/tests/unit/test_event_team_matcher.py
+++ b/tests/unit/test_event_team_matcher.py
@@ -1,7 +1,13 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
 from src.tournaments.event_team_matcher import (
     EventTeamSearchQuery,
     build_candidate_age_groups,
     classify_match_result,
+    fetch_db_candidates,
     rank_db_candidates,
 )
 
@@ -128,3 +134,107 @@ def test_classify_match_result_uses_margin_for_high_confidence():
     assert best_score is not None
     assert second_score is not None
     assert score_gap is not None and score_gap >= 0
+
+
+class _FakeQueryBuilder:
+    def __init__(self, pages, transient_failures=0, fatal_after=None):
+        self._pages = pages
+        self._transient_remaining = transient_failures
+        self._fatal_after = fatal_after
+        self._calls = 0
+        self._offset = 0
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def ilike(self, *_args, **_kwargs):
+        return self
+
+    def or_(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def range(self, start, _end):
+        self._offset = start
+        return self
+
+    def execute(self):
+        self._calls += 1
+        if self._transient_remaining > 0:
+            self._transient_remaining -= 1
+            raise httpx.ConnectError("UNEXPECTED_EOF_WHILE_READING")
+        if self._fatal_after is not None and self._calls > self._fatal_after:
+            raise RuntimeError("should not be called past fatal_after")
+        page_index = self._offset // 1000
+        data = self._pages[page_index] if page_index < len(self._pages) else []
+        return SimpleNamespace(data=data)
+
+
+class _FakeClient:
+    def __init__(self, builder):
+        self._builder = builder
+
+    def table(self, _name):
+        return self._builder
+
+
+def _query():
+    return EventTeamSearchQuery(
+        event_team_name="Test Team",
+        event_age_group="u12",
+        event_gender="Male",
+        event_club_name="Test Club",
+    )
+
+
+def test_fetch_db_candidates_retries_transient_connect_error(monkeypatch):
+    monkeypatch.setattr("src.tournaments.event_team_matcher.time.sleep", lambda _s: None)
+    builder = _FakeQueryBuilder(pages=[[{"team_id_master": "ok"}], []], transient_failures=2)
+    client = _FakeClient(builder)
+
+    rows = fetch_db_candidates(client, _query())
+
+    assert rows == [{"team_id_master": "ok"}]
+    # 2 transient failures + 1 success; loop exits because batch < page_size.
+    assert builder._calls == 3
+
+
+def test_fetch_db_candidates_raises_after_max_attempts(monkeypatch):
+    monkeypatch.setattr("src.tournaments.event_team_matcher.time.sleep", lambda _s: None)
+    builder = _FakeQueryBuilder(pages=[[]], transient_failures=99)
+    client = _FakeClient(builder)
+
+    with pytest.raises(httpx.ConnectError):
+        fetch_db_candidates(client, _query())
+
+    assert builder._calls == 3
+
+
+def test_fetch_db_candidates_does_not_retry_unrelated_errors(monkeypatch):
+    monkeypatch.setattr("src.tournaments.event_team_matcher.time.sleep", lambda _s: None)
+
+    class _Boom:
+        def select(self, *_a, **_k):
+            return self
+
+        def ilike(self, *_a, **_k):
+            return self
+
+        def or_(self, *_a, **_k):
+            return self
+
+        def eq(self, *_a, **_k):
+            return self
+
+        def range(self, *_a, **_k):
+            return self
+
+        def execute(self):
+            raise ValueError("not transient")
+
+    client = _FakeClient(_Boom())
+
+    with pytest.raises(ValueError):
+        fetch_db_candidates(client, _query())


### PR DESCRIPTION
`search_event_team_in_db` fans out hundreds of paginated `.range(...).execute()` calls per tournament scrape (one cohort with 37k matching teams = 37 sequential requests, and a typical event hits 6-10 cohorts). A single Cloudflare-edge TCP close mid-stream surfaces as `httpx.ConnectError: [SSL: UNEXPECTED_EOF_WHILE_READING]` and aborts the whole intake. Direct TLS to the Supabase host stays healthy throughout, so the failure is a transient pool-level cut, not a network outage.

Reproduced on a real intake: ~150 successful 200s over ~2.5 minutes, then one socket gets reaped and the run dies.

Wrap the page fetch in a small retry helper:
- Retries on `httpx.ConnectError` / `ReadError` / `RemoteProtocolError` / `ReadTimeout` / `WriteError` / `PoolTimeout`
- 3 attempts with 0.5s -> 1s -> 2s exponential backoff
- Logs each retry at WARNING so the streamlit console shows recovery
- Hand-rolled (no new dependency)
- Read-path only; alias-write helpers have a separate bare-except issue tracked in the gotcha memory

Tests cover transient-then-success, retries-exhausted-raises, and non-transient-error-passes-through.