### PR TITLE
feat(seo): GA state pillar + youth soccer levels explainer (Week 7)

### DIFF
--- a/frontend/content/blog/georgia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/georgia-youth-soccer-rankings-guide.mdx
@@ -1,0 +1,298 @@
+---
+title: 'Georgia (GA) Youth Soccer Rankings 2026'
+slug: 'georgia-youth-soccer-rankings-guide'
+excerpt: 'Find where your GA youth soccer club ranks among 789 teams. Concorde Fire, UFA, NASA Tophat, Southern Soccer Academy, Gwinnett SA and more — rated weekly by PowerScore. Free.'
+author: 'PitchRank Team'
+date: '2026-04-29'
+readingTime: '10 min read'
+tags: ['Georgia', 'Youth Soccer', 'Rankings', 'Parent Guide']
+keywords:
+  [
+    'ga youth soccer rankings',
+    'georgia youth soccer rankings',
+    'georgia soccer rankings',
+    'best youth soccer clubs georgia',
+    'atlanta youth soccer rankings',
+    'metro atlanta soccer rankings',
+    'georgia club soccer rankings',
+  ]
+---
+
+# Georgia Youth Soccer Rankings: The Complete Parent's Guide (2026)
+
+Your team just finished a Saturday at a complex off I-285. They went 2-1, splitting wins with a Gwinnett club and dropping a tight one to a Concorde Fire roster you'd never seen before. The bracket says you finished second. But what does that actually mean? Is your team good, or did Concorde just bring their A-roster?
+
+That's the question every Georgia soccer parent eventually asks. Between metro Atlanta's club density, Savannah's coastal scene, and Athens-Augusta-Columbus rosters that travel north for showcases, your team probably plays the same 10 opponents over and over — and rarely sees the rest of the state. Rankings are how that bigger picture comes into focus.
+
+## Why Georgia Soccer Rankings Matter
+
+Georgia is geographically lopsided in a way that hides true team strength. Your team in Forsyth County might never face a Savannah United roster. Your AFC Lightning team in South Metro might never travel to Athens.
+
+Rankings give you three things traditional league standings can't:
+
+1. **Cross-region context** — How does your North Atlanta ECNL Regional team actually compare to a top Concorde Fire roster from Intown Atlanta?
+2. **Informed club decisions** — When tryout season hits, rankings help you compare Concorde Fire, UFA, NASA Tophat, Southern Soccer Academy, and Gwinnett SA on the same scale instead of relying on word of mouth.
+3. **Realistic expectations** — Winning your Georgia Soccer flight is a starting point, not a finish line. The Georgia State Cup and regional showcases are where rankings get real.
+
+> **See where your team stands now:** [View all Georgia youth soccer rankings](/rankings/ga)
+
+## The Georgia Youth Soccer Landscape
+
+Georgia has 789 active youth soccer teams across our database. Here's how that breaks down regionally.
+
+### Geographic Soccer Regions
+
+- **Metro Atlanta — Intown & North** (Atlanta, Sandy Springs, Roswell, Alpharetta, Cumming) — The state's competitive engine. Anchored by Concorde Fire (129 teams), United Futbol Academy (97), NASA Tophat (82), Inter Atlanta FC Blues (48), and Roswell Santos SC (24). Dense competition, year-round outdoor play, and the strongest national-league representation in the state.
+- **Metro Atlanta — Gwinnett & North Suburbs** (Lawrenceville, Suwanee, Duluth, Cumming) — Gwinnett Soccer Academy (59 teams), Lanier Soccer Association (23), and Triumph Youth Soccer (17) lead this region. Strong feeders into ECNL and MLS NEXT through the Atlanta United Academy pipeline.
+- **Metro Atlanta — South & West Metro** (Fayette, Coweta, Henry, Cobb, Douglas) — Southern Soccer Academy (69 teams) and AFC Lightning (26) lead the south metro. Atlanta Fire United (33) and Rush Union Soccer (21) operate across multiple metros.
+- **North Georgia / Mountains** (Rome, Cartersville, Dalton, Gainesville) — Georgia Storm Soccer Academy (11 teams) and YMCA Arsenal Rome (10 teams) anchor the region. Many top players travel south to Atlanta clubs for showcase events.
+- **Coastal & South Georgia** (Savannah, Brunswick, Valdosta, Albany) — Savannah United Select (8 teams) leads the coast. Smaller but increasingly competitive, with players often traveling to Atlanta for higher-level play.
+- **Athens & Central Georgia** (Athens, Macon, Augusta, Columbus) — Athens United Soccer Association (9 teams), Steamers FC (8), and regional clubs serve the college-town and central-state corridor.
+
+### Major Georgia Soccer Clubs
+
+Based on our database, the largest youth soccer organizations in Georgia:
+
+| Club                         | Teams | Region              |
+| ---------------------------- | ----- | ------------------- |
+| Concorde Fire                | 129   | Intown / North ATL  |
+| United Futbol Academy (UFA)  | 97    | North Metro Atlanta |
+| NASA Tophat                  | 82    | Metro Atlanta       |
+| Southern Soccer Academy      | 69    | South Metro         |
+| Gwinnett Soccer Academy      | 59    | Gwinnett            |
+| Inter Atlanta FC Blues       | 48    | Intown Atlanta      |
+| Atlanta Fire United          | 33    | Metro Atlanta       |
+| AFC Lightning                | 26    | South Metro         |
+| Roswell Santos SC            | 24    | Roswell             |
+| Lanier Soccer Association    | 23    | Forsyth / Lanier    |
+| Rush Union Soccer            | 21    | Multi-region        |
+| Triumph Youth Soccer         | 17    | Metro Atlanta       |
+| Georgia Storm Soccer Academy | 11    | North Georgia       |
+| Savannah United Select       | 8     | Coastal             |
+
+These clubs compete across multiple leagues — from ECNL and MLS NEXT at the national level to NPL and Georgia Soccer premier divisions at the state level.
+
+### Leagues Active in Georgia
+
+Georgia teams compete across most national leagues PitchRank tracks:
+
+- **ECNL** (Elite Clubs National League) — Strong GA presence, particularly through Concorde Fire, NASA Tophat, and UFA.
+- **MLS NEXT** — Highest level for boys; the Atlanta United Academy is the local pipeline and pulls heavily from metro Atlanta clubs.
+- **Girls Academy (GA)** — National girls league with a growing Georgia footprint.
+- **NPL** (National Premier Leagues) — Competitive national league under US Club Soccer.
+- **ECNL Regional League** — Development tier below ECNL; the workhorse competitive league for many GA teams.
+- **National League** — US Youth Soccer national competition.
+
+Plus state-level competition through [Georgia Soccer](https://georgiasoccer.org/) (the Georgia State Soccer Association, or GSSA) — the governing body for youth soccer in the state, overseeing premier flight competition and the Georgia State Cup.
+
+## How Georgia Soccer Rankings Actually Work
+
+Most ranking systems — GotSoccer being the biggest — only count tournament games and reward quantity over quality. A team that enters 15 tournaments and beats weak opponents can outrank a team that plays a tougher schedule but enters fewer events.
+
+That's not how PitchRank works.
+
+### What PitchRank Tracks for Georgia Teams
+
+We track **every game we can find** — league play, tournaments, friendlies, showcases — across all 789 Georgia teams.
+
+Here's the short version of how your team's ranking is calculated:
+
+1. **Base rating** — Every team starts neutral and moves with each game played
+2. **Strength of schedule** — Beating a top Concorde Fire ECNL squad means more than beating a developmental team. Losing to a strong opponent hurts less than losing to a weak one.
+3. **Recency** — Last month's games count more than games from 10 months ago
+4. **Consistency** — Steady performance ranks higher than wild swings between blowout wins and bad losses
+
+The result is a **PowerScore between 0.0 and 1.0** that lets you compare teams within the same age group at a glance. Teams at the top of Georgia sit among the strongest rosters in their age groups, with Concorde Fire, NASA Tophat, UFA, Inter Atlanta FC Blues, and Gwinnett Soccer Academy consistently producing teams in that band across multiple age groups.
+
+### Georgia's Age Group Breakdown
+
+Georgia's team density varies by age group:
+
+| Age Group | Teams |
+| --------- | ----- |
+| U10       | 4     |
+| U11       | 39    |
+| U12       | 113   |
+| U13       | 177   |
+| U14       | 188   |
+| U15       | 129   |
+| U16       | 58    |
+| U17       | 44    |
+| U18       | 22    |
+| U19       | 15    |
+
+Peak competition is at U13 and U14, with U14 alone fielding 188 teams. Numbers thin meaningfully after U15 as players specialize, move to high school programs, or step away. If your child is U12 through U14 in Georgia, they're competing in the deepest age-group pools in the state.
+
+## What Your Georgia Team's Ranking Actually Tells You
+
+You check PitchRank and see your U13 team is ranked #38 in Georgia. What does that mean?
+
+### State vs National Rankings
+
+- **State rank** — Where your team stands among Georgia's 789 teams across age groups
+- **National rank** — Where your team stands among all teams in their age group across the country
+
+**Reality check:** Being top 30 in Georgia is legitimately strong — GA punches above its team-count weight thanks to metro Atlanta's competitive density. Being top 500 nationally is excellent. Top 100 nationally? Your team is elite.
+
+### Age Group Matters More Than You Think
+
+Rankings aren't comparable across age groups. A U12 team ranked #20 in Georgia isn't directly comparable to a U17 team ranked #20. Why?
+
+- **Competition density** — U14 has 188 teams; U17 has 44
+- **Development stages** — Rankings are more volatile in younger age groups
+- **Playing up/down** — Some U12 teams compete in U13 leagues for tougher competition
+
+**Pro tip:** Always check your specific age group when looking at [Georgia soccer rankings](/rankings/ga).
+
+### What Rankings Don't Tell You
+
+Rankings measure competitive results. They can't measure:
+
+- **Individual player development** — A top-ranked team might not be the best fit for your child's growth
+- **Coaching quality** — Some lower-ranked teams have better developmental coaches than win-now programs
+- **Team culture** — Your kid's enjoyment matters more than a number
+- **College fit** — D3 coaches care about GPA and character more than PowerScore
+
+If a club director sells you on rankings alone but can't explain their development philosophy, that's a red flag.
+
+## How to Use Georgia Rankings When Choosing a Club
+
+Tryout season in Georgia runs May through June. Rankings are one tool in your decision-making kit — here's how to use them wisely.
+
+### Questions to Ask Club Directors
+
+When you're comparing Concorde Fire vs UFA vs NASA Tophat vs Southern Soccer Academy vs Gwinnett SA:
+
+1. **"How do your teams' rankings trend over time?"** — Upward trends suggest good coaching. Flat or declining suggests stagnation.
+2. **"What's the strength of schedule for this age group?"** — Are they playing real competition or scheduling easy wins?
+3. **"How do your Georgia rankings compare to teams we'd face at regionals?"** — National context matters if your child has college ambitions.
+4. **"How many players from this age group have moved to ECNL, MLS NEXT, or the Atlanta United Academy?"** — Player progression matters more than team rank.
+
+### Finding the Right Competition Level
+
+The best team for your child isn't always the highest-ranked one. Look for a team that:
+
+- Plays opponents 10–20 ranking positions above AND below them
+- Gives your child 30+ minutes per game
+- Challenges without crushing confidence
+- Fits your family's travel budget and schedule
+
+**Georgia's advantage:** With clubs spread across Intown Atlanta, the North Metro, Gwinnett, the South Metro, and the coast, you have options at every competitive level. The harder choice is often I-285 traffic — Gwinnett families driving south for matches or Fayette families commuting north for showcases need to factor that in.
+
+### Red Flags
+
+- **Cherry-picking opponents** — Teams that pad records against weak Georgia Soccer flight opponents. Their ranking will plateau.
+- **Wild ranking swings** — Could signal roster instability or inconsistent coaching
+- **Ranking guarantees** — No legitimate club can promise specific rankings
+
+## The Atlanta vs Statewide Dynamic
+
+Georgia's biggest youth soccer divide isn't north-vs-south — it's between metro Atlanta's competitive density and the rest of the state's regional clubs. Metro Atlanta alone produces more competitive teams than most full states do, and clubs there compete on a national showcase calendar that's hard to match in Savannah, Augusta, or Columbus.
+
+What this means for parents:
+
+- **Metro Atlanta clubs** benefit from proximity to the Atlanta United Academy MLS NEXT pipeline, dense in-state competition, and a packed showcase calendar
+- **Coastal Georgia clubs** like Savannah United compete heavily within South Georgia and travel to Atlanta for showcase events
+- **Central Georgia clubs** in Athens, Macon, and Augusta sit geographically in the middle and increasingly anchor strong ECNL Regional and NPL rosters
+- **Cross-region play** is the cleanest measure of true team strength — when your team plays out of region, the ranking sharpens
+
+If your team only plays within metro Atlanta or only within South Georgia, rankings can be misleading. The true test comes at the Georgia State Cup and regional events.
+
+## Georgia State Cup and Rankings
+
+The Georgia State Cup (run by Georgia Soccer / GSSA) is the state's premier championship event. Rankings intersect here directly:
+
+- **Seeding** — Higher-ranked teams earn better tournament draws
+- **Competition quality** — State Cup draws Georgia's best from every region, so rankings are most accurate during and after this event
+- **Exposure** — College scouts and ODP staff use State Cup performances to filter which players to track
+
+If your team is ranked in the **top 10–15% in Georgia**, State Cup is where that ranking gets tested against the state's best.
+
+## The College Recruiting Reality Check
+
+Let's be honest about what Georgia soccer rankings mean for college recruiting.
+
+### What Coaches Actually Look At
+
+1. **Individual highlight video** — YOUR child, not team stats
+2. **Academic eligibility** — GPA and test scores filter players before rankings matter
+3. **Showcase attendance** — ECNL playoffs, MLS NEXT events, Disney showcases, and regional events where scouts are
+4. **Direct contact** — Emails to coaches with video links beat high rankings
+
+### Rankings by Division
+
+- **Division I** — Coaches notice teams in the **top 5% nationally** (very elite)
+- **Division II** — Top 15–20% nationally gets attention, but individual performance matters more
+- **Division III** — Rankings barely factor in. Academics, character, and fit drive decisions.
+
+**Georgia's edge:** The state is home to UGA, Georgia Tech, Georgia State, Mercer, Kennesaw State, Georgia Southern, and dozens of D2 and D3 programs. Use rankings to identify which Georgia clubs consistently place players in these programs and attend the major Atlanta-area showcases.
+
+## Using PitchRank to Track Georgia Rankings
+
+### Step 1: Find Your Team
+
+Visit [PitchRank.io](https://pitchrank.io) and search for your club by name and age group. You'll see your current state and national rank, recent game results, and PowerScore trend over time.
+
+### Step 2: Compare Your Competition
+
+Look at teams you regularly play against. Are they ranked higher or lower? This tells you if your league is appropriately competitive and whether your child is playing up or down.
+
+### Step 3: Track Changes Through the Season
+
+Rankings shift as new games are played. Check weekly to see how wins, losses, and tournament results move your team's ranking.
+
+> **Ready to check?** [See all Georgia youth soccer rankings](/rankings/ga)
+
+## Browse Georgia Rankings by Age Group
+
+Find your team's age group and gender to see the latest Georgia rankings:
+
+| Age Group | Boys                                      | Girls                                        |
+| --------- | ----------------------------------------- | -------------------------------------------- |
+| U10       | [Georgia U10 Boys](/rankings/ga/u10/male) | [Georgia U10 Girls](/rankings/ga/u10/female) |
+| U11       | [Georgia U11 Boys](/rankings/ga/u11/male) | [Georgia U11 Girls](/rankings/ga/u11/female) |
+| U12       | [Georgia U12 Boys](/rankings/ga/u12/male) | [Georgia U12 Girls](/rankings/ga/u12/female) |
+| U13       | [Georgia U13 Boys](/rankings/ga/u13/male) | [Georgia U13 Girls](/rankings/ga/u13/female) |
+| U14       | [Georgia U14 Boys](/rankings/ga/u14/male) | [Georgia U14 Girls](/rankings/ga/u14/female) |
+| U15       | [Georgia U15 Boys](/rankings/ga/u15/male) | [Georgia U15 Girls](/rankings/ga/u15/female) |
+| U16       | [Georgia U16 Boys](/rankings/ga/u16/male) | [Georgia U16 Girls](/rankings/ga/u16/female) |
+| U17       | [Georgia U17 Boys](/rankings/ga/u17/male) | [Georgia U17 Girls](/rankings/ga/u17/female) |
+| U19       | [Georgia U19 Boys](/rankings/ga/u19/male) | [Georgia U19 Girls](/rankings/ga/u19/female) |
+
+## Frequently Asked Questions
+
+### How are youth soccer teams ranked in Georgia?
+
+PitchRank tracks game-by-game results across 789 Georgia teams. Teams earn a PowerScore from 0.0 to 1.0 based on wins, opponent strength, recency, and consistency — updated weekly.
+
+### What are the biggest youth soccer clubs in Georgia?
+
+By team count: Concorde Fire (129 teams), United Futbol Academy (97), NASA Tophat (82), Southern Soccer Academy (69), Gwinnett Soccer Academy (59), Inter Atlanta FC Blues (48), Atlanta Fire United (33), and AFC Lightning (26).
+
+### How often do Georgia soccer rankings update?
+
+PitchRank updates rankings every Monday morning with the latest game results. Recent games are weighted more heavily than older ones.
+
+### What youth soccer leagues operate in Georgia?
+
+Georgia teams compete in ECNL, MLS NEXT (anchored by the Atlanta United Academy pipeline), Girls Academy (GA), NPL, ECNL Regional League, and National League — plus state competition through Georgia Soccer (GSSA) premier divisions and the Georgia State Cup.
+
+### How does the Atlanta metro compare to the rest of Georgia?
+
+The Atlanta metro produces the bulk of Georgia's top-ranked teams across age groups, with Concorde Fire, NASA Tophat, UFA, Gwinnett SA, and Inter Atlanta FC Blues consistently among the strongest. Savannah United, Steamers FC, and other regional clubs anchor competitive scenes outside metro Atlanta but typically travel north for showcase events.
+
+### Should my child be on the highest-ranked team possible?
+
+Not necessarily. The best team is one where your child gets meaningful playing time, faces the right level of competition, and develops in a positive environment. A top-ranked team where your kid sits the bench is worse than a mid-ranked team where they play every minute.
+
+### Do Georgia rankings help with college recruiting?
+
+Rankings provide context but aren't the main recruiting tool. Individual highlight video, academic eligibility, showcase attendance, and direct coach contact matter more. D1 coaches notice top 5% nationally. D3 coaches care more about GPA and fit.
+
+### Can clubs game the rankings?
+
+No. PitchRank's rating algorithm adjusts for opponent strength. Beating weaker Georgia Soccer flight opponents repeatedly won't inflate your ranking. Teams that avoid strong competition plateau quickly.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data. No politics, no favoritism — just math. Check your Georgia team's ranking at [PitchRank.io](https://pitchrank.io).

--- a/frontend/content/blog/youth-soccer-levels-explained.mdx
+++ b/frontend/content/blog/youth-soccer-levels-explained.mdx
@@ -1,0 +1,200 @@
+---
+title: 'Youth Soccer Levels Explained: ECNL, MLS NEXT, NPL & More (2026)'
+slug: 'youth-soccer-levels-explained'
+excerpt: 'A plain-English guide to the levels of youth soccer in the US — ECNL, MLS NEXT, GA, NPL, ECNL Regional, National League, state premier, and travel/rec. What each is, how they fit together, and what it actually means for your kid.'
+author: 'PitchRank Team'
+date: '2026-04-29'
+readingTime: '11 min read'
+tags: ['Youth Soccer', 'ECNL', 'MLS NEXT', 'Parent Guide', 'Club Soccer']
+keywords:
+  [
+    'youth soccer levels explained',
+    'levels of youth soccer',
+    'youth soccer league hierarchy',
+    'ecnl vs mls next',
+    'club soccer levels',
+    'travel soccer levels explained',
+    'what is npl soccer',
+  ]
+---
+
+# Youth Soccer Levels Explained: ECNL, MLS NEXT, NPL, and the Rest of the Pyramid (2026)
+
+If you've ever stood on a sideline trying to figure out whether your kid's team is "good," you've probably hit the same wall every other youth soccer parent hits: there's no single national league. There are at least seven, run by two competing organizations, with a confusing web of regional and state tiers underneath. ECNL, MLS NEXT, GA, NPL, ECNL-RL, EDP, National League, state premier — what does any of it actually mean?
+
+This is the guide I wish someone had handed me. It's a plain-English map of the US youth soccer pyramid, from the top of the mountain down to your local Saturday rec field — and what each level actually means for your child's development, your family's calendar, and your wallet.
+
+## Why Youth Soccer Has So Many "Levels"
+
+Most countries have one governing body for youth soccer. The US has two:
+
+- **US Soccer** — the federation that runs the senior national teams.
+- **US Youth Soccer (USYS)** — the youth wing of US Soccer, organized state-by-state through state associations (Cal North, NTSSA, NCYSA, etc.).
+- **US Club Soccer** — a separate sanctioning body with its own competitive structure.
+
+Both organizations sanction club soccer. Both run national-tier leagues. Most clubs participate in **both** systems simultaneously, fielding different teams in different leagues. That's why the picture is messy — there isn't one ladder, there are parallel ladders that occasionally connect.
+
+The good news: once you know the names and where they sit, the whole thing makes sense.
+
+> **Want to see how leagues stack up in your state?** [Browse PitchRank's state-by-state youth soccer rankings](/rankings).
+
+## The National-Platform Tier (Top of the Pyramid)
+
+These are the leagues college coaches and academy scouts actually watch. They draw teams from across the country and have their own showcase events.
+
+### ECNL (Elite Clubs National League)
+
+Run under US Club Soccer. The dominant girls top tier in the US, and a strong boys league as well. Clubs apply for membership; bids are competitive. Top ECNL girls events draw hundreds of college coaches.
+
+### MLS NEXT
+
+The boys top tier, run jointly by Major League Soccer. Includes MLS Academy teams (the Atlanta United, FC Dallas, NYCFC academies of the world) and high-end non-MLS clubs. MLS NEXT has its own scouting pipeline into MLS NEXT Pro and senior MLS rosters.
+
+### Girls Academy (GA)
+
+A girls-only top-tier national league launched in 2020 after the original US Soccer Development Academy folded. Operates parallel to ECNL on the girls side; some clubs play both, most pick one.
+
+### MLS NEXT Pro
+
+Not technically a youth league — it's the under-23 development tier between academy and senior MLS. Worth knowing because MLS NEXT players move into it and college recruiters track it.
+
+**Reality check:** Being on a national-platform team doesn't guarantee elite individual play. A backup midfielder on an ECNL roster may be getting less development than a starter on a strong NPL roster. Level is one signal, not the whole story.
+
+## The Regional/Development Tier
+
+The step below the national platforms — competitive, well-organized, and where most "good club teams" actually play.
+
+### ECNL Regional League (ECNL-RL or ECRL)
+
+ECNL's development tier. Played within a region, with promotion/relegation pathways toward full ECNL. Many clubs run an ECNL team and an ECNL-RL team in the same age group. The talent gap between top ECNL-RL teams and the bottom of full ECNL is often small.
+
+### NPL (National Premier Leagues)
+
+US Club Soccer's competitive league directly below ECNL. Strong national showcase calendar. NPL is the typical home for clubs that are competitive but don't hold an ECNL bid in a given age group.
+
+### EDP (Eastern Development Program)
+
+A Northeast/Mid-Atlantic regional league — heavy in NJ, NY, PA, MD, VA, DE. EDP runs everything from showcase divisions down through state-level brackets. A strong EDP Premier roster is a real competitive team.
+
+### DPL (Development Players League)
+
+A boys regional league, primarily in the eastern US, with national showcase events. Often a pathway league for clubs without MLS NEXT or full ECNL bids on the boys side.
+
+## The State + US Youth Soccer Tier
+
+Below the regional development leagues sit the US Youth Soccer leagues and state premier divisions.
+
+### National League (US Youth Soccer)
+
+USYS's flagship national competition, with conferences and a national playoff. Lower-profile than ECNL/MLS NEXT to college recruiters, but still a real national-level league.
+
+### State Premier Divisions
+
+Every state has a "premier" or "top flight" league run by the state association — VYSA Premier in Virginia, NCYSA Classic in North Carolina, CSL Premier in California, the list goes on. State premier is a wide range: the top flights in big states (CA, TX, FL, NY, NJ) are competitive; the equivalent in small states is closer to good travel soccer.
+
+### State Cups and US Youth Soccer Pathway
+
+State Cups are single-elimination tournaments run by each state association. Winners advance to regional, then national finals. State Cup is where state-tier teams get tested against the best in the state.
+
+## Recreational vs Travel vs Club: The Other Axis
+
+Levels above describe **competitive** soccer — but there's a separate axis underneath that.
+
+| Tier                                   | What it is                                                                                                              | Practice/week | Games/season | Travel                                |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- | ------------ | ------------------------------------- |
+| **Recreational ("rec")**               | Local league, run by a town or YMCA. Everyone plays, equal-ish minutes.                                                 | 1×            | ~10          | None — local fields                   |
+| **Travel** (sometimes called "select") | Tryout-based, plays other towns or clubs in a regional league                                                           | 2×            | ~16-20       | 30-90 min drives                      |
+| **Club**                               | Full club organization with multiple age groups; plays in a sanctioned league (state premier, NPL, ECNL-RL, ECNL, etc.) | 2-3×          | 20-40+       | Anywhere from regional to multi-state |
+
+"Club soccer" usually implies travel, but not all travel is "club" — some areas have town travel teams that don't belong to a club organization. The line between them blurs at the lower tiers.
+
+## How to Tell What Level Your Child Is Playing
+
+You don't need to ask your coach. Three quick checks:
+
+1. **Look at the schedule.** What league is at the top of the team's published schedule? "ECNL Regional Mid-Atlantic" tells you everything. "VYSA Premier" tells you something different.
+2. **Look at the travel radius.** A team that drives 30 minutes for every game is in a state or local league. A team that flies twice a year for showcases is at the national-platform tier.
+3. **Look at the game count.** ECNL/MLS NEXT teams play 25-40+ league games plus showcases. State premier teams play 16-20. Rec plays 8-12.
+
+If you see your team's results on PitchRank, you can see which clubs they regularly play — and the company they keep is the cleanest tell of all.
+
+## Does Level = College Recruiting Outcome?
+
+Let's be honest: level matters, but not as much as the marketing implies.
+
+### What level actually does for recruiting
+
+- **Visibility** — D1 coaches travel to ECNL Playoffs, MLS NEXT Cup, GA Showcase, and major national events. They show up to fewer state premier games.
+- **Strength of competition** — Playing top opponents week-in, week-out develops a player faster than running over weak ones.
+
+### What level doesn't do for recruiting
+
+- **It doesn't recruit you.** No coach signs a player off a team affiliation. They sign players from highlight video and direct contact.
+- **It doesn't override academics.** GPA and test scores filter D1, D2, and especially Ivy and academic D3 recruits before any soccer evaluation.
+- **It doesn't matter much for D3.** Most D3 college coaches care more about academic fit, character, and whether you're emailing them than what league your club plays in.
+
+A strong NPL or state premier player who emails coaches, attends ID camps, and has decent video will out-recruit a national-platform player who does nothing. Every year.
+
+## What "Level" Actually Means for Your Family
+
+Level translates into commitment more than anything else. Rough ranges:
+
+| Tier                  | Typical season cost | Typical practice volume | Travel weekends/year   |
+| --------------------- | ------------------- | ----------------------- | ---------------------- |
+| Recreational          | $100-300            | 1× per week             | 0                      |
+| Local travel          | $1,000-2,000        | 2× per week             | 2-4                    |
+| State premier / NPL   | $2,500-4,500        | 2-3× per week           | 6-10                   |
+| ECNL-RL / EDP Premier | $3,500-5,500        | 3× per week             | 8-12                   |
+| ECNL / MLS NEXT / GA  | $4,000-7,000+       | 3-4× per week           | 10-15+ (incl. flights) |
+
+Costs above are club fees only — they don't include travel, hotels, gas, food, gear, private training, or summer camps. The real all-in number is often 1.5-2× the headline fee.
+
+The right level for your family depends as much on your calendar and budget as it does on your child's ability. A stretched-thin family at the ECNL level usually has a worse year than a well-supported family at the NPL level.
+
+## How PitchRank Fits Into All This
+
+PitchRank doesn't care which league a team plays in. We track every game we can find — ECNL, MLS NEXT, NPL, ECNL-RL, EDP, state premier, even non-sanctioned showcases — and rate teams using a transparent rating algorithm based on results, opponent strength, recency, and consistency.
+
+The point isn't to argue ECNL is better than MLS NEXT. The point is that **two teams in different leagues can be directly compared** when they play overlapping opponents — which they do all the time, especially at showcases.
+
+That's how you can finally answer the question: _Is our team actually good, or are we just good in our league?_
+
+> **Find your team:** [Browse all youth soccer rankings](/rankings) by state and age group.
+
+## Frequently Asked Questions
+
+### What are the levels of youth soccer in the US?
+
+From top to bottom: national platforms (ECNL, MLS NEXT, Girls Academy), regional development leagues (ECNL Regional, NPL, EDP, DPL), the US Youth Soccer National League and state premier divisions, then local travel and recreational. The US has two parallel structures — US Club Soccer and US Youth Soccer — which is why the picture looks confusing.
+
+### Is ECNL or MLS NEXT higher level?
+
+For boys, MLS NEXT and ECNL are both top-tier and largely separate ecosystems — most top boys clubs play one or the other. For girls, ECNL is the dominant top tier alongside Girls Academy. "Higher" depends on the club, the age group, and your region.
+
+### What's the difference between ECNL and ECNL Regional League?
+
+ECNL is the national platform with showcase events drawing top college coaches. ECNL Regional League (often called ECNL-RL or ECRL) is the development tier directly below it, played mostly within a region. Many clubs run both, and rosters move between them.
+
+### What is NPL in soccer?
+
+NPL stands for National Premier Leagues — US Club Soccer's competitive league below ECNL. It's strong, well-attended at showcases, and a common alternative for clubs without an ECNL bid in a given age group.
+
+### Is travel soccer the same as club soccer?
+
+Roughly yes — most "club soccer" is travel soccer, meaning teams travel to play league games and tournaments. Recreational soccer typically stays within one local league. The line gets blurry at the lower travel tiers, where some town travel teams don't belong to a full club organization.
+
+### How do I know what league my kid's team plays in?
+
+Check the team's published schedule and the club's website. Each league publishes its own standings. Your team will play most weekend games against the same set of clubs — that pool tells you the level.
+
+### Does playing higher-level soccer help with college recruiting?
+
+Visibility helps, especially at the top tiers (ECNL, MLS NEXT, GA) where college coaches attend showcases. But individual highlight video, academic eligibility, and direct contact with coaches matter more than your team's league. A strong NPL player who emails coaches will out-recruit a national-platform player who does nothing.
+
+### Can a team move between levels season to season?
+
+Yes. Clubs apply for league bids each year. Teams get promoted, relegated, or move between platforms as rosters and results change. It's normal for a club's U14 ECNL team to drop to ECNL-RL the following year, or for a strong state premier team to earn an NPL bid.
+
+---
+
+**About PitchRank:** We track [youth soccer rankings](/rankings) across all 50 states using transparent, game-by-game data — every league, every level. No politics, no favoritism — just math. Find your team at [PitchRank.io](https://pitchrank.io).

--- a/frontend/lib/blog-faqs.ts
+++ b/frontend/lib/blog-faqs.ts
@@ -124,6 +124,49 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
     },
   ],
 
+  'georgia-youth-soccer-rankings-guide': [
+    {
+      question: 'How are youth soccer teams ranked in Georgia?',
+      answer:
+        'PitchRank tracks game-by-game results across 789 Georgia teams. Teams earn a PowerScore from 0.0 to 1.0 based on wins, opponent strength, recency, and consistency — updated weekly with real game data.',
+    },
+    {
+      question: 'What are the biggest youth soccer clubs in Georgia?',
+      answer:
+        'By team count: Concorde Fire (129 teams), United Futbol Academy (97), NASA Tophat (82), Southern Soccer Academy (69), Gwinnett Soccer Academy (59), Inter Atlanta FC Blues (48), Atlanta Fire United (33), and AFC Lightning (26).',
+    },
+    {
+      question: 'How often do Georgia soccer rankings update?',
+      answer:
+        'PitchRank updates rankings every Monday morning with the latest game results. Recent games are weighted more heavily than older ones.',
+    },
+    {
+      question: 'What youth soccer leagues operate in Georgia?',
+      answer:
+        'Georgia teams compete in ECNL, MLS NEXT (anchored by the Atlanta United Academy pipeline), Girls Academy (GA), NPL, ECNL Regional League, and National League — plus state competition through Georgia Soccer (GSSA) premier divisions and the Georgia State Cup.',
+    },
+    {
+      question: 'How does the Atlanta metro compare to the rest of Georgia?',
+      answer:
+        "The Atlanta metro produces the bulk of Georgia's top-ranked teams across age groups, with Concorde Fire, NASA Tophat, UFA, Gwinnett SA, and Inter Atlanta FC Blues consistently among the strongest. Savannah United, Steamers FC, and other regional clubs anchor competitive scenes outside metro Atlanta but typically travel north for showcase events.",
+    },
+    {
+      question: 'Should my child be on the highest-ranked team possible?',
+      answer:
+        'Not necessarily. The best team is one where your child gets meaningful playing time, faces the right level of competition, and develops in a positive environment. A top-ranked team where your kid sits the bench is worse than a mid-ranked team where they play every minute.',
+    },
+    {
+      question: 'Do Georgia rankings help with college recruiting?',
+      answer:
+        'Rankings provide context but are not the main recruiting tool. Individual highlight video, academic eligibility, showcase attendance, and direct coach contact matter more. D1 coaches notice top 5% nationally. D3 coaches care more about GPA and fit. Georgia is home to UGA, Georgia Tech, Georgia State, Mercer, Kennesaw State, and many D2/D3 programs.',
+    },
+    {
+      question: 'Can clubs game the Georgia rankings?',
+      answer:
+        "No. PitchRank's rating algorithm adjusts for opponent strength. Beating weaker Georgia Soccer flight opponents repeatedly will not inflate a team's ranking. Teams that avoid strong competition plateau quickly.",
+    },
+  ],
+
   'maryland-youth-soccer-rankings-guide': [
     {
       question: 'How are Maryland youth soccer teams ranked?',
@@ -569,6 +612,49 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
       question: "How often should I check my team's ranking?",
       answer:
         'Rankings update weekly on PitchRank (every Monday). Checking weekly gives you a sense of trends without overreacting to small fluctuations. Look at movement over a month for a clearer picture.',
+    },
+  ],
+
+  'youth-soccer-levels-explained': [
+    {
+      question: 'What are the levels of youth soccer in the US?',
+      answer:
+        'From top to bottom: national platforms (ECNL, MLS NEXT, Girls Academy), regional development leagues (ECNL Regional, NPL, EDP, DPL), the US Youth Soccer National League and state premier divisions, then local travel and recreational. The US has two parallel sanctioning structures — US Club Soccer and US Youth Soccer — which is why the picture looks confusing.',
+    },
+    {
+      question: 'Is ECNL or MLS NEXT higher level?',
+      answer:
+        'For boys, MLS NEXT and ECNL are both top-tier and largely separate ecosystems — most top boys clubs play one or the other. For girls, ECNL is the dominant top tier alongside Girls Academy. "Higher" depends on the club, the age group, and your region.',
+    },
+    {
+      question: 'What is the difference between ECNL and ECNL Regional League?',
+      answer:
+        'ECNL is the national platform with showcase events drawing top college coaches. ECNL Regional League (often called ECNL-RL or ECRL) is the development tier directly below it, played mostly within a region. Many clubs run both, and rosters move between them.',
+    },
+    {
+      question: 'What is NPL in soccer?',
+      answer:
+        "NPL stands for National Premier Leagues — US Club Soccer's competitive league below ECNL. It's strong, well-attended at showcases, and a common alternative for clubs without an ECNL bid in a given age group.",
+    },
+    {
+      question: 'Is travel soccer the same as club soccer?',
+      answer:
+        'Roughly yes — most "club soccer" is travel soccer, meaning teams travel to play league games and tournaments. Recreational soccer typically stays within one local league. The line gets blurry at the lower travel tiers, where some town travel teams do not belong to a full club organization.',
+    },
+    {
+      question: "How do I know what league my kid's team plays in?",
+      answer:
+        "Check the team's published schedule and the club's website. Each league publishes its own standings. Your team will play most weekend games against the same set of clubs — that pool tells you the level.",
+    },
+    {
+      question: 'Does playing higher-level soccer help with college recruiting?',
+      answer:
+        'Visibility helps, especially at the top tiers (ECNL, MLS NEXT, GA) where college coaches attend showcases. But individual highlight video, academic eligibility, and direct contact with coaches matter more than the team’s league. A strong NPL player who emails coaches will out-recruit a national-platform player who does nothing.',
+    },
+    {
+      question: 'Can a team move between levels season to season?',
+      answer:
+        "Yes. Clubs apply for league bids each year. Teams get promoted, relegated, or move between platforms as rosters and results change. It's normal for a club's U14 ECNL team to drop to ECNL-RL the following year, or for a strong state premier team to earn an NPL bid.",
     },
   ],
 

--- a/frontend/lib/cohort-seo.ts
+++ b/frontend/lib/cohort-seo.ts
@@ -114,6 +114,7 @@ const STATE_PILLAR_SLUGS: Record<string, { slug: string; title: string }> = {
   ca: { slug: 'california-youth-soccer-rankings-guide', title: 'California Youth Soccer Rankings Guide' },
   co: { slug: 'colorado-youth-soccer-rankings-guide', title: 'Colorado Youth Soccer Rankings Guide' },
   fl: { slug: 'florida-youth-soccer-rankings-guide', title: 'Florida Youth Soccer Rankings Guide' },
+  ga: { slug: 'georgia-youth-soccer-rankings-guide', title: 'Georgia Youth Soccer Rankings Guide' },
   md: { slug: 'maryland-youth-soccer-rankings-guide', title: 'Maryland Youth Soccer Rankings Guide' },
   mi: { slug: 'michigan-youth-soccer-rankings-guide', title: 'Michigan Youth Soccer Rankings Guide' },
   nj: { slug: 'new-jersey-youth-soccer-rankings-guide', title: 'New Jersey Youth Soccer Rankings Guide' },


### PR DESCRIPTION
## Summary

- **Georgia state pillar** at `frontend/content/blog/georgia-youth-soccer-rankings-guide.mdx` — 789 active GA teams, top clubs (Concorde Fire, UFA, NASA Tophat, SSA, Gwinnett SA), Atlanta-vs-statewide dynamic, Atlanta United Academy MLS NEXT pipeline angle.
- **Informational evergreen post** at `frontend/content/blog/youth-soccer-levels-explained.mdx` — plain-English explainer of ECNL, MLS NEXT, GA, NPL, ECNL-RL, EDP, National League, state premier, and the rec/travel/club axis. Targets `youth soccer levels explained` (currently pos 15.5 on GSC with no targeted content) — strong cross-link hub for all state pillars.
- Adds 8-FAQ blocks for both posts to `blog-faqs.ts` (FAQPage JSON-LD).
- Adds `ga` to `STATE_PILLAR_SLUGS` in `cohort-seo.ts` — `/rankings/ga/*` will now surface the related guide.

13 state pillars live after merge (10 MDX + CA/TX TSX + GA). IL and OH ship in a separate batch tomorrow via scheduled remote agent.

Completes Week 7 batch 3a of `docs/superpowers/specs/2026-04-16-seo-roadmap-design.md`.

## Test plan

- [x] `npx prettier --write` clean on all 4 files
- [x] `npx tsc --noEmit` clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)