### PR TITLE
fix(seo): remove PowerScore tier blocks from all 10 state pillars

### DIFF
--- a/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
@@ -85,13 +85,7 @@ Here's how we calculate Arizona soccer rankings without the math jargon:
 3. **Recency** — Games from last month matter more than games from 10 months ago
 4. **Consistency** — Teams that perform steadily rank higher than teams with wild swings
 
-The result? A **PowerScore between 0.0 and 1.0** where:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Arizona sit among the strongest rosters in their age groups, with Phoenix Rising FC, CCV Stars, FBSL, Arizona Arsenal, and RSL Arizona consistently producing teams in that band.
 
 ### Why Arizona Rankings Are Still Growing
 

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -82,13 +82,7 @@ PitchRank is different. We track:
 3. **Recency** — Games from last month matter more than games from 10 months ago
 4. **Consistency** — Teams that perform steadily rank higher than teams with wild swings
 
-The result? A **PowerScore between 0.0 and 1.0** where:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Colorado sit among the strongest rosters in their age groups, with Colorado Rapids Youth, Real Colorado, Colorado Storm, Colorado Rush, and Pride Soccer Club consistently producing teams in that band.
 
 ## What Your Colorado Team's Ranking Really Means
 

--- a/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
@@ -98,13 +98,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result is a **PowerScore between 0.0 and 1.0**:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited game data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Florida sit among the strongest rosters in their age groups, with Weston FC, Florida Elite, Chargers Soccer Club, Tampa Bay United, and Jacksonville FC consistently producing teams in that band.
 
 ### Florida's Age Group Breakdown
 

--- a/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
@@ -102,15 +102,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result is a **PowerScore between 0.0 and 1.0**:
-
-- **0.85+** = Elite, national-tier team
-- **0.70–0.84** = Top state tier — consistently competitive against the best MD has to offer
-- **0.50–0.69** = Solid competitive team, typically mid-pack premier / ECNL Regional / NPL
-- **0.30–0.49** = Developing or lower-flight competitive
-- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
-
-The top of Maryland currently sits in the **0.85–0.91** range, with Bethesda SC, Coppermine, Maryland United FC, Pipeline SC, and Old Line FC producing rosters in that band across multiple age groups.
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Maryland sit among the strongest rosters in their age groups, with Bethesda SC, Coppermine, Maryland United FC, Pipeline SC, and Old Line FC consistently producing teams in that band across multiple age groups.
 
 ### Maryland's Age Group Breakdown
 

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -82,13 +82,7 @@ PitchRank is different. We track:
 3. **Recency** — Games from last month matter more than games from 10 months ago
 4. **Consistency** — Teams that perform steadily rank higher than teams with wild swings
 
-The result? A **PowerScore between 0.0 and 1.0** where:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Michigan sit among the strongest rosters in their age groups, with Michigan Hawks, Vardar SC, Michigan Wolves, FC Alliance, and Rush Michigan consistently producing teams in that band.
 
 ## What Your Michigan Team's Ranking Really Means
 

--- a/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
@@ -91,13 +91,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result? A **PowerScore between 0.0 and 1.0** where:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of New Jersey sit among the strongest rosters in their age groups, with PDA, STA, Match Fit Academy, FC Copa, and TSF Academy consistently producing teams in that band.
 
 ## What Your NJ Team's Ranking Really Means
 

--- a/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
@@ -100,15 +100,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result is a **PowerScore between 0.0 and 1.0**:
-
-- **0.85+** = Elite, national-tier team
-- **0.70–0.84** = Top state tier — consistently competitive against the best NY has to offer
-- **0.50–0.69** = Solid competitive team, typically mid-pack premier / EDP Flight 1 / ECNL
-- **0.30–0.49** = Developing or lower-flight competitive
-- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
-
-The top of New York currently sits in the **0.80+** range, with World Class FC, SUSA FC, Atlantic United, and East Coast Surf all producing rosters in that band across multiple age groups.
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of New York sit among the strongest rosters in their age groups, with World Class FC, SUSA FC, Atlantic United, and East Coast Surf consistently producing teams in that band across multiple age groups.
 
 ### New York's Age Group Breakdown
 

