### PR TITLE
feat(intake): persist scrape resolutions to event_team_registry.csv

### DIFF
--- a/scripts/backtest_tournament_event.py
+++ b/scripts/backtest_tournament_event.py
@@ -17,7 +17,6 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
-from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +25,7 @@ from dotenv import load_dotenv
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from scripts.backtest_tournament_cohort import _fetch_rows_by_ids, _get_supabase  # noqa: E402
-from src.tournaments.event_team_matcher import EventTeamSearchQuery, search_event_team_in_db  # noqa: E402
+from src.tournaments.event_team_matcher import enrich_registry_rows_with_matcher  # noqa: E402
 from src.tournaments.seeding_optimizer import normalize_age_group, normalize_gender_label  # noqa: E402
 
 MIN_SUPPORTED_AGE = 10
@@ -101,9 +100,7 @@ def _fetch_event_games(client, event_name: str) -> list[dict[str, Any]]:
     while True:
         batch = (
             client.table("games")
-            .select(
-                "id,division_name,game_date,home_team_master_id,away_team_master_id,home_score,away_score"
-            )
+            .select("id,division_name,game_date,home_team_master_id,away_team_master_id,home_score,away_score")
             .eq("event_name", event_name)
             .eq("is_excluded", False)
             .not_.is_("home_score", "null")
@@ -140,83 +137,6 @@ def _fetch_rows_by_provider_ids(client, provider_ids: list[str]) -> list[dict[st
             or []
         )
     return rows
-
-
-def _matcher_query_from_registry_row(row: dict[str, Any]) -> EventTeamSearchQuery:
-    return EventTeamSearchQuery(
-        event_team_name=str(row.get("event_team_name") or "").strip(),
-        event_age_group=str(row.get("event_age_group") or row.get("display_age_group") or "").strip(),
-        event_gender=str(row.get("event_gender") or row.get("display_gender") or "").strip(),
-        event_club_name=str(row.get("event_club_name") or "").strip() or None,
-        search_age_group=str(row.get("search_age_group") or "").strip() or None,
-        provider_team_id=str(row.get("resolved_gotsport_provider_team_id") or "").strip() or None,
-    )
-
-
-def _enrich_registry_rows_with_matcher(
-    client,
-    registry_rows: list[dict[str, Any]],
-    *,
-    accepted_statuses: set[str] | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, int]]:
-    accepted_statuses = accepted_statuses or {"direct_provider_id", "strict_exact", "high_confidence"}
-    enriched_rows = deepcopy(registry_rows)
-    cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]] = {}
-    status_counts: dict[str, int] = defaultdict(int)
-
-    for row in enriched_rows:
-        row.setdefault("matcher_status", "")
-        row.setdefault("matcher_best_score", "")
-        row.setdefault("matcher_second_score", "")
-        row.setdefault("matcher_score_gap", "")
-        row.setdefault("matcher_resolved_team_id_master", "")
-        row.setdefault("matcher_resolved_team_name", "")
-        row.setdefault("matcher_resolved_club_name", "")
-        row.setdefault("matcher_resolved_provider_team_id", "")
-
-        if row.get("in_scope_u10_u19") != "True":
-            continue
-
-        existing_provider_id = str(row.get("resolved_gotsport_provider_team_id") or "").strip()
-        existing_status = str(row.get("canonical_resolution_status") or "").strip()
-        if existing_provider_id and existing_status not in {"", "none", "review"}:
-            continue
-
-        result = search_event_team_in_db(
-            client,
-            _matcher_query_from_registry_row(row),
-            limit=5,
-            cache=cache,
-        )
-        status_counts[result.resolved_status] += 1
-        row["matcher_status"] = result.resolved_status
-        row["matcher_best_score"] = "" if result.best_score is None else result.best_score
-        row["matcher_second_score"] = "" if result.second_score is None else result.second_score
-        row["matcher_score_gap"] = "" if result.score_gap is None else result.score_gap
-
-        if not result.matches:
-            continue
-
-        best = result.matches[0]
-        row["matcher_resolved_team_id_master"] = best.get("team_id_master", "")
-        row["matcher_resolved_team_name"] = best.get("team_name", "")
-        row["matcher_resolved_club_name"] = best.get("club_name", "")
-        row["matcher_resolved_provider_team_id"] = best.get("provider_team_id", "")
-
-        if result.resolved_status not in accepted_statuses:
-            continue
-
-        if not existing_provider_id:
-            row["resolved_gotsport_provider_team_id"] = best.get("provider_team_id", "") or existing_provider_id
-        if not row.get("resolved_team_id_master"):
-            row["resolved_team_id_master"] = best.get("team_id_master", "")
-        if not row.get("resolved_team_name"):
-            row["resolved_team_name"] = best.get("team_name", "")
-        if not row.get("resolved_club_name"):
-            row["resolved_club_name"] = best.get("club_name", "")
-        row["canonical_resolution_status"] = result.resolved_status
-
-    return enriched_rows, dict(status_counts)
 
 
 def _cohort_key(age_group: str, gender: str) -> tuple[str, str]:
