### PR TITLE
feat(seo): NY, VA, MD state pillars (Week 6 batch)

### DIFF
--- a/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,302 @@
+---
+title: 'Maryland (MD) Youth Soccer Rankings 2026'
+slug: 'maryland-youth-soccer-rankings-guide'
+excerpt: 'Find where your MD youth soccer club ranks among 1,500+ teams. Bethesda SC, Coppermine, Maryland United, Pipeline and more — rated weekly by PowerScore. Free.'
+author: 'PitchRank Team'
+date: '2026-04-28'
+readingTime: '10 min read'
+tags: ['Maryland', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'md youth soccer rankings',
+    'maryland youth soccer rankings',
+    'maryland soccer rankings',
+    'best youth soccer clubs maryland',
+    'baltimore youth soccer rankings',
+    'MD club soccer rankings',
+  ]
+---
+
+# Maryland Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+It's a Sunday afternoon at the Maryland SoccerPlex in Boyds. Your kid's U13 team just split a doubleheader — beat a Pipeline SC roster they hadn't faced before, then lost 1-0 to Bethesda. The coach says you're "right in the mix." But what does "the mix" actually look like across the state?
+
+That's the gap rankings fill. Maryland's competitive soccer scene splits cleanly between the Baltimore metro and the D.C. suburbs in Montgomery and Howard County, and most teams play almost exclusively within their own corridor. Without a state-wide picture, you can't tell whether your team is a Bethesda-tier squad or an upper-mid Baltimore-area roster — and the difference matters when tryouts come around.
+
+## Why Maryland Soccer Rankings Matter
+
+Maryland is geographically small but competitively split. Your team in Bethesda might play almost exclusively against other Montgomery County and NoVA clubs. Your team in Baltimore might never face a Bethesda or Potomac roster outside of state cup.
+
+Rankings give you three things traditional league standings can't:
+
+1. **Cross-region context** — How does your Baltimore-metro team actually compare to a top Bethesda or Potomac squad?
+2. **Informed club decisions** — When tryout season hits, rankings help you compare Bethesda SC, Coppermine, Pipeline, and Maryland United on the same scale instead of relying on coach reputation.
+3. **Realistic expectations** — Winning your MSYSA flight is great, but the state cup and ECNL regional showcases are where rankings sharpen against the state's true best.
+
+> **See where your team stands now:** [View all Maryland youth soccer rankings](/rankings/md)
+
+## The Maryland Youth Soccer Landscape
+
+Maryland has 1,572 active youth soccer teams across our database. Here's how that breaks down by region.
+
+### Geographic Soccer Regions
+
+- **Montgomery County / D.C. Suburbs** (Bethesda, Potomac, Rockville, Silver Spring, Gaithersburg) — Anchored by Bethesda SC (64 teams), Potomac Soccer Association (45), and Montgomery Soccer (24). The state's most competitive corridor, with strong pipelines into the D.C.-area MLS NEXT and ECNL platforms.
+- **Baltimore Metro** (Baltimore City, Baltimore County, Towson, Owings Mills) — Coppermine Soccer Club (62 teams), Pipeline SC (41), Liverpool FC International Academy Maryland (40), Baltimore Celtic Soccer Club (34), Baltimore Union Soccer Club (32), and Lutherville Timonium SC (24) anchor this region.
+- **Howard County / Central Maryland** (Columbia, Ellicott City, Laurel) — SAC/BA (60 teams), Maryland United Football Club (57), and Old Line Football Club (24) lead this fast-growing area between Baltimore and D.C.
+- **Anne Arundel County** (Annapolis, Severna Park, Pasadena) — Greater Severna Park Athletic Association (28 teams) and Pasadena Soccer Club (22) lead the corridor between Baltimore and Annapolis.
+- **Multi-region travel clubs** — Maryland Rush (31 teams) operates rosters across multiple Maryland metros.
+
+### Major Maryland Soccer Clubs
+
+Based on our database, the largest youth soccer organizations in Maryland:
+
+| Club                                             | Teams | Region              |
+| ------------------------------------------------ | ----- | ------------------- |
+| Bethesda SC                                      | 64    | Montgomery County   |
+| Coppermine Soccer Club                           | 62    | Baltimore Metro     |
+| SAC/BA                                           | 60    | Howard County       |
+| Maryland United Football Club                    | 57    | Howard County       |
+| Potomac Soccer Association                       | 45    | Montgomery County   |
+| Pipeline SC                                      | 41    | Baltimore Metro     |
+| Liverpool FC International Academy Maryland      | 40    | Baltimore Metro     |
+| Baltimore Celtic Soccer Club                     | 34    | Baltimore Metro     |
+| Baltimore Union Soccer Club                      | 32    | Baltimore Metro     |
+| Maryland Rush                                    | 31    | Multi-region        |
+| Greater Severna Park Athletic Association        | 28    | Anne Arundel        |
+| Old Line Football Club                           | 24    | Howard County       |
+| Montgomery Soccer (MSI)                          | 24    | Montgomery County   |
+| Lutherville Timonium Soccer Club                 | 24    | Baltimore Metro     |
+| Pasadena Soccer Club                             | 22    | Anne Arundel        |
+
+These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to MSYSA premier divisions at the state level.
+
+### Leagues Active in Maryland
+
+Maryland teams compete across most national leagues PitchRank tracks:
+
+- **ECNL** (Elite Clubs National League) — Strong MD presence, particularly through Bethesda SC and Pipeline SC.
+- **MLS NEXT** — Highest level for boys; D.C. United Academy and Philadelphia Union pipelines pull from MD clubs heavily.
+- **Girls Academy (GA)** — National girls league with growing MD representation.
+- **NPL** (National Premier Leagues) — Competitive national league under US Club Soccer.
+- **ECNL Regional League** — Development tier below ECNL; the workhorse competitive league for many MD teams.
+- **EDP** (Eastern Development Program) — Regional Northeast league; many Baltimore-corridor clubs play in EDP flights.
+- **National League** — US Youth Soccer national competition.
+
+Plus state-level competition through [MSYSA](https://www.msysa.org/) (Maryland State Youth Soccer Association) — the governing body for youth soccer in the state, overseeing premier flight competition and the Maryland State Cup.
+
+## How Maryland Soccer Rankings Actually Work
+
+Most ranking systems — GotSoccer being the biggest — only count tournament games and reward quantity over quality. A team that enters 15 tournaments and beats weak opponents can outrank a team that plays a tougher schedule but enters fewer events.
+
+That's not how PitchRank works.
+
+### What PitchRank Tracks for Maryland Teams
+
+We track **every game we can find** — league play, tournaments, friendlies, showcases — across all 1,572 Maryland teams.
+
+Here's the short version of how your team's ranking is calculated:
+
+1. **Base rating** — Every team starts neutral and moves with each game played
+2. **Strength of schedule** — Beating a top Bethesda SC ECNL squad means more than beating a developmental team. Losing to a strong opponent hurts less than losing to a weak one.
+3. **Recency** — Last month's games count more than games from 10 months ago
+4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
+
+The result is a **PowerScore between 0.0 and 1.0**:
+
+- **0.85+** = Elite, national-tier team
+- **0.70–0.84** = Top state tier — consistently competitive against the best MD has to offer
+- **0.50–0.69** = Solid competitive team, typically mid-pack premier / ECNL Regional / NPL
+- **0.30–0.49** = Developing or lower-flight competitive
+- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
+
+The top of Maryland currently sits in the **0.85–0.91** range, with Bethesda SC, Coppermine, Maryland United FC, Pipeline SC, and Old Line FC producing rosters in that band across multiple age groups.
+
+### Maryland's Age Group Breakdown
+
+Maryland's team density varies by age group:
+
+| Age Group | Teams |
+| --------- | ----- |
+| U10       | 156   |
+| U11       | 235   |
+| U12       | 264   |
+| U13       | 232   |
+| U14       | 206   |
+| U15       | 201   |
+| U16       | 120   |
+| U17       | 95    |
+| U18       | 28    |
+| U19       | 35    |
+
+Peak competition is at U11, U12, and U13 — each with over 230 teams. Numbers thin meaningfully after U15 as players specialize, move to high school programs, or step away. If your child is U11 through U13 in Maryland, they're competing in the deepest age-group pools in the state.
+
+## What Your Maryland Team's Ranking Actually Tells You
+
+You check PitchRank and see your U13 team is ranked #42 in Maryland. What does that mean?
+
+### State vs National Rankings
+
+- **State rank** — Where your team stands among Maryland's 1,572 teams across age groups
+- **National rank** — Where your team stands among all teams in their age group across the country
+
+**Reality check:** Being top 30 in Maryland is legitimately strong — MD punches above its team-count weight thanks to Bethesda's competitive density and proximity to D.C. and NoVA. Being top 500 nationally is excellent. Top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in Maryland isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — U12 has 264 teams; U17 has 95
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [Maryland soccer rankings](/rankings/md).
+
+### What Rankings Don't Tell You
+
+Rankings measure competitive results. They can't measure:
+
+- **Individual player development** — A top-ranked team might not be the best fit for your child's growth
+- **Coaching quality** — Some lower-ranked teams have better developmental coaches than win-now programs
+- **Team culture** — Your kid's enjoyment matters more than a number
+- **College fit** — D3 coaches care about GPA and character more than PowerScore
+
+If a club director sells you on rankings alone but can't explain their development philosophy, that's a red flag.
+
+## How to Use Maryland Rankings When Choosing a Club
+
+Tryout season in Maryland runs May through June. Rankings are one tool in your decision-making kit — here's how to use them wisely.
+
+### Questions to Ask Club Directors
+
+When you're comparing Bethesda vs Coppermine vs Pipeline vs Maryland United:
+
+1. **"How do your teams' rankings trend over time?"** — Upward trends suggest good coaching. Flat or declining suggests stagnation.
+2. **"What's the strength of schedule for this age group?"** — Are they playing real competition or scheduling easy wins?
+3. **"How do your Maryland rankings compare to teams we'd face at regionals?"** — National context matters if your child has college ambitions.
+4. **"How many players from this age group have moved to ECNL or MLS NEXT?"** — Player progression matters more than team rank.
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked one. Look for a team that:
+
+- Plays opponents 10–20 ranking positions above AND below them
+- Gives your child 30+ minutes per game
+- Challenges without crushing confidence
+- Fits your family's travel budget and schedule
+
+**Maryland's advantage:** With clubs spread across Bethesda, Baltimore, Howard County, and Anne Arundel, you have options at every competitive level — and travel between most of the state's major soccer hubs is under 90 minutes. The harder question is whether to commute to a top D.C. or NoVA program for higher-tier competition.
+
+### Red Flags
+
+- **Cherry-picking opponents** — Teams that pad records against weak MSYSA flight opponents. Their ranking will plateau.
+- **Wild ranking swings** — Could signal roster instability or inconsistent coaching
+- **Ranking guarantees** — No legitimate club can promise specific rankings
+
+## The Bethesda vs Baltimore Dynamic
+
+Maryland's biggest youth soccer divide is the I-95 corridor split between the Bethesda/Montgomery County clubs and the Baltimore-metro programs. The two regions play different competitive calendars, feed into different national platforms, and only see each other regularly at MSYSA state cup.
+
+What this means for parents:
+
+- **Montgomery County clubs** (Bethesda, Potomac, MSI) benefit from proximity to the D.C. youth soccer market and tend to play heavily against NoVA clubs in regional and showcase competition
+- **Baltimore-metro clubs** (Coppermine, Pipeline, Baltimore Celtic, Baltimore Union, Lutherville Timonium) compete in EDP and Northeast-leaning leagues, with more games against PA, DE, and southern NJ teams
+- **Howard County clubs** (SAC/BA, Maryland United, Old Line) bridge the two corridors geographically and increasingly produce nationally competitive rosters
+- **Cross-corridor play** is the cleanest measure of true team strength — when Bethesda meets a top Coppermine or Pipeline roster, that's where rankings sharpen
+
+If your team only plays within one corridor, rankings can underrepresent how you'd do across the state. The true test comes at state cup and regional events.
+
+## Maryland State Cup and Rankings
+
+The Maryland State Cup (run by MSYSA) is the state's premier championship event. Rankings intersect here directly:
+
+- **Seeding** — Higher-ranked teams earn better tournament draws
+- **Competition quality** — State Cup draws Maryland's best from every region, so rankings are most accurate during and after this event
+- **Exposure** — College scouts and ODP staff use State Cup performances to filter which players to track
+
+If your team is ranked in the **top 10–15% in Maryland**, State Cup is where that ranking gets tested against the state's best.
+
+## The College Recruiting Reality Check
+
+Let's be honest about what Maryland soccer rankings mean for college recruiting.
+
+### What Coaches Actually Look At
+
+1. **Individual highlight video** — YOUR child, not team stats
+2. **Academic eligibility** — GPA and test scores filter players before rankings matter
+3. **Showcase attendance** — Jefferson Cup, ECNL playoffs, EDP Showcase, and Capital Cup where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+### Rankings by Division
+
+- **Division I** — Coaches notice teams in the **top 5% nationally** (very elite)
+- **Division II** — Top 15–20% nationally gets attention, but individual performance matters more
+- **Division III** — Rankings barely factor in. Academics, character, and fit drive decisions.
+
+**Maryland's edge:** The state is home to the University of Maryland, Loyola, UMBC, Towson, Mount St. Mary's, and dozens of D3 programs at Johns Hopkins, Washington College, and the small-school circuit. Use rankings to identify which MD clubs consistently place players in these programs and attend Jefferson Cup and other major showcases.
+
+## Using PitchRank to Track Maryland Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your club by name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive and whether your child is playing up or down.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift as new games are played. Check weekly to see how wins, losses, and tournament results move your team's ranking.
+
+> **Ready to check?** [See all Maryland youth soccer rankings](/rankings/md)
+
+## Browse Maryland Rankings by Age Group
+
+Find your team's age group and gender to see the latest Maryland rankings:
+
+| Age Group | Boys                                        | Girls                                          |
+| --------- | ------------------------------------------- | ---------------------------------------------- |
+| U10       | [Maryland U10 Boys](/rankings/md/u10/male)  | [Maryland U10 Girls](/rankings/md/u10/female)  |
+| U11       | [Maryland U11 Boys](/rankings/md/u11/male)  | [Maryland U11 Girls](/rankings/md/u11/female)  |
+| U12       | [Maryland U12 Boys](/rankings/md/u12/male)  | [Maryland U12 Girls](/rankings/md/u12/female)  |
+| U13       | [Maryland U13 Boys](/rankings/md/u13/male)  | [Maryland U13 Girls](/rankings/md/u13/female)  |
+| U14       | [Maryland U14 Boys](/rankings/md/u14/male)  | [Maryland U14 Girls](/rankings/md/u14/female)  |
+| U15       | [Maryland U15 Boys](/rankings/md/u15/male)  | [Maryland U15 Girls](/rankings/md/u15/female)  |
+| U16       | [Maryland U16 Boys](/rankings/md/u16/male)  | [Maryland U16 Girls](/rankings/md/u16/female)  |
+| U17       | [Maryland U17 Boys](/rankings/md/u17/male)  | [Maryland U17 Girls](/rankings/md/u17/female)  |
+| U19       | [Maryland U19 Boys](/rankings/md/u19/male)  | [Maryland U19 Girls](/rankings/md/u19/female)  |
+
+## Frequently Asked Questions
+
+### How are youth soccer teams ranked in Maryland?
+
+PitchRank tracks game-by-game results across 1,572 Maryland teams. Teams earn a PowerScore from 0.0 to 1.0 based on wins, opponent strength, recency, and consistency — updated weekly.
+
+### What are the biggest youth soccer clubs in Maryland?
+
+By team count: Bethesda SC (64 teams), Coppermine (62), SAC/BA (60), Maryland United FC (57), Potomac Soccer Association (45), Pipeline SC (41), Liverpool FC International Academy Maryland (40), Baltimore Celtic (34), and Baltimore Union (32).
+
+### How often do Maryland soccer rankings update?
+
+PitchRank updates rankings every Monday morning with the latest game results. Recent games are weighted more heavily than older ones.
+
+### What youth soccer leagues operate in Maryland?
+
+Maryland teams compete in ECNL, MLS NEXT, Girls Academy (GA), NPL, ECNL Regional League, EDP, and National League — plus state competition through MSYSA premier divisions and the Maryland State Cup.
+
+### Should my child be on the highest-ranked team possible?
+
+Not necessarily. The best team is one where your child gets meaningful playing time, faces the right level of competition, and develops in a positive environment. A top-ranked team where your kid sits the bench is worse than a mid-ranked team where they play every minute.
+
+### Do Maryland rankings help with college recruiting?
+
+Rankings provide context but aren't the main recruiting tool. Individual highlight video, academic eligibility, showcase attendance, and direct coach contact matter more. D1 coaches notice top 5% nationally. D3 coaches care more about GPA and fit.
+
+### Can clubs game the rankings?
+
+No. PitchRank's algorithm adjusts for opponent strength. Beating weaker MSYSA flight opponents repeatedly won't inflate your ranking. Teams that avoid strong competition plateau quickly.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Maryland team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
@@ -51,23 +51,23 @@ Maryland has 1,572 active youth soccer teams across our database. Here's how tha
 
 Based on our database, the largest youth soccer organizations in Maryland:
 
-| Club                                             | Teams | Region              |
-| ------------------------------------------------ | ----- | ------------------- |
-| Bethesda SC                                      | 64    | Montgomery County   |
-| Coppermine Soccer Club                           | 62    | Baltimore Metro     |
-| SAC/BA                                           | 60    | Howard County       |
-| Maryland United Football Club                    | 57    | Howard County       |
-| Potomac Soccer Association                       | 45    | Montgomery County   |
-| Pipeline SC                                      | 41    | Baltimore Metro     |
-| Liverpool FC International Academy Maryland      | 40    | Baltimore Metro     |
-| Baltimore Celtic Soccer Club                     | 34    | Baltimore Metro     |
-| Baltimore Union Soccer Club                      | 32    | Baltimore Metro     |
-| Maryland Rush                                    | 31    | Multi-region        |
-| Greater Severna Park Athletic Association        | 28    | Anne Arundel        |
-| Old Line Football Club                           | 24    | Howard County       |
-| Montgomery Soccer (MSI)                          | 24    | Montgomery County   |
-| Lutherville Timonium Soccer Club                 | 24    | Baltimore Metro     |
-| Pasadena Soccer Club                             | 22    | Anne Arundel        |
+| Club                                        | Teams | Region            |
+| ------------------------------------------- | ----- | ----------------- |
+| Bethesda SC                                 | 64    | Montgomery County |
+| Coppermine Soccer Club                      | 62    | Baltimore Metro   |
+| SAC/BA                                      | 60    | Howard County     |
+| Maryland United Football Club               | 57    | Howard County     |
+| Potomac Soccer Association                  | 45    | Montgomery County |
+| Pipeline SC                                 | 41    | Baltimore Metro   |
+| Liverpool FC International Academy Maryland | 40    | Baltimore Metro   |
+| Baltimore Celtic Soccer Club                | 34    | Baltimore Metro   |
+| Baltimore Union Soccer Club                 | 32    | Baltimore Metro   |
+| Maryland Rush                               | 31    | Multi-region      |
+| Greater Severna Park Athletic Association   | 28    | Anne Arundel      |
+| Old Line Football Club                      | 24    | Howard County     |
+| Montgomery Soccer (MSI)                     | 24    | Montgomery County |
+| Lutherville Timonium Soccer Club            | 24    | Baltimore Metro   |
+| Pasadena Soccer Club                        | 22    | Anne Arundel      |
 
 These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to MSYSA premier divisions at the state level.
 
@@ -255,17 +255,17 @@ Rankings shift as new games are played. Check weekly to see how wins, losses, an
 
 Find your team's age group and gender to see the latest Maryland rankings:
 
-| Age Group | Boys                                        | Girls                                          |
-| --------- | ------------------------------------------- | ---------------------------------------------- |
-| U10       | [Maryland U10 Boys](/rankings/md/u10/male)  | [Maryland U10 Girls](/rankings/md/u10/female)  |
-| U11       | [Maryland U11 Boys](/rankings/md/u11/male)  | [Maryland U11 Girls](/rankings/md/u11/female)  |
-| U12       | [Maryland U12 Boys](/rankings/md/u12/male)  | [Maryland U12 Girls](/rankings/md/u12/female)  |
-| U13       | [Maryland U13 Boys](/rankings/md/u13/male)  | [Maryland U13 Girls](/rankings/md/u13/female)  |
-| U14       | [Maryland U14 Boys](/rankings/md/u14/male)  | [Maryland U14 Girls](/rankings/md/u14/female)  |
-| U15       | [Maryland U15 Boys](/rankings/md/u15/male)  | [Maryland U15 Girls](/rankings/md/u15/female)  |
-| U16       | [Maryland U16 Boys](/rankings/md/u16/male)  | [Maryland U16 Girls](/rankings/md/u16/female)  |
-| U17       | [Maryland U17 Boys](/rankings/md/u17/male)  | [Maryland U17 Girls](/rankings/md/u17/female)  |
-| U19       | [Maryland U19 Boys](/rankings/md/u19/male)  | [Maryland U19 Girls](/rankings/md/u19/female)  |
+| Age Group | Boys                                       | Girls                                         |
+| --------- | ------------------------------------------ | --------------------------------------------- |
+| U10       | [Maryland U10 Boys](/rankings/md/u10/male) | [Maryland U10 Girls](/rankings/md/u10/female) |
+| U11       | [Maryland U11 Boys](/rankings/md/u11/male) | [Maryland U11 Girls](/rankings/md/u11/female) |
+| U12       | [Maryland U12 Boys](/rankings/md/u12/male) | [Maryland U12 Girls](/rankings/md/u12/female) |
+| U13       | [Maryland U13 Boys](/rankings/md/u13/male) | [Maryland U13 Girls](/rankings/md/u13/female) |
+| U14       | [Maryland U14 Boys](/rankings/md/u14/male) | [Maryland U14 Girls](/rankings/md/u14/female) |
+| U15       | [Maryland U15 Boys](/rankings/md/u15/male) | [Maryland U15 Girls](/rankings/md/u15/female) |
+| U16       | [Maryland U16 Boys](/rankings/md/u16/male) | [Maryland U16 Girls](/rankings/md/u16/female) |
+| U17       | [Maryland U17 Boys](/rankings/md/u17/male) | [Maryland U17 Girls](/rankings/md/u17/female) |
+| U19       | [Maryland U19 Boys](/rankings/md/u19/male) | [Maryland U19 Girls](/rankings/md/u19/female) |
 
 ## Frequently Asked Questions
 

--- a/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,299 @@
+---
+title: 'New York (NY) Youth Soccer Rankings 2026'
+slug: 'new-york-youth-soccer-rankings-guide'
+excerpt: 'Find where your NY youth soccer club ranks among 3,600+ teams. Manhattan SC, SUSA FC, WNY Flash, Long Island SC and more — rated weekly by PowerScore. Free.'
+author: 'PitchRank Team'
+date: '2026-04-28'
+readingTime: '10 min read'
+tags: ['New York', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'ny youth soccer rankings',
+    'new york youth soccer rankings',
+    'new york soccer rankings',
+    'best youth soccer clubs new york',
+    'long island youth soccer rankings',
+    'NY club soccer rankings',
+  ]
+---
+
+# New York Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+It's a Saturday morning on Long Island. Your kid's U13 squad just finished a tight 2–1 win against a club from Brooklyn that you didn't know existed three weeks ago. The coach says they're "one of the better teams out east." But how would you actually know?
+
+That's the problem in New York youth soccer. Between Manhattan, Long Island, Westchester, the Hudson Valley, and the Buffalo–Rochester corridor, your team probably plays inside one bubble and never sees the others. Rankings are how you find out where your team really stands — and they only work if the system actually tracks every game your kid plays.
+
+## Why New York Soccer Rankings Matter
+
+New York isn't one soccer market. It's at least five, separated by geography, leagues, and travel cost:
+
+1. **Cross-region context** — A top Long Island team might never face a top Western New York team in league play. Without rankings, that comparison doesn't exist.
+2. **Informed club decisions** — When tryout season hits, rankings help you compare Manhattan SC, SUSA FC, World Class FC, and Albertson on the same scale instead of relying on coach pitches.
+3. **Realistic expectations** — Your team can dominate LIJSL premier and still be middle-of-the-pack against a top NYWYSA or ENY ECNL roster. The math doesn't lie.
+
+> **See where your team stands now:** [View all New York youth soccer rankings](/rankings/ny)
+
+## The New York Youth Soccer Landscape
+
+New York has 3,697 active youth soccer teams across our database — the fourth-largest pool in the country. Here's how that breaks down by region.
+
+### Geographic Soccer Regions
+
+- **NYC Metro** (Manhattan, Brooklyn, Queens, Bronx) — Anchored by Manhattan SC (81 teams) and Brooklyn United Academy (43 teams). Dense urban competition with limited turf access.
+- **Long Island** (Nassau and Suffolk Counties) — The state's deepest youth soccer market. SUSA FC (77 teams), Long Island SC (59), East Coast Surf (52), East Meadow (48), Smithtown Kickers (40), Garden City (39), Albertson (36), and Northport Cow Harbor (32) all anchor this region. Most play through LIJSL plus national platforms.
+- **Westchester & Hudson Valley** — Atlantic United SB/LGN SC (63 teams) and World Class FC (43 teams) lead here. Strong feeder pipelines into ECNL and MLS Next.
+- **Western New York** (Buffalo, Rochester, Syracuse) — Western New York Flash (77 teams) is the dominant program. NYWYSA-affiliated clubs play a different competitive calendar than downstate teams.
+- **Capital Region & North Country** (Albany, Saratoga, Glens Falls) — Smaller pool of clubs, mostly competing in NYWYSA premier divisions and traveling south or west for showcase events.
+
+### Major New York Soccer Clubs
+
+Based on our database, the largest youth soccer organizations in New York:
+
+| Club                                    | Teams | Region            |
+| --------------------------------------- | ----- | ----------------- |
+| Manhattan SC                            | 81    | NYC Metro         |
+| SUSA FC                                 | 77    | Long Island       |
+| Western New York Flash                  | 77    | Western NY        |
+| Atlantic United SB/LGN SC               | 63    | Hudson Valley     |
+| Long Island SC                          | 59    | Long Island       |
+| East Coast Surf                         | 52    | Long Island       |
+| East Meadow Soccer Club                 | 48    | Long Island       |
+| World Class FC                          | 43    | Westchester       |
+| Brooklyn United Academy                 | 43    | NYC Metro         |
+| Smithtown Kickers SC (LIJSL)            | 40    | Long Island       |
+| Garden City (LIJSL)                     | 39    | Long Island       |
+| Albertson Soccer Club                   | 36    | Long Island       |
+| LMFC                                    | 35    | Long Island       |
+| NY Rush                                 | 35    | Multi-region      |
+| Northport Cow Harbor United Soccer Club | 32    | Long Island       |
+
+These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to LIJSL, NYWYSA, and ENYYSA premier divisions at the state level.
+
+### Leagues Active in New York
+
+New York teams compete across most national leagues PitchRank tracks:
+
+- **ECNL** (Elite Clubs National League) — Top pathway for girls; growing boys division. Strong NY presence at clubs like World Class FC and East Coast Surf.
+- **MLS NEXT** — Highest level for boys, tied to MLS clubs. NYCFC Academy and New York Red Bulls Academy operate within this platform.
+- **Girls Academy (GA)** — National girls league with NY representation.
+- **NPL** (National Premier Leagues) — Competitive national league under US Club Soccer.
+- **ECNL Regional League** — Development tier below ECNL.
+- **EDP** (Eastern Development Program) — Regional league spanning the Northeast; many NY teams compete here in competitive flights.
+- **National League** — US Youth Soccer national competition.
+
+Plus state-level competition through [ENYYSA](https://www.enysoccer.com/) (Eastern New York Youth Soccer Association) and [NYWYSA](https://www.nywysa.com/) (New York West) — the two governing bodies that split the state and run regional state cups.
+
+## How New York Soccer Rankings Actually Work
+
+Most ranking systems — GotSoccer being the biggest — only count tournament games and reward quantity over quality. A team that enters 15 tournaments and beats weak opponents can outrank a team that plays a tougher schedule but enters fewer events.
+
+That's not how PitchRank works.
+
+### What PitchRank Tracks for New York Teams
+
+We track **every game we can find** — league play, tournaments, friendlies, showcases — across all 3,697 New York teams.
+
+Here's the short version of how your team's ranking is calculated:
+
+1. **Base rating** — Every team starts neutral and moves with each game played
+2. **Strength of schedule** — Beating a top SUSA FC squad means more than beating a developmental team. Losing to a strong opponent hurts less than losing to a weak one.
+3. **Recency** — Last month's games count more than games from 10 months ago
+4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
+
+The result is a **PowerScore between 0.0 and 1.0**:
+
+- **0.85+** = Elite, national-tier team
+- **0.70–0.84** = Top state tier — consistently competitive against the best NY has to offer
+- **0.50–0.69** = Solid competitive team, typically mid-pack premier / EDP Flight 1 / ECNL
+- **0.30–0.49** = Developing or lower-flight competitive
+- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
+
+The top of New York currently sits in the **0.80+** range, with World Class FC, SUSA FC, Atlantic United, and East Coast Surf all producing rosters in that band across multiple age groups.
+
+### New York's Age Group Breakdown
+
+New York's team density varies sharply by age group:
+
+| Age Group | Teams |
+| --------- | ----- |
+| U10       | 534   |
+| U11       | 671   |
+| U12       | 701   |
+| U13       | 538   |
+| U14       | 489   |
+| U15       | 360   |
+| U16       | 193   |
+| U17       | 133   |
+| U18       | 40    |
+| U19       | 38    |
+
+Peak competition is at U11 and U12 with over 670 teams each — among the densest youth soccer pools in any state. Numbers thin sharply after U15 as players specialize, move to high school programs, or step away. If your child is U11 or U12 in New York, they're competing in one of the deepest age-group pools in the country.
+
+## What Your New York Team's Ranking Actually Tells You
+
+You check PitchRank and see your U13 team is ranked #65 in New York. What does that mean?
+
+### State vs National Rankings
+
+- **State rank** — Where your team stands among New York's 3,697 teams across age groups
+- **National rank** — Where your team stands among all teams in their age group across the country
+
+**Reality check:** Being top 50 in New York is legitimately strong — this is the country's fourth-largest state by team count. Being top 500 nationally is excellent. Top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in New York isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — U12 has 701 teams; U17 has 133
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [New York soccer rankings](/rankings/ny).
+
+### What Rankings Don't Tell You
+
+Rankings measure competitive results. They can't measure:
+
+- **Individual player development** — A top-ranked team might not be the best fit for your child's growth
+- **Coaching quality** — Some lower-ranked teams have better developmental coaches than win-now programs
+- **Team culture** — Your kid's enjoyment matters more than a number
+- **College fit** — D3 coaches care about GPA and character more than PowerScore
+
+If a club director sells you on rankings alone but can't explain their development philosophy, that's a red flag.
+
+## How to Use New York Rankings When Choosing a Club
+
+Tryout season in New York runs May through June. Rankings are one tool in your decision-making kit — here's how to use them wisely.
+
+### Questions to Ask Club Directors
+
+When you're comparing Manhattan SC vs World Class FC vs SUSA FC:
+
+1. **"How do your teams' rankings trend over time?"** — Upward trends suggest good coaching. Flat or declining suggests stagnation.
+2. **"What's the strength of schedule for this age group?"** — Are they playing real competition or scheduling easy wins?
+3. **"How do your New York rankings compare to teams we'd face at regionals?"** — National context matters if your child has college ambitions.
+4. **"How many players from this age group have moved to ECNL or MLS NEXT?"** — Player progression matters more than team rank.
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked one. Look for a team that:
+
+- Plays opponents 10–20 ranking positions above AND below them
+- Gives your child 30+ minutes per game
+- Challenges without crushing confidence
+- Fits your family's travel budget and schedule
+
+**New York's advantage:** With clubs spread from Manhattan to Buffalo, you have options at every competitive level. The harder choice is travel — Long Island parents commuting to Westchester showcases or upstate families driving to NYC tournaments need to factor that into the rankings comparison.
+
+### Red Flags
+
+- **Cherry-picking opponents** — Teams that pad records against weak LIJSL or local-flight opponents. Their ranking will plateau.
+- **Wild ranking swings** — Could signal roster instability or inconsistent coaching
+- **Ranking guarantees** — No legitimate club can promise specific rankings
+
+## The Long Island vs NYC Metro Dynamic
+
+New York's biggest youth soccer divide isn't east-vs-west — it's between Long Island's club density and the rest of the state's metro and regional clubs. Long Island alone produces more competitive teams in the U11–U14 range than most full states do, and LIJSL premier divisions act as a de facto state league for nearly half of NY's youth soccer talent.
+
+What this means for parents:
+
+- **Long Island clubs** benefit from year-round outdoor play, dense local competition, and short travel between meaningful games
+- **NYC and Westchester clubs** play deeper into national platforms (ECNL, MLS NEXT, GA) earlier in the development pyramid
+- **Western NY clubs** like WNY Flash compete more often into Pennsylvania and Ohio than against downstate NY — which means their NY ranking can underestimate their true level until showcase season
+
+If your team only plays within Long Island, rankings can underrepresent how you'd do against an Atlantic United or World Class FC roster. The true test comes at state cup and regional showcases.
+
+## New York State Cup and Rankings
+
+New York runs **two** state cups — one through ENYYSA (Eastern New York) and one through NYWYSA (Western New York). Rankings intersect with both:
+
+- **Seeding** — Higher-ranked teams earn better tournament draws
+- **Competition quality** — State cups draw the best from each side of the state, so rankings sharpen during and after these events
+- **Exposure** — College scouts and regional ODP staff use state cup performances to filter which players to track
+
+If your team is ranked in the **top 10–15% in New York**, state cup is where that ranking gets tested against the state's best.
+
+## The College Recruiting Reality Check
+
+Let's be honest about what New York soccer rankings mean for college recruiting.
+
+### What Coaches Actually Look At
+
+1. **Individual highlight video** — YOUR child, not team stats
+2. **Academic eligibility** — GPA and test scores filter players before rankings matter
+3. **Showcase attendance** — Jefferson Cup, ECNL playoffs, EDP Showcase, and Disney events where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+### Rankings by Division
+
+- **Division I** — Coaches notice teams in the **top 5% nationally** (very elite)
+- **Division II** — Top 15–20% nationally gets attention, but individual performance matters more
+- **Division III** — Rankings barely factor in. Academics, character, and fit drive decisions.
+
+**New York's edge:** The state is home to Syracuse, Cornell, St. John's, Hofstra, Stony Brook, Binghamton, and dozens of D2 and D3 programs. Use rankings to identify which NY clubs consistently place players in these programs and attend Northeast showcases.
+
+## Using PitchRank to Track New York Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your club by name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive and whether your child is playing up or down.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift as new games are played. Check weekly to see how wins, losses, and tournament results move your team's ranking.
+
+> **Ready to check?** [See all New York youth soccer rankings](/rankings/ny)
+
+## Browse New York Rankings by Age Group
+
+Find your team's age group and gender to see the latest New York rankings:
+
+| Age Group | Boys                                       | Girls                                         |
+| --------- | ------------------------------------------ | --------------------------------------------- |
+| U10       | [New York U10 Boys](/rankings/ny/u10/male) | [New York U10 Girls](/rankings/ny/u10/female) |
+| U11       | [New York U11 Boys](/rankings/ny/u11/male) | [New York U11 Girls](/rankings/ny/u11/female) |
+| U12       | [New York U12 Boys](/rankings/ny/u12/male) | [New York U12 Girls](/rankings/ny/u12/female) |
+| U13       | [New York U13 Boys](/rankings/ny/u13/male) | [New York U13 Girls](/rankings/ny/u13/female) |
+| U14       | [New York U14 Boys](/rankings/ny/u14/male) | [New York U14 Girls](/rankings/ny/u14/female) |
+| U15       | [New York U15 Boys](/rankings/ny/u15/male) | [New York U15 Girls](/rankings/ny/u15/female) |
+| U16       | [New York U16 Boys](/rankings/ny/u16/male) | [New York U16 Girls](/rankings/ny/u16/female) |
+| U17       | [New York U17 Boys](/rankings/ny/u17/male) | [New York U17 Girls](/rankings/ny/u17/female) |
+| U19       | [New York U19 Boys](/rankings/ny/u19/male) | [New York U19 Girls](/rankings/ny/u19/female) |
+
+## Frequently Asked Questions
+
+### How are youth soccer teams ranked in New York?
+
+PitchRank tracks game-by-game results across 3,697 New York teams. Teams earn a PowerScore from 0.0 to 1.0 based on wins, opponent strength, recency, and consistency — updated weekly.
+
+### What are the biggest youth soccer clubs in New York?
+
+By team count: Manhattan SC (81 teams), SUSA FC (77), Western New York Flash (77), Atlantic United SB/LGN SC (63), Long Island SC (59), East Coast Surf (52), East Meadow (48), and World Class FC (43).
+
+### How often do New York soccer rankings update?
+
+PitchRank updates rankings every Monday morning with the latest game results. Recent games are weighted more heavily than older ones.
+
+### What youth soccer leagues operate in New York?
+
+New York teams compete in ECNL, MLS NEXT, Girls Academy (GA), NPL, ECNL Regional League, EDP, and National League — plus state competitions through ENYYSA (eastern NY) and NYWYSA (western NY), and the dominant LIJSL premier divisions on Long Island.
+
+### Should my child be on the highest-ranked team possible?
+
+Not necessarily. The best team is one where your child gets meaningful playing time, faces the right level of competition, and develops in a positive environment. A top-ranked team where your kid sits the bench is worse than a mid-ranked team where they play every minute.
+
+### Do New York rankings help with college recruiting?
+
+Rankings provide context but aren't the main recruiting tool. Individual highlight video, academic eligibility, showcase attendance, and direct coach contact matter more. D1 coaches notice top 5% nationally. D3 coaches care more about GPA and fit.
+
+### Can clubs game the rankings?
+
+No. PitchRank's algorithm adjusts for opponent strength. Beating weaker LIJSL or regional opponents repeatedly won't inflate your ranking. Teams that avoid strong competition plateau quickly.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your New York team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
@@ -49,23 +49,23 @@ New York has 3,697 active youth soccer teams across our database — the fourth-
 
 Based on our database, the largest youth soccer organizations in New York:
 
-| Club                                    | Teams | Region            |
-| --------------------------------------- | ----- | ----------------- |
-| Manhattan SC                            | 81    | NYC Metro         |
-| SUSA FC                                 | 77    | Long Island       |
-| Western New York Flash                  | 77    | Western NY        |
-| Atlantic United SB/LGN SC               | 63    | Hudson Valley     |
-| Long Island SC                          | 59    | Long Island       |
-| East Coast Surf                         | 52    | Long Island       |
-| East Meadow Soccer Club                 | 48    | Long Island       |
-| World Class FC                          | 43    | Westchester       |
-| Brooklyn United Academy                 | 43    | NYC Metro         |
-| Smithtown Kickers SC (LIJSL)            | 40    | Long Island       |
-| Garden City (LIJSL)                     | 39    | Long Island       |
-| Albertson Soccer Club                   | 36    | Long Island       |
-| LMFC                                    | 35    | Long Island       |
-| NY Rush                                 | 35    | Multi-region      |
-| Northport Cow Harbor United Soccer Club | 32    | Long Island       |
+| Club                                    | Teams | Region        |
+| --------------------------------------- | ----- | ------------- |
+| Manhattan SC                            | 81    | NYC Metro     |
+| SUSA FC                                 | 77    | Long Island   |
+| Western New York Flash                  | 77    | Western NY    |
+| Atlantic United SB/LGN SC               | 63    | Hudson Valley |
+| Long Island SC                          | 59    | Long Island   |
+| East Coast Surf                         | 52    | Long Island   |
+| East Meadow Soccer Club                 | 48    | Long Island   |
+| World Class FC                          | 43    | Westchester   |
+| Brooklyn United Academy                 | 43    | NYC Metro     |
+| Smithtown Kickers SC (LIJSL)            | 40    | Long Island   |
+| Garden City (LIJSL)                     | 39    | Long Island   |
+| Albertson Soccer Club                   | 36    | Long Island   |
+| LMFC                                    | 35    | Long Island   |
+| NY Rush                                 | 35    | Multi-region  |
+| Northport Cow Harbor United Soccer Club | 32    | Long Island   |
 
 These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to LIJSL, NYWYSA, and ENYYSA premier divisions at the state level.
 

--- a/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
@@ -51,23 +51,23 @@ Virginia has 1,511 active youth soccer teams across our database. Here's how tha
 
 Based on our database, the largest youth soccer organizations in Virginia:
 
-| Club                              | Teams | Region        |
-| --------------------------------- | ----- | ------------- |
-| Beach FC                          | 127   | Hampton Roads |
-| Richmond United                   | 122   | Richmond      |
-| Arlington Soccer                  | 69    | NoVA          |
-| Springfield SYC                   | 59    | NoVA          |
-| Prince William Soccer Inc         | 48    | NoVA          |
-| VA Rush Soccer Club               | 48    | Multi-region  |
-| Braddock Road Youth Club          | 42    | NoVA          |
-| Virginia Soccer Association       | 41    | Richmond      |
-| Loudoun Soccer Club               | 41    | NoVA          |
-| Virginia United FC                | 40    | Multi-region  |
-| McLean YS                         | 38    | NoVA          |
-| Chesapeake United SC              | 36    | Hampton Roads |
-| Alexandria SA                     | 36    | NoVA          |
-| Virginia Revolution SC            | 35    | Hampton Roads |
-| Great Falls Reston Soccer Club    | 34    | NoVA          |
+| Club                           | Teams | Region        |
+| ------------------------------ | ----- | ------------- |
+| Beach FC                       | 127   | Hampton Roads |
+| Richmond United                | 122   | Richmond      |
+| Arlington Soccer               | 69    | NoVA          |
+| Springfield SYC                | 59    | NoVA          |
+| Prince William Soccer Inc      | 48    | NoVA          |
+| VA Rush Soccer Club            | 48    | Multi-region  |
+| Braddock Road Youth Club       | 42    | NoVA          |
+| Virginia Soccer Association    | 41    | Richmond      |
+| Loudoun Soccer Club            | 41    | NoVA          |
+| Virginia United FC             | 40    | Multi-region  |
+| McLean YS                      | 38    | NoVA          |
+| Chesapeake United SC           | 36    | Hampton Roads |
+| Alexandria SA                  | 36    | NoVA          |
+| Virginia Revolution SC         | 35    | Hampton Roads |
+| Great Falls Reston Soccer Club | 34    | NoVA          |
 
 These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to VYSA premier divisions at the state level.
 
@@ -255,8 +255,8 @@ Rankings shift as new games are played. Check weekly to see how wins, losses, an
 
 Find your team's age group and gender to see the latest Virginia rankings:
 
-| Age Group | Boys                                      | Girls                                        |
-| --------- | ----------------------------------------- | -------------------------------------------- |
+| Age Group | Boys                                       | Girls                                         |
+| --------- | ------------------------------------------ | --------------------------------------------- |
 | U10       | [Virginia U10 Boys](/rankings/va/u10/male) | [Virginia U10 Girls](/rankings/va/u10/female) |
 | U11       | [Virginia U11 Boys](/rankings/va/u11/male) | [Virginia U11 Girls](/rankings/va/u11/female) |
 | U12       | [Virginia U12 Boys](/rankings/va/u12/male) | [Virginia U12 Girls](/rankings/va/u12/female) |

--- a/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,302 @@
+---
+title: 'Virginia (VA) Youth Soccer Rankings 2026'
+slug: 'virginia-youth-soccer-rankings-guide'
+excerpt: 'Find where your VA youth soccer club ranks among 1,500+ teams. Beach FC, Richmond United, Arlington Soccer, Loudoun and more — rated weekly by PowerScore. Free.'
+author: 'PitchRank Team'
+date: '2026-04-28'
+readingTime: '10 min read'
+tags: ['Virginia', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'va youth soccer rankings',
+    'virginia youth soccer rankings',
+    'virginia soccer rankings',
+    'best youth soccer clubs virginia',
+    'northern virginia soccer rankings',
+    'VA club soccer rankings',
+  ]
+---
+
+# Virginia Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+Your team just finished a Saturday tournament in Fredericksburg. They went 2-1, beating an Arlington club you've never played and losing to a Beach FC roster that drove up from Virginia Beach. The standings say you finished third. But what does that actually mean? Is your team good, or did Beach FC just bring their A-team for the day?
+
+That's the question every Virginia soccer parent eventually asks. Between Northern Virginia's commuter clubs, Richmond's growing competitive scene, and Hampton Roads' coastal pipeline, your team probably plays the same 10 opponents over and over — and rarely sees the rest of the state. Rankings are how that bigger picture comes into focus.
+
+## Why Virginia Soccer Rankings Matter
+
+Virginia is geographically split in a way that hides true team strength. Your team in Loudoun County might never face a Richmond United squad. Your Beach FC team in Virginia Beach might never travel to McLean.
+
+Rankings give you three things traditional league standings can't:
+
+1. **Cross-region context** — How does your Northern Virginia ECNL Regional team actually compare to a top Beach FC roster from Tidewater?
+2. **Informed club decisions** — When tryout season hits, rankings help you compare Arlington Soccer, Loudoun, Springfield SYC, and McLean YS on the same scale instead of relying on word of mouth.
+3. **Realistic expectations** — Winning your VYSA flight is a starting point, not a finish line. The state cup and regional showcases are where rankings get real.
+
+> **See where your team stands now:** [View all Virginia youth soccer rankings](/rankings/va)
+
+## The Virginia Youth Soccer Landscape
+
+Virginia has 1,511 active youth soccer teams across our database. Here's how that breaks down regionally.
+
+### Geographic Soccer Regions
+
+- **Northern Virginia (NoVA)** — Anchored by Arlington Soccer (69 teams), Springfield SYC (59), Prince William Soccer Inc (48), Braddock Road Youth Club (42), Loudoun Soccer Club (41), McLean YS (38), Alexandria SA (36), and Great Falls Reston Soccer Club (34). This is the densest competitive region in the state, with strong feeders into ECNL and MLS NEXT through proximity to D.C. clubs.
+- **Hampton Roads / Tidewater** (Virginia Beach, Chesapeake, Norfolk) — Beach FC (127 teams) is the largest single club in Virginia, with Chesapeake United SC (36) and Virginia Revolution SC (35) rounding out the region.
+- **Richmond Metro** — Richmond United (122 teams) and Virginia Soccer Association (41 teams) lead this fast-growing market. Strong competitive base from local rec/travel leagues moving up into national platforms.
+- **Western Virginia & Shenandoah Valley** (Roanoke, Lynchburg, Charlottesville, Harrisonburg) — Smaller but growing club presence; many teams travel to Richmond, NoVA, or D.C. for top-flight competition.
+- **Multi-region travel clubs** — VA Rush Soccer Club (48 teams) and Virginia United FC (40 teams) operate across multiple Virginia metros and run rosters in several locations.
+
+### Major Virginia Soccer Clubs
+
+Based on our database, the largest youth soccer organizations in Virginia:
+
+| Club                              | Teams | Region        |
+| --------------------------------- | ----- | ------------- |
+| Beach FC                          | 127   | Hampton Roads |
+| Richmond United                   | 122   | Richmond      |
+| Arlington Soccer                  | 69    | NoVA          |
+| Springfield SYC                   | 59    | NoVA          |
+| Prince William Soccer Inc         | 48    | NoVA          |
+| VA Rush Soccer Club               | 48    | Multi-region  |
+| Braddock Road Youth Club          | 42    | NoVA          |
+| Virginia Soccer Association       | 41    | Richmond      |
+| Loudoun Soccer Club               | 41    | NoVA          |
+| Virginia United FC                | 40    | Multi-region  |
+| McLean YS                         | 38    | NoVA          |
+| Chesapeake United SC              | 36    | Hampton Roads |
+| Alexandria SA                     | 36    | NoVA          |
+| Virginia Revolution SC            | 35    | Hampton Roads |
+| Great Falls Reston Soccer Club    | 34    | NoVA          |
+
+These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to VYSA premier divisions at the state level.
+
+### Leagues Active in Virginia
+
+Virginia teams compete across most national leagues PitchRank tracks:
+
+- **ECNL** (Elite Clubs National League) — Strong VA presence, particularly through Arlington Soccer, Beach FC, and Richmond United.
+- **MLS NEXT** — Highest level for boys; D.C.-area academies pull from NoVA clubs heavily.
+- **Girls Academy (GA)** — National girls league with growing VA representation.
+- **NPL** (National Premier Leagues) — Competitive national league under US Club Soccer.
+- **ECNL Regional League** — Development tier below ECNL; the workhorse competitive league for many VA teams.
+- **EDP** (Eastern Development Program) — Regional Northeast league; Northern Virginia clubs are heavy participants.
+- **National League** — US Youth Soccer national competition.
+
+Plus state-level competition through [VYSA](https://www.vysa.com/) (Virginia Youth Soccer Association) — the governing body for youth soccer in the state, overseeing premier flight competition and the Virginia State Cup.
+
+## How Virginia Soccer Rankings Actually Work
+
+Most ranking systems — GotSoccer being the biggest — only count tournament games and reward quantity over quality. A team that enters 15 tournaments and beats weak opponents can outrank a team that plays a tougher schedule but enters fewer events.
+
+That's not how PitchRank works.
+
+### What PitchRank Tracks for Virginia Teams
+
+We track **every game we can find** — league play, tournaments, friendlies, showcases — across all 1,511 Virginia teams.
+
+Here's the short version of how your team's ranking is calculated:
+
+1. **Base rating** — Every team starts neutral and moves with each game played
+2. **Strength of schedule** — Beating a top Arlington Soccer ECNL squad means more than beating a developmental team. Losing to a strong opponent hurts less than losing to a weak one.
+3. **Recency** — Last month's games count more than games from 10 months ago
+4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
+
+The result is a **PowerScore between 0.0 and 1.0**:
+
+- **0.85+** = Elite, national-tier team
+- **0.70–0.84** = Top state tier — consistently competitive against the best VA has to offer
+- **0.50–0.69** = Solid competitive team, typically mid-pack premier / ECNL Regional / NPL
+- **0.30–0.49** = Developing or lower-flight competitive
+- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
+
+The top of Virginia currently sits in the **0.85–0.91** range, with Arlington Soccer, Bethesda-feeder rosters, Springfield SYC, Alexandria SA, and Virginia Soccer Association producing teams in that band across multiple age groups.
+
+### Virginia's Age Group Breakdown
+
+Virginia's team density varies by age group:
+
+| Age Group | Teams |
+| --------- | ----- |
+| U10       | 136   |
+| U11       | 215   |
+| U12       | 233   |
+| U13       | 235   |
+| U14       | 233   |
+| U15       | 202   |
+| U16       | 106   |
+| U17       | 82    |
+| U18       | 42    |
+| U19       | 27    |
+
+Peak competition is at U12, U13, and U14 — each with over 230 teams. Numbers thin meaningfully after U15 as players specialize, move to high school programs, or step away. If your child is U12 through U14 in Virginia, they're competing in the deepest age-group pools in the state.
+
+## What Your Virginia Team's Ranking Actually Tells You
+
+You check PitchRank and see your U13 team is ranked #38 in Virginia. What does that mean?
+
+### State vs National Rankings
+
+- **State rank** — Where your team stands among Virginia's 1,511 teams across age groups
+- **National rank** — Where your team stands among all teams in their age group across the country
+
+**Reality check:** Being top 30 in Virginia is legitimately strong — VA punches above its team-count weight thanks to NoVA's competitive density. Being top 500 nationally is excellent. Top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in Virginia isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — U12 has 233 teams; U17 has 82
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [Virginia soccer rankings](/rankings/va).
+
+### What Rankings Don't Tell You
+
+Rankings measure competitive results. They can't measure:
+
+- **Individual player development** — A top-ranked team might not be the best fit for your child's growth
+- **Coaching quality** — Some lower-ranked teams have better developmental coaches than win-now programs
+- **Team culture** — Your kid's enjoyment matters more than a number
+- **College fit** — D3 coaches care about GPA and character more than PowerScore
+
+If a club director sells you on rankings alone but can't explain their development philosophy, that's a red flag.
+
+## How to Use Virginia Rankings When Choosing a Club
+
+Tryout season in Virginia runs May through June. Rankings are one tool in your decision-making kit — here's how to use them wisely.
+
+### Questions to Ask Club Directors
+
+When you're comparing Arlington Soccer vs Loudoun vs Springfield SYC vs McLean:
+
+1. **"How do your teams' rankings trend over time?"** — Upward trends suggest good coaching. Flat or declining suggests stagnation.
+2. **"What's the strength of schedule for this age group?"** — Are they playing real competition or scheduling easy wins?
+3. **"How do your Virginia rankings compare to teams we'd face at regionals?"** — National context matters if your child has college ambitions.
+4. **"How many players from this age group have moved to ECNL or MLS NEXT?"** — Player progression matters more than team rank.
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked one. Look for a team that:
+
+- Plays opponents 10–20 ranking positions above AND below them
+- Gives your child 30+ minutes per game
+- Challenges without crushing confidence
+- Fits your family's travel budget and schedule
+
+**Virginia's advantage:** With clubs spread across NoVA, Richmond, and Hampton Roads, you have options at every competitive level. The harder choice is often I-95 traffic — Tidewater families driving north for showcases or Richmond families commuting to D.C.-area events need to factor that in.
+
+### Red Flags
+
+- **Cherry-picking opponents** — Teams that pad records against weak VYSA flight opponents. Their ranking will plateau.
+- **Wild ranking swings** — Could signal roster instability or inconsistent coaching
+- **Ranking guarantees** — No legitimate club can promise specific rankings
+
+## The NoVA vs Hampton Roads Dynamic
+
+Virginia's biggest youth soccer divide isn't north-vs-south — it's between Northern Virginia's competitive density and the rest of the state's regional clubs. NoVA alone produces more competitive teams than most full states do, and clubs there compete on a national showcase calendar that's hard to match in Tidewater or Richmond.
+
+What this means for parents:
+
+- **Northern Virginia clubs** benefit from proximity to the D.C. metro youth soccer market, MLS NEXT academies, and dense in-state competition
+- **Hampton Roads clubs** like Beach FC and Chesapeake United compete heavily within Tidewater and travel to Richmond and NoVA for showcase events
+- **Richmond clubs** sit geographically in the middle and increasingly anchor strong ECNL Regional and NPL rosters
+- **Cross-region play** is the cleanest measure of true team strength — when your team plays out of region, the ranking sharpens
+
+If your team only plays within NoVA or only within Tidewater, rankings can be misleading. The true test comes at state cup and regional events.
+
+## Virginia State Cup and Rankings
+
+The Virginia State Cup (run by VYSA) is the state's premier championship event. Rankings intersect here directly:
+
+- **Seeding** — Higher-ranked teams earn better tournament draws
+- **Competition quality** — State Cup draws Virginia's best from every region, so rankings are most accurate during and after this event
+- **Exposure** — College scouts and ODP staff use State Cup performances to filter which players to track
+
+If your team is ranked in the **top 10–15% in Virginia**, State Cup is where that ranking gets tested against the state's best.
+
+## The College Recruiting Reality Check
+
+Let's be honest about what Virginia soccer rankings mean for college recruiting.
+
+### What Coaches Actually Look At
+
+1. **Individual highlight video** — YOUR child, not team stats
+2. **Academic eligibility** — GPA and test scores filter players before rankings matter
+3. **Showcase attendance** — Jefferson Cup, ECNL playoffs, Disney events, and Capital Cup where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+### Rankings by Division
+
+- **Division I** — Coaches notice teams in the **top 5% nationally** (very elite)
+- **Division II** — Top 15–20% nationally gets attention, but individual performance matters more
+- **Division III** — Rankings barely factor in. Academics, character, and fit drive decisions.
+
+**Virginia's edge:** The state is home to UVA, Virginia Tech, William & Mary, JMU, George Mason, VCU, Old Dominion, and dozens of D2 and D3 programs. Use rankings to identify which VA clubs consistently place players in these programs and attend Jefferson Cup and other major showcases.
+
+## Using PitchRank to Track Virginia Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your club by name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive and whether your child is playing up or down.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift as new games are played. Check weekly to see how wins, losses, and tournament results move your team's ranking.
+
+> **Ready to check?** [See all Virginia youth soccer rankings](/rankings/va)
+
+## Browse Virginia Rankings by Age Group
+
+Find your team's age group and gender to see the latest Virginia rankings:
+
+| Age Group | Boys                                      | Girls                                        |
+| --------- | ----------------------------------------- | -------------------------------------------- |
+| U10       | [Virginia U10 Boys](/rankings/va/u10/male) | [Virginia U10 Girls](/rankings/va/u10/female) |
+| U11       | [Virginia U11 Boys](/rankings/va/u11/male) | [Virginia U11 Girls](/rankings/va/u11/female) |
+| U12       | [Virginia U12 Boys](/rankings/va/u12/male) | [Virginia U12 Girls](/rankings/va/u12/female) |
+| U13       | [Virginia U13 Boys](/rankings/va/u13/male) | [Virginia U13 Girls](/rankings/va/u13/female) |
+| U14       | [Virginia U14 Boys](/rankings/va/u14/male) | [Virginia U14 Girls](/rankings/va/u14/female) |
+| U15       | [Virginia U15 Boys](/rankings/va/u15/male) | [Virginia U15 Girls](/rankings/va/u15/female) |
+| U16       | [Virginia U16 Boys](/rankings/va/u16/male) | [Virginia U16 Girls](/rankings/va/u16/female) |
+| U17       | [Virginia U17 Boys](/rankings/va/u17/male) | [Virginia U17 Girls](/rankings/va/u17/female) |
+| U19       | [Virginia U19 Boys](/rankings/va/u19/male) | [Virginia U19 Girls](/rankings/va/u19/female) |
+
+## Frequently Asked Questions
+
+### How are youth soccer teams ranked in Virginia?
+
+PitchRank tracks game-by-game results across 1,511 Virginia teams. Teams earn a PowerScore from 0.0 to 1.0 based on wins, opponent strength, recency, and consistency — updated weekly.
+
+### What are the biggest youth soccer clubs in Virginia?
+
+By team count: Beach FC (127 teams), Richmond United (122), Arlington Soccer (69), Springfield SYC (59), Prince William Soccer (48), VA Rush (48), Braddock Road (42), Virginia Soccer Association (41), and Loudoun Soccer Club (41).
+
+### How often do Virginia soccer rankings update?
+
+PitchRank updates rankings every Monday morning with the latest game results. Recent games are weighted more heavily than older ones.
+
+### What youth soccer leagues operate in Virginia?
+
+Virginia teams compete in ECNL, MLS NEXT, Girls Academy (GA), NPL, ECNL Regional League, EDP, and National League — plus state competition through VYSA premier divisions and the Virginia State Cup.
+
+### Should my child be on the highest-ranked team possible?
+
+Not necessarily. The best team is one where your child gets meaningful playing time, faces the right level of competition, and develops in a positive environment. A top-ranked team where your kid sits the bench is worse than a mid-ranked team where they play every minute.
+
+### Do Virginia rankings help with college recruiting?
+
+Rankings provide context but aren't the main recruiting tool. Individual highlight video, academic eligibility, showcase attendance, and direct coach contact matter more. D1 coaches notice top 5% nationally. D3 coaches care more about GPA and fit.
+
+### Can clubs game the rankings?
+
+No. PitchRank's algorithm adjusts for opponent strength. Beating weaker VYSA flight opponents repeatedly won't inflate your ranking. Teams that avoid strong competition plateau quickly.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Virginia team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/lib/blog-faqs.ts
+++ b/frontend/lib/blog-faqs.ts
@@ -124,6 +124,34 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
     },
   ],
 
+  'maryland-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Maryland youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Maryland teams using a rating algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 1,572+ Maryland teams.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in Maryland?',
+      answer:
+        'Major Maryland youth soccer clubs include Bethesda SC, Coppermine Soccer Club, SAC/BA, Maryland United FC, Potomac Soccer Association, Pipeline SC, Baltimore Celtic, and Baltimore Union. Rankings vary by age group — check PitchRank for current standings.',
+    },
+    {
+      question: 'How often are Maryland soccer rankings updated?',
+      answer:
+        'Maryland youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'Does PitchRank cover ECNL and MLS NEXT results in Maryland?',
+      answer:
+        'Yes. PitchRank covers all major leagues and tournaments including ECNL, MLS NEXT, EDP, and state-level competitions through MSYSA. All verified game results count toward rankings regardless of the league.',
+    },
+    {
+      question: 'How do Bethesda and Baltimore area clubs compare in rankings?',
+      answer:
+        "Both regions produce nationally competitive clubs. Bethesda SC, Potomac, and Montgomery-area programs anchor the D.C.-corridor scene, while Coppermine, Pipeline, Baltimore Celtic, and Baltimore Union lead the Baltimore metro. Use PitchRank's state filter to compare clubs across regions.",
+    },
+  ],
+
   'michigan-youth-soccer-rankings-guide': [
     {
       question: 'How are Michigan youth soccer teams ranked?',
@@ -177,6 +205,34 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
       question: 'Can New Jersey team rankings help with college recruiting?',
       answer:
         "Rankings provide context for college coaches evaluating players. A team's position in their age group shows relative strength, and coaches can see how a player's team performs against top competition. However, individual highlight video, academics, and showcase attendance matter more than team rankings alone.",
+    },
+  ],
+
+  'new-york-youth-soccer-rankings-guide': [
+    {
+      question: 'How are New York youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks New York teams using a rating algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 3,697+ New York teams.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in New York?',
+      answer:
+        'Major New York youth soccer clubs include Manhattan SC, SUSA FC, Western New York Flash, Atlantic United, Long Island SC, East Coast Surf, East Meadow, World Class FC, and Brooklyn United Academy. Rankings vary by age group.',
+    },
+    {
+      question: 'How often are New York soccer rankings updated?',
+      answer:
+        'New York youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'Does PitchRank cover LIJSL and EDP results in New York?',
+      answer:
+        "Yes. PitchRank ingests results from LIJSL premier divisions, EDP, ECNL, MLS NEXT, and major tournaments. All verified game results count toward a team's ranking regardless of the league or event.",
+    },
+    {
+      question: 'How do Long Island and NYC metro clubs compare in rankings?',
+      answer:
+        "Long Island has the deepest team density in the state, with SUSA FC, Long Island SC, East Coast Surf, and East Meadow leading. NYC and Westchester clubs like Manhattan SC, World Class FC, and Atlantic United compete more heavily on national platforms (ECNL, MLS NEXT) earlier in the development pyramid. Use PitchRank's state filter to compare clubs across regions.",
     },
   ],
 
