### PR TITLE
fix(streamlit): use poll-based file watcher

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -10,6 +10,10 @@ headless = true
 port = 8501
 enableCORS = false
 enableXsrfProtection = true
+# Use the polling watcher: the default watchdog-based watcher crashes on
+# Windows when site-packages and the repo live on different drives
+# (os.path.commonpath raises ValueError, killing the watcher thread).
+fileWatcherType = "poll"
 
 [browser]
 gatherUsageStats = false


### PR DESCRIPTION
The default watchdog-based watcher crashes on Windows when watched paths span drives:

```
File "streamlit/watcher/event_based_path_watcher.py", line 402, in handle_path_change_event
    and os.path.commonpath([path, abs_changed_path]) == path
File "<frozen ntpath>", line 861, in commonpath
ValueError: Paths don't have the same drive
```

This kills the watcher thread silently — hot-reload stops working from that point on, but the app keeps serving. Easy to miss until you wonder why edits aren't reflecting.

Set `[server] fileWatcherType = "poll"` in `.streamlit/config.toml`. Polling has no cross-drive issue. Trade-off is a small CPU/reload-latency cost (sub-second vs ~1s), acceptable for a dev-only triage tool.

Surfaced while debugging an unrelated TLS scrape error (PR #688). The watcher trace was noise alongside the scrape failure but is a real, latent bug — fixing standalone so it doesn't get bundled with either active fix.