### PR TITLE
Shell 08: MatchBalance Report Card UI embed + exports + audit

### DIFF
--- a/src/tournaments/reports/compute.py
+++ b/src/tournaments/reports/compute.py
@@ -16,7 +16,7 @@ artifacts.
 identity from ``summary.json["cohort"]`` but Shell 06 normalizes
 ``gender`` to ``"Male"/"Female"`` (cf.
 ``scripts/backtest_tournament_cohort.py:864`` ``normalize_gender_label``).
-The registry CSV, override ledger, and ``run_orchestrator._override_in_cohort``
+The registry CSV, override ledger, and ``run_orchestrator.override_in_cohort``
 all use ``"Boys"/"Girls"``. This module reads ``run_metadata.json``
 (orchestrator-emitted at ``run_orchestrator.py:594``) so ``cohort_gender``
 matches the rest of the storage layer — required for the

--- a/src/tournaments/reports/render_csv.py
+++ b/src/tournaments/reports/render_csv.py
@@ -23,6 +23,7 @@ from src.tournaments.storage._io import write_csv
 
 __all__ = [
     "METRICS_FIELDNAMES",
+    "REPORT_CARD_CSV_NAMES",
     "RISK_FLAG_FIELDNAMES",
     "TEAM_MOVEMENT_FIELDNAMES",
     "render_all_csv",
@@ -30,6 +31,19 @@ __all__ = [
     "render_risk_flags_csv",
     "render_team_movements_csv",
 ]
+
+
+REPORT_CARD_CSV_NAMES: tuple[str, ...] = (
+    "comparison_metrics.csv",
+    "comparison_risk_flags.csv",
+    "comparison_team_movements.csv",
+)
+"""On-disk filenames written by ``render_all_csv`` (insertion order =
+metrics → risk flags → team movements). Single source of truth for any
+helper that bundles or enumerates the Report Card CSVs (e.g.
+``ui.zip_run_csvs``); keeps the export bundle in sync if a fourth CSV
+ever lands.
+"""
 
 
 _FORMULA_INJECTION_PREFIXES: frozenset[str] = frozenset({"=", "+", "-", "@", "\t", "\r", "\n"})

--- a/src/tournaments/reports/render_html.py
+++ b/src/tournaments/reports/render_html.py
@@ -110,13 +110,21 @@ def render_html(
     report_card: ReportCard,
     *,
     mode: Literal["embedded", "standalone"] = "standalone",
+    show_override_audit: bool = True,
 ) -> str:
     """Render the ReportCard. ``mode`` controls whether the output is a
     self-contained HTML document (``standalone``) or a body fragment
     (``embedded``) for Streamlit's ``st.html`` embed.
+
+    ``show_override_audit`` defaults to True so legacy callers (the
+    persisted ``comparison.html`` written by ``compute_and_persist_report_card``,
+    Export-HTML downloads) keep the in-template audit details block.
+    Shell 08's inline embed passes ``False`` because an outside expander
+    surfaces the same data with richer formatting and additionally shows
+    scenario-level overrides the embedded template does not.
     """
     template = _env.get_template("report_card.html")
-    fragment = template.render(report_card=report_card)
+    fragment = template.render(report_card=report_card, show_override_audit=show_override_audit)
     if mode == "embedded":
         return fragment
     # ``event_name`` / ``gender`` / ``age_group`` come from provider scrape
@@ -148,14 +156,19 @@ def write_html(
     path: Path,
     *,
     mode: Literal["embedded", "standalone"] = "standalone",
+    show_override_audit: bool = True,
 ) -> Path:
     """Atomically write the rendered HTML to ``path``.
 
     Mirrors ``_io.write_json``'s ``.tmp`` + ``os.replace`` + fsync
     pattern at ``storage/_io.py:40``. HTML isn't JSON, so we use
     ``Path.write_bytes`` against the ``.tmp`` path then ``os.replace``.
+
+    ``show_override_audit`` is forwarded to ``render_html`` so the persisted
+    ``comparison.html`` (written by ``compute_and_persist_report_card``)
+    retains its audit ``<details>`` block by default.
     """
-    rendered = render_html(report_card, mode=mode)
+    rendered = render_html(report_card, mode=mode, show_override_audit=show_override_audit)
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_name(path.name + ".tmp")

--- a/src/tournaments/reports/templates/report_card.html
+++ b/src/tournaments/reports/templates/report_card.html
@@ -146,7 +146,7 @@ delta-flat
     </section>
   {% endif %}
 
-  {% if report_card.override_audit %}
+  {% if show_override_audit and report_card.override_audit %}
     <details class="rc-section rc-audit">
       <summary class="rc-eyebrow">Override audit log &middot; {{ report_card.override_audit | length }} records</summary>
       <ul class="rc-list rc-mono">

--- a/src/tournaments/reports/ui.py
+++ b/src/tournaments/reports/ui.py
@@ -1,0 +1,251 @@
+"""Streamlit-free helpers for the Shell 08 Report Card UI surface.
+
+Sibling to ``compute.py`` / ``render_html.py`` / ``render_csv.py``. Holds
+the lazy compute-or-load gate (``ensure_report_card``), the export-bundle
+helper (``zip_run_csvs``), the audit-row projector (``project_audit_row``),
+and the small label/format/filename helpers consumed by ``tournament_intake.py``.
+
+Streamlit MUST NOT be imported here so unit tests can exercise these
+helpers without a Streamlit runtime.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from src.tournaments.reports.compute import (
+    ReportCardError,
+    compute_and_persist_report_card,
+    read_comparison_json,
+)
+from src.tournaments.reports.render_csv import REPORT_CARD_CSV_NAMES
+from src.tournaments.reports.schema import ReportCard
+from src.tournaments.storage.event_key import run_dir as _run_dir
+from src.tournaments.storage.run_layout import acquire_run_lock
+from src.tournaments.storage.schema_version import SchemaVersionError
+
+__all__ = [
+    "DISPLAY_COLS",
+    "derive_export_filenames",
+    "ensure_report_card",
+    "format_run_label",
+    "format_run_timestamp",
+    "project_audit_row",
+    "safe_read_comparison_json",
+    "zip_run_csvs",
+]
+
+
+DISPLAY_COLS: tuple[str, ...] = (
+    "ts",
+    "actor",
+    "type",
+    "team_ref",
+    "reason",
+    "delta_balance_score",
+)
+"""Columns surfaced in the Shell 08 override-audit panel.
+
+Nested ``before`` / ``after`` / ``schema_version`` keys are deliberately
+omitted — pandas would render them as object-repr cells and clutter the
+display. ``project_audit_row`` projects each record down to this set
+before the dataframe is built.
+"""
+
+
+_SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
+
+_LOAD_ERRORS: tuple[type[BaseException], ...] = (
+    SchemaVersionError,
+    ValueError,
+    json.JSONDecodeError,
+    FileNotFoundError,
+    OSError,
+    KeyError,
+    TypeError,
+    AttributeError,
+)
+"""Exceptions ``read_comparison_json`` may raise that should normalize
+to ``ReportCardError``. Covers the I/O layer (``OSError`` / ``FileNotFoundError``),
+the JSON layer (``json.JSONDecodeError`` / ``ValueError``), the schema-version
+gate (``SchemaVersionError``), AND the structural-shape layer (``KeyError`` /
+``TypeError`` / ``AttributeError``) — the last group covers JSON-valid but
+shape-invalid payloads (``[]``, ``{}``, missing nested keys) that would
+otherwise bubble through ``ReportCard.from_dict``'s bracket-access reads.
+"""
+
+
+def _load_persisted_card(comparison_path: Path, run_id: str) -> ReportCard:
+    """Read ``comparison.json``, normalizing failure modes to ``ReportCardError``.
+
+    Used by both branches of ``ensure_report_card`` (outer sentinel-hit
+    fast path and inside-lock lost-update guard) so the swallow-list and
+    error-message format live in one place.
+    """
+    try:
+        return read_comparison_json(comparison_path)
+    except _LOAD_ERRORS as exc:
+        raise ReportCardError(f"Cannot load Report Card for run {run_id!r}: {exc}") from exc
+
+
+def safe_read_comparison_json(comparison_path: Path) -> ReportCard | None:
+    """Best-effort read of ``comparison.json``; returns ``None`` on any failure.
+
+    Used by render-time helpers that need the persisted Report Card for
+    display labels (e.g. the previous-runs dropdown's optimized-score
+    column) but must NOT explode the surrounding render when a single
+    legacy / corrupt artifact exists. Catches the same exception family
+    as ``_load_persisted_card`` plus ``ReportCardError`` itself, since the
+    underlying ``read_comparison_json`` may raise it via the schema gate.
+    """
+    try:
+        return read_comparison_json(comparison_path)
+    except (ReportCardError, *_LOAD_ERRORS):
+        return None
+
+
+def ensure_report_card(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+    lock_timeout: float = 30.0,
+) -> ReportCard:
+    """Sentinel-gated lazy compute-or-load.
+
+    If ``runs/<run_id>/report_card.done`` exists, read the cached
+    ``comparison.json``. Otherwise acquire the per-run lock at
+    ``runs/<run_id>/.report.lock`` (with ``lock_timeout`` to absorb
+    concurrent-tab contention), re-check the sentinel inside the critical
+    section (lost-update guard so a sibling tab that just finished
+    computing isn't recomputed redundantly), then call
+    ``compute_and_persist_report_card``.
+
+    All non-lock failures (corrupt ``comparison.json``, schema mismatch,
+    missing artifacts, OS errors) are normalized to ``ReportCardError`` so
+    the caller's UI branch only needs to catch ``ReportCardError`` and
+    ``RunLockError``.
+    """
+    run_dir_path = _run_dir(event_key, scenario, run_id, base_dir=base_dir)
+    sentinel = run_dir_path / "report_card.done"
+    comparison_path = run_dir_path / "comparison.json"
+
+    if sentinel.exists():
+        return _load_persisted_card(comparison_path, run_id)
+
+    with acquire_run_lock(event_key, scenario, run_id, base_dir=base_dir, timeout=lock_timeout):
+        # Lost-update guard: a sibling tab may have completed the compute
+        # between our sentinel check above and the lock acquire here.
+        if sentinel.exists():
+            return _load_persisted_card(comparison_path, run_id)
+        try:
+            return compute_and_persist_report_card(event_key, scenario, run_id, base_dir=base_dir)
+        except (ReportCardError, *_LOAD_ERRORS) as exc:
+            raise ReportCardError(f"Cannot load Report Card for run {run_id!r}: {exc}") from exc
+
+
+def zip_run_csvs(run_dir_path: Path) -> bytes:
+    """Bundle the Report Card CSVs into an in-memory ZIP.
+
+    Reads each entry of ``REPORT_CARD_CSV_NAMES`` from ``run_dir_path``
+    (typically the promoted ``runs/<run_id>/`` directory) and bundles them
+    with ``ZIP_DEFLATED``. Sourcing the filename list from ``render_csv``
+    keeps the export bundle in sync if a fourth CSV ever lands.
+
+    Raises ``FileNotFoundError`` if any expected CSV is missing — callers
+    translate that to a user-visible warning. Post-
+    ``compute_and_persist_report_card`` all three are written atomically
+    by ``render_all_csv``, so this should not occur in normal operation.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name in REPORT_CARD_CSV_NAMES:
+            csv_path = run_dir_path / name
+            archive.writestr(name, csv_path.read_bytes())
+    return buffer.getvalue()
+
+
+def project_audit_row(record: dict[str, Any]) -> dict[str, Any]:
+    """Project an override-audit record to the display columns.
+
+    Picks ``DISPLAY_COLS`` from ``record`` (defaulting missing keys to
+    empty string), then maps both ``delta_balance_score=None`` (the per-run
+    audit's hardcoded value at ``run_orchestrator.py:702``) and missing /
+    empty values (scenario-level records read from ``load_overrides`` lack
+    the field entirely) to the literal string ``"n/a"`` BEFORE pandas
+    coerces ``None`` to NaN. The ``(None, "")`` predicate is required —
+    ``is None`` alone would leave the missing-key path producing an empty
+    cell, inconsistent with per-run rows.
+    """
+    projected = {key: record.get(key, "") for key in DISPLAY_COLS}
+    if projected["delta_balance_score"] in (None, ""):
+        projected["delta_balance_score"] = "n/a"
+    return projected
+
+
+def format_run_timestamp(iso_string: str | None) -> str:
+    """Format an ISO-8601 timestamp as ``YYYY-MM-DD HH:MM`` (wall-clock, minute-truncated).
+
+    Does NOT convert non-UTC offsets — the displayed wall-clock time is
+    whatever the source string encodes. All current writers
+    (``utc_now_iso`` and ``run_metadata.json``) emit ``+00:00``, so the
+    label is effectively UTC today; legacy/external payloads with other
+    offsets would render in their source timezone.
+
+    Returns the literal ``"unknown"`` for ``None`` or unparseable input
+    rather than raising — the dropdown's ``format_func`` calls this for
+    every visible run, so a single legacy/corrupt ``run_metadata.json``
+    must not explode the entire selectbox render.
+    """
+    if iso_string is None:
+        return "unknown"
+    try:
+        parsed = datetime.fromisoformat(iso_string)
+    except (TypeError, ValueError):
+        return "unknown"
+    return parsed.strftime("%Y-%m-%d %H:%M")
+
+
+def format_run_label(
+    run_id: str,
+    ended_at: str | None,
+    balance_score_optimized: float | None,
+) -> str:
+    """Build a fixed-format label for the previous-runs ``selectbox``.
+
+    Format: ``"{ts} · BS {score}"`` — ``ts`` from ``format_run_timestamp``
+    (``"unknown"`` fallback) and ``score`` rounded to integer or ``"n/a"``
+    when the run pre-dates the Report Card sentinel write.
+    """
+    ts_display = format_run_timestamp(ended_at)
+    if balance_score_optimized is None:
+        return f"{ts_display} · BS n/a"
+    return f"{ts_display} · BS {balance_score_optimized:.0f}"
+
+
+def derive_export_filenames(card: ReportCard) -> dict[str, str]:
+    """Return ``{"html", "json", "zip"}`` filenames for the export buttons.
+
+    Slug pattern: ``report_card_<event_slug>_<gender>_<age>_<run_id>.<ext>``.
+    All free-form fields run through ``re.sub(r"[^a-zA-Z0-9]+", "_", ...)``
+    so spaces, slashes, and Unicode characters are normalized into
+    ASCII-safe segments — no path-traversal characters can land in
+    ``file_name``.
+    """
+    event_slug = _SLUG_RE.sub("_", card.event_name).strip("_") or "event"
+    gender_slug = _SLUG_RE.sub("_", card.gender).strip("_") or "cohort"
+    age_slug = _SLUG_RE.sub("_", card.age_group).strip("_") or "cohort"
+    run_slug = _SLUG_RE.sub("_", card.run_id).strip("_") or "run"
+    stem = f"report_card_{event_slug}_{gender_slug}_{age_slug}_{run_slug}"
+    return {
+        "html": f"{stem}.html",
+        "json": f"{stem}.json",
+        "zip": f"{stem}.zip",
+    }

--- a/src/tournaments/run_orchestrator.py
+++ b/src/tournaments/run_orchestrator.py
@@ -95,6 +95,7 @@ __all__ = [
     "RunOutcome",
     "execute_run",
     "generate_run_id",
+    "override_in_cohort",
     "preflight",
 ]
 
@@ -636,7 +637,7 @@ def _assert_summary_present(staging_dir: Path) -> None:
         raise RuntimeError(f"cohort CLI did not produce summary.json at {staging_dir}")
 
 
-def _override_in_cohort(
+def override_in_cohort(
     record: dict[str, Any],
     age: str,
     gender: str,
@@ -693,7 +694,7 @@ def _write_run_overrides_audit(
 
     audit_path = staging_dir / "run_overrides_audit.jsonl"
     for record in overrides:
-        if not _override_in_cohort(record, age, gender, registry_by_pid):
+        if not override_in_cohort(record, age, gender, registry_by_pid):
             continue
         audit_entry = {
             **record,

--- a/src/tournaments/storage/__init__.py
+++ b/src/tournaments/storage/__init__.py
@@ -80,7 +80,9 @@ from src.tournaments.storage.registry import (
 )
 from src.tournaments.storage.rescrape import RescrapeReport, merge_rescrape
 from src.tournaments.storage.run_layout import (
+    RunLockError,
     RunStateError,
+    acquire_run_lock,
     cancel_run,
     create_staging_run,
     fail_run,
@@ -169,6 +171,8 @@ __all__ = [
     "fail_run",
     "cancel_run",
     "list_runs",
+    "acquire_run_lock",
+    "RunLockError",
     "RunStateError",
     "check_games_import_status",
     # raw-scrape re-exports

--- a/src/tournaments/storage/_file_lock.py
+++ b/src/tournaments/storage/_file_lock.py
@@ -1,0 +1,104 @@
+"""Platform-abstracted advisory file-lock contextmanager.
+
+Factored out of ``scenario.py`` so multiple sibling lock-helpers can share
+the same platform pair and retry/sleep loop. Today: the per-scenario lock
+at ``scenarios/<name>/.run.lock`` (``acquire_scenario_lock``) and the
+per-run lock at ``runs/<run_id>/.report.lock`` (``acquire_run_lock``).
+
+The lockfile is purely a presence/lock primitive — see the no-IO contract
+note in ``scenario.py`` module docstring. Callers MUST translate
+``FileLockError`` to a typed subclass at their boundary
+(``ScenarioLockError`` / ``RunLockError``) so downstream catches stay
+specific.
+
+Resolved once at module load: the platform branch and the inner module
+imports don't need to re-run on every acquire call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+__all__ = [
+    "FileLockError",
+    "_acquire_file_lock",
+]
+
+
+class FileLockError(RuntimeError):
+    """Raised when an advisory file lock cannot be acquired within ``timeout``.
+
+    Sibling helpers (``acquire_scenario_lock``, ``acquire_run_lock``)
+    translate this to their typed subclass at the boundary so callers
+    continue to catch the specific exception they expect.
+    """
+
+
+def _build_platform_lock_pair() -> tuple[Callable[[int], None], Callable[[int], None]]:
+    """Build ``(lock_fn, unlock_fn)`` for the current platform."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        def lock_fn(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+        def unlock_fn(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        def lock_fn(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def unlock_fn(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+    return lock_fn, unlock_fn
+
+
+_LOCK_FN, _UNLOCK_FN = _build_platform_lock_pair()
+
+
+@contextlib.contextmanager
+def _acquire_file_lock(lock_path: Path, *, timeout: float) -> Iterator[None]:
+    """Acquire the advisory lock at ``lock_path``.
+
+    Timeout semantics:
+
+    - ``timeout == 0.0`` — attempt acquire exactly once. Raise
+      ``FileLockError`` immediately on contention.
+    - ``timeout > 0`` — retry with brief sleeps until elapsed time exceeds
+      ``timeout``, then raise.
+
+    The parent directory of ``lock_path`` must already exist; opening the
+    fd in a missing directory raises ``FileNotFoundError`` — that's a
+    caller-ordering bug, not a lock bug.
+
+    The lock is released and the fd closed on exit. The lockfile itself is
+    NOT deleted — it persists for the next acquirer.
+    """
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
+    locked = False
+    try:
+        deadline = time.monotonic() + timeout if timeout > 0 else None
+        while True:
+            try:
+                _LOCK_FN(fd)
+                locked = True
+                break
+            except (BlockingIOError, OSError):
+                if deadline is None or time.monotonic() >= deadline:
+                    raise FileLockError(f"file lock at {lock_path} is held by another process")
+                time.sleep(0.05)
+        yield
+    finally:
+        try:
+            if locked:
+                _UNLOCK_FN(fd)
+        finally:
+            os.close(fd)

--- a/src/tournaments/storage/run_layout.py
+++ b/src/tournaments/storage/run_layout.py
@@ -33,15 +33,20 @@ they are caller-owned.
 
 from __future__ import annotations
 
+import contextlib
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
+from src.tournaments.storage._file_lock import FileLockError, _acquire_file_lock
 from src.tournaments.storage._io import utc_now_iso, write_json
-from src.tournaments.storage.event_key import scenario_dir
+from src.tournaments.storage.event_key import run_dir, scenario_dir
 from src.tournaments.storage.schema_version import stamp_schema_version
 
 __all__ = [
+    "RunLockError",
     "RunStateError",
+    "acquire_run_lock",
     "cancel_run",
     "create_staging_run",
     "fail_run",
@@ -52,6 +57,10 @@ __all__ = [
 
 class RunStateError(RuntimeError):
     """Raised when a run-state transition cannot complete safely."""
+
+
+class RunLockError(RuntimeError):
+    """Raised when ``acquire_run_lock`` cannot acquire within ``timeout``."""
 
 
 def _runs_root(event_key: str, scenario: str, base_dir: Path | str) -> Path:
@@ -189,3 +198,43 @@ def list_runs(
                 continue
         names.append(entry.name)
     return names
+
+
+@contextlib.contextmanager
+def acquire_run_lock(
+    event_key: str,
+    scenario: str,
+    run_id: str,
+    *,
+    base_dir: Path | str = "reports",
+    timeout: float = 0.0,
+) -> Iterator[None]:
+    """Acquire the per-run advisory lock at ``runs/<run_id>/.report.lock``.
+
+    Mirrors ``acquire_scenario_lock`` (same timeout semantics, same no-IO
+    contract on the lockfile) but scopes contention to a single run rather
+    than the whole scenario. Used by Shell 08's lazy-trigger
+    ``ensure_report_card`` so concurrent first-views of the same run
+    serialize without blocking other cohorts' run-button or save paths.
+
+    Timeout semantics:
+
+    - ``timeout == 0.0`` (default) — attempt acquire exactly once. Raise
+      ``RunLockError`` immediately on contention.
+    - ``timeout > 0`` — retry with brief sleeps until elapsed time exceeds
+      ``timeout``, then raise.
+
+    The run directory must already exist (i.e. the run has been promoted
+    from ``<run_id>.tmp/`` to ``<run_id>/``). Opening the lockfile in a
+    missing directory raises ``FileNotFoundError`` — that's a caller-
+    ordering bug, not a lock bug.
+
+    The lock is released and the fd closed on exit. The lockfile itself is
+    NOT deleted — it persists for the next acquirer.
+    """
+    lock_path = run_dir(event_key, scenario, run_id, base_dir=base_dir) / ".report.lock"
+    try:
+        with _acquire_file_lock(lock_path, timeout=timeout):
+            yield
+    except FileLockError as exc:
+        raise RunLockError(f"run {run_id!r} is locked by another process") from exc

--- a/src/tournaments/storage/scenario.py
+++ b/src/tournaments/storage/scenario.py
@@ -6,8 +6,8 @@ without copying ``intake/`` (the scrape genuinely is shared).
 
 Spec §9 line 320 mandates a per-scenario file lock at
 ``scenarios/<name>/.run.lock`` so two run subprocesses can't race the same
-scenario. ``acquire_scenario_lock`` implements it as an OS advisory lock —
-``fcntl.flock`` on POSIX, ``msvcrt.locking`` on Windows.
+scenario. ``acquire_scenario_lock`` implements it as an OS advisory lock
+via the platform-abstracted ``_acquire_file_lock`` helper.
 
 **No-IO contract on the lockfile:** the helper opens the fd and immediately
 acquires the lock without any intervening reads or writes. Callers MUST NOT
@@ -20,13 +20,11 @@ presence/lock primitive.
 from __future__ import annotations
 
 import contextlib
-import os
 import shutil
-import sys
-import time
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from pathlib import Path
 
+from src.tournaments.storage._file_lock import FileLockError, _acquire_file_lock
 from src.tournaments.storage.event_key import scenario_dir, scenarios_dir
 
 __all__ = [
@@ -90,35 +88,6 @@ def list_scenarios(event_key: str, *, base_dir: Path | str = "reports") -> list[
     return sorted(entry.name for entry in root.iterdir() if entry.is_dir())
 
 
-def _build_platform_lock_pair() -> tuple[Callable[[int], None], Callable[[int], None]]:
-    """Build ``(lock_fn, unlock_fn)`` for the current platform.
-
-    Resolved once at module load — the platform branch and module imports
-    don't need to re-run on every ``acquire_scenario_lock`` call.
-    """
-    if sys.platform == "win32":
-        import msvcrt
-
-        def lock_fn(fd: int) -> None:
-            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-
-        def unlock_fn(fd: int) -> None:
-            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-    else:
-        import fcntl
-
-        def lock_fn(fd: int) -> None:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-        def unlock_fn(fd: int) -> None:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-
-    return lock_fn, unlock_fn
-
-
-_LOCK_FN, _UNLOCK_FN = _build_platform_lock_pair()
-
-
 @contextlib.contextmanager
 def acquire_scenario_lock(
     event_key: str,
@@ -144,25 +113,8 @@ def acquire_scenario_lock(
     NOT deleted — it persists for the next acquirer.
     """
     lock_path = scenario_dir(event_key, scenario, base_dir=base_dir) / ".run.lock"
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
-    locked = False
     try:
-        deadline = time.monotonic() + timeout if timeout > 0 else None
-        while True:
-            try:
-                _LOCK_FN(fd)
-                locked = True
-                break
-            except (BlockingIOError, OSError):
-                if deadline is None or time.monotonic() >= deadline:
-                    raise ScenarioLockError(f"scenario {scenario!r} is locked by another process")
-                time.sleep(0.05)
-        yield
-    finally:
-        if locked:
-            try:
-                _UNLOCK_FN(fd)
-            finally:
-                os.close(fd)
-        else:
-            os.close(fd)
+        with _acquire_file_lock(lock_path, timeout=timeout):
+            yield
+    except FileLockError as exc:
+        raise ScenarioLockError(f"scenario {scenario!r} is locked by another process") from exc

--- a/tests/unit/test_reports_persist.py
+++ b/tests/unit/test_reports_persist.py
@@ -16,6 +16,8 @@ from src.tournaments.reports.compute import (
     compute_and_persist_report_card,
     read_comparison_json,
 )
+from src.tournaments.storage._io import append_jsonl
+from src.tournaments.storage.schema_version import stamp_schema_version
 from tests.unit.test_reports_compute import (
     EVENT_KEY,
     RUN_ID,
@@ -24,6 +26,29 @@ from tests.unit.test_reports_compute import (
     _write_division_recommendations,
     _write_summary,
 )
+
+
+def _seed_run_overrides_audit(run_path: Path) -> None:
+    """Seed ``run_overrides_audit.jsonl`` with one schema-stamped row.
+
+    Mirrors what ``run_orchestrator._write_run_overrides_audit`` produces:
+    the source override dict spread plus ``run_id`` / ``applied_at`` /
+    ``delta_balance_score=None``, schema-stamped before append.
+    """
+    record = {
+        "ts": "2026-04-30T11:00:00+00:00",
+        "actor": "ops@pitchrank.io",
+        "type": "accept_match",
+        "team_ref": "pid-1",
+        "reason": "manual review",
+        "before": {},
+        "after": {},
+        "run_id": RUN_ID,
+        "applied_at": "2026-04-30T12:00:00+00:00",
+        "delta_balance_score": None,
+    }
+    append_jsonl(run_path / "run_overrides_audit.jsonl", stamp_schema_version(record))
+
 
 _ARTIFACTS: tuple[str, ...] = (
     "comparison.json",
@@ -108,3 +133,23 @@ def test_compute_report_card_pure_does_not_write(tmp_path: Path):
 
     for name in _ARTIFACTS:
         assert not (run_path / name).exists(), f"compute_report_card leaked artifact: {name}"
+
+
+def test_comparison_html_retains_audit_details_block(tmp_path: Path):
+    """``compute_and_persist_report_card → write_html → render_html →
+    template`` chain must preserve the override-audit ``<details>`` block
+    when ``card.override_audit`` is non-empty.
+
+    Guards against accidental kwarg drops (Step 1b's ``show_override_audit``
+    would silently suppress the block on a regression because Jinja's
+    default Undefined is falsy)."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    _seed_run_overrides_audit(run_path)
+
+    rc = compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert len(rc.override_audit) >= 1
+
+    text = (run_path / "comparison.html").read_text(encoding="utf-8")
+    assert text.count("rc-audit") >= 1

--- a/tests/unit/test_reports_render_html.py
+++ b/tests/unit/test_reports_render_html.py
@@ -126,6 +126,39 @@ def test_override_audit_collapsed_in_details():
     assert "accept_match" in rendered
 
 
+def test_render_html_show_override_audit_false_suppresses_details():
+    """Shell 08's inline embed passes ``show_override_audit=False`` so the
+    outside expander is the single source of truth — the in-iframe
+    ``<details>`` block must NOT render."""
+    rendered = render_html(_hand_built_report(), show_override_audit=False)
+    assert 'class="rc-section rc-audit"' not in rendered
+    # Sanity: the rest of the report still renders.
+    assert "Phoenix Cup 2026" in rendered
+
+
+def test_render_html_show_override_audit_true_default_renders_details():
+    """Default-True keeps legacy callers (Export-HTML, persisted
+    ``comparison.html``) showing the audit details block."""
+    rendered = render_html(_hand_built_report(), show_override_audit=True)
+    assert 'class="rc-section rc-audit"' in rendered
+
+
+def test_write_html_default_preserves_audit_details(tmp_path: Path):
+    """``write_html(...)`` without the kwarg must persist the audit block.
+
+    Guards against a future refactor that drops the kwarg forwarding from
+    ``write_html`` to ``render_html`` — would silently strip the audit
+    from the on-disk ``comparison.html`` (Jinja's default Undefined is
+    falsy, so ``{% if show_override_audit and ... %}`` would suppress
+    without raising)."""
+    rc = _hand_built_report()
+    out = tmp_path / "comparison.html"
+    write_html(rc, out)
+    text = out.read_text(encoding="utf-8")
+    assert 'class="rc-section rc-audit"' in text
+    assert "accept_match" in text
+
+
 def test_metric_value_rendering_formats():
     rendered = render_html(_hand_built_report())
     # rate=0.22 should render as 22%; rate=0.41 as 41%

--- a/tests/unit/test_reports_ui.py
+++ b/tests/unit/test_reports_ui.py
@@ -1,0 +1,443 @@
+"""Unit tests for ``src.tournaments.reports.ui``.
+
+Covers the lazy compute-or-load gate (``ensure_report_card``), the
+per-run lock contention path, the export-bundle helper (``zip_run_csvs``),
+the audit-row projector, and the small label / format / filename helpers.
+
+Reuses the fixture builders from ``test_reports_compute`` so the run-dir
+scaffold matches the rest of the report-card suite.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from src.tournaments.reports.compute import (
+    ReportCardError,
+    compute_and_persist_report_card,
+)
+from src.tournaments.reports.schema import (
+    BalanceScore,
+    Metric,
+    OverrideAuditRow,
+    ReportCard,
+)
+from src.tournaments.reports.ui import (
+    DISPLAY_COLS,
+    derive_export_filenames,
+    ensure_report_card,
+    format_run_label,
+    format_run_timestamp,
+    project_audit_row,
+    safe_read_comparison_json,
+    zip_run_csvs,
+)
+from src.tournaments.storage.run_layout import RunLockError, acquire_run_lock
+from tests.unit.test_reports_compute import (
+    EVENT_KEY,
+    RUN_ID,
+    SCENARIO,
+    _bootstrap,
+    _write_division_recommendations,
+    _write_summary,
+)
+
+# ---------------------------------------------------------------------------
+# ensure_report_card
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_report_card_loads_when_sentinel_exists(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    expected = compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert (run_path / "report_card.done").exists()
+
+    rc = ensure_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert rc.run_id == expected.run_id
+    assert rc.balance_score.optimized == pytest.approx(expected.balance_score.optimized)
+
+
+def test_ensure_report_card_triggers_compute_when_sentinel_absent(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    assert not (run_path / "report_card.done").exists()
+
+    rc = ensure_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    # Sentinel is now present and the returned card matches what's on disk.
+    assert (run_path / "report_card.done").exists()
+    assert (run_path / "comparison.json").exists()
+    assert rc.run_id == RUN_ID
+
+
+def test_ensure_report_card_raises_run_lock_error_on_contention(tmp_path: Path):
+    """Holding ``runs/<run_id>/.report.lock`` externally makes the lazy
+    trigger fail fast with ``RunLockError`` rather than blocking the UI."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    # Sentinel absent so the lock branch runs.
+    assert not (run_path / "report_card.done").exists()
+
+    with acquire_run_lock(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path, timeout=0.0):
+        with pytest.raises(RunLockError):
+            ensure_report_card(
+                EVENT_KEY,
+                SCENARIO,
+                RUN_ID,
+                base_dir=tmp_path,
+                lock_timeout=0.05,
+            )
+
+
+def test_ensure_report_card_lost_update_guard_skips_recompute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When the sentinel appears between the outer check and the lock
+    acquire, the inside-lock re-check loads via ``read_comparison_json``
+    without re-running ``compute_and_persist_report_card``."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    # Persist a valid Report Card, then delete the sentinel so the outer
+    # check at the top of ensure_report_card sees it absent.
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    sentinel = run_path / "report_card.done"
+    sentinel_bytes = sentinel.read_bytes()
+    sentinel.unlink()
+
+    # Replace acquire_run_lock with a stub that materializes the sentinel
+    # mid-flight — simulates a sibling tab finishing compute between the
+    # outer sentinel check and our lock acquire.
+    @contextlib.contextmanager
+    def _restoring_lock(*_args, **_kwargs):
+        sentinel.write_bytes(sentinel_bytes)
+        yield
+
+    monkeypatch.setattr("src.tournaments.reports.ui.acquire_run_lock", _restoring_lock)
+
+    # And make compute_and_persist_report_card raise so any leak through
+    # the lost-update guard surfaces loudly.
+    def _exploding_compute(*_args, **_kwargs):
+        raise RuntimeError("compute_and_persist_report_card should not be called")
+
+    monkeypatch.setattr(
+        "src.tournaments.reports.ui.compute_and_persist_report_card",
+        _exploding_compute,
+    )
+
+    rc = ensure_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    assert rc.run_id == RUN_ID
+
+
+def test_ensure_report_card_normalizes_corrupt_json_to_report_card_error(tmp_path: Path):
+    """A corrupt persisted ``comparison.json`` raises ``ReportCardError``,
+    not the underlying ``json.JSONDecodeError`` / ``OSError``. Lets the
+    UI catch a single typed exception."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    (run_path / "comparison.json").write_text("not json", encoding="utf-8")
+
+    with pytest.raises(ReportCardError):
+        ensure_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+
+def test_ensure_report_card_normalizes_shape_invalid_json_to_report_card_error(tmp_path: Path):
+    """JSON-valid but shape-invalid ``comparison.json`` (e.g. ``{}``,
+    missing required keys) must surface as ``ReportCardError`` — not a
+    raw ``KeyError`` from ``ReportCard.from_dict``'s bracket access.
+    Guards the ``_LOAD_ERRORS`` swallow against the codex-flagged regression."""
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+    # Empty object: ``schema_version`` defaults to 1 (lenient), but every
+    # required field (event_key, run_id, balance_score, ...) is missing
+    # so ``ReportCard.from_dict`` raises ``KeyError``.
+    (run_path / "comparison.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ReportCardError):
+        ensure_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# safe_read_comparison_json
+# ---------------------------------------------------------------------------
+
+
+def test_safe_read_comparison_json_returns_card_when_well_formed(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    card = safe_read_comparison_json(run_path / "comparison.json")
+    assert card is not None
+    assert card.run_id == RUN_ID
+
+
+def test_safe_read_comparison_json_returns_none_for_missing_file(tmp_path: Path):
+    assert safe_read_comparison_json(tmp_path / "nonexistent.json") is None
+
+
+def test_safe_read_comparison_json_returns_none_for_corrupt_json(tmp_path: Path):
+    path = tmp_path / "comparison.json"
+    path.write_text("not json", encoding="utf-8")
+    assert safe_read_comparison_json(path) is None
+
+
+def test_safe_read_comparison_json_returns_none_for_shape_invalid_json(tmp_path: Path):
+    """JSON-valid but missing required keys must produce ``None``, not
+    raise ``KeyError`` upward into the dropdown render."""
+    path = tmp_path / "comparison.json"
+    path.write_text("{}", encoding="utf-8")
+    assert safe_read_comparison_json(path) is None
+
+
+# ---------------------------------------------------------------------------
+# zip_run_csvs
+# ---------------------------------------------------------------------------
+
+
+def test_zip_run_csvs_bundles_three_expected_files(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    blob = zip_run_csvs(run_path)
+    assert isinstance(blob, bytes)
+
+    with zipfile.ZipFile(io.BytesIO(blob), "r") as archive:
+        names = sorted(archive.namelist())
+        assert names == [
+            "comparison_metrics.csv",
+            "comparison_risk_flags.csv",
+            "comparison_team_movements.csv",
+        ]
+        # Each entry round-trips verbatim against the on-disk file.
+        for name in names:
+            assert archive.read(name) == (run_path / name).read_bytes()
+
+
+def test_zip_run_csvs_raises_when_csv_missing(tmp_path: Path):
+    run_path = _bootstrap(tmp_path)
+    _write_summary(run_path)
+    _write_division_recommendations(run_path)
+    compute_and_persist_report_card(EVENT_KEY, SCENARIO, RUN_ID, base_dir=tmp_path)
+
+    (run_path / "comparison_risk_flags.csv").unlink()
+
+    with pytest.raises(FileNotFoundError):
+        zip_run_csvs(run_path)
+
+
+# ---------------------------------------------------------------------------
+# project_audit_row
+# ---------------------------------------------------------------------------
+
+
+def test_project_audit_row_picks_only_display_cols_and_drops_nested_fields():
+    record = {
+        "schema_version": 1,
+        "ts": "2026-04-30T12:00:00+00:00",
+        "actor": "ops@pitchrank.io",
+        "type": "accept_match",
+        "team_ref": "pid-1",
+        "reason": "manual review",
+        "delta_balance_score": None,
+        "before": {"some": "nested"},
+        "after": {"more": "nested"},
+        "run_id": "u14_boys_test",
+        "applied_at": "2026-04-30T12:00:00+00:00",
+    }
+    projected = project_audit_row(record)
+
+    assert set(projected) == set(DISPLAY_COLS)
+    assert "before" not in projected
+    assert "after" not in projected
+    assert "schema_version" not in projected
+    assert projected["ts"] == "2026-04-30T12:00:00+00:00"
+    assert projected["delta_balance_score"] == "n/a"
+
+
+def test_project_audit_row_maps_none_delta_to_n_a():
+    record = {"ts": "x", "actor": "y", "type": "z", "team_ref": "p", "reason": "r", "delta_balance_score": None}
+    assert project_audit_row(record)["delta_balance_score"] == "n/a"
+
+
+def test_project_audit_row_maps_empty_string_delta_to_n_a():
+    record = {"ts": "x", "actor": "y", "type": "z", "team_ref": "p", "reason": "r", "delta_balance_score": ""}
+    assert project_audit_row(record)["delta_balance_score"] == "n/a"
+
+
+def test_project_audit_row_maps_missing_delta_to_n_a():
+    """Scenario-level overrides (raw ``load_overrides`` records) lack the
+    field entirely. The (None, "") predicate must still produce "n/a"."""
+    record = {"ts": "x", "actor": "y", "type": "external", "team_ref": "p", "reason": "r"}
+    assert project_audit_row(record)["delta_balance_score"] == "n/a"
+
+
+def test_project_audit_row_preserves_numeric_delta():
+    record = {"ts": "x", "actor": "y", "type": "z", "team_ref": "p", "reason": "r", "delta_balance_score": 1.5}
+    assert project_audit_row(record)["delta_balance_score"] == 1.5
+
+
+# ---------------------------------------------------------------------------
+# format_run_label / format_run_timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_format_run_timestamp_returns_unknown_for_none():
+    assert format_run_timestamp(None) == "unknown"
+
+
+def test_format_run_timestamp_returns_unknown_for_malformed():
+    assert format_run_timestamp("not-a-date") == "unknown"
+    assert format_run_timestamp("") == "unknown"
+
+
+def test_format_run_timestamp_truncates_to_minute():
+    assert format_run_timestamp("2026-04-30T12:34:56+00:00") == "2026-04-30 12:34"
+
+
+def test_format_run_label_includes_truncated_timestamp_and_score():
+    label = format_run_label("u14_boys_x", "2026-04-30T12:34:56+00:00", 78.4)
+    assert label == "2026-04-30 12:34 · BS 78"
+
+
+def test_format_run_label_renders_n_a_when_score_missing():
+    label = format_run_label("u14_boys_x", "2026-04-30T12:34:56+00:00", None)
+    assert label == "2026-04-30 12:34 · BS n/a"
+
+
+def test_format_run_label_renders_unknown_timestamp_with_score():
+    label = format_run_label("u14_boys_x", None, 81.0)
+    assert label == "unknown · BS 81"
+
+
+def test_format_run_label_renders_unknown_and_n_a_when_both_missing():
+    assert format_run_label("u14_boys_x", None, None) == "unknown · BS n/a"
+
+
+# ---------------------------------------------------------------------------
+# derive_export_filenames
+# ---------------------------------------------------------------------------
+
+
+def _hand_card(*, event_name: str, gender: str, age_group: str, run_id: str) -> ReportCard:
+    return ReportCard(
+        event_key=EVENT_KEY,
+        scenario=SCENARIO,
+        run_id=run_id,
+        age_group=age_group,
+        gender=gender,
+        event_name=event_name,
+        computed_at="2026-04-30T12:00:00+00:00",
+        balance_score=BalanceScore(actual=None, optimized=70.0, delta=None, preset_id="default"),
+        metrics=(Metric(label="x", actual=None, optimized=0, delta=None, unit="count"),),
+        risk_flags=(),
+        top_reasons=(),
+        team_movements=(),
+        override_audit=(),
+    )
+
+
+def test_derive_export_filenames_produces_expected_keys():
+    card = _hand_card(
+        event_name="Phoenix Cup 2026",
+        gender="Boys",
+        age_group="u14",
+        run_id="u14_boys_20260430T120000_aaaaaaaaaaaa",
+    )
+    names = derive_export_filenames(card)
+
+    assert set(names) == {"html", "json", "zip"}
+    assert names["html"].endswith(".html")
+    assert names["zip"].endswith(".zip")
+    assert names["json"].endswith(".json")
+
+
+def test_derive_export_filenames_slugifies_spaces_and_unicode():
+    card = _hand_card(
+        event_name="Phoenix · Cup / 2026",  # contains separators + unicode dot
+        gender="Boys",
+        age_group="u14",
+        run_id="u14_boys_x",
+    )
+    names = derive_export_filenames(card)
+
+    # Slug collapses every non-alphanumeric run to a single underscore.
+    assert "/" not in names["html"]
+    assert " " not in names["html"]
+    assert "·" not in names["html"]
+    assert names["html"].startswith("report_card_Phoenix_Cup_2026_Boys_u14_")
+
+
+def test_derive_export_filenames_no_path_traversal_chars():
+    """All free-form fields slugify safely — no ``..`` / ``/`` / ``\\``
+    can land in the on-disk filename a browser will write."""
+    card = _hand_card(
+        event_name="../../etc/passwd",
+        gender="Boys/Girls",
+        age_group="u14",
+        run_id="u14_boys_x",
+    )
+    names = derive_export_filenames(card)
+
+    for value in names.values():
+        assert ".." not in value
+        assert "/" not in value
+        assert "\\" not in value
+
+
+def test_derive_export_filenames_handles_all_blank_fields():
+    """Empty/blank fields fall back to literal placeholders rather than
+    producing ``report_card____.html``."""
+    card = _hand_card(event_name="", gender="", age_group="", run_id="")
+    names = derive_export_filenames(card)
+
+    # ``card.run_id`` empty would slugify to "" — the helper substitutes
+    # "run" so the filename remains parseable.
+    assert "report_card_event_cohort_cohort_run" in names["html"]
+
+
+# ---------------------------------------------------------------------------
+# OverrideAuditRow integration with project_audit_row
+# ---------------------------------------------------------------------------
+
+
+def test_project_audit_row_works_on_override_audit_row_record():
+    """Regression: OverrideAuditRow.record dicts survive projection
+    untouched and the delta mapping fires for the orchestrator's
+    hardcoded None."""
+    row = OverrideAuditRow.from_dict(
+        {
+            "schema_version": 1,
+            "ts": "2026-04-30T11:00:00+00:00",
+            "actor": "ops",
+            "type": "accept_match",
+            "team_ref": "pid-1",
+            "reason": "ok",
+            "before": {"x": 1},
+            "after": {"y": 2},
+            "delta_balance_score": None,
+        }
+    )
+    projected = project_audit_row(row.record)
+    assert projected["type"] == "accept_match"
+    assert projected["delta_balance_score"] == "n/a"
+    assert "before" not in projected

--- a/tests/unit/test_run_orchestrator.py
+++ b/tests/unit/test_run_orchestrator.py
@@ -1011,7 +1011,7 @@ def test_orphan_tmp_cleanup_removes_old_dirs(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# _override_in_cohort — manual_add and recompute_medians branches
+# override_in_cohort — manual_add and recompute_medians branches
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_storage_run_layout.py
+++ b/tests/unit/test_storage_run_layout.py
@@ -14,7 +14,9 @@ import pytest
 
 from src.tournaments.storage.event_key import scenario_dir
 from src.tournaments.storage.run_layout import (
+    RunLockError,
     RunStateError,
+    acquire_run_lock,
     cancel_run,
     create_staging_run,
     fail_run,
@@ -135,3 +137,53 @@ def test_list_runs_completed_only_filters(tmp_path: Path):
 def test_list_runs_empty_when_no_runs_dir(tmp_path: Path):
     ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
     assert list_runs(EVENT_KEY, SCENARIO, base_dir=tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# acquire_run_lock — mirrors the per-scenario lock contract at the per-run path
+# ---------------------------------------------------------------------------
+
+
+def _promote_run(tmp_path: Path, run_id: str) -> Path:
+    """Stage + promote a run so its directory exists for lock acquisition."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    create_staging_run(EVENT_KEY, SCENARIO, run_id, base_dir=tmp_path)
+    return promote_run(EVENT_KEY, SCENARIO, run_id, base_dir=tmp_path)
+
+
+def test_acquire_run_lock_holds_within_context(tmp_path: Path):
+    run_path = _promote_run(tmp_path, "run_lock_001")
+    with acquire_run_lock(EVENT_KEY, SCENARIO, "run_lock_001", base_dir=tmp_path):
+        assert (run_path / ".report.lock").exists()
+
+
+def test_acquire_run_lock_raises_immediately_with_zero_timeout(tmp_path: Path):
+    """``timeout=0.0`` is once-and-raise — mirrors scenario-lock contract."""
+    _promote_run(tmp_path, "run_lock_002")
+    with acquire_run_lock(EVENT_KEY, SCENARIO, "run_lock_002", base_dir=tmp_path):
+        with pytest.raises(RunLockError):
+            with acquire_run_lock(
+                EVENT_KEY,
+                SCENARIO,
+                "run_lock_002",
+                base_dir=tmp_path,
+                timeout=0.0,
+            ):
+                pytest.fail("inner acquire should have raised")
+
+
+def test_acquire_run_lock_lockfile_persists_after_release(tmp_path: Path):
+    """Lockfile is presence/lock primitive — not deleted on context exit."""
+    run_path = _promote_run(tmp_path, "run_lock_003")
+    with acquire_run_lock(EVENT_KEY, SCENARIO, "run_lock_003", base_dir=tmp_path):
+        pass
+    assert (run_path / ".report.lock").exists()
+
+
+def test_acquire_run_lock_raises_filenotfound_when_run_dir_missing(tmp_path: Path):
+    """Calling acquire_run_lock for a run that never existed surfaces a
+    plain ``FileNotFoundError`` (caller-ordering bug, not a lock bug)."""
+    ensure_scenario(EVENT_KEY, SCENARIO, base_dir=tmp_path)
+    with pytest.raises(FileNotFoundError):
+        with acquire_run_lock(EVENT_KEY, SCENARIO, "run_never_promoted", base_dir=tmp_path):
+            pytest.fail("acquire should have raised before yielding")

--- a/tournament_intake.py
+++ b/tournament_intake.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import html
+import json
 import logging
 import os
 import sys
@@ -20,7 +21,9 @@ from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import streamlit as st
+import streamlit.components.v1 as components
 
 from config.settings import (
     PROJECT_NAME,
@@ -40,9 +43,23 @@ from src.tournaments.event_team_matcher import (
     enrich_registry_rows_with_matcher,
     search_event_team_in_db,
 )
+from src.tournaments.reports import (
+    ReportCardError,
+    render_html,
+)
+from src.tournaments.reports.ui import (
+    derive_export_filenames,
+    ensure_report_card,
+    format_run_label,
+    format_run_timestamp,
+    project_audit_row,
+    safe_read_comparison_json,
+    zip_run_csvs,
+)
 from src.tournaments.run_orchestrator import (
     ProgressEvent,
     execute_run,
+    override_in_cohort,
     preflight,
 )
 from src.tournaments.seeding_optimizer import (
@@ -55,6 +72,7 @@ from src.tournaments.storage import (
     DivisionStructure,
     EventMetadata,
     RegistryPersistResult,
+    RunLockError,
     RunStateError,
     ScenarioLockError,
     SchemaVersionError,
@@ -85,7 +103,10 @@ from src.tournaments.storage import (
     write_frozen_medians,
     write_structure,
 )
-from src.tournaments.storage._io import utc_now_iso
+from src.tournaments.storage import (
+    run_dir as _run_dir,
+)
+from src.tournaments.storage._io import read_json, utc_now_iso
 from src.tournaments.triage import (
     _STRENGTH_MODES,
     SOURCE_EXPLICIT,
@@ -97,6 +118,7 @@ from src.tournaments.triage import (
     _is_play_up,
     build_override_record,
     project_overrides,
+    registry_provider_id,
     resolve_division_assignment,
 )
 from supabase import create_client
@@ -3013,6 +3035,250 @@ def _render_advanced_settings(
 # ---------------------------------------------------------------------------
 
 
+@st.cache_data(ttl=60)
+def _build_registry_by_pid(event_key: str, scenario: str) -> dict[str, Any]:
+    """Cache the registry as ``provider_id → TeamRegistryEntry``.
+
+    Cache key is ``(event_key, scenario)`` — the registry CSV is read at
+    most once per scenario per minute. Intake-time changes to the registry
+    surface in the audit panel within 60s; acceptable v1 staleness.
+
+    The dict is consumed by ``override_in_cohort`` (Step 6) to filter
+    scenario-level overrides down to the active cohort. Without it, every
+    override of types ``assign``, ``external``, ``merge``, etc. is
+    silently filtered out (the predicate returns False whenever the
+    registry lookup misses).
+    """
+    registry = read_registry(event_key, scenario)
+    return {pid: entry for entry in registry if (pid := registry_provider_id(entry))}
+
+
+_METADATA_READ_ERRORS: tuple[type[BaseException], ...] = (
+    FileNotFoundError,
+    json.JSONDecodeError,
+    OSError,
+    AttributeError,
+    KeyError,
+    TypeError,
+    ValueError,
+)
+"""Exceptions the dropdown-filter loop tolerates when probing run-dir
+metadata. Covers I/O (``FileNotFoundError`` / ``OSError``), JSON
+(``json.JSONDecodeError`` / ``ValueError``), AND structural-shape errors
+(``AttributeError`` / ``KeyError`` / ``TypeError``) — a JSON-valid but
+shape-invalid ``run_metadata.json`` (legacy/manually-edited) would
+otherwise crash the entire previous-runs dropdown render.
+"""
+
+
+def _read_ended_at(event_key: str, scenario: str, run_id_: str) -> str | None:
+    """Return ``run_metadata.json["ended_at"]`` or ``None`` if absent.
+
+    Not cached — local file read (single ``read_json`` per call,
+    sub-millisecond) and any TTL window introduces a stale-label window
+    when a new run completes. Raises ``_METADATA_READ_ERRORS`` on missing
+    / corrupt / shape-invalid metadata; the dropdown filter catches those
+    to exclude unreadable runs.
+    """
+    payload = read_json(_run_dir(event_key, scenario, run_id_) / "run_metadata.json")
+    return payload.get("ended_at")
+
+
+def _read_optimized_score(event_key: str, scenario: str, run_id_: str) -> float | None:
+    """Return ``balance_score.optimized`` from a persisted Report Card.
+
+    Returns ``None`` when ``report_card.done`` is absent (no Report Card
+    has been computed yet) or when the ``comparison.json`` is corrupt,
+    schema-mismatched, or shape-invalid. The defensive read via
+    ``safe_read_comparison_json`` is REQUIRED because the dropdown's
+    ``format_func`` lambda calls this for EVERY visible run on every
+    render — a single corrupt ``comparison.json`` in the run history
+    would otherwise explode the entire dropdown.
+    """
+    run_dir_path = _run_dir(event_key, scenario, run_id_)
+    if not (run_dir_path / "report_card.done").exists():
+        return None
+    card = safe_read_comparison_json(run_dir_path / "comparison.json")
+    return card.balance_score.optimized if card is not None else None
+
+
+def _render_cohort_completed_run(
+    *,
+    event_key: str,
+    scenario: str,
+    age: str,
+    gender: str,
+    run_id: str,
+) -> None:
+    """Render the Shell 08 completed-run surface for one cohort.
+
+    Body order: previous-runs dropdown → lazy-load Report Card → header
+    line → action row (Export HTML / CSV / JSON + Re-run) → inline iframe
+    embed → collapsed override-audit panel.
+    """
+    # --- Previous-runs dropdown ------------------------------------------
+    # Build the cohort-scoped run list and prefetch the per-run label inputs
+    # in a single pass. The selectbox ``format_func`` lambda fires for every
+    # visible run on every Streamlit rerun; doing dict lookups against this
+    # cache keeps the dropdown render O(N) file reads instead of O(N) per
+    # rerun. Skip ``_read_ended_at``-unreadable runs (corrupt/legacy) so the
+    # widget never offers an option that would crash on selection.
+    cohort_prefix = f"{age}_{gender.lower()}_"
+    all_runs = [r for r in list_runs(event_key, scenario, completed_only=True) if r.startswith(cohort_prefix)]
+    runs: list[str] = []
+    label_inputs: dict[str, tuple[str | None, float | None]] = {}
+    for r in reversed(all_runs):
+        try:
+            ended_at_value = _read_ended_at(event_key, scenario, r)
+        except _METADATA_READ_ERRORS:
+            continue
+        label_inputs[r] = (ended_at_value, _read_optimized_score(event_key, scenario, r))
+        runs.append(r)
+
+    # Reconcile stale ``run_id`` BEFORE selectbox renders. Streamlit raises
+    # ``StreamlitAPIException`` when the keyed widget's session-state value
+    # is not in ``options`` — pop and rerun rather than crash.
+    if not runs:
+        st.session_state.current_run_id_by_cohort.pop((age, gender), None)
+        st.session_state.pop(f"prev_run_select_{age}_{gender}", None)
+        st.warning("No readable runs for this cohort. Click Run backtest to start fresh.")
+        st.rerun()
+    if run_id not in runs:
+        st.session_state.current_run_id_by_cohort[(age, gender)] = runs[0]
+        st.session_state.pop(f"prev_run_select_{age}_{gender}", None)
+        st.rerun()
+
+    if len(runs) > 1:
+        select_key = f"prev_run_select_{age}_{gender}"
+        # Synchronize the keyed widget's session-state value to the loaded
+        # ``run_id`` BEFORE the widget renders — once the widget exists, its
+        # session-state value takes precedence over any ``index=`` argument,
+        # so the explicit pre-write is the source of truth.
+        if st.session_state.get(select_key) != run_id:
+            st.session_state[select_key] = run_id
+        selected = st.selectbox(
+            label=f"Run for {gender} {age}",
+            options=runs,
+            format_func=lambda r: format_run_label(r, *label_inputs[r]),
+            key=select_key,
+        )
+        if selected != run_id:
+            st.session_state.current_run_id_by_cohort[(age, gender)] = selected
+            st.rerun()
+
+    # --- Lazy compute / load ---------------------------------------------
+    try:
+        with st.spinner("Generating Report Card..."):
+            card = ensure_report_card(event_key, scenario, run_id)
+    except RunLockError:
+        st.warning("Another tab is generating this run's Report Card. Reload in 30s.")
+        return
+    except ReportCardError as exc:
+        st.error(f"Cannot load Report Card: {exc}")
+        return
+
+    # --- Header line -----------------------------------------------------
+    run_dir_path = _run_dir(event_key, scenario, run_id)
+    ended_at, _ = label_inputs.get(run_id, (None, None))
+    if ended_at is None:
+        try:
+            done_payload = read_json(run_dir_path / "done.json")
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            done_payload = {}
+        ended_at = done_payload.get("promoted_at")
+    ended_at_display = format_run_timestamp(ended_at)
+    if card.balance_score.actual is not None:
+        bs_summary = f"{card.balance_score.actual:.0f} → {card.balance_score.optimized:.0f}"
+    else:
+        bs_summary = f"{card.balance_score.optimized:.0f} (actual n/a)"
+    st.caption(f"Last run · ended {ended_at_display} · Balance Score {bs_summary}")
+
+    # --- Action row ------------------------------------------------------
+    filenames = derive_export_filenames(card)
+    html_path = run_dir_path / "comparison.html"
+    if html_path.exists():
+        html_data: bytes = html_path.read_bytes()
+    else:
+        html_data = render_html(card, mode="standalone").encode("utf-8")
+
+    c1, c2, c3, c4, _ = st.columns([1, 1, 1, 1, 2])
+    with c1:
+        st.download_button(
+            "Export HTML",
+            data=html_data,
+            file_name=filenames["html"],
+            mime="text/html",
+            key=f"export_html_{age}_{gender}",
+        )
+    with c2:
+        try:
+            zip_data = zip_run_csvs(run_dir_path)
+        except FileNotFoundError as exc:
+            st.error(f"CSV export unavailable: {exc}")
+        else:
+            st.download_button(
+                "Export CSV",
+                data=zip_data,
+                file_name=filenames["zip"],
+                mime="application/zip",
+                key=f"export_csv_{age}_{gender}",
+            )
+    with c3:
+        st.download_button(
+            "Export JSON",
+            data=(run_dir_path / "comparison.json").read_bytes(),
+            file_name=filenames["json"],
+            mime="application/json",
+            key=f"export_json_{age}_{gender}",
+        )
+    with c4:
+        if st.button(
+            "Re-run",
+            key=f"rerun_{age}_{gender}",
+            help="Clear this cohort's loaded run and show the Run button again.",
+        ):
+            st.session_state.current_run_id_by_cohort.pop((age, gender), None)
+            st.session_state.pop(f"prev_run_select_{age}_{gender}", None)
+            st.rerun()
+
+    # --- Inline iframe embed ---------------------------------------------
+    # ``mode="standalone"`` is required so the inline ``<style>`` block ships
+    # inside the iframe; ``mode="embedded"`` returns a CSS-less fragment.
+    # ``show_override_audit=False`` suppresses the in-iframe ``<details>``
+    # because the outside expander below is the single source of truth.
+    components.html(
+        render_html(card, mode="standalone", show_override_audit=False),
+        height=900,
+        scrolling=True,
+    )
+
+    # --- Override audit panel --------------------------------------------
+    per_run_rows = [project_audit_row(entry.record) for entry in card.override_audit]
+    scenario_records = load_overrides(event_key, scenario)
+    registry_by_pid = _build_registry_by_pid(event_key, scenario)
+    scenario_rows = [
+        project_audit_row(record)
+        for record in scenario_records
+        if override_in_cohort(record, age, gender, registry_by_pid)
+    ]
+    with st.expander(
+        f"Override log · {len(per_run_rows)} per-run · {len(scenario_rows)} scenario",
+        expanded=False,
+    ):
+        st.markdown("**Per-run overrides**")
+        if per_run_rows:
+            st.dataframe(pd.DataFrame(per_run_rows), width="stretch")
+            st.caption("ⓘ Per-override delta_balance_score is deferred to v2.")
+        else:
+            st.caption("No per-run overrides applied for this cohort.")
+
+        st.markdown("**Scenario-level overrides**")
+        if scenario_rows:
+            st.dataframe(pd.DataFrame(scenario_rows), width="stretch")
+        else:
+            st.caption("No scenario-level overrides for this cohort.")
+
+
 def _render_cohort_run_control(
     *,
     event_key: str,
@@ -3036,7 +3302,13 @@ def _render_cohort_run_control(
     button_key = f"run_btn_{age}_{gender}"
     cohort_run_id = st.session_state.current_run_id_by_cohort.get((age, gender))
     if cohort_run_id is not None:
-        st.caption(f"Run loaded: {cohort_run_id}")
+        _render_cohort_completed_run(
+            event_key=event_key,
+            scenario=scenario,
+            age=age,
+            gender=gender,
+            run_id=cohort_run_id,
+        )
         return
 
     result = preflight(event_key, scenario, age, gender, supabase_client=supabase_client)


### PR DESCRIPTION
Final v1 shell of the MatchBalance backtest intake project. Embeds the Shell 07 Report Card under each completed cohort: previous-runs dropdown, inline iframe of the rendered HTML, three Export buttons (HTML / CSV-as-ZIP / JSON), Re-run, and a collapsed override-audit panel that surfaces both per-run and scenario-level overrides for the active cohort.

The Streamlit surface stays thin. All compute and rendering lives in `src/tournaments/reports/ui.py` (Streamlit-free, unit-tested) and the existing `compute_and_persist_report_card`. The lazy gate computes the Report Card on first view, then reads from disk on subsequent views.

## Changes

- **`src/tournaments/storage/_file_lock.py`**: factor the platform-abstracted advisory lock out of `scenario.py`. Both `acquire_scenario_lock` and the new `acquire_run_lock` (`runs/<run_id>/.report.lock`) delegate to it and translate `FileLockError` to their typed subclass at the boundary.
- **`src/tournaments/reports/ui.py`** (new): `ensure_report_card` (sentinel-gated lazy compute-or-load with per-run lock + lost-update guard), `safe_read_comparison_json` (best-effort wrapper that returns `None` on any failure including shape errors), `zip_run_csvs`, `project_audit_row`, `format_run_label` / `format_run_timestamp`, `derive_export_filenames`.
- **`src/tournaments/reports/render_html.py` + template**: `show_override_audit` kwarg on `render_html` and `write_html` (default `True`). Shell 08's inline embed passes `False` so the outside expander is the single source of truth; the persisted `comparison.html` keeps the audit details block.
- **`tournament_intake.py`**: replace the `cohort_run_id is not None` early-return at line 3037 with `_render_cohort_completed_run`. New helpers prefetch `(ended_at, optimized_score)` per visible run so the selectbox `format_func` does dict lookups instead of N file reads per Streamlit rerun. Override audit panel filters scenario-level overrides by cohort using a `@st.cache_data(ttl=60)` registry index.
- **`run_orchestrator.py`**: rename `_override_in_cohort` to `override_in_cohort` (now public; reused by the audit panel).

## Lazy compute-or-load flow

```mermaid
sequenceDiagram
  participant UI as _render_cohort_completed_run
  participant E as ensure_report_card
  participant L as acquire_run_lock
  participant FS as runs/<run_id>/

  UI->>E: load(event_key, scenario, run_id)
  E->>FS: report_card.done exists?
  alt sentinel present
    FS-->>E: yes
    E->>FS: read comparison.json
    FS-->>UI: ReportCard
  else sentinel absent
    E->>L: acquire .report.lock (timeout=30s)
    L-->>E: held
    E->>FS: report_card.done exists? (lost-update guard)
    alt sibling tab finished compute
      FS-->>E: yes
      E->>FS: read comparison.json
    else still absent
      E->>FS: compute_and_persist_report_card
      FS-->>E: ReportCard + 6 artifacts
    end
    E-->>UI: ReportCard
  end
```

## Tests

177 unit + integration pass. New coverage:
- 29 tests in `tests/unit/test_reports_ui.py` (lazy gate, lock contention, lost-update guard, error normalization, shape-invalid JSON, zip bundle, audit projection, label formatters, filename slugification, `safe_read_comparison_json`).
- 4 tests in `tests/unit/test_storage_run_layout.py` mirroring `acquire_scenario_lock`'s contract at the per-run lockfile path.
- 3 tests in `tests/unit/test_reports_render_html.py` covering the `show_override_audit` flag.
- 1 regression test in `tests/unit/test_reports_persist.py` confirming the persisted `comparison.html` retains its audit details block.

Plan: `.turbo/plans/matchbalance-backtest-intake-08-report-card-ui-and-exports.md`. Manual UI smoke (the only realistic test of the iframe embed) is deferred to operator testing per the plan.

Closes the MatchBalance v1 backtest intake (Shells 01-10 all done).
