### PR TITLE
fix(gotsport): walk per-team schedule pages to capture played history

### DIFF
--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -2081,6 +2081,53 @@ class GotsportScraper(ProviderScraper):
                     logger.warning(f"Error parsing schedule page {schedule_url}: {e}")
                     continue
 
+            # Per-team schedule walk: /schedules?group=X only lists upcoming
+            # fixtures for season-long bracket events, so played-game history
+            # is invisible there. /schedules?team={reg_id} (registration ID,
+            # NOT API team ID) renders the team's full event schedule with
+            # one <table> per match — past + future. Validator dedup
+            # (provider:date:sorted_team_ids) collapses the home/away
+            # duplicates that arise from walking both teams' pages.
+            # Disable with GOTSPORT_SKIP_PER_TEAM_WALK=1.
+            if os.getenv("GOTSPORT_SKIP_PER_TEAM_WALK") != "1":
+                # Reg_ids accumulate in api_team_id_cache during the per-group
+                # walk (any reg_id observed on a /schedules?group=X page is
+                # added as a key). Fall back to scanning the event page if
+                # the cache is empty (e.g. all groups failed).
+                team_reg_ids = set(api_team_id_cache.keys())
+                if not team_reg_ids:
+                    team_reg_ids = set(re.findall(r"[?&]team=(\d+)", response.text))
+                max_team_pages = int(os.getenv("GOTSPORT_MAX_TEAM_PAGES", "200"))
+                if len(team_reg_ids) > max_team_pages:
+                    logger.warning(
+                        f"Event has {len(team_reg_ids)} team pages, limiting to {max_team_pages}"
+                    )
+                    team_reg_ids = set(list(team_reg_ids)[:max_team_pages])
+                logger.info(f"Walking {len(team_reg_ids)} per-team schedule pages")
+                pre_team_walk_count = len(games)
+                for idx, reg_id in enumerate(team_reg_ids):
+                    team_url = f"{self.EVENT_BASE}/{event_id}/schedules?team={reg_id}"
+                    try:
+                        team_games = self._parse_games_from_schedule_page(
+                            team_url,
+                            event_id,
+                            event_name,
+                            since_date,
+                            teams_by_name,
+                            api_team_id_cache,
+                            registration_to_api,
+                        )
+                        games.extend(team_games)
+                        if page_delay > 0:
+                            time.sleep(page_delay)
+                    except Exception as e:
+                        logger.warning(f"Error parsing per-team schedule {team_url}: {e}")
+                        continue
+                logger.info(
+                    f"Per-team walk added {len(games) - pre_team_walk_count} game records "
+                    f"(pre-dedup) from {len(team_reg_ids)} team pages"
+                )
+
             # Log resolution summary
             resolved_count = sum(1 for v in api_team_id_cache.values() if v is not None)
             unresolved_count = sum(1 for v in api_team_id_cache.values() if v is None)


### PR DESCRIPTION
## Summary

Fixes the GitHub Action **Scrape Specific GotSport Event** (and the auto-event scrape workflows that share `GotsportScraper.scrape_games_from_schedule_pages`) silently importing 0 games for season-long bracket events.

## Root cause

`/schedules?group={X}` only renders **upcoming fixtures**. For a season-long NPL/CCL bracket like event 51028 (group=458913 has MP=14 played per team), every visible row had no scores → `_is_empty_score` dropped all 160 records → the importer reported "Games processed: 160, Games accepted: 0" with every other counter at zero.

Played history actually lives on `/schedules?team={REGISTRATION_ID}` — same 7-column layout, but the page renders one `<table>` per match for the team's full event schedule (past + future). The existing `_parse_games_from_schedule_page` already iterates every `<table>` on a page, so it works as-is.

Quirk worth knowing: per-team URLs require the **registration ID** (numeric, e.g. `3714426`), not the API team ID. `/schedules?team={api_id}` redirects to login.

## Implementation

- After the per-group walk, iterate each known registration ID and call the existing parser on `/schedules?team={reg_id}`.
- Reg_ids come from `api_team_id_cache` (already populated during the per-group walk).
- Validator dedup (`provider:date:sorted_team_ids` in `_validate_games`) collapses the home/away duplicates from walking both teams' pages — no double-counting.
- `GOTSPORT_SKIP_PER_TEAM_WALK=1` disables the new walk; `GOTSPORT_MAX_TEAM_PAGES=200` caps it (default 200).

## Risk profile (per discussion)

- **Tournaments**: zero behavior change — per-group walk already captures matches that play and resolve quickly.
- **Season/league events**: now correctly captures played history in addition to upcoming fixtures.
- **Worst case if anything goes wrong**: validator dedup + game_uid uniqueness make the failure mode "0 new games imported" — same as today, no data corruption possible.
- **No DB schema or workflow YAML changes**.

## Verification

Local run on event 51028 with `--no-auto-import`:

```
Scraping 20 schedule pages
Walking 96 per-team schedule pages
Per-team walk added 1158 game records (pre-dedup) from 96 team pages
Total games scraped from schedule pages: 1318
```

JSONL inspection:
- 1318 raw records: **592 played + 726 unplayed**
- Played dates span Apr 4 → Apr 26, 2026 (full 30-day lookback window)
- 8 distinct play dates, ~296 unique games (×2 perspectives)

Per-team walk runtime: ~80s for 96 teams at default 0.1s page delay. Well under the 3-hour workflow timeout.

## Test plan

- [ ] Re-run `Scrape Specific GotSport Event` workflow against event 51028 from this branch
- [ ] Confirm IMPORT_RESULT now shows nonzero `games_accepted`
- [ ] Spot-check a few imported games against `system.gotsport.com/org_event/events/51028/results?group=458913`
- [ ] Check duplicates_skipped is roughly half of games_processed (perspective dedup working)
- [ ] (Optional) Run on a tournament-style event to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)