@@ -289,6 +345,34 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
       question: 'Can Texas youth soccer rankings help with college recruiting?',
       answer:
         "Rankings provide context for college coaches evaluating players. A team's position in their age group shows relative strength, and coaches can see how a player's team performs against top competition. However, individual highlight video, academics, and showcase attendance matter more than team rankings alone.",
+    },
+  ],
+
+  'virginia-youth-soccer-rankings-guide': [
+    {
+      question: 'How are Virginia youth soccer teams ranked?',
+      answer:
+        'PitchRank ranks Virginia teams using a rating algorithm that evaluates game-by-game results, strength of schedule, goal differential, recency, and consistency. Rankings are updated every Monday with real game data from 1,511+ Virginia teams.',
+    },
+    {
+      question: 'What are the top youth soccer clubs in Virginia?',
+      answer:
+        'Major Virginia youth soccer clubs include Beach FC, Richmond United, Arlington Soccer, Springfield SYC, Prince William Soccer, VA Rush, Braddock Road Youth Club, Virginia Soccer Association, and Loudoun Soccer Club. Rankings vary by age group.',
+    },
+    {
+      question: 'How often are Virginia soccer rankings updated?',
+      answer:
+        'Virginia youth soccer rankings are updated every Monday morning with the latest game results from the previous week.',
+    },
+    {
+      question: 'Does PitchRank cover ECNL and MLS NEXT results in Virginia?',
+      answer:
+        'Yes. PitchRank covers all major leagues and tournaments including ECNL, MLS NEXT, EDP, ECNL Regional, NPL, and state-level competitions through VYSA. All verified game results count toward rankings regardless of the league.',
+    },
+    {
+      question: 'How do Northern Virginia and Hampton Roads clubs compare?',
+      answer:
+        "Northern Virginia has the deepest competitive density, anchored by Arlington Soccer, Springfield SYC, Loudoun, McLean, and Alexandria SA — plus tight integration with the D.C. metro youth soccer market. Hampton Roads' Beach FC is the largest single club in the state and competes heavily within Tidewater plus showcases in NoVA and Richmond. Use PitchRank's state filter to compare clubs across regions.",
     },
   ],
 

