### PR TITLE
Shell 02: wire gotsport tier-section parser into live scrape + persist 5 fields

### DIFF
--- a/scripts/diagnose_puri_cup_buckets.py
+++ b/scripts/diagnose_puri_cup_buckets.py
@@ -52,7 +52,9 @@ print(f"sincsports provider_id (UUID): {sincsports_provider_id}\n")
 # 2. Pull recent build_logs rows for sincsports game_import stage
 rows = (
     sb.table("build_logs")
-    .select("build_id, started_at, completed_at, records_processed, records_succeeded, records_failed, metrics, parameters")
+    .select(
+        "build_id, started_at, completed_at, records_processed, records_succeeded, records_failed, metrics, parameters"
+    )
     .eq("stage", "game_import")
     .eq("provider_id", sincsports_provider_id)
     .gte("started_at", "2026-04-20")
@@ -105,8 +107,17 @@ for r in rows.data:
 
     print(f"--- {started}  build_id={build_id}")
     print(f"    parameters={json.dumps(params)}")
-    print(f"    processed={processed:>5} | accepted={accepted:>5} | quarantined={quarantined:>4} | dup_found={dup_found:>4} | dup_skipped={dup_skipped:>4}")
-    print(f"    failed_match={failed_match:>4} | empty_pid={empty_pid:>3} | empty_date={empty_date:>3} | empty_scores={empty_scores:>3} | dup_key_viol={dup_key_viol:>3}")
-    print(f"    teams_matched={teams_matched:>4} | teams_created={teams_created:>3} | matched_games={matched_count:>4} | partial_games={partial_count:>3}")
+    print(
+        f"    processed={processed:>5} | accepted={accepted:>5} | quarantined={quarantined:>4} "
+        f"| dup_found={dup_found:>4} | dup_skipped={dup_skipped:>4}"
+    )
+    print(
+        f"    failed_match={failed_match:>4} | empty_pid={empty_pid:>3} | empty_date={empty_date:>3} "
+        f"| empty_scores={empty_scores:>3} | dup_key_viol={dup_key_viol:>3}"
+    )
+    print(
+        f"    teams_matched={teams_matched:>4} | teams_created={teams_created:>3} "
+        f"| matched_games={matched_count:>4} | partial_games={partial_count:>3}"
+    )
     print(f"    BUCKET SUM = {bucket_sum} (drift from processed = {drift})")
     print()

--- a/scripts/scrape_specific_event.py
+++ b/scripts/scrape_specific_event.py
@@ -21,6 +21,10 @@ from rich.panel import Panel
 
 from scripts.scrape_new_gotsport_events import load_scraped_events, save_scraped_event
 from src.scrapers.gotsport_event import EventCaptchaGatedError, GotSportEventScraper
+from src.scrapers.gotsport_tier_parser import (
+    EventTeamMembershipCollisionError,
+    TierSubfetchError,
+)
 from supabase import create_client
 
 console = Console()
@@ -106,10 +110,7 @@ def scrape_specific_event(
                 revalidate=revalidate,
             )
             total_teams = sum(len(teams) for teams in cohort_teams.values())
-            console.print(
-                f"[green]✅ Intake: {len(cohort_teams)} brackets, "
-                f"{total_teams} teams classified[/green]\n"
-            )
+            console.print(f"[green]✅ Intake: {len(cohort_teams)} brackets, {total_teams} teams classified[/green]\n")
         except EventCaptchaGatedError as e:
             console.print(
                 f"[yellow]⚠️  Event {event_id} is CAPTCHA-gated — scrape skipped.[/yellow]\n"
@@ -118,6 +119,16 @@ def scrape_specific_event(
                 f"  artifact: {e.artifact_path}[/dim]"
             )
             return
+        except TierSubfetchError as e:
+            console.print(
+                f"[red]❌ Tier subfetch failed: event={e.event_id} "
+                f"group={e.group_id} kind={e.underlying_kind}[/red]\n"
+                f"[dim]  details: {e.details}[/dim]"
+            )
+            return
+        except EventTeamMembershipCollisionError as e:
+            console.print(f"[red]❌ Tier collision: event={e.event_id} mode={e.mode}[/red]\n[dim]  details: {e}[/dim]")
+            return
         except Exception as e:
             console.print(
                 f"[red]❌ Cohort intake failed for event {event_id}: {e}[/red]\n"
@@ -125,8 +136,7 @@ def scrape_specific_event(
             )
     else:
         console.print(
-            f"[dim]Skipping cohort intake (--skip-intake). "
-            f"Aliases will NOT be written for event {event_id}.[/dim]\n"
+            f"[dim]Skipping cohort intake (--skip-intake). Aliases will NOT be written for event {event_id}.[/dim]\n"
         )
 
     # Scrape games

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -32,8 +32,15 @@ except ImportError:
     certifi = None
 
 from src.base import GameData
+from src.scrapers._age_normalization import normalize_age
 from src.scrapers.base import BaseScraper
 from src.scrapers.event_team import EventTeam
+from src.scrapers.gotsport_tier_parser import (
+    MICRO_OUT_OF_SCOPE_AGES,
+    EnrichmentResult,
+    FetchedSubpage,
+    enrich_teams_with_tiers,
+)
 from src.scrapers.intake_journal import DURABLE_ACTIONS, IntakeJournal, compute_skip_set
 from src.scrapers.provider import (
     CanonicalResolution,
@@ -599,6 +606,12 @@ class GotSportScraper(BaseScraper):
             return False
 
 
+# Leading ``U<digits>`` token on ``EventTeam.age_group``. The caller-side
+# filter in ``fetch_teams_by_cohort`` decides micro-cohort membership via
+# ``MICRO_OUT_OF_SCOPE_AGES`` against the digits captured here — the regex
+# itself is age-agnostic, so loose values like ``"Unknown"`` fall through.
+_LEADING_U_AGE_RE = re.compile(r"^[Uu](\d{1,2})", re.IGNORECASE)
+
 # Markers for gotsport's per-event reCAPTCHA v2 challenge page
 # (observed 2026-04-24 on events 45224, 40550, 40610 among others).
 # Detection is permissive: any of these patterns is enough — the three tend
@@ -723,9 +736,7 @@ def _extract_captcha_signals_from_parts(
     return None
 
 
-def _extract_captcha_signals(
-    response: requests.Response, fallback_target_url: str
-) -> Optional[dict]:
+def _extract_captcha_signals(response: requests.Response, fallback_target_url: str) -> Optional[dict]:
     """Thin wrapper around ``_extract_captcha_signals_from_parts``.
 
     Pulls the four parts out of a ``requests.Response`` and delegates. Keeps
@@ -740,9 +751,7 @@ def _extract_captcha_signals(
     )
 
 
-def extract_event_teams_by_bracket_from_soup(
-    soup: BeautifulSoup, event_id: str
-) -> Dict[str, List[EventTeam]]:
+def extract_event_teams_by_bracket_from_soup(soup: BeautifulSoup, event_id: str) -> Dict[str, List[EventTeam]]:
     """Pure-parse counterpart to ``GotsportScraper.extract_event_teams_by_bracket``.
 
     Takes the parsed BeautifulSoup snapshot directly so the new
@@ -850,9 +859,7 @@ def extract_event_teams_by_bracket_from_soup(
         for header in all_headers:
             header_text = header.get_text(strip=True)
             # Look for bracket patterns like "SUPER PRO - U9B", "GOLD - U8B", etc.
-            if re.search(
-                r"(SUPER|ELITE|PRO|BLACK|GOLD|SILVER|BRONZE|PREMIER|CHAMPIONSHIP)", header_text, re.I
-            ):
+            if re.search(r"(SUPER|ELITE|PRO|BLACK|GOLD|SILVER|BRONZE|PREMIER|CHAMPIONSHIP)", header_text, re.I):
                 # This looks like a bracket header
                 # Look for team links or data near this header
                 parent = header.find_parent()
@@ -919,9 +926,7 @@ def extract_event_teams_by_bracket_from_soup(
                 # Create bracket name from team data
                 age_group = team.get("display_age_group", "Unknown")
                 gender_code = (
-                    "B"
-                    if "Male" in team.get("display_gender", "") or team.get("gender", "").lower() == "m"
-                    else "G"
+                    "B" if "Male" in team.get("display_gender", "") or team.get("gender", "").lower() == "m" else "G"
                 )
                 bracket_name = f"{age_group}{gender_code}"
 
@@ -1018,9 +1023,7 @@ def extract_event_teams_by_bracket_from_soup(
                         match = re.search(r"/teams?/(\d+)", href)
                         if match:
                             team_id = match.group(1)
-                            team_name = (
-                                link.get_text(strip=True) or link.get("title", "") or f"Team {team_id}"
-                            )
+                            team_name = link.get_text(strip=True) or link.get("title", "") or f"Team {team_id}"
 
                             # Extract age_group - prioritize birth year in team name
                             age_group = None
@@ -1206,13 +1209,7 @@ class GotsportScraper(ProviderScraper):
         # on 0 rows; wrap to surface a typed error with an actionable
         # message instead of a raw postgrest APIError.
         try:
-            result = (
-                supabase_client.table("providers")
-                .select("id, code")
-                .eq("code", "gotsport")
-                .single()
-                .execute()
-            )
+            result = supabase_client.table("providers").select("id, code").eq("code", "gotsport").single().execute()
         except Exception as e:
             raise UnsupportedProviderError(
                 f"'gotsport' not registered in providers table — run migrations. Inner: {e}"
@@ -1325,9 +1322,7 @@ class GotsportScraper(ProviderScraper):
             )
         return response
 
-    def _write_captcha_artifact(
-        self, event_id: str, captcha: dict, event_url: str
-    ) -> Path:
+    def _write_captcha_artifact(self, event_id: str, captcha: dict, event_url: str) -> Path:
         """Persist a captcha_challenge.json artifact alongside intake logs.
 
         Path matches the `reports/<event_key>/intake/` convention set by the
@@ -1351,7 +1346,9 @@ class GotsportScraper(ProviderScraper):
         artifact_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         logger.warning(
             "[captcha_detected] event_id=%s sitekey=%s artifact=%s",
-            event_id, captcha["sitekey"], artifact_path,
+            event_id,
+            captcha["sitekey"],
+            artifact_path,
         )
         return artifact_path
 
@@ -1551,7 +1548,6 @@ class GotsportScraper(ProviderScraper):
                     # follow-up commit after the smoke check empirically confirms parity.
                     logger.debug("No bracket structure found (legacy side-effect call retained for review)...")
                     self.extract_event_teams(event_id)
-
 
                 if brackets:
                     total_teams = sum(len(teams) for teams in brackets.values())
@@ -2961,15 +2957,53 @@ class GotsportScraper(ProviderScraper):
 
         journal = IntakeJournal(event_key=event_key)
         journal.startup_cleanup()
+        run_id = datetime.now(timezone.utc).isoformat()
 
         # Reset the matcher candidate cache for this scrape so stale entries
         # from a prior event don't leak into this one.
         self._matcher_cache = {}
 
-        # Surface a CAPTCHA gate before doing any further parse work.
-        self._fetch_event_page(event_id)
+        # Surface a CAPTCHA gate before doing any further parse work; capture
+        # the response so the orchestrator can reuse the soup without a 3rd fetch.
+        landing_response = self._fetch_event_page(event_id)
+        landing_soup = BeautifulSoup(landing_response.text, "html.parser")
 
+        # DELIBERATE DUAL FETCH: ``landing_soup`` above feeds the tier orchestrator;
+        # the call below independently re-fetches inside its retry/404/SSL loop. Do
+        # NOT consolidate by passing ``landing_soup`` to ``extract_event_teams_by_bracket_from_soup``
+        # without first lifting that retry scaffolding to the soup-only path —
+        # consolidating today would silently drop the production retry coverage.
         teams_by_bracket = self.extract_event_teams_by_bracket(event_id)
+
+        # --- Tier-section enrichment ----------------------------------------
+        # The closure mirrors ``_make_zenrows_request`` for routing and
+        # ``_fetch_event_page`` for the deliberate omission of
+        # ``raise_for_status`` — gotsport/ZenRows may serve a captcha
+        # challenge body with a non-2xx status, and the orchestrator's
+        # captcha detection must run BEFORE any HTTP-error short-circuit.
+        def _subpage_fetcher(group_id: int) -> FetchedSubpage:
+            url = f"{self.EVENT_BASE}/{event_id}/schedules?group={group_id}"
+            if self.use_zenrows:
+                resp = self._make_zenrows_request(url)
+            else:
+                resp = self.session.get(url, timeout=self.timeout)
+            if self.delay_min > 0 or self.delay_max > 0:
+                time.sleep(random.uniform(self.delay_min, self.delay_max))
+            return FetchedSubpage(
+                html=resp.text or "",
+                final_url=str(resp.url or ""),
+                zr_final_url=resp.headers.get("Zr-Final-Url"),
+                redirect_locations=[hr.headers.get("Location") or "" for hr in resp.history or []],
+            )
+
+        enrichment_by_team_id = enrich_teams_with_tiers(
+            landing_soup,
+            teams_by_bracket,
+            event_id=event_id,
+            event_key=event_key,
+            run_id=run_id,
+            subpage_fetcher=_subpage_fetcher,
+        )
 
         # --- First pass: skip-set + classification ---------------------------
         prior_store = journal.read()
@@ -2984,11 +3018,24 @@ class GotsportScraper(ProviderScraper):
         all_resolutions: Dict[str, tuple[ScrapedTeam, CanonicalResolution]] = {}
         bracket_occurrences: Dict[str, List[str]] = {}
         live_pids: Set[str] = set()
+        dropped_out_of_scope_count = 0
 
         for bracket_name, event_teams in teams_by_bracket.items():
             bracket_scraped: List[ScrapedTeam] = []
             for event_team in event_teams:
-                scraped = _event_team_to_scraped_team(event_team, bracket_name)
+                age_raw = (event_team.age_group or "").strip()
+                m = _LEADING_U_AGE_RE.match(age_raw)
+                if m:
+                    age_lc = normalize_age(int(m.group(1)))
+                    if age_lc in MICRO_OUT_OF_SCOPE_AGES:
+                        dropped_out_of_scope_count += 1
+                        continue
+
+                scraped = _event_team_to_scraped_team(
+                    event_team,
+                    bracket_name,
+                    enrichment=enrichment_by_team_id.get(event_team.team_id),
+                )
                 bracket_scraped.append(scraped)
                 pid = scraped.provider_team_id
                 if not pid:
@@ -3008,16 +3055,13 @@ class GotsportScraper(ProviderScraper):
             scraped_by_bracket[bracket_name] = bracket_scraped
 
         # --- Second pass: route + journal -----------------------------------
-        run_id = datetime.now(timezone.utc).isoformat()
         stats: Dict[str, int] = {}
 
         journal.open_for_append()
         try:
             for pid, (scraped, resolution) in all_resolutions.items():
                 brackets_for_team = bracket_occurrences.get(pid, [])
-                action_dict = self._route_to_writer(
-                    scraped, resolution, brackets_for_team, event_id, source_url
-                )
+                action_dict = self._route_to_writer(scraped, resolution, brackets_for_team, event_id, source_url)
                 action = action_dict.get("action", "none")
                 stats[action] = stats.get(action, 0) + 1
                 if action in DURABLE_ACTIONS:
@@ -3034,7 +3078,8 @@ class GotsportScraper(ProviderScraper):
                 else:
                     logger.info(
                         "[journal_skip] provider_team_id=%s action=%s — will retry on next run",
-                        pid, action,
+                        pid,
+                        action,
                     )
         finally:
             journal.close()
@@ -3047,12 +3092,14 @@ class GotsportScraper(ProviderScraper):
 
         logger.info(
             "[fetch_teams_by_cohort] event_id=%s brackets=%d unique_teams=%d "
-            "resolved=%d skipped=%d compact_kept=%d compact_dropped=%d stats=%s",
+            "resolved=%d skipped=%d dropped_out_of_scope_teams=%d "
+            "compact_kept=%d compact_dropped=%d stats=%s",
             event_id,
             len(teams_by_bracket),
             len(live_pids),
             len(all_resolutions),
             len(skip_set),
+            dropped_out_of_scope_count,
             kept,
             dropped,
             stats,
@@ -3092,11 +3139,7 @@ class GotsportScraper(ProviderScraper):
             )
 
         if resolution.resolved_status in ("direct_provider_id", "review"):
-            suggested_master = (
-                resolution.candidates[0].get("team_id_master")
-                if resolution.candidates
-                else None
-            )
+            suggested_master = resolution.candidates[0].get("team_id_master") if resolution.candidates else None
             match_details = {
                 "age_group": scraped.cohort_age_group,
                 "gender": scraped.cohort_gender,
@@ -3154,16 +3197,11 @@ class GotsportScraper(ProviderScraper):
                 .execute()
             )
         except Exception as e:
-            logger.warning(
-                "[revalidate_query_failed] falling back to full revalidation: %s", e
-            )
+            logger.warning("[revalidate_query_failed] falling back to full revalidation: %s", e)
             return set()
         curated: Set[str] = set()
         for row in getattr(result, "data", None) or []:
-            if (
-                row.get("review_status") == "approved"
-                and row.get("match_method") in curated_methods
-            ):
+            if row.get("review_status") == "approved" and row.get("match_method") in curated_methods:
                 curated.add(row["provider_team_id"])
         return curated
 
@@ -3211,13 +3249,9 @@ class GotsportScraper(ProviderScraper):
             event_age_group=team.cohort_age_group,
             event_gender=team.cohort_gender,
             event_club_name=team.club_name,
-            provider_team_id=(
-                team.provider_team_id if provider_id_status == "resolved" else None
-            ),
+            provider_team_id=(team.provider_team_id if provider_id_status == "resolved" else None),
         )
-        result = search_event_team_in_db(
-            self.supabase_client, query, cache=self._matcher_cache
-        )
+        result = search_event_team_in_db(self.supabase_client, query, cache=self._matcher_cache)
 
         team_id_master, match_method = _route_resolution(result.resolved_status, result.best_score)
 
@@ -3257,9 +3291,7 @@ def _provider_id_resolution_status(team: ScrapedTeam) -> str:
     return "resolved"
 
 
-def _route_resolution(
-    resolved_status: str, best_score: Optional[float]
-) -> tuple[Optional[str], Optional[str]]:
+def _route_resolution(resolved_status: str, best_score: Optional[float]) -> tuple[Optional[str], Optional[str]]:
     """Apply the plan's routing table. Returns ``(sentinel, match_method)``.
 
     ``sentinel`` is a truthy placeholder when the resolution routes to
@@ -3279,7 +3311,11 @@ def _route_resolution(
     return (None, None)  # "none" or unknown
 
 
-def _event_team_to_scraped_team(event_team: "EventTeam", bracket_name: str) -> ScrapedTeam:
+def _event_team_to_scraped_team(
+    event_team: "EventTeam",
+    bracket_name: str,
+    enrichment: Optional["EnrichmentResult"] = None,
+) -> ScrapedTeam:
     """Convert the legacy ``EventTeam`` row to the ``ProviderScraper``-shaped
     ``ScrapedTeam``.
 
@@ -3293,6 +3329,10 @@ def _event_team_to_scraped_team(event_team: "EventTeam", bracket_name: str) -> S
     - ``club_name`` — left as None; downstream extraction in
       ``resolve_canonical_team_id`` is handled by the matcher's
       ``extract_club_from_name`` fallback.
+
+    ``enrichment`` carries the Shell-02 tier-section fields. When ``None``
+    (no orchestrator hit for this ``team_id``) the dataclass-default
+    sentinels apply (``"none"`` / ``"unenriched"``).
     """
     pid = (event_team.team_id or "").strip()
     return ScrapedTeam(
@@ -3305,6 +3345,11 @@ def _event_team_to_scraped_team(event_team: "EventTeam", bracket_name: str) -> S
         bracket_name=event_team.bracket_name or bracket_name,
         playing_up=event_team.playing_up,
         has_view_rankings_link=bool(pid),
+        group_name=enrichment.group_name if enrichment else None,
+        group_id=enrichment.group_id if enrichment else None,
+        tier_discovery_source=enrichment.tier_discovery_source if enrichment else "none",
+        tier_membership_source=enrichment.tier_membership_source if enrichment else "none",
+        tier_parse_outcome=enrichment.tier_parse_outcome if enrichment else "unenriched",
     )
 
 
@@ -3352,12 +3397,8 @@ def _build_jsonl_record(
     scraper_state = _scraper_state_from_action(action)
 
     if scraper_state == "alias_written":
-        canonical_match_method = (
-            action_dict.get("match_method") or resolution.match_method
-        )
-        canonical_team_id_master = (
-            action_dict.get("team_id_master") or resolution.team_id_master
-        )
+        canonical_match_method = action_dict.get("match_method") or resolution.match_method
+        canonical_team_id_master = action_dict.get("team_id_master") or resolution.team_id_master
     else:
         canonical_match_method = None
         canonical_team_id_master = None
@@ -3373,6 +3414,11 @@ def _build_jsonl_record(
         "bracket_name": scraped.bracket_name,
         "playing_up": scraped.playing_up,
         "has_view_rankings_link": scraped.has_view_rankings_link,
+        "group_name": scraped.group_name,
+        "group_id": scraped.group_id,
+        "tier_discovery_source": scraped.tier_discovery_source,
+        "tier_membership_source": scraped.tier_membership_source,
+        "tier_parse_outcome": scraped.tier_parse_outcome,
         "provider_id_resolution_status": resolution.provider_id_resolution_status,
         "also_appears_in_brackets": brackets,
         "canonical": {

--- a/src/scrapers/gotsport_tier_parser.py
+++ b/src/scrapers/gotsport_tier_parser.py
@@ -123,9 +123,7 @@ OUTCOME_UNENRICHED: TierParseOutcome = "unenriched"
 # fires when too many landing labels fail to parse — surfaces drift).
 # ---------------------------------------------------------------------------
 
-IN_SCOPE_AGES: frozenset[str] = frozenset(
-    {"u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u19"}
-)
+IN_SCOPE_AGES: frozenset[str] = frozenset({"u10", "u11", "u12", "u13", "u14", "u15", "u16", "u17", "u19"})
 MICRO_OUT_OF_SCOPE_AGES: frozenset[str] = frozenset({"u6", "u7", "u8", "u9"})
 UNKNOWN_PREFIX_GATE_THRESHOLD: float = 0.10
 INVERSE_COLLISION_STRICT_MODE: bool = False
@@ -240,8 +238,7 @@ class TierSubfetchError(Exception):
         self.underlying_kind = underlying_kind
         self.details = details
         super().__init__(
-            f"event {event_id} group {group_id} subfetch failed ({underlying_kind}): "
-            f"{subpage_url} — {details}"
+            f"event {event_id} group {group_id} subfetch failed ({underlying_kind}): {subpage_url} — {details}"
         )
 
 
@@ -299,7 +296,7 @@ def strip_cohort_prefix(text: str) -> tuple[str, str, TierParseOutcome]:
         if not m:
             continue
         prefix_span = m.group(0)
-        rest = text[m.end():]
+        rest = text[m.end() :]
         rest = _FORMAT_TOKEN_RE.sub("", rest)
         rest = rest.strip()
         if not rest:
@@ -384,9 +381,7 @@ def _resolve_cohort(
     return (age_key, gender)
 
 
-def extract_tier_catalog(
-    soup: BeautifulSoup, *, event_id: str
-) -> dict[int, RawTierLabel]:
+def extract_tier_catalog(soup: BeautifulSoup, *, event_id: str) -> dict[int, RawTierLabel]:
     """Walk the landing page's ``?group=<id>`` anchors and build a per-gid catalog.
 
     Inline forward-collision detection (per spec): if two anchors carry the
@@ -534,6 +529,20 @@ _AbortKind = Literal[
 ]
 
 
+_FILENAME_RESERVED_RE = re.compile(r'[<>:"/\\|?*]')
+
+
+def _safe_filename_token(run_id: str) -> str:
+    """Sanitize a string for use as a filename component on every supported OS.
+
+    Windows rejects ``<>:"/\\|?*`` (and a few NTFS-reserved names that are
+    out of scope here); macOS rejects ``:``; Linux tolerates everything.
+    All reserved chars collapse to ``-``, and ``+`` is rewritten to ``_``
+    so ISO-8601 timezone offsets like ``+00:00`` round-trip distinguishably.
+    """
+    return _FILENAME_RESERVED_RE.sub("-", run_id).replace("+", "_")
+
+
 def _write_abort_artifact(
     event_key: str,
     *,
@@ -547,7 +556,7 @@ def _write_abort_artifact(
 ) -> Path:
     path = _write_intake_artifact(
         event_key,
-        filename=f"tier_orchestrator_abort__{run_id}.json",
+        filename=f"tier_orchestrator_abort__{_safe_filename_token(run_id)}.json",
         payload={
             "event_key": event_key,
             "run_id": run_id,
@@ -633,9 +642,7 @@ def enrich_teams_with_tiers(
     # known-out-of-scope micro cohorts (u6..u9) get dropped. Single predicate
     # captures that semantics directly.
     in_scope_catalog: dict[int, RawTierLabel] = {
-        label.group_id: label
-        for label in catalog.values()
-        if label.cohort_age_group not in MICRO_OUT_OF_SCOPE_AGES
+        label.group_id: label for label in catalog.values() if label.cohort_age_group not in MICRO_OUT_OF_SCOPE_AGES
     }
 
     unknown_prefix_labels = [
@@ -643,11 +650,7 @@ def enrich_teams_with_tiers(
     ]
     unknown_prefix_count = len(unknown_prefix_labels)
     total_candidates = len(in_scope_catalog)
-    gated = (
-        (unknown_prefix_count / total_candidates) > UNKNOWN_PREFIX_GATE_THRESHOLD
-        if total_candidates > 0
-        else False
-    )
+    gated = (unknown_prefix_count / total_candidates) > UNKNOWN_PREFIX_GATE_THRESHOLD if total_candidates > 0 else False
 
     # 3. Write metrics artifact IMMEDIATELY — before any subfetch.
     _write_metric_artifact(
@@ -701,7 +704,7 @@ def enrich_teams_with_tiers(
             fallback_target_url=subpage_url,
         )
         if signals is not None:
-            _write_abort_artifact(
+            abort_path = _write_abort_artifact(
                 event_key,
                 run_id=run_id,
                 attempted_group_ids=attempted_group_ids,
@@ -719,6 +722,7 @@ def enrich_teams_with_tiers(
                 provider_event_id=event_id,
                 captcha_url=signals.get("captcha_url", subpage_url),
                 sitekey=signals.get("sitekey"),
+                artifact_path=abort_path,
             )
 
         try:
@@ -825,9 +829,7 @@ def enrich_teams_with_tiers(
         for team_id in results_by_gid.get(gid, ()):
             if team_id in enrichment:
                 continue
-            membership = (
-                MEMBERSHIP_AMBIGUOUS if team_id in inverse_collision_teams else MEMBERSHIP_SUBPAGE
-            )
+            membership = MEMBERSHIP_AMBIGUOUS if team_id in inverse_collision_teams else MEMBERSHIP_SUBPAGE
             enrichment[team_id] = EnrichmentResult(
                 group_name=label.tier_residue,
                 group_id=label.group_id,

--- a/src/scrapers/provider.py
+++ b/src/scrapers/provider.py
@@ -60,6 +60,15 @@ class ScrapedTeam:
     playing_up: bool = False
     has_view_rankings_link: bool = False
     meta: dict[str, Any] = field(default_factory=dict)
+    # Tier-section enrichment (Shell 02 — gotsport tier-section parser).
+    # IMPORTANT: ``group_name`` here is the TIER RESIDUE (e.g., "Red", "GOLD"),
+    # NOT the bracket-section label that ``EventTeam.group_name`` carries.
+    # See ``.turbo/specs/gotsport-tier-section-parser.md`` for the persisted-data contract.
+    group_name: str | None = None
+    group_id: int | None = None
+    tier_discovery_source: str = "none"
+    tier_membership_source: str = "none"
+    tier_parse_outcome: str = "unenriched"
 
 
 @dataclass(frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,55 @@ from __future__ import annotations
 import pandas as pd
 
 
+class FakeResponse:
+    """Minimal ``requests.Response`` stand-in for tests that exercise the
+    gotsport scrape path without network. ``fetch_teams_by_cohort`` reads
+    ``response.text`` directly to build the landing soup, and the
+    tier-orchestrator subpage closure reads ``.url`` / ``.headers`` /
+    ``.history`` for ZenRows-aware captcha detection — bare ``MagicMock()``
+    does not satisfy that contract."""
+
+    def __init__(self, text: str = "", url: str = ""):
+        self.text = text
+        self.url = url
+        self.headers: dict[str, str] = {}
+        self.history: list = []
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def trim_landing_to_gids(html: str, keep_gids: list[int]) -> str:
+    """Drop landing-page rows whose ``?group=`` anchor isn't in the keep-set.
+
+    Used to keep gotsport tier-parser tests hermetic when only a subset of
+    per-tier subpages have been captured as fixtures. Collects rows-to-drop
+    FIRST then decomposes — calling ``row.decompose()`` mid-iteration leaves
+    stale Tag refs whose ``a.get(...)`` raises.
+
+    ``BeautifulSoup`` is imported lazily so unrelated test modules don't
+    pay the bs4 import cost when this helper is unused.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    rows_to_drop = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if "schedules?group=" not in href:
+            continue
+        if any(f"group={g}" in href for g in keep_gids):
+            continue
+        parent = a.find_parent()
+        row = parent.find_parent() if parent else None
+        if row is not None:
+            rows_to_drop.append(row)
+    for row in rows_to_drop:
+        row.decompose()
+    return str(soup)
+
+
 def make_game_pair(
     gid,
     date,

--- a/tests/integration/test_gotsport_tier_persistence.py
+++ b/tests/integration/test_gotsport_tier_persistence.py
@@ -1,0 +1,287 @@
+"""End-to-end wiring of ``enrich_teams_with_tiers`` into ``fetch_teams_by_cohort``.
+
+Exercises the live wiring against captured 42433 fixtures: trims the landing
+soup to the 3 gids whose ``schedules?group=<gid>`` subpages we have on disk,
+mocks ``self.session.get`` to read those fixtures, asserts the 5 tier fields
+land in ``raw_scrape.jsonl`` with the expected residues.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import logging
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.scrapers.gotsport import (
+    EventCaptchaGatedError,
+    EventTeam,
+    GotsportScraper,
+)
+from src.scrapers.provider import CanonicalResolution
+from tests.conftest import FakeResponse, trim_landing_to_gids
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "gotsport"
+EVENT_ID = "42433"
+EVENT_URL = f"https://system.gotsport.com/org_event/events/{EVENT_ID}"
+
+# Captured subpage gids — U13 Boys Red, Blue, White respectively.
+CAPTURED_GIDS = [365847, 365849, 365850]
+
+# Sampled team_ids extracted from each captured subpage at fixture-write time.
+TEAM_IN_RED = "3194980"
+TEAM_IN_BLUE = "3551474"
+TEAM_IN_WHITE = "3194970"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scraper() -> GotsportScraper:
+    supabase = MagicMock()
+    supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+        "id": "provider-uuid",
+        "code": "gotsport",
+    }
+    return GotsportScraper(supabase, "gotsport", skip_team_id_resolution=True)
+
+
+def _synthetic_team(team_id: str, *, age_group: str = "U13") -> EventTeam:
+    return EventTeam(
+        team_id=team_id,
+        team_name=f"Team {team_id}",
+        bracket_name="bracket",
+        age_group=age_group,
+        gender="M",
+    )
+
+
+def _resolution(team_id_master: str = "m") -> CanonicalResolution:
+    return CanonicalResolution(
+        team_id_master=team_id_master,
+        confidence=0.99,
+        resolved_status="direct_provider_id",
+        match_method="direct_id",
+        candidates=[],
+        provider_id_resolution_status="resolved",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wired_scraper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GotsportScraper:
+    """Scraper with IntakeJournal + tier-orchestrator artifacts redirected to
+    ``tmp_path``, ``_fetch_event_page`` returning the trimmed 42433 landing,
+    and ``self.session.get`` reading captured per-tier fixtures."""
+    s = _make_scraper()
+    from src.scrapers import gotsport as gs
+
+    real_journal = gs.IntakeJournal
+    monkeypatch.setattr(
+        gs,
+        "IntakeJournal",
+        lambda event_key, base_dir="reports": real_journal(event_key=event_key, base_dir=tmp_path),
+    )
+    real_enrich = gs.enrich_teams_with_tiers
+    monkeypatch.setattr(
+        gs,
+        "enrich_teams_with_tiers",
+        functools.partial(real_enrich, base_dir=tmp_path),
+    )
+
+    landing_html = (FIXTURES / f"event_{EVENT_ID}.html").read_text(encoding="utf-8")
+    trimmed = trim_landing_to_gids(landing_html, CAPTURED_GIDS)
+    monkeypatch.setattr(s, "_fetch_event_page", lambda eid: FakeResponse(text=trimmed, url=EVENT_URL))
+
+    def _session_get(url, *args, **kwargs):
+        m = re.search(r"group=(\d+)", url)
+        if not m:
+            return FakeResponse(text="", url=url)
+        gid = int(m.group(1))
+        path = FIXTURES / f"event_{EVENT_ID}__group_{gid}.html"
+        return FakeResponse(text=path.read_text(encoding="utf-8"), url=url)
+
+    s.session = MagicMock()
+    s.session.get = _session_get
+    # Disable per-subfetch throttle so the test runs in deterministic time.
+    s.delay_min = 0.0
+    s.delay_max = 0.0
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Golden path
+# ---------------------------------------------------------------------------
+
+
+@patch("src.scrapers.gotsport.upsert_team_alias")
+@patch.object(GotsportScraper, "resolve_canonical_team_id")
+@patch.object(GotsportScraper, "extract_event_teams_by_bracket")
+def test_golden_path_persists_tier_fields_to_jsonl(
+    mock_extract,
+    mock_resolve,
+    mock_upsert,
+    wired_scraper,
+    tmp_path,
+    caplog,
+):
+    """Trimmed landing → orchestrator subfetches 3 captured gids → enrichment
+    populated → ``raw_scrape.jsonl`` carries the 5 tier fields with expected
+    residues for U13 Boys Red/Blue/White."""
+    mock_extract.return_value = {
+        "U13 Boys Red": [_synthetic_team(TEAM_IN_RED)],
+        "U13 Boys Blue": [_synthetic_team(TEAM_IN_BLUE)],
+        "U13 Boys White": [_synthetic_team(TEAM_IN_WHITE)],
+    }
+    mock_resolve.return_value = _resolution()
+    mock_upsert.return_value = {"action": "created"}
+
+    caplog.set_level(logging.INFO, logger="src.scrapers.gotsport")
+    wired_scraper.fetch_teams_by_cohort(EVENT_URL, force_teams=True)
+
+    journal_path = tmp_path / f"gotsport__{EVENT_ID}__unknown" / "intake" / "raw_scrape.jsonl"
+    assert journal_path.exists(), f"no journal at {journal_path}"
+    records = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines() if line]
+    by_pid = {r["provider_team_id"]: r for r in records}
+
+    red = by_pid[TEAM_IN_RED]
+    assert red["group_name"] == "Red"
+    assert red["group_id"] == 365847
+    assert red["tier_discovery_source"] == "landing"
+    assert red["tier_membership_source"] == "subpage"
+    assert red["tier_parse_outcome"] == "matched"
+
+    assert by_pid[TEAM_IN_BLUE]["group_name"] == "Blue"
+    assert by_pid[TEAM_IN_BLUE]["group_id"] == 365849
+    assert by_pid[TEAM_IN_WHITE]["group_name"] == "White"
+    assert by_pid[TEAM_IN_WHITE]["group_id"] == 365850
+
+    # End-of-scrape summary log includes the new dropped count field.
+    assert any("dropped_out_of_scope_teams=" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat read passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_load_raw_scrape_returns_legacy_records_without_tier_keys(tmp_path):
+    """Legacy ``raw_scrape.jsonl`` records (pre-Shell-02) lack the 5 tier
+    keys. ``load_raw_scrape`` returns ``list[dict]`` — no implicit
+    rehydration / no ``"unenriched"`` injection."""
+    from src.tournaments.storage.raw_scrape import load_raw_scrape
+
+    event_key = f"gotsport__{EVENT_ID}__unknown"
+    intake = tmp_path / event_key / "intake"
+    intake.mkdir(parents=True, exist_ok=True)
+    legacy_record = {
+        "run_id": "2026-04-29T00:00:00+00:00",
+        "provider_team_id": "legacy-1",
+        "team_name": "Legacy Team",
+        "alias_writer_action": "created",
+    }
+    (intake / "raw_scrape.jsonl").write_text(json.dumps(legacy_record) + "\n", encoding="utf-8")
+
+    records = load_raw_scrape(event_key=event_key, base_dir=tmp_path)
+    assert len(records) == 1
+    assert records[0].get("tier_parse_outcome") is None
+    assert records[0].get("group_name") is None
+
+
+# ---------------------------------------------------------------------------
+# Captcha mid-subfetch
+# ---------------------------------------------------------------------------
+
+
+@patch("src.scrapers.gotsport.upsert_team_alias")
+@patch.object(GotsportScraper, "resolve_canonical_team_id")
+@patch.object(GotsportScraper, "extract_event_teams_by_bracket")
+def test_captcha_mid_subfetch_propagates_and_writes_safe_filename_artifact(
+    mock_extract,
+    mock_resolve,
+    mock_upsert,
+    wired_scraper,
+    tmp_path,
+):
+    """An orchestrator subfetch returns a captcha body → orchestrator raises
+    ``EventCaptchaGatedError`` and writes ``tier_orchestrator_abort__<safe>.json``
+    with sanitized run_id — Windows rejects ``:`` in filenames, so the ISO
+    ``run_id`` must be sanitized for the artifact name while the payload
+    keeps the canonical form. No journal write occurs (``open_for_append``
+    happens AFTER enrichment)."""
+    mock_extract.return_value = {"U13 Boys Red": [_synthetic_team(TEAM_IN_RED)]}
+    mock_resolve.return_value = _resolution()
+    mock_upsert.return_value = {"action": "created"}
+
+    captcha_body = '<html><body>Please verify to continue.<div data-sitekey="6Lc1234567890">x</div></body></html>'
+
+    def _captcha_get(url, *args, **kwargs):
+        return FakeResponse(text=captcha_body, url=url)
+
+    wired_scraper.session.get = _captcha_get
+
+    with pytest.raises(EventCaptchaGatedError):
+        wired_scraper.fetch_teams_by_cohort(EVENT_URL, force_teams=True)
+
+    intake = tmp_path / f"gotsport__{EVENT_ID}__unknown" / "intake"
+    journal = intake / "raw_scrape.jsonl"
+    assert (not journal.exists()) or journal.read_text(encoding="utf-8") == ""
+
+    abort_files = list(intake.glob("tier_orchestrator_abort__*.json"))
+    assert len(abort_files) == 1, f"expected 1 abort file, got {abort_files}"
+    fname = abort_files[0].name
+    assert ":" not in fname, f"unsanitized run_id in filename: {fname}"
+    abort = json.loads(abort_files[0].read_text(encoding="utf-8"))
+    assert abort["failure_kind"] == "captcha"
+    # Metrics artifact written immediately after discovery — survives the abort.
+    assert (intake / "tier_parse_metrics.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Micro-cohort filter (fail-open)
+# ---------------------------------------------------------------------------
+
+
+@patch("src.scrapers.gotsport.upsert_team_alias")
+@patch.object(GotsportScraper, "resolve_canonical_team_id")
+@patch.object(GotsportScraper, "extract_event_teams_by_bracket")
+def test_u7_micro_cohort_dropped_loose_age_kept(
+    mock_extract,
+    mock_resolve,
+    mock_upsert,
+    wired_scraper,
+    tmp_path,
+    caplog,
+):
+    """Positive U7 leading-token → drop. ``"Unknown"`` age_group → kept
+    (fail-open polarity)."""
+    mock_extract.return_value = {
+        "U7 Boys Red": [_synthetic_team("U7-team", age_group="U7")],
+        "U13 Loose": [_synthetic_team(TEAM_IN_RED, age_group="Unknown")],
+    }
+    mock_resolve.return_value = _resolution()
+    mock_upsert.return_value = {"action": "created"}
+
+    caplog.set_level(logging.INFO, logger="src.scrapers.gotsport")
+    wired_scraper.fetch_teams_by_cohort(EVENT_URL, force_teams=True)
+
+    journal_path = tmp_path / f"gotsport__{EVENT_ID}__unknown" / "intake" / "raw_scrape.jsonl"
+    records = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines() if line]
+    by_pid = {r["provider_team_id"]: r for r in records}
+
+    assert "U7-team" not in by_pid, "U7 micro-cohort must be filtered"
+    assert TEAM_IN_RED in by_pid, "loose age_group ('Unknown') must be kept (fail-open)"
+
+    summary_lines = [r.message for r in caplog.records if "dropped_out_of_scope_teams=" in r.message]
+    assert summary_lines, "no fetch_teams_by_cohort summary line emitted"
+    assert "dropped_out_of_scope_teams=1" in summary_lines[0]

--- a/tests/unit/test_fetch_teams_by_cohort.py
+++ b/tests/unit/test_fetch_teams_by_cohort.py
@@ -19,6 +19,7 @@ All tests use mocks for ``supabase``, ``extract_event_teams_by_bracket``,
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -33,6 +34,7 @@ from src.scrapers.gotsport import (
     _scraper_state_from_action,
 )
 from src.scrapers.provider import CanonicalResolution, ScrapedTeam
+from tests.conftest import FakeResponse
 
 
 EVENT_URL = "https://system.gotsport.com/org_event/events/42434"
@@ -99,8 +101,17 @@ def scraper(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GotsportScraper:
         return real_journal(event_key=event_key, base_dir=tmp_path)
 
     monkeypatch.setattr(gs, "IntakeJournal", _journal_in_tmp)
+    # Redirect tier-orchestrator artifact writes to tmp_path too — without
+    # this, ``enrich_teams_with_tiers`` writes ``tier_parse_metrics.json``
+    # under the live ``reports/`` directory on every test run.
+    real_enrich = gs.enrich_teams_with_tiers
+    monkeypatch.setattr(
+        gs,
+        "enrich_teams_with_tiers",
+        functools.partial(real_enrich, base_dir=tmp_path),
+    )
     # Also stub _fetch_event_page so no network hit.
-    monkeypatch.setattr(s, "_fetch_event_page", lambda event_id: MagicMock())
+    monkeypatch.setattr(s, "_fetch_event_page", lambda event_id: FakeResponse())
     return s
 
 
@@ -176,9 +187,15 @@ def test_build_jsonl_record_alias_written():
 
 def test_build_jsonl_record_queued_clears_match_method():
     scraped = ScrapedTeam(
-        provider_team_id="t1", team_name="T1", club_name=None,
-        cohort_age_group="u13", cohort_gender="M", division=None,
-        bracket_name="U13B", playing_up=False, has_view_rankings_link=True,
+        provider_team_id="t1",
+        team_name="T1",
+        club_name=None,
+        cohort_age_group="u13",
+        cohort_gender="M",
+        division=None,
+        bracket_name="U13B",
+        playing_up=False,
+        has_view_rankings_link=True,
     )
     res = _resolution(
         resolved_status="review",
@@ -188,9 +205,13 @@ def test_build_jsonl_record_queued_clears_match_method():
         candidates=[{"team_id_master": "candidate-1"}],
     )
     record = _build_jsonl_record(
-        scraped=scraped, resolution=res,
-        action_dict={"action": "queued"}, brackets=["U13B"],
-        run_id="r", source_url=EVENT_URL, provider_event_id="42434",
+        scraped=scraped,
+        resolution=res,
+        action_dict={"action": "queued"},
+        brackets=["U13B"],
+        run_id="r",
+        source_url=EVENT_URL,
+        provider_event_id="42434",
     )
     assert record["canonical"]["scraper_state"] == "review_queued"
     assert record["canonical"]["match_method"] is None
@@ -205,9 +226,7 @@ def test_build_jsonl_record_queued_clears_match_method():
 @patch("src.scrapers.gotsport.enqueue_match_review")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_direct_id_at_threshold_routes_to_upsert(
-    mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper
-):
+def test_direct_id_at_threshold_routes_to_upsert(mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper):
     mock_extract.return_value = {"U13B Elite": [_event_team("t1")]}
     mock_resolve.return_value = _resolution(
         resolved_status="direct_provider_id",
@@ -259,9 +278,7 @@ def test_direct_id_below_threshold_routes_to_queue_with_reason(
 @patch("src.scrapers.gotsport.enqueue_match_review")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_strict_exact_routes_to_upsert_fuzzy_auto(
-    mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper
-):
+def test_strict_exact_routes_to_upsert_fuzzy_auto(mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper):
     mock_extract.return_value = {"B1": [_event_team("t1")]}
     mock_resolve.return_value = _resolution(
         resolved_status="strict_exact",
@@ -281,9 +298,7 @@ def test_strict_exact_routes_to_upsert_fuzzy_auto(
 @patch("src.scrapers.gotsport.enqueue_match_review")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_review_routes_to_queue_no_reason(
-    mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper
-):
+def test_review_routes_to_queue_no_reason(mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper):
     mock_extract.return_value = {"B1": [_event_team("t1")]}
     mock_resolve.return_value = _resolution(
         resolved_status="review",
@@ -332,9 +347,7 @@ def test_none_status_neither_writes_nor_journals(
 @patch("src.scrapers.gotsport.enqueue_match_review")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_multi_bracket_team_gets_single_writer_call(
-    mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper
-):
+def test_multi_bracket_team_gets_single_writer_call(mock_extract, mock_resolve, mock_enqueue, mock_upsert, scraper):
     """One provider_team_id in 2 brackets → ONE upsert call, with
     ``match_details.also_appears_in_brackets`` listing both."""
     et = _event_team("t1")
@@ -387,9 +400,7 @@ def test_multi_bracket_review_carries_all_brackets_in_match_details(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_default_skip_set_skips_already_resolved(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_default_skip_set_skips_already_resolved(mock_extract, mock_resolve, mock_upsert, scraper):
     # Pre-seed the journal with a durable record for t1.
     from src.scrapers.intake_journal import IntakeJournal
     from src.scrapers import gotsport as gs
@@ -397,11 +408,13 @@ def test_default_skip_set_skips_already_resolved(
     # Use the same monkeypatched IntakeJournal to pre-seed.
     journal = gs.IntakeJournal("gotsport__42434__unknown")
     with journal:
-        journal.append({
-            "run_id": "2026-04-24T10:00:00+00:00",
-            "provider_team_id": "t1",
-            "alias_writer_action": "created",
-        })
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:00:00+00:00",
+                "provider_team_id": "t1",
+                "alias_writer_action": "created",
+            }
+        )
 
     mock_extract.return_value = {"B1": [_event_team("t1"), _event_team("t2")]}
     mock_resolve.return_value = _resolution(
@@ -423,18 +436,18 @@ def test_default_skip_set_skips_already_resolved(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_force_teams_bypasses_skip_set(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_force_teams_bypasses_skip_set(mock_extract, mock_resolve, mock_upsert, scraper):
     from src.scrapers import gotsport as gs
 
     journal = gs.IntakeJournal("gotsport__42434__unknown")
     with journal:
-        journal.append({
-            "run_id": "2026-04-24T10:00:00+00:00",
-            "provider_team_id": "t1",
-            "alias_writer_action": "created",
-        })
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:00:00+00:00",
+                "provider_team_id": "t1",
+                "alias_writer_action": "created",
+            }
+        )
 
     mock_extract.return_value = {"B1": [_event_team("t1"), _event_team("t2")]}
     mock_resolve.return_value = _resolution(
@@ -453,9 +466,7 @@ def test_force_teams_bypasses_skip_set(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_revalidate_reprocesses_non_curated_rows(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_revalidate_reprocesses_non_curated_rows(mock_extract, mock_resolve, mock_upsert, scraper):
     """Plan: --revalidate re-resolves non-curated rows. Curated = review_status
     ='approved' AND match_method in {direct_id, manual, manual_review,
     manual_queue, import}. Machine-written fuzzy_auto rows are NOT curated."""
@@ -463,16 +474,20 @@ def test_revalidate_reprocesses_non_curated_rows(
 
     journal = gs.IntakeJournal("gotsport__42434__unknown")
     with journal:
-        journal.append({
-            "run_id": "2026-04-24T10:00:00+00:00",
-            "provider_team_id": "t1",
-            "alias_writer_action": "created",
-        })
-        journal.append({
-            "run_id": "2026-04-24T10:00:00+00:00",
-            "provider_team_id": "t2",
-            "alias_writer_action": "created",
-        })
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:00:00+00:00",
+                "provider_team_id": "t1",
+                "alias_writer_action": "created",
+            }
+        )
+        journal.append(
+            {
+                "run_id": "2026-04-24T10:00:00+00:00",
+                "provider_team_id": "t2",
+                "alias_writer_action": "created",
+            }
+        )
 
     # DB: t1 is curated (direct_id + approved); t2 is machine (fuzzy_auto).
     scraper.supabase_client.table.return_value.select.return_value.eq.return_value.in_.return_value.execute.return_value.data = [
@@ -503,9 +518,7 @@ def test_revalidate_reprocesses_non_curated_rows(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_db_error_action_not_written_to_journal(
-    mock_extract, mock_resolve, mock_upsert, scraper, tmp_path
-):
+def test_db_error_action_not_written_to_journal(mock_extract, mock_resolve, mock_upsert, scraper, tmp_path):
     """Per plan Step 4: db_error is non-durable — skip JSONL, log, retry next run."""
     from src.scrapers import gotsport as gs
 
@@ -529,9 +542,7 @@ def test_db_error_action_not_written_to_journal(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_durable_action_is_written_to_journal(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_durable_action_is_written_to_journal(mock_extract, mock_resolve, mock_upsert, scraper):
     from src.scrapers import gotsport as gs
 
     mock_extract.return_value = {"B1": [_event_team("t1")]}
@@ -558,9 +569,7 @@ def test_durable_action_is_written_to_journal(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_compaction_runs_at_end(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_compaction_runs_at_end(mock_extract, mock_resolve, mock_upsert, scraper):
     from src.scrapers import gotsport as gs
 
     mock_extract.return_value = {"B1": [_event_team("t1"), _event_team("t2")]}
@@ -581,9 +590,7 @@ def test_compaction_runs_at_end(
 @patch("src.scrapers.gotsport.upsert_team_alias")
 @patch.object(GotsportScraper, "resolve_canonical_team_id")
 @patch.object(GotsportScraper, "extract_event_teams_by_bracket")
-def test_removed_teams_artifact_on_pid_drop(
-    mock_extract, mock_resolve, mock_upsert, scraper
-):
+def test_removed_teams_artifact_on_pid_drop(mock_extract, mock_resolve, mock_upsert, scraper):
     """A team present in the journal but absent from this run's live set
     becomes a 'removed_provider_team_id' in the artifact."""
     import json as _json
@@ -593,12 +600,14 @@ def test_removed_teams_artifact_on_pid_drop(
     journal = gs.IntakeJournal("gotsport__42434__unknown")
     with journal:
         for pid in ("t1", "t2"):
-            journal.append({
-                "run_id": "2026-04-24T10:00:00+00:00",
-                "provider_team_id": pid,
-                "alias_writer_action": "created",
-                "canonical": {"scraper_state": "alias_written"},
-            })
+            journal.append(
+                {
+                    "run_id": "2026-04-24T10:00:00+00:00",
+                    "provider_team_id": pid,
+                    "alias_writer_action": "created",
+                    "canonical": {"scraper_state": "alias_written"},
+                }
+            )
 
     # Live scrape includes only t1 (t2 dropped).
     mock_extract.return_value = {"B1": [_event_team("t1")]}

--- a/tests/unit/test_gotsport_tier_orchestrator.py
+++ b/tests/unit/test_gotsport_tier_orchestrator.py
@@ -127,9 +127,7 @@ class TestDiscoveryEmpty:
         )
         assert out == {}
         # Metrics still written with total_candidates=0.
-        payload = json.loads(
-            (tmp_path / "ek" / "intake" / "tier_parse_metrics.json").read_text()
-        )
+        payload = json.loads((tmp_path / "ek" / "intake" / "tier_parse_metrics.json").read_text())
         assert payload["total_candidates"] == 0
 
 
@@ -398,13 +396,11 @@ class TestUnknownPrefixGate:
         rows = []
         for i in range(8):
             rows.append(
-                f'<div><div><b>U10 Boys Tier{i}</b>'
-                f'<a href="/schedules?group={1000 + i}">Schedule</a></div></div>'
+                f'<div><div><b>U10 Boys Tier{i}</b><a href="/schedules?group={1000 + i}">Schedule</a></div></div>'
             )
         for i in range(2):
             rows.append(
-                f'<div><div><b>Adult Co-Ed Hammer{i}</b>'
-                f'<a href="/schedules?group={9000 + i}">Schedule</a></div></div>'
+                f'<div><div><b>Adult Co-Ed Hammer{i}</b><a href="/schedules?group={9000 + i}">Schedule</a></div></div>'
             )
         soup = BeautifulSoup("<html><body>" + "".join(rows) + "</body></html>", "html.parser")
 
@@ -429,12 +425,8 @@ class TestUnknownPrefixGate:
 class TestMemoryLifecycle:
     def test_two_separate_events_dont_share_state(self, tmp_path):
         soup = BeautifulSoup(_two_tier_landing(), "html.parser")
-        fetcher_a = _make_fetcher(
-            {1001: _subpage(_team_html([100])), 1002: _subpage(_team_html([200]))}
-        )
-        fetcher_b = _make_fetcher(
-            {1001: _subpage(_team_html([300])), 1002: _subpage(_team_html([400]))}
-        )
+        fetcher_a = _make_fetcher({1001: _subpage(_team_html([100])), 1002: _subpage(_team_html([200]))})
+        fetcher_b = _make_fetcher({1001: _subpage(_team_html([300])), 1002: _subpage(_team_html([400]))})
         out_a = enrich_teams_with_tiers(
             soup,
             teams_by_bracket={},
@@ -474,9 +466,7 @@ class TestConcurrencyDeterminism:
         def fetcher(gid):
             if gid == 1001:
                 time.sleep(0.05)  # arrives second
-            return _subpage(
-                (sub_1001 if gid == 1001 else sub_1002).read_text(encoding="utf-8")
-            )
+            return _subpage((sub_1001 if gid == 1001 else sub_1002).read_text(encoding="utf-8"))
 
         out = enrich_teams_with_tiers(
             soup,
@@ -500,9 +490,7 @@ class TestConcurrencyDeterminism:
 class TestEnrichmentResultShape:
     def test_returns_frozen_dataclasses(self, tmp_path):
         soup = BeautifulSoup(_two_tier_landing(), "html.parser")
-        fetcher = _make_fetcher(
-            {1001: _subpage(_team_html([100])), 1002: _subpage(_team_html([200]))}
-        )
+        fetcher = _make_fetcher({1001: _subpage(_team_html([100])), 1002: _subpage(_team_html([200]))})
         out = enrich_teams_with_tiers(
             soup,
             teams_by_bracket={},
@@ -516,3 +504,25 @@ class TestEnrichmentResultShape:
             assert isinstance(result, EnrichmentResult)
             with pytest.raises(AttributeError):
                 result.group_id = 99  # type: ignore[misc]
+
+
+class TestSafeFilenameToken:
+    """Windows rejects ``<>:"/\\|?*`` in filenames; the abort-artifact filename
+    must sanitize the ISO ``run_id`` while the payload preserves it."""
+
+    def test_iso_run_id_round_trip(self):
+        from src.scrapers.gotsport_tier_parser import _safe_filename_token
+
+        assert _safe_filename_token("2026-04-29T00:00:00+00:00") == "2026-04-29T00-00-00_00-00"
+
+    def test_no_op_when_no_specials(self):
+        from src.scrapers.gotsport_tier_parser import _safe_filename_token
+
+        assert _safe_filename_token("rid") == "rid"
+
+    @pytest.mark.parametrize("ch", ["<", ">", ":", '"', "/", "\\", "|", "?", "*"])
+    def test_strips_every_windows_reserved_char(self, ch):
+        from src.scrapers.gotsport_tier_parser import _safe_filename_token
+
+        out = _safe_filename_token(f"a{ch}b")
+        assert ch not in out, f"reserved char {ch!r} survived sanitization: {out!r}"

--- a/tests/unit/test_gotsport_tier_parser_fixtures.py
+++ b/tests/unit/test_gotsport_tier_parser_fixtures.py
@@ -25,6 +25,7 @@ from src.scrapers.gotsport_tier_parser import (
     enrich_teams_with_tiers,
     extract_tier_catalog,  # noqa: F401  (used in TestEvent47021CaptchaLanding only — keep flat import)
 )
+from tests.conftest import trim_landing_to_gids
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "gotsport"
 
@@ -68,9 +69,24 @@ class TestEvent49371Comprehensive:
     # All in-scope U10+ gids per the captured corpus (excludes 485437 U-8,
     # 485438 U-7, 485443 U-9 GIRLS — those are micro-cohort skips).
     IN_SCOPE_GIDS = [
-        485294, 485295, 485296, 485297, 485298, 485299, 485300, 485301,
-        485425, 485434, 485435, 485436, 485439, 485440, 485441, 485442,
-        485444, 485513,
+        485294,
+        485295,
+        485296,
+        485297,
+        485298,
+        485299,
+        485300,
+        485301,
+        485425,
+        485434,
+        485435,
+        485436,
+        485439,
+        485440,
+        485441,
+        485442,
+        485444,
+        485513,
     ]
 
     @pytest.fixture
@@ -163,33 +179,12 @@ SAMPLED_EVENTS = [
 def test_sampled_event_subfetches_resolve_residues(event_id, gids, expected_residues, tmp_path):
     if not _has_subpages_for(event_id, gids):
         pytest.skip(f"event {event_id} subpages not fully captured")
-    soup = BeautifulSoup(
-        (FIXTURES / f"event_{event_id}.html").read_text(encoding="utf-8"),
-        "html.parser",
-    )
+    landing_html = (FIXTURES / f"event_{event_id}.html").read_text(encoding="utf-8")
+    # Trim the landing to the sampled gids so the orchestrator only attempts
+    # subfetches we have fixtures for. Helper lives in tests/conftest.py.
+    soup = BeautifulSoup(trim_landing_to_gids(landing_html, list(gids)), "html.parser")
     fetcher = _fetcher_from_disk(event_id)
 
-    # We need to limit which gids actually run subfetches. The orchestrator
-    # walks the full landing catalog by default. Trim the soup by removing
-    # rows for any ``?group=`` anchor whose gid isn't in our sampled set.
-    # IMPORTANT: collect rows-to-drop FIRST, then decompose — calling
-    # ``row.decompose()`` mid-iteration leaves stale Tag objects in the
-    # remaining list (with ``attrs == None``) and ``a.get(...)`` crashes.
-    rows_to_drop = []
-    for a in soup.find_all("a", href=True):
-        href = a["href"]
-        if "schedules?group=" not in href:
-            continue
-        if any(f"group={g}" in href for g in gids):
-            continue
-        parent = a.find_parent()
-        row = parent.find_parent() if parent else None
-        if row is not None:
-            rows_to_drop.append(row)
-    for row in rows_to_drop:
-        row.decompose()
-
-    # Now run with a fetcher that only knows our sampled gids.
     out = enrich_teams_with_tiers(
         soup,
         teams_by_bracket={},
@@ -202,8 +197,7 @@ def test_sampled_event_subfetches_resolve_residues(event_id, gids, expected_resi
     seen_residues = {r.group_name for r in out.values() if r.group_name}
     for residue in expected_residues:
         assert residue in seen_residues, (
-            f"event {event_id}: expected residue {residue!r} not found; "
-            f"got {sorted(seen_residues)}"
+            f"event {event_id}: expected residue {residue!r} not found; got {sorted(seen_residues)}"
         )
 
 


### PR DESCRIPTION
## Summary

Wires the Shell 01 tier-section parser into `GotsportScraper.fetch_teams_by_cohort` so every gotsport scrape now captures per-team tier residue alongside the existing canonical-team-id resolution. Five new fields land in `raw_scrape.jsonl` per in-scope team: `group_name`, `group_id`, `tier_discovery_source`, `tier_membership_source`, `tier_parse_outcome`. This unlocks Phase A (registry CSV column) and Phase B (auto-derive `DivisionStructure`) as separate future specs.

## What changed

- `ScrapedTeam` gains 5 optional tier fields with sensible defaults. `ScrapedTeam.group_name` is the TIER RESIDUE (e.g., "Red", "GOLD"), different semantic from `EventTeam.group_name`, which is the legacy bracket-section label.
- `fetch_teams_by_cohort` now captures the landing soup from the captcha pre-check, builds an inline `_subpage_fetcher` closure (routed through ZenRows when configured), calls `enrich_teams_with_tiers` before the team-resolution loop, and joins enrichment results back via `enrichment_by_team_id.get(event_team.team_id)`.
- `_build_jsonl_record` persists the 5 keys at the top level of the JSONL record so downstream readers can `record.get("group_name")` etc.
- Caller-side U10-U19 filter (fail-open): teams whose `EventTeam.age_group` parses cleanly to a `U6/U7/U8/U9` leading token are filtered out. Loose values (`None`, `"Unknown"`, slash-forms) fall through and are kept. Operator-visible via `dropped_out_of_scope_teams=N` in the per-event summary log.
- `_safe_filename_token` sanitizes ISO `run_id` for the abort-artifact filename so the Windows operator workspace does not break on `:` / `+`. Payload's `run_id` field carries the unsanitized ISO timestamp; only the filename is sanitized.
- Subpage captcha re-raise now attaches the abort artifact path (operator tooling can show `artifact: <path>` for subpage captchas, matching the landing case).
- `scripts/scrape_specific_event.py` gains explicit handlers for `TierSubfetchError` and `EventTeamMembershipCollisionError` ahead of the generic `except Exception`, so validation gates fail visibly instead of being swallowed.
- Tests: new integration test at `tests/integration/test_gotsport_tier_persistence.py` covers golden path, legacy backwards-compat read, mid-subfetch captcha, and U7 micro-cohort drop with fail-open polarity. New parametrized test class `TestSafeFilenameToken` covers every Windows-reserved character. Shared `FakeResponse` + `trim_landing_to_gids` helpers hoisted to `tests/conftest.py`.

## Behavior changes

- U6-U9 are now silently filtered from `raw_scrape.jsonl`. Operators see `dropped_out_of_scope_teams=N` in the per-event log line. Old `raw_scrape.jsonl` files retain U6-U9 rows from prior scrapes; `intake_journal.compact()` does not delete them, so the first post-Shell-02 scrape per event will produce `removed_teams.json` entries flagging those historical U6-U9 teams as "removed". Downstream `registry.py` already gates on `in_scope_u10_u19`, so the persistence-layer noise is contained.
- Per-event all-or-nothing journaling. A single subfetch failure on subfetch N of M aborts the entire event's journal write. `compute_skip_set` recovers on the next run because no records were durably written. Deliberate trade-off vs. partial-commit complexity.

## Deferred (filed in `.turbo/improvements.md`)

- Duplicate-fetch elimination between `_fetch_event_page` and `extract_event_teams_by_bracket`. The dual fetch is preserved here because the retry/404/SSL-recovery loop lives only in `extract_event_teams_by_bracket`. A Phase 0.x refactor will lift retry into a `_from_soup` wrapper.
- `INVERSE_COLLISION_STRICT_MODE` flag flip stays `False`. Shell 01 reported 0/78 + 0/16 inverse collisions; flipping waits for production-data baseline.
- Source #2 (`/schedules` index) and Source #3 (legacy header regex) deferred to Phase 0.1, re-introduce when a `Group A`/`Pool B`-style event surfaces.
- Backlog also captures: `artifact_path` on collision exceptions, CLI test coverage for `scrape_specific_event.py`, status-code surfacing on landing fetch, fetch-throttle helper extraction.

## Stop-loss

If Tier 2 median wall-clock per event exceeds 5 minutes, switch `max_concurrent_subfetches=2` before merge (currently default `=1`).

## Tier 2 status

Not yet executed (operator follow-up). Tier 1 (fixture replay) green: 114 of 114 tier-related tests pass. The plan documents that merge proceeds on Tier 1 alone if Tier 2 is captcha-dominated.

## Test plan

- [x] `pytest tests/unit/test_fetch_teams_by_cohort.py tests/unit/test_gotsport_tier_orchestrator.py tests/unit/test_gotsport_tier_parser.py tests/unit/test_gotsport_tier_parser_fixtures.py tests/integration/test_gotsport_tier_persistence.py` (114 passed)
- [x] `pytest tests/ --ignore=tests/test_enhanced_pipeline.py` (1446 passed)
- [x] `ruff check` clean on touched files
- [ ] Tier 2 live validation: `python scripts/scrape_specific_event.py <eid> --force-teams` for events 42433, 44692, 45394, 46103, 46958, 49371, 49407, 50469
