### PR TITLE
fix(import): surface hidden ingest counters + skip score-clobber on tournament re-ingest

### DIFF
--- a/scripts/diagnose_failed_matches.py
+++ b/scripts/diagnose_failed_matches.py
@@ -1,0 +1,95 @@
+"""Identify the SincSports tournament-schedule teams with no alias-map entry.
+
+Run after a tournament-schedule import that reports failed_games_count > 0.
+Reads the most recent sincsports tournament JSONL, computes the unique
+(team_id, team_name) pairs across both perspectives, and checks
+team_alias_map for each. The records the importer dropped to failed_match
+are typically the ones whose teams have no SincSports provider_team_id
+entry yet.
+
+This is a diagnostic, not a fix. It outputs a list the operator can either
+seed manually into team_alias_map or accept as a known-limitation set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+env_local = Path(__file__).parent.parent / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    load_dotenv(Path(__file__).parent.parent / ".env")
+
+if not os.environ.get("SUPABASE_KEY") and os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
+    os.environ["SUPABASE_KEY"] = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+
+from supabase import create_client  # noqa: E402
+
+
+def latest_tournament_jsonl() -> Path:
+    raw = Path(__file__).parent.parent / "data" / "raw"
+    files = sorted(raw.glob("sincsports_games_tournament_*.jsonl"))
+    if not files:
+        print("ERROR: no sincsports tournament JSONL in data/raw", file=sys.stderr)
+        sys.exit(1)
+    return files[-1]
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        path = Path(sys.argv[1])
+    else:
+        path = latest_tournament_jsonl()
+
+    print(f"Reading: {path}")
+
+    teams: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        rec = json.loads(line)
+        for tid_field, tname_field in (("team_id", "team_name"), ("opponent_id", "opponent_name")):
+            tid = rec.get(tid_field) or ""
+            tname = rec.get(tname_field) or ""
+            if tid:
+                teams.setdefault(tid, tname)
+    print(f"Unique teams in JSONL: {len(teams)}")
+
+    sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+    prov = sb.table("providers").select("id").eq("code", "sincsports").execute()
+    sincsports_id = prov.data[0]["id"]
+
+    chunk = 100
+    tids = list(teams.keys())
+    matched: set[str] = set()
+    for i in range(0, len(tids), chunk):
+        batch = tids[i : i + chunk]
+        res = (
+            sb.table("team_alias_map")
+            .select("provider_team_id")
+            .eq("provider_id", sincsports_id)
+            .in_("provider_team_id", batch)
+            .execute()
+        )
+        for row in res.data:
+            matched.add(row["provider_team_id"])
+
+    missing = [(tid, teams[tid]) for tid in tids if tid not in matched]
+
+    print(f"\nIn alias_map: {len(matched)}")
+    print(f"Missing from alias_map: {len(missing)}")
+    print()
+    for tid, tname in sorted(missing, key=lambda x: x[1]):
+        print(f"  {tid:>10}  {tname}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diagnose_puri_cup_buckets.py
+++ b/scripts/diagnose_puri_cup_buckets.py
@@ -1,0 +1,112 @@
+"""Query build_logs for recent SincSports tournament imports.
+
+Per gotcha_import_games_enhanced_dedup.md: IMPORT_RESULT line under-reports
+because only 4 of the 19 ImportMetrics counters are surfaced. The full
+counters live in build_logs.metrics (JSONB).
+
+Goal: surface the bucket distribution for any sincsports game_import runs
+in the last week, focused on the Puri Cup window (~2026-04-25). If a single
+clear "silent" bucket dominates, that's the real root cause.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Bridge SUPABASE_KEY <- SUPABASE_SERVICE_ROLE_KEY per memory
+# gotcha_supabase_key_env_mismatch.md
+sys.path.append(str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+env_local = Path(__file__).parent.parent / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    load_dotenv(Path(__file__).parent.parent / ".env")
+
+if not os.environ.get("SUPABASE_KEY") and os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
+    os.environ["SUPABASE_KEY"] = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+
+from supabase import create_client  # noqa: E402
+
+url = os.environ.get("SUPABASE_URL")
+key = os.environ.get("SUPABASE_KEY")
+if not url or not key:
+    print("ERROR: SUPABASE_URL or SUPABASE_KEY missing", file=sys.stderr)
+    sys.exit(1)
+
+sb = create_client(url, key)
+
+# 1. Find the SincSports provider_id (UUID)
+prov = sb.table("providers").select("id, code").eq("code", "sincsports").execute()
+if not prov.data:
+    print("No sincsports provider row found", file=sys.stderr)
+    sys.exit(1)
+sincsports_provider_id = prov.data[0]["id"]
+print(f"sincsports provider_id (UUID): {sincsports_provider_id}\n")
+
+# 2. Pull recent build_logs rows for sincsports game_import stage
+rows = (
+    sb.table("build_logs")
+    .select("build_id, started_at, completed_at, records_processed, records_succeeded, records_failed, metrics, parameters")
+    .eq("stage", "game_import")
+    .eq("provider_id", sincsports_provider_id)
+    .gte("started_at", "2026-04-20")
+    .order("started_at", desc=True)
+    .limit(20)
+    .execute()
+)
+
+if not rows.data:
+    print("No sincsports game_import rows in build_logs since 2026-04-20")
+    sys.exit(0)
+
+print(f"Found {len(rows.data)} sincsports game_import runs since 2026-04-20:\n")
+
+# 3. For each row, surface the full bucket distribution
+for r in rows.data:
+    build_id = r.get("build_id")
+    started = r.get("started_at", "")
+    metrics = r.get("metrics") or {}
+    params = r.get("parameters") or {}
+
+    processed = metrics.get("games_processed", 0)
+    accepted = metrics.get("games_accepted", 0)
+    quarantined = metrics.get("games_quarantined", 0)
+    dup_found = metrics.get("duplicates_found", 0)
+    dup_skipped = metrics.get("duplicates_skipped", 0)
+    failed_match = metrics.get("failed_games_count", 0)
+    empty_pid = metrics.get("skipped_empty_provider_ids", 0)
+    empty_date = metrics.get("skipped_empty_game_date", 0)
+    empty_scores = metrics.get("skipped_empty_scores", 0)
+    dup_key_viol = metrics.get("duplicate_key_violations", 0)
+    teams_matched = metrics.get("teams_matched", 0)
+    teams_created = metrics.get("teams_created", 0)
+    matched_count = metrics.get("matched_games_count", 0)
+    partial_count = metrics.get("partial_games_count", 0)
+
+    # Sum of input-consuming buckets
+    bucket_sum = (
+        accepted
+        + quarantined
+        + dup_found
+        + dup_skipped
+        + failed_match
+        + empty_pid
+        + empty_date
+        + empty_scores
+        + dup_key_viol
+    )
+    drift = processed - bucket_sum
+
+    print(f"--- {started}  build_id={build_id}")
+    print(f"    parameters={json.dumps(params)}")
+    print(f"    processed={processed:>5} | accepted={accepted:>5} | quarantined={quarantined:>4} | dup_found={dup_found:>4} | dup_skipped={dup_skipped:>4}")
+    print(f"    failed_match={failed_match:>4} | empty_pid={empty_pid:>3} | empty_date={empty_date:>3} | empty_scores={empty_scores:>3} | dup_key_viol={dup_key_viol:>3}")
+    print(f"    teams_matched={teams_matched:>4} | teams_created={teams_created:>3} | matched_games={matched_count:>4} | partial_games={partial_count:>3}")
+    print(f"    BUCKET SUM = {bucket_sum} (drift from processed = {drift})")
+    print()

--- a/scripts/import_games_enhanced.py
+++ b/scripts/import_games_enhanced.py
@@ -513,6 +513,14 @@ async def main():
                             aggregated_metrics.fuzzy_matches_auto += result.fuzzy_matches_auto
                             aggregated_metrics.fuzzy_matches_manual += result.fuzzy_matches_manual
                             aggregated_metrics.fuzzy_matches_rejected += result.fuzzy_matches_rejected
+                            aggregated_metrics.failed_games_count += result.failed_games_count
+                            aggregated_metrics.skipped_empty_provider_ids += result.skipped_empty_provider_ids
+                            aggregated_metrics.skipped_empty_game_date += result.skipped_empty_game_date
+                            aggregated_metrics.skipped_empty_scores += result.skipped_empty_scores
+                            aggregated_metrics.duplicate_key_violations += result.duplicate_key_violations
+                            aggregated_metrics.duplicate_links_backfilled += result.duplicate_links_backfilled
+                            aggregated_metrics.matched_games_count += result.matched_games_count
+                            aggregated_metrics.partial_games_count += result.partial_games_count
                             aggregated_metrics.errors.extend(result.errors)
                             completed_batches += 1
 
@@ -544,6 +552,14 @@ async def main():
                         aggregated_metrics.fuzzy_matches_auto += result.fuzzy_matches_auto
                         aggregated_metrics.fuzzy_matches_manual += result.fuzzy_matches_manual
                         aggregated_metrics.fuzzy_matches_rejected += result.fuzzy_matches_rejected
+                        aggregated_metrics.failed_games_count += result.failed_games_count
+                        aggregated_metrics.skipped_empty_provider_ids += result.skipped_empty_provider_ids
+                        aggregated_metrics.skipped_empty_game_date += result.skipped_empty_game_date
+                        aggregated_metrics.skipped_empty_scores += result.skipped_empty_scores
+                        aggregated_metrics.duplicate_key_violations += result.duplicate_key_violations
+                        aggregated_metrics.duplicate_links_backfilled += result.duplicate_links_backfilled
+                        aggregated_metrics.matched_games_count += result.matched_games_count
+                        aggregated_metrics.partial_games_count += result.partial_games_count
                         aggregated_metrics.errors.extend(result.errors)
                         completed_batches += 1
 
@@ -590,6 +606,31 @@ async def main():
         console.print(f"  [green]Auto-matched: {aggregated_metrics.fuzzy_matches_auto:,}[/green]")
         console.print(f"  [yellow]Queued for review: {aggregated_metrics.fuzzy_matches_manual:,}[/yellow]")
         console.print(f"  [red]Rejected: {aggregated_metrics.fuzzy_matches_rejected:,}[/red]")
+
+        # Surface previously-hidden counters so operators can see why records didn't land.
+        # Without this, runs where every game was unplayed (skipped_empty_scores) or unmatched
+        # (failed_games_count) look identical to "everything vanished" in the rich console.
+        if aggregated_metrics.failed_games_count > 0:
+            console.print(
+                f"  [yellow]Failed match (no team resolution): {aggregated_metrics.failed_games_count:,}[/yellow]"
+            )
+        if aggregated_metrics.skipped_empty_scores > 0:
+            console.print(
+                f"  [yellow]Skipped (empty scores — unplayed?): {aggregated_metrics.skipped_empty_scores:,}[/yellow]"
+            )
+        if aggregated_metrics.skipped_empty_provider_ids > 0:
+            console.print(
+                f"  [yellow]Skipped (empty provider IDs): {aggregated_metrics.skipped_empty_provider_ids:,}[/yellow]"
+            )
+        if aggregated_metrics.skipped_empty_game_date > 0:
+            console.print(
+                f"  [yellow]Skipped (empty game_date): {aggregated_metrics.skipped_empty_game_date:,}[/yellow]"
+            )
+        if aggregated_metrics.duplicate_key_violations > 0:
+            console.print(
+                f"  [yellow]Duplicate-key violations: {aggregated_metrics.duplicate_key_violations:,}[/yellow]"
+            )
+
         console.print(f"  Processing time: {aggregated_metrics.processing_time_seconds:.2f}s")
 
         # Partial failure reporting

--- a/scripts/scrape_sincsports_tournament_schedule.py
+++ b/scripts/scrape_sincsports_tournament_schedule.py
@@ -22,11 +22,19 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+# Sub-U10 division codes (e.g. U08M01, U09F02). PitchRank rankings are u10+
+# (config/settings.py:_BIRTH_YEARS), so sub-u10 records would only inflate the
+# scraper output and the importer's failed-match counter without ever
+# contributing to a ranking. Filtered before JSONL emit by default;
+# --include-sub-u10 opts in for future use.
+_SUB_U10_CODE_RE = re.compile(r"^U0[89]", re.IGNORECASE)
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -87,6 +95,7 @@ def perspective_record(g: TournamentGame, *, perspective: str) -> dict:
 
     return {
         "provider": "sincsports",
+        "source": "sincsports_tournament_schedule",
         "team_id": team_id,
         "opponent_id": opp_id,
         "team_name": team_name,
@@ -127,6 +136,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Include Scheduled-but-not-yet-played games in the JSONL output (default: skip)",
     )
+    p.add_argument(
+        "--include-sub-u10",
+        action="store_true",
+        help="Include U08/U09 division games (default: skip; PitchRank ranks u10+)",
+    )
     p.add_argument("--auto-import", action="store_true", help="Run import_games_enhanced.py after scraping")
     p.add_argument("--dry-run", action="store_true", help="Print summary only; no JSONL or import")
     return p.parse_args()
@@ -159,6 +173,16 @@ def main() -> int:
     ]
     keep = [g for g in keep if g.date]  # drop unscheduled rows lacking a date
     console.print(f"[cyan]After status/date filter: {len(keep)} games to emit[/cyan]")