--- a/frontend/lib/cohort-seo.ts
+++ b/frontend/lib/cohort-seo.ts
@@ -114,11 +114,14 @@ const STATE_PILLAR_SLUGS: Record<string, { slug: string; title: string }> = {
   ca: { slug: 'california-youth-soccer-rankings-guide', title: 'California Youth Soccer Rankings Guide' },
   co: { slug: 'colorado-youth-soccer-rankings-guide', title: 'Colorado Youth Soccer Rankings Guide' },
   fl: { slug: 'florida-youth-soccer-rankings-guide', title: 'Florida Youth Soccer Rankings Guide' },
+  md: { slug: 'maryland-youth-soccer-rankings-guide', title: 'Maryland Youth Soccer Rankings Guide' },
   mi: { slug: 'michigan-youth-soccer-rankings-guide', title: 'Michigan Youth Soccer Rankings Guide' },
   nj: { slug: 'new-jersey-youth-soccer-rankings-guide', title: 'New Jersey Youth Soccer Rankings Guide' },
+  ny: { slug: 'new-york-youth-soccer-rankings-guide', title: 'New York Youth Soccer Rankings Guide' },
   nc: { slug: 'north-carolina-youth-soccer-rankings-guide', title: 'North Carolina Youth Soccer Rankings Guide' },
   pa: { slug: 'pennsylvania-youth-soccer-rankings-guide', title: 'Pennsylvania Youth Soccer Rankings Guide' },
   tx: { slug: 'texas-youth-soccer-rankings-guide', title: 'Texas Youth Soccer Rankings Guide' },
+  va: { slug: 'virginia-youth-soccer-rankings-guide', title: 'Virginia Youth Soccer Rankings Guide' },
 };
 
 export function getRelatedGuide(stateCode: string): { slug: string; title: string } | null {

--- a/scripts/pillar_state_data.py
+++ b/scripts/pillar_state_data.py
@@ -96,7 +96,7 @@ def main():
             print(f"  {count:>3}t  avg={avg_p:>5.2f}  top={top_p:>5.2f}  {club}")
 
         ages = ages_by_state.get(state, [])
-        print(f"\nAge group breakdown:")
+        print("\nAge group breakdown:")
         for age, count in ages:
             print(f"  {age:<6} {count:>5}")
 

--- a/scripts/pillar_state_data.py
+++ b/scripts/pillar_state_data.py
@@ -1,0 +1,105 @@
+"""Pull pillar-content data for a target list of states.
+
+For each state: total active teams, top clubs by team count, age-group breakdown,
+and active leagues. Output is human-readable for drop-in use in MDX pillar drafts.
+"""
+
+import os
+import sys
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv("C:/PitchRank/.env.local")
+
+TARGET_STATES = ["NY", "VA", "MD"]
+
+
+TOTAL_QUERY = """
+SELECT t.state_code, COUNT(DISTINCT t.id) AS team_count
+FROM teams t
+JOIN rankings_full r ON t.team_id_master = r.team_id
+WHERE t.state_code = ANY(%s)
+  AND r.status = 'Active'
+  AND t.is_deprecated = FALSE
+GROUP BY t.state_code
+ORDER BY t.state_code;
+"""
+
+CLUBS_QUERY = """
+SELECT t.state_code,
+       t.club_name,
+       COUNT(DISTINCT t.id) AS team_count,
+       AVG(r.power_score_final)::numeric(6,2) AS avg_power,
+       MAX(r.power_score_final)::numeric(6,2) AS top_power
+FROM teams t
+JOIN rankings_full r ON t.team_id_master = r.team_id
+WHERE t.state_code = ANY(%s)
+  AND r.status = 'Active'
+  AND t.club_name IS NOT NULL
+  AND t.club_name <> ''
+  AND t.is_deprecated = FALSE
+GROUP BY t.state_code, t.club_name
+HAVING COUNT(DISTINCT t.id) >= 3
+ORDER BY t.state_code, team_count DESC, avg_power DESC;
+"""
+
+AGE_GROUP_QUERY = """
+SELECT t.state_code,
+       t.age_group,
+       COUNT(DISTINCT t.id) AS team_count
+FROM teams t
+JOIN rankings_full r ON t.team_id_master = r.team_id
+WHERE t.state_code = ANY(%s)
+  AND r.status = 'Active'
+  AND t.is_deprecated = FALSE
+  AND t.age_group IS NOT NULL
+GROUP BY t.state_code, t.age_group
+ORDER BY t.state_code, t.age_group;
+"""
+
+
+def main():
+    states = sys.argv[1:] if len(sys.argv) > 1 else TARGET_STATES
+    states = [s.upper() for s in states]
+
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor()
+
+    cur.execute(TOTAL_QUERY, (states,))
+    totals = {row[0]: row[1] for row in cur.fetchall()}
+
+    cur.execute(CLUBS_QUERY, (states,))
+    clubs_by_state = {}
+    for state, club, count, avg_p, top_p in cur.fetchall():
+        clubs_by_state.setdefault(state, []).append(
+            (club, count, float(avg_p), float(top_p))
+        )
+
+    cur.execute(AGE_GROUP_QUERY, (states,))
+    ages_by_state = {}
+    for state, age, count in cur.fetchall():
+        ages_by_state.setdefault(state, []).append((age, count))
+
+    cur.close()
+    conn.close()
+
+    for state in states:
+        total = totals.get(state, 0)
+        print(f"\n{'=' * 60}")
+        print(f"{state} — {total:,} active teams")
+        print('=' * 60)
+
+        clubs = clubs_by_state.get(state, [])[:15]
+        print(f"\nTop {len(clubs)} clubs by team count:")
+        for club, count, avg_p, top_p in clubs:
+            print(f"  {count:>3}t  avg={avg_p:>5.2f}  top={top_p:>5.2f}  {club}")
+
+        ages = ages_by_state.get(state, [])
+        print(f"\nAge group breakdown:")
+        for age, count in ages:
+            print(f"  {age:<6} {count:>5}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pillar_state_data.py
+++ b/scripts/pillar_state_data.py
@@ -6,11 +6,17 @@ and active leagues. Output is human-readable for drop-in use in MDX pillar draft
 
 import os
 import sys
+from pathlib import Path
 
 import psycopg2
 from dotenv import load_dotenv
 
-load_dotenv("C:/PitchRank/.env.local")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+env_local = REPO_ROOT / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv(REPO_ROOT / ".env")
 
 TARGET_STATES = ["NY", "VA", "MD"]
 


### PR DESCRIPTION
## Summary
- Three new state pillar blog posts (NY, VA, MD) with state-specific data: top clubs by team count, geographic regions, age-group breakdowns, active leagues, and state cup context.
- Each pillar follows the NC/PA template established in PR #659.
- Wires each new slug into \`BLOG_FAQS\` (drives FAQPage JSON-LD) and \`STATE_PILLAR_SLUGS\` (drives the Related Guide cross-link from \`/rankings/{state}\`).
- Adds \`scripts/pillar_state_data.py\` helper that pulls total active teams, top clubs, and age-group breakdowns for a list of states from \`rankings_full\` — for use on the remaining ~12 state pillars.

## Roadmap context
Week 6 of the [20-week SEO roadmap](docs/superpowers/specs/2026-04-16-seo-roadmap-design.md). Brings live state pillar count from 9 → 12 (AZ, CA, CO, FL, MD, MI, NJ, NY, NC, PA, TX, VA).

## Data pulled (all from \`rankings_full\` join, active teams only)
- **NY** — 3,697 active teams; top clubs Manhattan SC (81), SUSA FC (77), WNY Flash (77), Atlantic United (63), Long Island SC (59), East Coast Surf (52)
- **VA** — 1,511 active teams; top clubs Beach FC (127), Richmond United (122), Arlington Soccer (69), Springfield SYC (59), Loudoun (41)
- **MD** — 1,572 active teams; top clubs Bethesda SC (64), Coppermine (62), SAC/BA (60), Maryland United FC (57), Pipeline SC (41)

## Test plan
- [ ] \`tsc --noEmit\` clean (verified locally)
- [ ] Visit each new pillar in preview: \`/blog/new-york-youth-soccer-rankings-guide\`, \`/blog/virginia-...\`, \`/blog/maryland-...\`
- [ ] Verify Related Guide link appears on \`/rankings/ny\`, \`/rankings/va\`, \`/rankings/md\`
- [ ] Spot-check FAQPage JSON-LD via Rich Results Test on one new pillar
- [ ] Submit new URLs to GSC after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)