### PR TITLE
fix(predictor): predict draw for symmetric inputs to fix CI flake

### DIFF
--- a/frontend/lib/matchPredictor.test.ts
+++ b/frontend/lib/matchPredictor.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { calculateCommonOpponentSignal, predictMatch } from './matchPredictor';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { calculateCommonOpponentSignal, predictMatch, warmMatchPredictorCalibration } from './matchPredictor';
 import type { Game, TeamWithRanking } from './types';
+
+beforeAll(async () => {
+  // Calibration JSON loads fire-and-forget at module init; awaiting here makes
+  // every test deterministic regardless of how fast the load resolves.
+  await warmMatchPredictorCalibration();
+});
 
 function makeTeam(overrides: Partial<TeamWithRanking> = {}): TeamWithRanking {
   return {
@@ -153,6 +159,42 @@ describe('predictMatch', () => {
     expect(prediction.winProbabilityA).toBeLessThan(1);
     expect(prediction.expectedScore.teamA).toBeGreaterThanOrEqual(0);
     expect(prediction.expectedScore.teamB).toBeGreaterThanOrEqual(0);
+  });
+
+  it('predicts draw for symmetric inputs even with non-sparse history', () => {
+    // Non-sparse symmetric inputs: heuristic-draw conditions DO NOT trigger
+    // (sparseMatchup=false because games_played=22), so the symmetric-inputs
+    // short-circuit is the only path that returns 'draw'. Without it, the
+    // asymmetric outcome-calibration prior would tip the predicted winner to
+    // whichever side has the slightly higher prior.
+    const teamA = makeTeam({
+      team_id_master: 'team-a',
+      team_name: 'Twin A 14B',
+      games_played: 22,
+      wins: 11,
+      losses: 7,
+      draws: 4,
+      win_percentage: 50,
+      power_score_final: 0.6,
+      glicko_rating: 1600,
+      glicko_rd: 60,
+      sos_norm: 0.55,
+      offense_norm: 0.6,
+      defense_norm: 0.55,
+    });
+    const teamB = makeTeam({
+      ...teamA,
+      team_id_master: 'team-b',
+      team_name: 'Twin B 14B',
+    });
+
+    const prediction = predictMatch(teamA, teamB, []);
+
+    expect(prediction.predictedWinner).toBe('draw');
+    expect(prediction.winProbabilityA).toBeCloseTo(prediction.winProbabilityB, 9);
+    expect(
+      (prediction.winProbabilityA + prediction.winProbabilityB + (prediction.drawProbability ?? 0)).toFixed(6)
+    ).toBe('1.000000');
   });
 
   it('shrinks overconfident edges when same-age evidence is weak', () => {

--- a/frontend/lib/matchPredictor.ts
+++ b/frontend/lib/matchPredictor.ts
@@ -772,6 +772,11 @@ function calibrateProbability(rawProb: number): number {
 // ~16% of games end in draws, so this captures close matchups
 const DRAW_THRESHOLD = 0.03; // |winProb - 0.5| < 3% → predict draw
 
+// Tolerance for treating two teams' raw win probabilities as equal. Symmetric
+// inputs produce equal raw probabilities; this guards against the asymmetric
+// outcome calibration prior tipping the predicted winner deterministically.
+const SYMMETRY_EPSILON = 1e-9;
+
 /**
  * Get age-adjusted league average goals per team
  * Uses calibrated parameters from age_group_parameters.json if available,
@@ -1265,29 +1270,40 @@ export function predictMatch(teamA: TeamWithRanking, teamB: TeamWithRanking, all
   const rawWinProbA = winProbA;
   const rawDrawProbability = normalizedDrawProbability;
   const rawWinProbB = winProbB;
-  [winProbA, normalizedDrawProbability, winProbB] = applyOutcomeCalibration(
-    rawWinProbA,
-    rawDrawProbability,
-    rawWinProbB
-  );
+  // Symmetric inputs (identical features for both teams) produce equal raw win
+  // probabilities. Skip the asymmetric prior blend in applyOutcomeCalibration so
+  // a tiny prior gap doesn't tip the predicted winner toward whichever side has
+  // the slightly higher prior in the calibration JSON.
+  const rawWinGap = Math.abs(rawWinProbA - rawWinProbB);
+  const symmetricRawWinProbs = rawWinGap < SYMMETRY_EPSILON;
+  if (!symmetricRawWinProbs) {
+    [winProbA, normalizedDrawProbability, winProbB] = applyOutcomeCalibration(
+      rawWinProbA,
+      rawDrawProbability,
+      rawWinProbB
+    );
+  }
 
   const drawOverrideThreshold = getAgeSpecificDrawOverrideThreshold(effectiveAge);
   const hasOutcomeCalibration = Boolean(outcomeCalibrationParams && outcomeCalibrationParams.enabled !== false);
-  const predictedWinner: 'team_a' | 'team_b' | 'draw' = hasOutcomeCalibration
-    ? drawOverrideThreshold != null &&
+  const decisiveWinner: 'team_a' | 'team_b' = winProbA >= winProbB ? 'team_a' : 'team_b';
+
+  let predictedWinner: 'team_a' | 'team_b' | 'draw';
+  if (symmetricRawWinProbs) {
+    predictedWinner = 'draw';
+  } else if (hasOutcomeCalibration) {
+    const calibratedDrawOverride =
+      drawOverrideThreshold != null &&
       rawDrawProbability >= drawOverrideThreshold &&
-      Math.abs(rawWinProbA - rawWinProbB) < (outcomeCalibrationParams?.draw_override_max_win_gap ?? 0.1)
-      ? 'draw'
-      : winProbA >= winProbB
-        ? 'team_a'
-        : 'team_b'
-    : (normalizedDrawProbability + DRAW_THRESHOLD >= Math.max(winProbA, winProbB) &&
-          Math.abs(winProbA - winProbB) < 0.12) ||
-        (closeDecisiveEdge && sparseMatchup && normalizedDrawProbability >= DEFAULT_DRAW_RATE * 0.9)
-      ? 'draw'
-      : winProbA >= winProbB
-        ? 'team_a'
-        : 'team_b';
+      rawWinGap < (outcomeCalibrationParams?.draw_override_max_win_gap ?? 0.1);
+    predictedWinner = calibratedDrawOverride ? 'draw' : decisiveWinner;
+  } else {
+    const heuristicDraw =
+      (normalizedDrawProbability + DRAW_THRESHOLD >= Math.max(winProbA, winProbB) &&
+        Math.abs(winProbA - winProbB) < 0.12) ||
+      (closeDecisiveEdge && sparseMatchup && normalizedDrawProbability >= DEFAULT_DRAW_RATE * 0.9);
+    predictedWinner = heuristicDraw ? 'draw' : decisiveWinner;
+  }
 
   const expectedScore =
     predictedWinner === 'draw'


### PR DESCRIPTION
## Summary

`matchPredictor.test.ts` "sparse evenly matched data" was flaking on `main` (4/9 recent CI runs failed Apr 26-27). Root cause: `heuristic_outcome_calibration.json` ships an asymmetric prior (`team_a=0.4316`, `team_b=0.4350`). When two teams have identical features, raw `winProbA === winProbB` exactly, but `applyOutcomeCalibration` blends each side with its own prior, so `winProbB` ends up slightly larger and the predictor deterministically returns `'team_b'` instead of `'draw'`. The flake came from a load race: `loadOutcomeCalibrationParameters()` is fire-and-forget at module init, so when it hadn't resolved yet the heuristic fallback path correctly returned `'draw'`; once loaded, the calibrated path tipped to `'team_b'`.

## Fix

- Add `SYMMETRY_EPSILON = 1e-9` and a `symmetricRawWinProbs` short-circuit before `applyOutcomeCalibration`. When raw win probabilities are equal within epsilon, skip the prior blend and force `predictedWinner = 'draw'`. Epsilon is sized for ~few-ULP Poisson convolution sum-order drift; ten orders of magnitude tighter than any meaningful semantic difference, six orders looser than realistic FP drift.
- Hoist `rawWinGap = Math.abs(rawWinProbA - rawWinProbB)` (was computed twice) and flatten the previously-4-deep nested ternary into an if/else chain with a `decisiveWinner` helper. Logic verified byte-identical on the non-symmetric path.
- Add `beforeAll(() => warmMatchPredictorCalibration())` to the test suite to deterministically warm all 4 calibration loaders, eliminating the load-timing flake source.
- Add a non-sparse symmetric-inputs test (games_played=22) that uniquely exercises the new short-circuit. The pre-existing sparse test exercises both the heuristic-draw path and the symmetric path; this new test isolates the symmetric path.

## Test plan

- [x] `npx vitest run lib/matchPredictor.test.ts` (5/5 pass, was 4/4)
- [x] `npx vitest run lib/` (54/54 pass)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint lib/matchPredictor.ts` clean
- [x] CI Quality Gate green