@@ -323,7 +243,9 @@ def _fetch_orphaned_games_for_team_ids(
         while True:
             response = (
                 client.table("games")
-                .select("id,event_name,division_name,game_date,home_team_master_id,away_team_master_id,home_score,away_score")
+                .select(
+                    "id,event_name,division_name,game_date,home_team_master_id,away_team_master_id,home_score,away_score"
+                )
                 .is_("event_name", "null")
                 .gte("game_date", start_date)
                 .lte("game_date", end_date)
@@ -400,7 +322,9 @@ def _build_request_payload(
                     "event_team_name": event_team_name,
                     "event_age_group": age_group,
                     "event_gender": gender,
-                    "actual_division_name": actual_division_name.removeprefix(f"BU{age_group.removeprefix('u')} ").strip()  # noqa: E501
+                    "actual_division_name": actual_division_name.removeprefix(
+                        f"BU{age_group.removeprefix('u')} "
+                    ).strip()  # noqa: E501
                     if actual_division_name.startswith("BU")
                     else actual_division_name,
                 }
@@ -511,7 +435,7 @@ def main() -> int:
     event_team_registry_csv = Path(args.event_team_registry_csv) if args.event_team_registry_csv else None
     registry_rows = _load_event_team_registry_rows(event_team_registry_csv)
     if registry_rows:
-        registry_rows, matcher_status_counts = _enrich_registry_rows_with_matcher(client, registry_rows)
+        registry_rows, matcher_status_counts = enrich_registry_rows_with_matcher(client, registry_rows)
         _write_csv(output_dir / "event_team_registry_with_matcher.csv", registry_rows)
         registry_team_ids_by_division, unresolved_registry_entries_by_division = _build_registry_division_team_map(
             client,
@@ -522,7 +446,9 @@ def main() -> int:
             expected_team_ids_by_division[division_name].update(team_ids)
         for division_name, team_ids in registry_team_ids_by_division.items():
             expected_team_ids_by_division[division_name].update(team_ids)
-        all_expected_team_ids = sorted({team_id for team_ids in expected_team_ids_by_division.values() for team_id in team_ids})  # noqa: E501
+        all_expected_team_ids = sorted(
+            {team_id for team_ids in expected_team_ids_by_division.values() for team_id in team_ids}
+        )  # noqa: E501
         event_dates = sorted({str(row["game_date"]) for row in event_games if row.get("game_date")})
         if all_expected_team_ids and event_dates:
             orphaned_games = _fetch_orphaned_games_for_team_ids(
@@ -544,11 +470,7 @@ def main() -> int:
                     division_games_by_division[division_name].append(row)
                 recovered_orphaned_counts[division_name] = len(recovered_games)
 
-    merged_event_games = [
-        row
-        for division_rows in division_games_by_division.values()
-        for row in division_rows
-    ]
+    merged_event_games = [row for division_rows in division_games_by_division.values() for row in division_rows]
     teams_by_division = _build_division_team_map(merged_event_games)
     statuses = _cohort_status_rows(event_structure, teams_by_division)
 
@@ -600,9 +522,7 @@ def main() -> int:
             teams_by_id=teams_by_id,
         )
         request_payload["actual_games_override"] = [
-            row
-            for division in divisions
-            for row in division_games_by_division.get(str(division["division_name"]), [])
+            row for division in divisions for row in division_games_by_division.get(str(division["division_name"]), [])
         ]
         _write_json(request_path, request_payload)
 
@@ -642,7 +562,9 @@ def main() -> int:
         if summary_path.exists():
             summary = json.loads(summary_path.read_text(encoding="utf-8"))
             result_payload["actual_average_goal_differential"] = summary["actual_results"]["average_goal_differential"]
-            result_payload["optimized_average_goal_differential"] = summary["optimized_projection"]["simulated_schedule"][  # noqa: E501
+            result_payload["optimized_average_goal_differential"] = summary["optimized_projection"][
+                "simulated_schedule"
+            ][  # noqa: E501
                 "average_goal_differential"
             ]
             result_payload["close_game_rate_delta"] = summary["comparison_to_actual"]["close_game_rate_delta"]

--- a/src/tournaments/event_team_matcher.py
+++ b/src/tournaments/event_team_matcher.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import defaultdict
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from difflib import SequenceMatcher
 from typing import Any, Callable, TypeVar
@@ -234,7 +236,10 @@ def _club_similarity(left: str | None, right: str | None) -> float:
 
 def _same_club(event_club_name: str | None, candidate_club_name: str | None) -> tuple[bool, float, bool]:
     similarity = _club_similarity(event_club_name, candidate_club_name)
-    exact = bool(_normalize_club_name(event_club_name) and _normalize_club_name(event_club_name) == _normalize_club_name(candidate_club_name))  # noqa: E501
+    exact = bool(
+        _normalize_club_name(event_club_name)
+        and _normalize_club_name(event_club_name) == _normalize_club_name(candidate_club_name)
+    )  # noqa: E501
     return exact or similarity >= 0.80, similarity, exact
 
 
@@ -281,7 +286,11 @@ def rank_db_candidates(
                 continue
 
         same_club, club_similarity, club_exact = _same_club(event_club_name, candidate.get("club_name"))
-        if club_exact and score < 0.99 and _should_skip_pair(event_team_name, candidate_name, club_name=event_club_name or ""):  # noqa: E501
+        if (
+            club_exact
+            and score < 0.99
+            and _should_skip_pair(event_team_name, candidate_name, club_name=event_club_name or "")
+        ):  # noqa: E501
             continue
 
         normalized_candidate_name = _normalize_free_text(candidate_name)
@@ -361,8 +370,10 @@ def classify_match_result(matches: list[EventTeamMatch]) -> tuple[str, float | N
     if best.score_reason == "provider_team_id":
         return "direct_provider_id", best.score, second_score, score_gap
 
-    if best.normalized_name_exact and (best.same_club or best.club_similarity == 0.0) and (
-        second_score is None or best.score - second_score >= 0.01
+    if (
+        best.normalized_name_exact
+        and (best.same_club or best.club_similarity == 0.0)
+        and (second_score is None or best.score - second_score >= 0.01)
     ):
         return "strict_exact", best.score, second_score, score_gap
 
@@ -405,3 +416,108 @@ def search_event_team_in_db(
         candidate_age_groups=build_candidate_age_groups(query),
         matches=[asdict(match) for match in matches],
     )
+
+
+def _query_from_registry_row(row: dict[str, Any]) -> EventTeamSearchQuery:
+    return EventTeamSearchQuery(
+        event_team_name=str(row.get("event_team_name") or "").strip(),
+        event_age_group=str(row.get("event_age_group") or row.get("display_age_group") or "").strip(),
+        event_gender=str(row.get("event_gender") or row.get("display_gender") or "").strip(),
+        event_club_name=str(row.get("event_club_name") or "").strip() or None,
+        search_age_group=str(row.get("search_age_group") or "").strip() or None,
+        provider_team_id=str(row.get("resolved_gotsport_provider_team_id") or "").strip() or None,
+    )
+
+
+def enrich_registry_rows_with_matcher(
+    client,
+    registry_rows: list[dict[str, Any]],
+    *,
+    accepted_statuses: set[str] | None = None,
+    cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Run the team matcher over registry rows and back-fill matcher_* columns.
+
+    Skips rows where ``in_scope_u10_u19 != "True"`` (literal-string contract,
+    matches ``backtest_tournament_event.py:177``). Short-circuits rows whose
+    ``resolved_gotsport_provider_team_id`` is set AND ``canonical_resolution_status``
+    is in ``{"direct_provider_id", "strict_exact", "high_confidence"}`` — those
+    are already canonically resolved and the matcher pass would just confirm
+    what's there.
+
+    Score columns store raw float (or ``""`` for None) at the in-memory dict
+    shape; CSV serialization stringifies the float. Never emits ``"0.0"`` or
+    ``"None"`` for missing.
+
+    For accepted matches, the canonical ``resolved_*`` columns are filled
+    only when currently empty (operator-edit preservation policy from the
+    legacy CLI flow). ``canonical_resolution_status`` is the column-output
+    written unconditionally on accepted matches — Step 2's ``build_registry_entry``
+    leaves it ``""`` so this pass is the sole writer.
+
+    The ``cache`` parameter is load-bearing for performance — memory
+    ``gotcha_matcher_cache_load_bearing.md``: without per-batch caching,
+    scrapes go from minutes to 30+ minutes. When ``cache`` is None, a fresh
+    dict is allocated for this call (preserves the CLI's ``cache=None`` call
+    site). When provided, the cache is mutated in place and the caller can
+    inspect post-call.
+    """
+    accepted_statuses = accepted_statuses or {"direct_provider_id", "strict_exact", "high_confidence"}
+    enriched_rows = deepcopy(registry_rows)
+    if cache is None:
+        cache = {}
+    status_counts: dict[str, int] = defaultdict(int)
+
+    for row in enriched_rows:
+        row.setdefault("matcher_status", "")
+        row.setdefault("matcher_best_score", "")
+        row.setdefault("matcher_second_score", "")
+        row.setdefault("matcher_score_gap", "")
+        row.setdefault("matcher_resolved_team_id_master", "")
+        row.setdefault("matcher_resolved_team_name", "")
+        row.setdefault("matcher_resolved_club_name", "")
+        row.setdefault("matcher_resolved_provider_team_id", "")
+
+        if row.get("in_scope_u10_u19") != "True":
+            continue
+
+        existing_provider_id = str(row.get("resolved_gotsport_provider_team_id") or "").strip()
+        existing_status = str(row.get("canonical_resolution_status") or "").strip()
+        if existing_provider_id and existing_status not in {"", "none", "review"}:
+            continue
+
+        result = search_event_team_in_db(
+            client,
+            _query_from_registry_row(row),
+            limit=5,
+            cache=cache,
+        )
+        status_counts[result.resolved_status] += 1
+        row["matcher_status"] = result.resolved_status
+        row["matcher_best_score"] = "" if result.best_score is None else result.best_score
+        row["matcher_second_score"] = "" if result.second_score is None else result.second_score
+        row["matcher_score_gap"] = "" if result.score_gap is None else result.score_gap
+
+        if not result.matches:
+            continue
+
+        best = result.matches[0]
+        row["matcher_resolved_team_id_master"] = best.get("team_id_master", "")
+        row["matcher_resolved_team_name"] = best.get("team_name", "")
+        row["matcher_resolved_club_name"] = best.get("club_name", "")
+        row["matcher_resolved_provider_team_id"] = best.get("provider_team_id", "")
+
+        if result.resolved_status not in accepted_statuses:
+            continue
+
+        if not existing_provider_id:
+            row["resolved_gotsport_provider_team_id"] = best.get("provider_team_id", "") or existing_provider_id
+        if not row.get("resolved_team_id_master"):
+            row["resolved_team_id_master"] = best.get("team_id_master", "")
+        if not row.get("resolved_team_name"):
+            row["resolved_team_name"] = best.get("team_name", "")
+        if not row.get("resolved_club_name"):
+            row["resolved_club_name"] = best.get("club_name", "")
+        row["canonical_resolution_status"] = result.resolved_status
+
+    return enriched_rows, dict(status_counts)

--- a/src/tournaments/storage/__init__.py
+++ b/src/tournaments/storage/__init__.py
@@ -69,7 +69,12 @@ from src.tournaments.storage.raw_scrape import (
     load_raw_scrape,
 )
 from src.tournaments.storage.registry import (
+    RegistryPersistResult,
     TeamRegistryEntry,
+    build_registry_entries,
+    build_registry_entry,
+    compute_dropped_pids,
+    persist_registry_for_scenario,
     read_registry,
     write_registry,
 )
@@ -120,6 +125,7 @@ __all__ = [
     # dataclasses
     "EventMetadata",
     "TeamRegistryEntry",
+    "RegistryPersistResult",
     "DivisionStructure",
     "CohortStructure",
     "CohortConstraints",
@@ -136,6 +142,10 @@ __all__ = [
     "write_event_metadata",
     "read_registry",
     "write_registry",
+    "build_registry_entry",
+    "build_registry_entries",
+    "compute_dropped_pids",
+    "persist_registry_for_scenario",
     "read_structure",
     "write_structure",
     "read_constraints",

--- a/src/tournaments/storage/registry.py
+++ b/src/tournaments/storage/registry.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+from src.tournaments.seeding_optimizer import normalize_age_group, normalize_gender_label
 from src.tournaments.storage._io import read_csv, read_json, write_csv, write_json
 from src.tournaments.storage.event_key import scenario_dir
 from src.tournaments.storage.schema_version import (
@@ -46,10 +47,17 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "FIELDNAMES",
+    "RegistryPersistResult",
     "TeamRegistryEntry",
+    "build_registry_entries",
+    "build_registry_entry",
+    "compute_dropped_pids",
+    "persist_registry_for_scenario",
     "read_registry",
     "write_registry",
 ]
+
+_ACCEPTED_CANONICAL_STATUSES: frozenset[str] = frozenset({"direct_provider_id", "strict_exact", "high_confidence"})
 
 
 FIELDNAMES: tuple[str, ...] = (
@@ -187,4 +195,210 @@ def write_registry(
     write_json(
         _schema_path(scenario_path),
         stamp_schema_version({"fieldnames": list(FIELDNAMES)}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scrape-pipeline persistence (Shell 10)
+#
+# These helpers translate ``intake/raw_scrape.jsonl`` records into
+# ``TeamRegistryEntry`` rows and persist them to ``scenarios/<name>/event_team_registry.csv``.
+# Per spec §8 line 289, the registry is a derived, regenerable artifact —
+# clean-rebuild every scrape; operator state survives via ``overrides.jsonl``
+# layered at read time by ``triage.project_overrides``.
+# ---------------------------------------------------------------------------
+
+
+def _normalize_age_safe(value: Any) -> str:
+    """Wrap ``normalize_age_group`` so empty / malformed cohort tags don't crash the scrape.
+
+    ``normalize_age_group("")`` raises ``ValueError`` — we don't want a single
+    bad cohort tag to abort the whole registry build. Returns ``""`` on
+    failure; the caller's ``_in_scope_u10_u19`` then resolves to ``"False"``
+    so the row is admitted but skipped by the matcher pass.
+    """
+    try:
+        return normalize_age_group(str(value or ""))
+    except ValueError:
+        return ""
+
+
+def _in_scope_u10_u19(normalized_age_group: str) -> str:
+    """Return literal-string ``"True"``/``"False"`` per the CLI gate at
+    ``backtest_tournament_event.py:177``.
+
+    Input is the output of ``normalize_age_group`` (e.g. ``"u14"``); strip
+    leading ``"u"``, parse int, return ``"True"`` if ``10 <= n <= 19`` else
+    ``"False"``. On parse failure (empty / non-numeric) return ``"False"`` —
+    out-of-scope is the safe default.
+    """
+    if not normalized_age_group.startswith("u"):
+        return "False"
+    try:
+        n = int(normalized_age_group.removeprefix("u"))
+    except ValueError:
+        return "False"
+    return "True" if 10 <= n <= 19 else "False"
+
+
+def build_registry_entry(record: dict[str, Any]) -> TeamRegistryEntry:
+    """Map one ``intake/raw_scrape.jsonl`` record to a ``TeamRegistryEntry``.
+
+    Record shape per ``src/scrapers/gotsport.py::_build_jsonl_record``: top-level
+    ``provider_team_id``, ``team_name``, ``club_name``, ``cohort_age_group``,
+    ``cohort_gender``, ``provider_id_resolution_status``, plus a nested
+    ``canonical: {team_id_master, confidence, resolved_status, match_method,
+    scraper_state}`` dict that may legitimately be missing or ``None`` on
+    pre-canonical or partial-write tail-recovery records (mirrors
+    ``triage._classify_team_state`` defensive access).
+
+    ``canonical_resolution_status`` is left ``""`` here — ``enrich_registry_rows_with_matcher``
+    is the sole writer (see ``src/tournaments/event_team_matcher.py``). All
+    ``matcher_*`` columns are also ``""``; the matcher pass populates them
+    for rows where the short-circuit at ``_enrich`` doesn't fire.
+
+    Every value is coerced to ``str``; missing values become ``""`` (the CSV
+    round-trips strings only).
+    """
+    canonical = record.get("canonical") or {}
+    raw_age = str(record.get("cohort_age_group") or "")
+    raw_gender = str(record.get("cohort_gender") or "")
+    normalized_age = _normalize_age_safe(raw_age)
+    normalized_gender = normalize_gender_label(raw_gender) if raw_gender else ""
+
+    provider_id_status = str(record.get("provider_id_resolution_status") or "")
+    provider_team_id = str(record.get("provider_team_id") or "")
+    resolved_pid = provider_team_id if provider_id_status == "resolved" else ""
+
+    scraper_state = str(canonical.get("scraper_state") or "")
+    canonical_team_id = str(canonical.get("team_id_master") or "") if scraper_state == "alias_written" else ""
+
+    return TeamRegistryEntry(
+        event_registration_id="",
+        event_team_name=str(record.get("team_name") or ""),
+        event_age_group=normalized_age,
+        display_age_group=raw_age,
+        event_gender=normalized_gender,
+        display_gender=raw_gender,
+        event_club_name=str(record.get("club_name") or ""),
+        search_age_group="",
+        resolved_gotsport_provider_team_id=resolved_pid,
+        canonical_resolution_status="",
+        in_scope_u10_u19=_in_scope_u10_u19(normalized_age),
+        resolved_team_id_master=canonical_team_id,
+        resolved_team_name="",
+        resolved_club_name="",
+        matcher_status="",
+        matcher_best_score="",
+        matcher_second_score="",
+        matcher_score_gap="",
+        matcher_resolved_team_id_master="",
+        matcher_resolved_team_name="",
+        matcher_resolved_club_name="",
+        matcher_resolved_provider_team_id="",
+    )
+
+
+def build_registry_entries(records: list[dict[str, Any]]) -> list[TeamRegistryEntry]:
+    """Build a registry-row list from journal records, deduped by ``provider_team_id``.
+
+    Defensive dedupe (first-seen wins) — ``IntakeJournal.read()`` already
+    returns ``dict[pid, record]`` so duplicates would normally be impossible.
+    Logs at DEBUG when dedupe actually fires so a future journal-format change
+    that admits duplicates surfaces in tests.
+    """
+    seen: set[str] = set()
+    entries: list[TeamRegistryEntry] = []
+    for record in records:
+        pid = str(record.get("provider_team_id") or "")
+        if pid and pid in seen:
+            logger.debug("[registry] dedupe fired for provider_team_id=%s", pid)
+            continue
+        if pid:
+            seen.add(pid)
+        entries.append(build_registry_entry(record))
+    return entries
+
+
+def compute_dropped_pids(
+    event_key: str,
+    scenario: str,
+    fresh: list[TeamRegistryEntry],
+    *,
+    base_dir: Path | str = "reports",
+) -> list[str]:
+    """Return ``provider_team_id`` values present in the on-disk registry but absent from ``fresh``.
+
+    Lock contract: **caller MUST hold ``acquire_scenario_lock(event_key, scenario)``**
+    for the result to be consistent with the about-to-be-written registry.
+    Calling this helper outside any lock (e.g., from a diagnostic CLI) returns
+    data that may already be stale relative to the on-disk CSV.
+
+    Entries with empty ``resolved_gotsport_provider_team_id`` are intentionally
+    invisible to the diff — they appear in NEITHER ``existing_pids`` NOR
+    ``fresh_pids``. The truthy filter prevents collapsing all unresolved
+    entries onto a phantom empty-string key.
+
+    Returns ``[]`` when the registry CSV does not yet exist (first scrape).
+    """
+    try:
+        existing = read_registry(event_key, scenario, base_dir=base_dir)
+    except FileNotFoundError:
+        return []
+    existing_pids = {e.resolved_gotsport_provider_team_id for e in existing if e.resolved_gotsport_provider_team_id}
+    fresh_pids = {e.resolved_gotsport_provider_team_id for e in fresh if e.resolved_gotsport_provider_team_id}
+    return sorted(existing_pids - fresh_pids)
+
+
+@dataclass(frozen=True)
+class RegistryPersistResult:
+    """Per-scenario outcome of a registry write.
+
+    ``lock_contention`` is the discriminator the streamlit UI dispatches on —
+    string-matching ``error`` is brittle because the message is operator-
+    facing and may be reworded or i18n'd. The boolean is set ``True`` only
+    when catching ``ScenarioLockError``; for other failures the caller sets
+    it ``False`` and stashes the exception text in ``error``.
+    """
+
+    scenario: str
+    written: bool
+    row_count: int
+    dropped_pids: list[str]
+    lock_contention: bool = False
+    error: str | None = None
+
+
+def persist_registry_for_scenario(
+    event_key: str,
+    scenario: str,
+    fresh: list[TeamRegistryEntry],
+    *,
+    base_dir: Path | str = "reports",
+) -> RegistryPersistResult:
+    """Compute dropped pids and clean-overwrite the registry CSV for one scenario.
+
+    Locking is the caller's responsibility — this helper does NOT take or
+    hold any lock. Tests pass ``base_dir=tmp_path`` and exercise directly.
+    Internal exceptions (``OSError``, ``PermissionError``, anything from
+    ``compute_dropped_pids`` / ``write_registry``) PROPAGATE; the caller
+    catches them and converts to a non-``written`` ``RegistryPersistResult``.
+    """
+    dropped_pids = compute_dropped_pids(event_key, scenario, fresh, base_dir=base_dir)
+    write_registry(event_key, scenario, fresh, base_dir=base_dir)
+    if dropped_pids:
+        logger.warning(
+            "Registry rebuild for scenario=%s dropped %d orphaned pid(s) keyed by "
+            "resolved_gotsport_provider_team_id: %s",
+            scenario,
+            len(dropped_pids),
+            dropped_pids,
+        )
+    return RegistryPersistResult(
+        scenario=scenario,
+        written=True,
+        row_count=len(fresh),
+        dropped_pids=dropped_pids,
+        lock_contention=False,
+        error=None,
     )

--- a/tests/unit/test_backtest_tournament_event.py
+++ b/tests/unit/test_backtest_tournament_event.py
@@ -164,9 +164,15 @@ def test_enrich_registry_rows_with_matcher_promotes_high_confidence_match(monkey
             }
         ]
 
-    monkeypatch.setattr(event_backtest, "search_event_team_in_db", lambda *args, **kwargs: FakeResult())
+    # Shell 10 lifted enrich_registry_rows_with_matcher into the matcher module —
+    # patch the symbol where the function actually looks it up.
+    from src.tournaments import event_team_matcher
 
-    enriched_rows, status_counts = event_backtest._enrich_registry_rows_with_matcher(client=None, registry_rows=registry_rows)
+    monkeypatch.setattr(event_team_matcher, "search_event_team_in_db", lambda *args, **kwargs: FakeResult())
+
+    enriched_rows, status_counts = event_team_matcher.enrich_registry_rows_with_matcher(
+        client=None, registry_rows=registry_rows
+    )
 
     assert status_counts == {"high_confidence": 1}
     assert enriched_rows[0]["matcher_status"] == "high_confidence"

--- a/tests/unit/test_event_team_matcher.py
+++ b/tests/unit/test_event_team_matcher.py
@@ -7,6 +7,7 @@ from src.tournaments.event_team_matcher import (
     EventTeamSearchQuery,
     build_candidate_age_groups,
     classify_match_result,
+    enrich_registry_rows_with_matcher,
     fetch_db_candidates,
     rank_db_candidates,
 )
@@ -238,3 +239,116 @@ def test_fetch_db_candidates_does_not_retry_unrelated_errors(monkeypatch):
 
     with pytest.raises(ValueError):
         fetch_db_candidates(client, _query())
+
+
+# ---------------------------------------------------------------------------
+# Shell 10: enrich_registry_rows_with_matcher (lifted from
+# scripts/backtest_tournament_event.py)
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    """Captures whether the matcher would have been called.
+
+    The matcher pass calls ``client.table(...).select(...).ilike(...).or_(...).eq(...)
+    .range(...).execute()``. Tests that assert a row is short-circuited use
+    ``raise_on_call=True`` so the test fails loudly if the matcher fires.
+    """
+
+    def __init__(self, raise_on_call: bool = False):
+        self.raise_on_call = raise_on_call
+        self.calls = 0
+
+    def table(self, *_args, **_kwargs):
+        self.calls += 1
+        if self.raise_on_call:
+            raise AssertionError("matcher should have been short-circuited")
+        return self
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def ilike(self, *_args, **_kwargs):
+        return self
+
+    def or_(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def range(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=[])
+
+
+def _registry_row(**overrides):
+    base = {
+        "event_team_name": "Test FC 2014",
+        "event_age_group": "u14",
+        "display_age_group": "U14",
+        "event_gender": "Male",
+        "display_gender": "Male",
+        "event_club_name": "Test FC",
+        "search_age_group": "",
+        "resolved_gotsport_provider_team_id": "",
+        "canonical_resolution_status": "",
+        "in_scope_u10_u19": "True",
+        "resolved_team_id_master": "",
+        "resolved_team_name": "",
+        "resolved_club_name": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_enrich_registry_rows_with_matcher_returns_tuple():
+    client = _StubClient(raise_on_call=True)
+    rows = [_registry_row(in_scope_u10_u19="False")]
+    enriched, status_counts = enrich_registry_rows_with_matcher(client, rows)
+    assert isinstance(enriched, list)
+    assert isinstance(status_counts, dict)
+
+
+def test_enrich_registry_rows_with_matcher_skips_out_of_scope():
+    client = _StubClient(raise_on_call=True)
+    rows = [_registry_row(in_scope_u10_u19="False")]
+    enriched, status_counts = enrich_registry_rows_with_matcher(client, rows)
+    # Out-of-scope rows are skipped entirely; matcher_* columns stay "".
+    assert enriched[0]["matcher_status"] == ""
+    assert status_counts == {}
+    assert client.calls == 0
+
+
+def test_enrich_registry_rows_with_matcher_idempotent_on_accepted():
+    """Accepted rows short-circuit at the existing_provider_id + status gate."""
+    client = _StubClient(raise_on_call=True)
+    rows = [
+        _registry_row(
+            resolved_gotsport_provider_team_id="12345",
+            canonical_resolution_status="strict_exact",
+        )
+    ]
+    enriched, status_counts = enrich_registry_rows_with_matcher(client, rows)
+    assert enriched[0]["matcher_status"] == ""
+    assert enriched[0]["canonical_resolution_status"] == "strict_exact"
+    assert status_counts == {}
+    assert client.calls == 0
+
+
+def test_enrich_registry_rows_with_matcher_uses_provided_cache():
+    """Passing an explicit cache dict allows the caller to inspect post-call."""
+    client = _StubClient(raise_on_call=False)
+    cache: dict[tuple[tuple[str, ...], str, bool], list[dict]] = {}
+    # in_scope_u10_u19="False" so the matcher is never called — the cache
+    # itself is checked only for the threading invariant: the helper must
+    # accept and use the provided dict instead of allocating a private one.
+    rows = [_registry_row(in_scope_u10_u19="False")]
+    enriched, _ = enrich_registry_rows_with_matcher(client, rows, cache=cache)
+    # Cache was the same object passed in (helper mutated it, didn't shadow).
+    assert isinstance(cache, dict)
+    # Helper accepted the kwarg (proves the lift expanded the signature).
+    enriched_again, _ = enrich_registry_rows_with_matcher(client, rows, cache=cache, accepted_statuses={"strict_exact"})
+    assert isinstance(enriched_again, list)

--- a/tests/unit/test_persist_registry_after_scrape.py
+++ b/tests/unit/test_persist_registry_after_scrape.py
@@ -1,0 +1,153 @@
+"""Unit tests for ``tournament_intake._persist_registry_after_scrape``.
+
+The factored helper is exercised without Streamlit mocks — it returns plain
+Python data, takes ``base_dir`` end-to-end, and the supabase_client is None
+in these tests so the matcher-enrichment branch short-circuits with
+``matcher_*`` columns staying ``""``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.scrapers.intake_journal import IntakeJournal
+from src.tournaments.storage import (
+    RegistryPersistResult,
+    ScenarioLockError,
+    ensure_scenario,
+    read_registry,
+)
+from tournament_intake import _persist_registry_after_scrape
+
+EVENT_KEY = "gotsport__99999__2026"
+
+
+def _seed_journal(base_dir: Path, *, records: list[dict]) -> None:
+    journal = IntakeJournal(event_key=EVENT_KEY, base_dir=base_dir)
+    journal.open_for_append()
+    try:
+        for record in records:
+            journal.append(record)
+    finally:
+        journal.close()
+
+
+def _journal_record(pid: str, *, age: str = "U14", gender: str = "Male") -> dict:
+    return {
+        "provider_team_id": pid,
+        "team_name": f"Team {pid}",
+        "club_name": "Club X",
+        "cohort_age_group": age,
+        "cohort_gender": gender,
+        "provider_id_resolution_status": "resolved",
+        "canonical": {
+            "scraper_state": "alias_written",
+            "team_id_master": f"master-{pid}",
+            "resolved_status": "strict_exact",
+        },
+    }
+
+
+def test_persist_writes_registry_for_active_scenario(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    _seed_journal(tmp_path, records=[_journal_record("111"), _journal_record("222")])
+
+    results = _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+    assert len(results) == 1
+    assert results[0].scenario == "default"
+    assert results[0].written is True
+    assert results[0].row_count == 2
+
+    loaded = read_registry(EVENT_KEY, "default", base_dir=tmp_path)
+    assert {e.resolved_gotsport_provider_team_id for e in loaded} == {"111", "222"}
+
+
+def test_persist_skips_matcher_when_supabase_client_is_none(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    _seed_journal(tmp_path, records=[_journal_record("111")])
+
+    results = _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+    assert results[0].written is True
+    loaded = read_registry(EVENT_KEY, "default", base_dir=tmp_path)
+    # Matcher pass skipped → matcher_* columns stay "".
+    assert loaded[0].matcher_status == ""
+    assert loaded[0].matcher_best_score == ""
+
+
+def test_persist_fans_out_to_every_scenario(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    ensure_scenario(EVENT_KEY, "branch_a", base_dir=tmp_path)
+    _seed_journal(tmp_path, records=[_journal_record("111"), _journal_record("222")])
+
+    results = _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+    by_scenario = {r.scenario: r for r in results}
+    assert set(by_scenario) == {"default", "branch_a"}
+    assert by_scenario["default"].written is True
+    assert by_scenario["branch_a"].written is True
+    assert by_scenario["default"].row_count == 2
+    assert by_scenario["branch_a"].row_count == 2
+
+    for scenario in ("default", "branch_a"):
+        loaded = read_registry(EVENT_KEY, scenario, base_dir=tmp_path)
+        assert {e.resolved_gotsport_provider_team_id for e in loaded} == {"111", "222"}
+
+
+def test_persist_records_lock_contention_per_scenario(tmp_path: Path):
+    """Lock failure on one scenario does not abort the fan-out."""
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    ensure_scenario(EVENT_KEY, "branch_a", base_dir=tmp_path)
+    _seed_journal(tmp_path, records=[_journal_record("111")])
+
+    real_acquire = __import__(
+        "src.tournaments.storage.scenario", fromlist=["acquire_scenario_lock"]
+    ).acquire_scenario_lock
+
+    import contextlib
+
+    def fake_acquire(event_key, scenario, *, base_dir, timeout):
+        if scenario == "branch_a":
+            raise ScenarioLockError(f"scenario {scenario!r} is locked by another process")
+        return real_acquire(event_key, scenario, base_dir=base_dir, timeout=timeout)
+
+    @contextlib.contextmanager
+    def fake_acquire_cm(*args, **kwargs):
+        # Re-raise on entry to simulate contention.
+        result = fake_acquire(*args, **kwargs)
+        with result:
+            yield
+
+    with patch("tournament_intake.acquire_scenario_lock", fake_acquire_cm):
+        results = _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+    by_scenario = {r.scenario: r for r in results}
+    assert by_scenario["default"].written is True
+    assert by_scenario["branch_a"].written is False
+    assert by_scenario["branch_a"].lock_contention is True
+    assert by_scenario["branch_a"].error == "locked by another tab"
+
+
+def test_persist_raises_when_no_scenarios_exist(tmp_path: Path):
+    """ensure_scenario must precede; no scenarios = caller-ordering bug."""
+    # Note: we deliberately do NOT call ensure_scenario.
+    _seed_journal(tmp_path, records=[_journal_record("111")])
+
+    with pytest.raises(RuntimeError, match="ensure_scenario must precede"):
+        _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+
+def test_persist_empty_journal_writes_header_only_csv(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, "default", base_dir=tmp_path)
+    # No journal records appended.
+
+    results = _persist_registry_after_scrape(EVENT_KEY, "default", supabase_client=None, base_dir=tmp_path)
+
+    assert isinstance(results[0], RegistryPersistResult)
+    assert results[0].written is True
+    assert results[0].row_count == 0
+    assert read_registry(EVENT_KEY, "default", base_dir=tmp_path) == []

--- a/tests/unit/test_storage_registry.py
+++ b/tests/unit/test_storage_registry.py
@@ -14,7 +14,12 @@ from pathlib import Path
 from src.tournaments.storage.event_key import scenario_dir
 from src.tournaments.storage.registry import (
     FIELDNAMES,
+    RegistryPersistResult,
     TeamRegistryEntry,
+    build_registry_entries,
+    build_registry_entry,
+    compute_dropped_pids,
+    persist_registry_for_scenario,
     read_registry,
     write_registry,
 )
@@ -121,3 +126,221 @@ def test_fieldnames_drift_logs_warning_not_raises(tmp_path: Path, caplog):
         loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
     assert loaded[0].event_team_name == "Team A"
     assert any("FIELDNAMES drift" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Shell 10: build_registry_entry / compute_dropped_pids / persist_registry_for_scenario
+# ---------------------------------------------------------------------------
+
+
+def _journal_record(
+    *,
+    pid: str = "12345",
+    team_name: str = "Test FC 2014",
+    club_name: str = "Test FC",
+    cohort_age: str = "U14",
+    cohort_gender: str = "Male",
+    provider_id_status: str = "resolved",
+    canonical: dict | None = None,
+) -> dict:
+    return {
+        "provider_team_id": pid,
+        "team_name": team_name,
+        "club_name": club_name,
+        "cohort_age_group": cohort_age,
+        "cohort_gender": cohort_gender,
+        "provider_id_resolution_status": provider_id_status,
+        "canonical": canonical
+        if canonical is not None
+        else {
+            "scraper_state": "alias_written",
+            "team_id_master": "master-abc",
+            "resolved_status": "strict_exact",
+        },
+    }
+
+
+def test_build_registry_entry_maps_journal_record():
+    entry = build_registry_entry(_journal_record())
+    assert entry.event_team_name == "Test FC 2014"
+    assert entry.event_age_group == "u14"
+    assert entry.display_age_group == "U14"
+    assert entry.event_gender == "Male"
+    assert entry.in_scope_u10_u19 == "True"
+    assert entry.resolved_gotsport_provider_team_id == "12345"
+    assert entry.resolved_team_id_master == "master-abc"
+    # canonical_resolution_status is left empty — matcher pass is sole writer.
+    assert entry.canonical_resolution_status == ""
+    # All matcher_* columns are empty in the builder; matcher pass populates.
+    assert entry.matcher_status == ""
+    assert entry.matcher_best_score == ""
+
+
+def test_build_registry_entry_in_scope_for_u10_through_u19():
+    for age in ("u10", "u14", "u19"):
+        entry = build_registry_entry(_journal_record(cohort_age=age))
+        assert entry.in_scope_u10_u19 == "True", age
+
+
+def test_build_registry_entry_out_of_scope_for_u8_and_u20():
+    for age in ("U8", "u9", "u20"):
+        entry = build_registry_entry(_journal_record(cohort_age=age))
+        assert entry.in_scope_u10_u19 == "False", age
+
+
+def test_build_registry_entry_handles_missing_canonical():
+    base = _journal_record()
+    base["canonical"] = None
+    entry_none = build_registry_entry(base)
+
+    no_key = _journal_record()
+    no_key.pop("canonical", None)
+    entry_no_key = build_registry_entry(no_key)
+
+    for entry in (entry_none, entry_no_key):
+        # No crash; resolved_team_id_master left empty when no canonical.
+        assert entry.resolved_team_id_master == ""
+
+
+def test_build_registry_entry_handles_malformed_age():
+    entry = build_registry_entry(_journal_record(cohort_age=""))
+    assert entry.event_age_group == ""
+    assert entry.in_scope_u10_u19 == "False"
+
+
+def test_build_registry_entry_resolved_pid_only_when_status_resolved():
+    entry = build_registry_entry(_journal_record(provider_id_status="placeholder"))
+    assert entry.resolved_gotsport_provider_team_id == ""
+
+
+def test_build_registry_entries_dedupes_multibracket():
+    records = [_journal_record(pid="111"), _journal_record(pid="111", team_name="DUP")]
+    entries = build_registry_entries(records)
+    assert len(entries) == 1
+    # First-seen wins.
+    assert entries[0].event_team_name == "Test FC 2014"
+
+
+def test_compute_dropped_pids(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    existing = [
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="a"),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="b"),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="c"),
+    ]
+    write_registry(EVENT_KEY, SCENARIO, existing, base_dir=tmp_path)
+    fresh = [
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="b"),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="c"),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="d"),
+    ]
+    dropped = compute_dropped_pids(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path)
+    assert dropped == ["a"]
+
+
+def test_compute_dropped_pids_first_scrape(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    fresh = [TeamRegistryEntry(resolved_gotsport_provider_team_id="a")]
+    assert compute_dropped_pids(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path) == []
+
+
+def test_compute_dropped_pids_ignores_unresolved(tmp_path: Path):
+    """Entries with empty pid appear in NEITHER set — invisible to the diff."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    existing = [
+        TeamRegistryEntry(resolved_gotsport_provider_team_id=""),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="b"),
+    ]
+    write_registry(EVENT_KEY, SCENARIO, existing, base_dir=tmp_path)
+    fresh = [
+        TeamRegistryEntry(resolved_gotsport_provider_team_id=""),
+        TeamRegistryEntry(resolved_gotsport_provider_team_id="b"),
+    ]
+    # Both unresolved entries are invisible — "" is not "dropped".
+    assert compute_dropped_pids(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path) == []
+
+
+def test_persist_registry_for_scenario_writes_clean(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    fresh = [TeamRegistryEntry(event_team_name="X", resolved_gotsport_provider_team_id="a")]
+    result = persist_registry_for_scenario(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path)
+    assert isinstance(result, RegistryPersistResult)
+    assert result.written is True
+    assert result.row_count == 1
+    assert result.dropped_pids == []
+    assert result.lock_contention is False
+    loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded == fresh
+
+
+def test_persist_registry_for_scenario_overwrites_existing(tmp_path: Path):
+    """Clean-rebuild — no merge. Prior matcher_* values are not preserved."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    prior = [
+        TeamRegistryEntry(
+            resolved_gotsport_provider_team_id="a",
+            matcher_resolved_team_name="Operator Edited",
+        )
+    ]
+    write_registry(EVENT_KEY, SCENARIO, prior, base_dir=tmp_path)
+    fresh = [TeamRegistryEntry(resolved_gotsport_provider_team_id="a")]
+    persist_registry_for_scenario(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path)
+    loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert loaded == fresh
+    # The "Operator Edited" string is gone — clean overwrite by design.
+    assert loaded[0].matcher_resolved_team_name == ""
+
+
+def test_persist_registry_for_scenario_returns_dropped_pids(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    write_registry(
+        EVENT_KEY,
+        SCENARIO,
+        [
+            TeamRegistryEntry(resolved_gotsport_provider_team_id="a"),
+            TeamRegistryEntry(resolved_gotsport_provider_team_id="b"),
+        ],
+        base_dir=tmp_path,
+    )
+    fresh = [TeamRegistryEntry(resolved_gotsport_provider_team_id="b")]
+    result = persist_registry_for_scenario(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path)
+    assert result.dropped_pids == ["a"]
+
+
+def test_persist_registry_for_scenario_empty_journal(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    result = persist_registry_for_scenario(EVENT_KEY, SCENARIO, [], base_dir=tmp_path)
+    assert result.written is True
+    assert result.row_count == 0
+    assert read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path) == []
+
+
+def test_persist_registry_for_scenario_all_out_of_scope(tmp_path: Path):
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    fresh = [
+        build_registry_entry(_journal_record(pid="1", cohort_age="U8")),
+        build_registry_entry(_journal_record(pid="2", cohort_age="u9")),
+    ]
+    assert all(e.in_scope_u10_u19 == "False" for e in fresh)
+    result = persist_registry_for_scenario(EVENT_KEY, SCENARIO, fresh, base_dir=tmp_path)
+    assert result.written is True
+    assert result.row_count == 2
+    loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    assert all(e.in_scope_u10_u19 == "False" for e in loaded)
+
+
+def test_matcher_status_locked_vocabulary(tmp_path: Path):
+    """Round-trip a registry with each locked-vocabulary value; FIELDNAMES contract holds."""
+    locked = ["", "strict_exact", "high_confidence", "direct_provider_id", "review", "none"]
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    entries = [
+        TeamRegistryEntry(
+            resolved_gotsport_provider_team_id=f"pid-{i}",
+            matcher_status=value,
+        )
+        for i, value in enumerate(locked)
+    ]
+    write_registry(EVENT_KEY, SCENARIO, entries, base_dir=tmp_path)
+    loaded = read_registry(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    seen = {e.matcher_status for e in loaded}
+    assert seen <= set(locked)

--- a/tournament_intake.py
+++ b/tournament_intake.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import html
+import logging
 import os
 import sys
 import uuid
@@ -36,6 +37,7 @@ from src.scrapers.provider import (
 from src.tournaments.division_render import render_division_container
 from src.tournaments.event_team_matcher import (
     EventTeamSearchQuery,
+    enrich_registry_rows_with_matcher,
     search_event_team_in_db,
 )
 from src.tournaments.run_orchestrator import (
@@ -52,20 +54,25 @@ from src.tournaments.storage import (
     CohortStructure,
     DivisionStructure,
     EventMetadata,
+    RegistryPersistResult,
     RunStateError,
     ScenarioLockError,
     SchemaVersionError,
+    TeamRegistryEntry,
     acquire_scenario_lock,
     append_override,
+    build_registry_entries,
     check_games_import_status,
     compute_frozen_medians,
     ensure_scenario,
     event_key,
     intake_dir,
     list_runs,
+    list_scenarios,
     load_overrides,
     load_raw_scrape,
     parse_event_key,
+    persist_registry_for_scenario,
     read_constraints,
     read_event_metadata,
     read_frozen_medians,
@@ -93,6 +100,8 @@ from src.tournaments.triage import (
     resolve_division_assignment,
 )
 from supabase import create_client
+
+logger = logging.getLogger(__name__)
 
 # Page configuration
 st.set_page_config(
@@ -573,6 +582,120 @@ def _show_captcha_error(exc: EventCaptchaGatedError) -> None:
     )
 
 
+def _persist_registry_after_scrape(
+    event_key_value: str,
+    scenario_active: str,
+    supabase_client: Any,
+    *,
+    base_dir: Path | str = "reports",
+) -> list[RegistryPersistResult]:
+    """Translate the just-written ``intake/raw_scrape.jsonl`` into per-scenario
+    ``event_team_registry.csv`` files.
+
+    Sourcing the registry from the journal (rather than from the scraper's
+    return value) keeps the ``ProviderScraper`` ABC scenario-blind. The
+    journal is fully compacted by the time this runs — ``journal.compact()``
+    fires synchronously inside ``fetch_teams_by_cohort`` and inside the
+    event-tier ``_acquire_scrape_lock``, before this helper is invoked.
+
+    The matcher cache lives in this single ``enrich_registry_rows_with_matcher``
+    call; the per-scenario fan-out below operates on already-enriched
+    entries. Threading the cache into the per-scenario loop would re-run the
+    matcher per scenario for no benefit (per memory
+    ``gotcha_matcher_cache_load_bearing.md``).
+
+    Returns one ``RegistryPersistResult`` per scenario; the caller (the
+    Streamlit ``_run_scrape``) renders them via
+    ``_render_registry_persist_results`` after ``st.rerun()``.
+    """
+    journal_records = load_raw_scrape(event_key_value, base_dir=base_dir)
+    fresh_entries = build_registry_entries(journal_records)
+
+    if supabase_client is None:
+        logger.warning(
+            "supabase_client is None; persisting registry without matcher enrichment "
+            "(every matcher_* column will be '')"
+        )
+        enriched_entries: list[TeamRegistryEntry] = fresh_entries
+    else:
+        matcher_cache: dict[tuple[tuple[str, ...], str, bool], list[dict[str, Any]]] = {}
+        enriched_rows, _status_counts = enrich_registry_rows_with_matcher(
+            supabase_client,
+            [e.to_row() for e in fresh_entries],
+            cache=matcher_cache,
+        )
+        enriched_entries = [TeamRegistryEntry.from_row(r) for r in enriched_rows]
+
+    scenarios = list_scenarios(event_key_value, base_dir=base_dir)
+    if not scenarios:
+        raise RuntimeError(
+            f"ensure_scenario must precede _persist_registry_after_scrape; "
+            f"got empty scenario list for event_key={event_key_value!r} "
+            f"(active={scenario_active!r})"
+        )
+
+    results: list[RegistryPersistResult] = []
+    for scenario in scenarios:
+        try:
+            with acquire_scenario_lock(event_key_value, scenario, base_dir=base_dir, timeout=2.0):
+                results.append(
+                    persist_registry_for_scenario(event_key_value, scenario, enriched_entries, base_dir=base_dir)
+                )
+        except ScenarioLockError:
+            results.append(
+                RegistryPersistResult(
+                    scenario=scenario,
+                    written=False,
+                    row_count=0,
+                    dropped_pids=[],
+                    lock_contention=True,
+                    error="locked by another tab",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — partial-success contract
+            logger.exception("persist_registry_for_scenario failed for scenario=%s", scenario)
+            results.append(
+                RegistryPersistResult(
+                    scenario=scenario,
+                    written=False,
+                    row_count=0,
+                    dropped_pids=[],
+                    lock_contention=False,
+                    error=str(exc),
+                )
+            )
+    return results
+
+
+def _render_registry_persist_results() -> None:
+    """Surface per-scenario registry-persistence outcomes after ``st.rerun()``.
+
+    ``_run_scrape`` stashes the result list on ``st.session_state`` BEFORE
+    calling ``st.rerun()`` because Streamlit discards transient widgets
+    (``st.error`` / ``st.warning`` / ``st.info``) on the next script run.
+    The renderer dispatches on ``lock_contention: bool`` (NOT on the ``error``
+    string contents) — the dataclass discriminator is the contract.
+
+    Clears the session-state slot after rendering so messages don't re-render
+    on every subsequent rerun.
+    """
+    results: list[RegistryPersistResult] = st.session_state.get("_last_registry_persist_results", [])
+    if not results:
+        return
+    for r in results:
+        if r.written:
+            suffix = f" (dropped {len(r.dropped_pids)} orphan pid(s))" if r.dropped_pids else ""
+            st.info(f"Registry written for scenario '{r.scenario}': {r.row_count} rows{suffix}")
+        elif r.lock_contention:
+            st.warning(f"Scenario '{r.scenario}' was locked by another tab — registry not refreshed for that scenario.")
+        else:
+            st.error(
+                f"Scenario '{r.scenario}' failed to persist registry: {r.error}. "
+                f"Click Scrape to retry — the registry is regenerable."
+            )
+    st.session_state.pop("_last_registry_persist_results", None)
+
+
 def _run_scrape(url: str, supabase_client: Any) -> None:
     """Wire the Scrape button to ``get_provider_scraper(...)`` in-process."""
     try:
@@ -598,6 +721,11 @@ def _run_scrape(url: str, supabase_client: Any) -> None:
             try:
                 with st.spinner("Scraping cohorts (this may take 1-3 min)..."):
                     scraper.fetch_teams_by_cohort(url)
+                with st.spinner("Persisting team registry..."):
+                    persist_results = _persist_registry_after_scrape(
+                        key, st.session_state.scenario_name, supabase_client
+                    )
+                    st.session_state._last_registry_persist_results = persist_results
             finally:
                 st.session_state._scrape_in_progress = False
     except _ScrapeLockContended:
@@ -3013,6 +3141,7 @@ def main() -> None:
     supabase_client = get_database()
     _render_rekey_banner()
     _render_intake_section(supabase_client)
+    _render_registry_persist_results()
 
     key = st.session_state.event_key
     if not key:


### PR DESCRIPTION
## Summary

Wires the missing scrape → `event_team_registry.csv` persistence step. Before this change, the streamlit intake wrote `intake/raw_scrape.jsonl` and `scenarios/<name>/group_structure_summary.csv` but never the per-team registry CSV. `write_registry` was exported but only called by tests, so triage's `is_ready` and the cohort drill-in UI both crashed with `FileNotFoundError` on every event.

Per spec §8 line 289 ("rescrape writes only to `intake/` — scenario files are untouched"), the registry is treated as a **derived, regenerable artifact**. Operator state lives in `overrides.jsonl` and is layered at READ time via `triage.project_overrides` — verified: zero `write_registry` calls in `src/tournaments/triage.py`. Therefore: clean-rebuild every scrape, no three-way merge.

## What changed

- **Lift** `_enrich_registry_rows_with_matcher` + `_matcher_query_from_registry_row` from `scripts/backtest_tournament_event.py` to `src/tournaments/event_team_matcher.py`. Public name now `enrich_registry_rows_with_matcher`; signature expanded with `cache: dict | None = None` so the streamlit pipeline can share a per-batch matcher cache (load-bearing per memory `gotcha_matcher_cache_load_bearing.md`).
- **Add** `build_registry_entry`, `build_registry_entries`, `compute_dropped_pids`, `persist_registry_for_scenario`, `RegistryPersistResult` to `src/tournaments/storage/registry.py`. The dataclass carries a `lock_contention: bool` discriminator so the UI dispatches on the field rather than string-matching `error` text.
- **Factor** `_persist_registry_after_scrape` at module scope in `tournament_intake.py` (unit-testable without Streamlit mocks). Reads journal once, runs matcher enrichment once with shared cache, fans out per-scenario writes inside `acquire_scenario_lock(... timeout=2.0)`. Wired into `_run_scrape` after `fetch_teams_by_cohort`.
- **Stash + render** results on `st.session_state._last_registry_persist_results` BEFORE `st.rerun()`; new `_render_registry_persist_results()` renderer surfaces them post-rerun (Streamlit discards transient widgets on rerun).
- **None-guard** for `supabase_client`: when None, matcher enrichment is skipped with a WARNING log; registry still persists with `matcher_*` columns blank.

## Plan

Full design + reviewer convergence record at `.turbo/plans/matchbalance-backtest-intake-10-scrape-registry-persistence.md`. The plan went through two `/refine-plan` rounds with two reviewers each before implementation; the round-1 P0 (proposed merge premise contradicts spec) was the design pivot to clean-rebuild.

## Test plan

- [x] `python -m pytest tests/unit/test_storage_registry.py tests/unit/test_event_team_matcher.py tests/unit/test_persist_registry_after_scrape.py tests/unit/test_backtest_tournament_event.py` — 46/46 pass
- [x] Phoenix Cup 2026 offline smoke: rebuilt registry from existing `reports/gotsport__42434__unknown/intake/raw_scrape.jsonl` produced 350 rows with `in_scope_u10_u19` distinct values exactly `{"True", "False"}`
- [ ] In-app smoke: `streamlit run tournament_intake.py`, paste `https://system.gotsport.com/org_event/events/42434`, click Scrape, confirm "Persisting team registry..." spinner, confirm cohort drill-in no longer raises `FileNotFoundError`, confirm `Cohorts ready` advances above `0/N`
- [ ] Rescrape edge case: re-click Scrape on the same event, confirm row counts stable, confirm `overrides.jsonl` mtime unchanged

## Out of scope (follow-ups noted in plan Risks)

- Schema sidecar / CSV write-order race window (Shell 02 territory — `write_registry` itself)
- Pre-existing `triage.is_ready` false-positive bug when registry is empty (this PR makes that codepath routinely reachable; fix is its own change)
- Manual-add registry representation when Shell 04 manual-adds eventually need registry-CSV rows