### PR TITLE
seo(robots): allow AI search crawlers on public pages

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -19,17 +19,177 @@ Disallow: /mission-control
 Disallow: /api/
 Disallow: /test
 
-# AI Search Crawlers — block completely
+# AI Search Crawlers — allow public pages, mirror auth/internal disallows
 User-agent: GPTBot
-Disallow: /
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
 
 User-agent: ClaudeBot
-Disallow: /
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: anthropic-ai
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: Claude-User
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
 
 User-agent: PerplexityBot
-Disallow: /
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
 
-# Block known scraping bots that ignore polite rules
+User-agent: Perplexity-User
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: Applebot-Extended
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: cohere-ai
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+User-agent: meta-externalagent
+Allow: /
+Disallow: /teams/
+Disallow: /watchlist
+Disallow: /compare
+Disallow: /login
+Disallow: /signup
+Disallow: /upgrade
+Disallow: /auth/
+Disallow: /mission-control
+Disallow: /api/
+Disallow: /test
+
+# Aggressive scrapers that ignore polite rules — keep blocked
 User-agent: Bytespider
 Disallow: /
 


### PR DESCRIPTION
## Summary
- Reverses blanket `Disallow: /` on GPTBot, ClaudeBot, PerplexityBot in `frontend/public/robots.txt` — these were blocking PitchRank from being cited in AI search engines.
- Adds explicit `Allow: /` rules for 12 major AI crawlers (training + retrieval): GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, anthropic-ai, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, cohere-ai, meta-externalagent.
- Each AI UA gets the same `Disallow:` mirror as `User-agent: *`, so premium-gated routes (`/teams/`, `/watchlist`, `/compare`, `/api/`, `/mission-control`, `/auth/`, `/login`, `/signup`, `/upgrade`, `/test`) stay off-limits.
- Bytespider stays blocked — known aggressive scraper, doesn't power any major consumer LLM.

## Why
Hour-zero veto fix from the GEO playbook (`.turbo/geo-playbook-2026-04-29.md`). Until this lands, no other GEO work matters because none of the AI engines can read pitchrank.io.

## Tradeoffs (already discussed)
- Marginal incremental scraping risk vs being the canonical citation in parent / category AI queries. Net heavily positive — competitive moat is the rating engine + weekly refresh, not stale per-row data.
- Honor-system block didn't stop UA-spoofers anyway; layered defenses (rate limiting, WAF, ToS) are the real protection if it becomes a problem.

## Test plan
- [ ] After deploy, fetch `https://www.pitchrank.io/robots.txt` and confirm AI UAs show `Allow: /` with mirrored disallows
- [ ] Spot-check `User-agent: GPTBot` (line 22) and `User-agent: PerplexityBot` (~line 100) sections
- [ ] Verify Vercel CDN/firewall isn't separately blocking these UAs
- [ ] Within 7 days: spot-check Vercel Analytics or server logs for AI-bot fetches on `/blog/*` and `/rankings/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)