+
+    if not args.include_sub_u10:
+        before = len(keep)
+        keep = [g for g in keep if not _SUB_U10_CODE_RE.match(g.division_code or "")]
+        dropped = before - len(keep)
+        if dropped:
+            console.print(
+                f"[cyan]Filtered {dropped} sub-U10 games "
+                f"(use --include-sub-u10 to keep them)[/cyan]"
+            )
 
     if args.dry_run:
         return 0

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -755,13 +755,24 @@ class EnhancedETLPipeline:
                     )
 
                     if master_ids_match:
-                        # Same teams, different scores - update existing game
-                        games_to_update.append(game)
-                        logger.info(
-                            f"[Pipeline] Will UPDATE game {game_uid}: scores differ "
-                            f"(home={game.get('home_provider_id')}, away={game.get('away_provider_id')}, "
-                            f"new scores={game.get('home_score')}-{game.get('away_score')})"
-                        )
+                        # Provenance-gated: SincSports tournament-schedule re-ingest must NOT
+                        # clobber scores from prior per-team imports. The schedule.aspx route
+                        # is run alongside per-team scrapes and we treat the existing row as
+                        # authoritative when scores differ. Other providers keep the
+                        # UPDATE-on-score-diff behavior unchanged.
+                        if game.get("source") == "sincsports_tournament_schedule":
+                            logger.info(
+                                f"[Pipeline] Skipping score UPDATE for tournament re-ingest: {game_uid} "
+                                f"(existing per-team scrape scores are authoritative)"
+                            )
+                        else:
+                            # Same teams, different scores - update existing game
+                            games_to_update.append(game)
+                            logger.info(
+                                f"[Pipeline] Will UPDATE game {game_uid}: scores differ "
+                                f"(home={game.get('home_provider_id')}, away={game.get('away_provider_id')}, "
+                                f"new scores={game.get('home_score')}-{game.get('away_score')})"
+                            )
                     else:
                         # Different teams (e.g., U13 vs U14, or HD vs AD) - this is a different game
                         # This should be rare now since game_uid includes age_group and division