--- a/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
@@ -103,13 +103,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result is a **PowerScore between 0.0 and 1.0**:
-
-- **0.85+** = Elite national-level team
-- **0.70-0.84** = Top competitive tier
-- **0.50-0.69** = Solid competitive team
-- **0.30-0.49** = Developing/mid-level
-- **Below 0.30** = Recreational or limited game data
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of North Carolina sit among the strongest rosters in their age groups, with Charlotte Soccer Academy, NCFC, Wake FC, and Charlotte Independence consistently producing teams in that band.
 
 ### North Carolina's Age Group Breakdown
 

--- a/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
@@ -106,15 +106,7 @@ PitchRank uses a game-by-game rating engine. Here's how PA team rankings get cal
 4. **Margin and score aren't the whole story** — we care about who beat whom; blowouts over weak teams don't inflate rankings the way some systems allow
 5. **Recency is weighted** — this spring's games matter more than last fall's
 
-The rating gets normalized into a **PowerScore between 0.0 and 1.0** so it's easier to read:
-
-- **0.85+** = Elite, national-tier team
-- **0.70–0.84** = Top state tier — consistently competitive against the best PA has to offer
-- **0.50–0.69** = Solid competitive team, typically mid-pack in premier/EDP Flight 1 / ECNL
-- **0.30–0.49** = Developing or lower-flight competitive
-- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
-
-As a benchmark, the top end of Pennsylvania sits at roughly **0.94–0.95** — FC DELCO's MLS Next U11 group, Penn Fusion's ECNL G08/07, and FC DELCO's U17 side all live in that range.
+The rating gets normalized into a **PowerScore between 0.0 and 1.0** so it's easier to read at a glance. Teams at the top of Pennsylvania sit among the strongest rosters in their age groups — FC DELCO's MLS Next U11 group, Penn Fusion's ECNL G08/07, and FC DELCO's U17 side all live in that band.
 
 ### Why Pennsylvania Rankings Are Reliable
 

--- a/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
@@ -102,15 +102,7 @@ Here's the short version of how your team's ranking is calculated:
 3. **Recency** — Last month's games count more than games from 10 months ago
 4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
 
-The result is a **PowerScore between 0.0 and 1.0**:
-
-- **0.85+** = Elite, national-tier team
-- **0.70–0.84** = Top state tier — consistently competitive against the best VA has to offer
-- **0.50–0.69** = Solid competitive team, typically mid-pack premier / ECNL Regional / NPL
-- **0.30–0.49** = Developing or lower-flight competitive
-- **Below 0.30** = Recreational, limited data, or very young ages with thin schedules
-
-The top of Virginia currently sits in the **0.85–0.91** range, with Arlington Soccer, Bethesda-feeder rosters, Springfield SYC, Alexandria SA, and Virginia Soccer Association producing teams in that band across multiple age groups.
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Virginia sit among the strongest rosters in their age groups, with Arlington Soccer, Springfield SYC, Alexandria SA, and Virginia Soccer Association consistently producing teams in that band across multiple age groups.
 
 ### Virginia's Age Group Breakdown
 


### PR DESCRIPTION
## Summary
Strip the "0.85+ = Elite, 0.70-0.84 = Top tier..." bullet list and any explicit benchmark ranges (PA's 0.94-0.95, NY's 0.80+, VA/MD's 0.85-0.91) from all 10 shipped state pillars. Replace with relative-language prose naming each state's top clubs.

10 files / +10 / -78. Two commits:
1. NC, PA, NY, VA, MD (first batch).
2. AZ, CO, FL, MI, NJ (second batch — same edit pattern).

## Why
Per the standing rule (\`feedback_no_powerscore_tiers_in_content.md\`): no PowerScore tier brackets in user-facing content — they're arbitrary cutoffs and parents below the threshold feel deflated. NC/PA shipped with the violation; later pillars mirrored the pattern.

## Test plan
- [ ] Spot-check one pillar in preview (e.g. \`/blog/maryland-youth-soccer-rankings-guide\`) — confirm tier list is gone and prose flows
- [ ] \`grep -E "^- \*\*0\.85\+|^- \*\*0\.70-" frontend/content/blog/*.mdx\` returns zero matches (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)