--- a/src/models/game_matcher.py
+++ b/src/models/game_matcher.py
@@ -676,6 +676,10 @@ class GameHistoryMatcher:
             "provider_id": provider_id,
             "source_url": game_data.get("source_url"),
             "scraped_at": game_data.get("scraped_at"),
+            # Provenance tag from the scraper (e.g., "sincsports_tournament_schedule").
+            # Read by enhanced_pipeline._bulk_insert_games to gate score-UPDATE behavior
+            # for tournament re-ingest paths.
+            "source": game_data.get("source"),
             "match_status": match_status,  # Keep for tracking
             "raw_data": game_data,  # Store original for debugging
         }


### PR DESCRIPTION
## Summary

- Rich-console summary now shows the 4 previously-hidden ingest counters whenever non-zero (`failed_games_count`, `skipped_empty_scores`, `skipped_empty_provider_ids`, `skipped_empty_game_date`, `duplicate_key_violations`). Without this, runs where every game was unplayed (e.g. GotSport event 51028 = 160 unplayed fixtures) read as "everything vanished" because the rich console only printed 5 of 19 `ImportMetrics` counters.
- Streaming aggregator at `scripts/import_games_enhanced.py:506-516` and `:537-547` was missing 8 fields. Multi-batch runs now correctly aggregate `failed_games_count`, `skipped_empty_*`, `duplicate_key_violations`, `duplicate_links_backfilled`, `matched_games_count`, `partial_games_count`. Without this, `IMPORT_RESULT:` JSON showed zeros across multi-batch streaming runs even when individual batches had non-zero counts.
- New top-level `source: "sincsports_tournament_schedule"` provenance tag emitted by the schedule.aspx scraper, copied through `match_game_history()` into the matched game_record, and gated at `enhanced_pipeline.py:759` to **skip** the score-UPDATE branch for tournament re-ingest. Pre-existing per-team `games.aspx` scores are now treated as authoritative and never clobbered. Other providers keep their UPDATE-on-score-diff behavior unchanged.
- Scraper now filters `^U0[89]` division codes before JSONL emit (default; `--include-sub-u10` opts in). PitchRank rankings are u10+, so sub-u10 games would only inflate `failed_match`.
- Two diagnostic scripts (`diagnose_puri_cup_buckets.py`, `diagnose_failed_matches.py`) for narrow follow-up investigations against `build_logs` and `team_alias_map`.

## Why this is shipping now

Empirical query against `build_logs` for recent SincSports runs showed the original "440 records vanished" framing was always `failed_games_count` — exposed in `IMPORT_RESULT` JSON but hidden from the rich console. Buckets always sum to `games_processed` (drift = 0). The fix is much smaller than the bug initially suggested.

## Test plan

- [ ] Re-run the GotSport event 51028 import. Rich console should plainly show `Skipped (empty scores — unplayed?): 160` instead of the previous all-zeros output.
- [ ] Re-ingest a previously-imported SincSports tournament JSONL. Confirm via SQL that `goals_for`/`goals_against` for previously-imported games are unchanged. Log line `[Pipeline] Skipping score UPDATE for tournament re-ingest: <game_uid>` should appear for any score-diff overlap.
- [ ] Run `scripts/scrape_sincsports_tournament_schedule.py --tid <tid>` against a tournament with U08/U09 brackets. JSONL output excludes those records; stderr shows `Filtered N sub-U10 games`. Re-run with `--include-sub-u10` and confirm they're included.
- [ ] Run `scripts/diagnose_puri_cup_buckets.py` and confirm it prints the bucket distribution for recent SincSports runs.
- [ ] Run a multi-batch streaming import (large JSONL, default batch_size). Confirm `IMPORT_RESULT` JSON's `failed_games_count` and `skipped_empty_scores` are non-zero and accurate when applicable (previously always 0 in multi-batch streaming mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)