### PR TITLE
feat(mission-control): admin subscription dashboard

### DIFF
--- a/docs/superpowers/specs/2026-05-01-admin-subscription-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-01-admin-subscription-dashboard-design.md
@@ -1,0 +1,192 @@
+# Admin Subscription Dashboard
+
+**Date:** 2026-05-01
+**Author:** Dallas Heidt
+**Status:** Approved — ready for implementation
+
+## Goal
+
+A clean internal dashboard at `/mission-control` that gives the admin a real-time view of the subscription business. Optimized for daily decision-making, not user display.
+
+## Daily questions the dashboard must answer
+
+1. How many paying customers do I have?
+2. How much MRR do I have?
+3. How many people are on trial?
+4. Who is about to convert (trials ending soon)?
+5. Are trials converting into paid?
+6. Which paying customers need attention (past_due)?
+
+## Scope
+
+### In scope (v1)
+
+- KPI cards: MRR, Active Paid Subs (with monthly/annual split), Active Trials, Trials Ending ≤7d
+- Attention-needed section: count + table of `past_due` subscriptions
+- Trial pipeline table: customer email, trial end date, days remaining, plan interval, sorted by soonest end
+- Conversion: 30-day rolling cohort percentage (with Y of Z denominator visible)
+- Auto-refresh on page load; manual refresh via plain link/reload
+
+### Out of scope (v1)
+
+- Trend chart (subscriptions over time)
+- CSV export
+- Date-range picker
+- Reading from Supabase (`user_profiles`) — Stripe is single source of truth for this page
+- Schema migrations
+
+## Architecture
+
+### Route
+
+`frontend/app/mission-control/page.tsx` — React Server Component, `export const dynamic = 'force-dynamic'`. Auth is already enforced by `frontend/middleware.ts` which gates `/mission-control` to `plan = 'admin'`.
+
+### Data layer
+
+`frontend/lib/admin/subscription-metrics.ts` exports a single function:
+
+```ts
+export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics>
+```
+
+Pulls from Stripe API only. No Supabase reads. Makes three list calls (auto-paginated):
+
+1. `stripe.subscriptions.list({ status: 'active' })` — for MRR + active paid count + interval split.
+2. `stripe.subscriptions.list({ status: 'trialing' })` — for trial count + pipeline table.
+3. `stripe.subscriptions.list({ status: 'past_due' })` — for attention-needed section. Excluded from MRR.
+4. `stripe.subscriptions.list({ created: { gte: now − 60d } })` (all statuses) — for conversion cohort.
+
+Customer emails are resolved by `expand: ['data.customer']` on each list call so we don't make per-customer fetches.
+
+### Output shape
+
+```ts
+type SubscriptionMetrics = {
+  mrr: number; // USD dollars, computed from active subs only
+  activePaid: {
+    total: number;
+    monthly: number;
+    annual: number;
+  };
+  trials: {
+    total: number;
+    endingIn3Days: number;
+    endingIn7Days: number;
+    list: Array<{
+      id: string;
+      email: string;
+      trialEnd: string; // ISO
+      daysRemaining: number;
+      interval: 'month' | 'year';
+    }>;
+  };
+  pastDue: {
+    total: number;
+    list: Array<{
+      id: string;
+      email: string;
+      interval: 'month' | 'year';
+    }>;
+  };
+  conversion: {
+    window: '30d';
+    sample: number; // Z — trials started 31–60 days ago that have completed
+    converted: number; // Y — of those, currently active
+    percent: number | null; // null if sample < 5
+  };
+  generatedAt: string; // ISO
+  errors: string[]; // section-level errors, empty if everything succeeded
+};
+```
+
+### MRR formula
+
+For each subscription where `status === 'active'`:
+
+- For each line item, monthly equivalent = `unit_amount × quantity / (interval === 'year' ? 12 : 1)`.
+- Sum across items, then across subscriptions.
+- Divide by 100 to convert cents to dollars.
+
+`past_due` and `trialing` are explicitly excluded from MRR.
+
+### Active paid breakdown
+
+For each `status === 'active'` subscription, classify by the recurring `interval` of its primary line item (`items.data[0].price.recurring.interval`). `month` → monthly; `year` → annual.
+
+### Trials ending bucketing
+
+`trial_end` is a Unix timestamp on the subscription. For each `trialing` subscription:
+
+- `daysRemaining = ceil((trial_end - now) / 86400)`
+- `endingIn3Days`: `daysRemaining <= 3`
+- `endingIn7Days`: `daysRemaining <= 7` (superset of 3)
+
+### Conversion math (30-day rolling)
+
+- Denominator (`sample`): subscriptions where the original `trial_start` falls in `[now − 60d, now − 30d]` AND `trial_end < now` (trial completed). Statuses can be any.
+- Numerator (`converted`): of those, `status === 'active'`.
+- If `sample < 5`, return `percent: null` and the UI shows "Not enough data yet".
+
+### Caching / freshness
+
+None for v1. Page is admin-only and infrequent. Each load hits Stripe directly. Manual refresh is a hard reload.
+
+### Error handling
+
+`getSubscriptionMetrics()` wraps each Stripe list call in try/catch. On failure, the relevant section returns zero/empty values and an error message is appended to `errors[]`. The page renders an inline banner per error rather than crashing.
+
+## UI
+
+Server component renders into existing `Card` components from `@/components/ui/card`. Layout:
+
+```
+Header: "Mission Control · Subscriptions"  · "As of {generatedAt}"  · [Refresh link]
+
+[ MRR card ]  [ Active Paid card ]  [ Active Trials card ]  [ Ending ≤7d card ]
+                ↳ "M monthly · A annual"                       ↳ "K in 3d"
+
+[ Attention Needed ]
+  N past_due subscriptions
+  table: email | interval
+
+[ Trial Pipeline ]
+  table: email | trial ends | days | interval
+  sorted by trial end ascending
+
+[ Conversion ]
+  XX%  ·  Y of Z trials started 31–60 days ago are now active
+  (or "Not enough data yet" when sample < 5)
+```
+
+Tailwind v4 classes mirroring existing app patterns (`bg-muted/30`, `text-muted-foreground`, `font-display`, `Card`, `Badge`).
+
+## Files
+
+**New:**
+
+1. `frontend/lib/admin/subscription-metrics.ts` — data fetcher and math.
+2. `frontend/app/mission-control/page.tsx` — Server Component renderer.
+3. `frontend/lib/admin/__tests__/subscription-metrics.test.ts` — unit tests.
+
+**Modified:** none. Middleware already gates the route.
+
+## Testing
+
+Unit tests in `frontend/lib/admin/__tests__/subscription-metrics.test.ts` with mocked Stripe responses:
+
+- MRR sums monthly + (annual ÷ 12) correctly.
+- MRR excludes `past_due` and `trialing`.
+- Active paid split classifies monthly vs annual by `interval`.
+- Trial bucketing: `endingIn3Days` ⊆ `endingIn7Days`.
+- Trial list sorted ascending by `trial_end`.
+- Conversion: `percent === null` when `sample < 5`.
+- Conversion: Y/Z math on a fixed cohort.
+- Section error fallback returns zero values + error string.
+
+Manual verification: load `/mission-control` as the admin account, eyeball numbers against Stripe dashboard.
+
+## Risks
+
+- **Stripe rate limits:** Each load makes ~4 list calls with auto-pagination. Acceptable for admin-only page; not user-facing.
+- **`trial_start` field availability:** Stripe puts `trial_start` on the subscription object only when there was a trial. For non-trial subs in the 60-day window, we filter them out (no trial → not part of cohort denominator).
+- **Currency assumption:** v1 assumes USD. If multi-currency is added later, MRR math must convert.

--- a/docs/superpowers/specs/2026-05-01-admin-subscription-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-01-admin-subscription-dashboard-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-A clean internal dashboard at `/mission-control` that gives the admin a real-time view of the subscription business. Optimized for daily decision-making, not user display.
+A clean internal dashboard at `/mission-control/subscriptions` (sibling to the existing model-accuracy `/mission-control` page) that gives the admin a real-time view of the subscription business. Optimized for daily decision-making, not user display.
 
 ## Daily questions the dashboard must answer
 
@@ -39,7 +39,7 @@ A clean internal dashboard at `/mission-control` that gives the admin a real-tim
 
 ### Route
 
-`frontend/app/mission-control/page.tsx` — React Server Component, `export const dynamic = 'force-dynamic'`. Auth is already enforced by `frontend/middleware.ts` which gates `/mission-control` to `plan = 'admin'`.
+`frontend/app/mission-control/subscriptions/page.tsx` — React Server Component, `export const dynamic = 'force-dynamic'`. Auth is already enforced by `frontend/middleware.ts` which gates anything under `/mission-control` to `plan = 'admin'` via `pathname.startsWith('/mission-control')`.
 
 ### Data layer
 
@@ -165,10 +165,10 @@ Tailwind v4 classes mirroring existing app patterns (`bg-muted/30`, `text-muted-
 **New:**
 
 1. `frontend/lib/admin/subscription-metrics.ts` — data fetcher and math.
-2. `frontend/app/mission-control/page.tsx` — Server Component renderer.
+2. `frontend/app/mission-control/subscriptions/page.tsx` — Server Component renderer.
 3. `frontend/lib/admin/__tests__/subscription-metrics.test.ts` — unit tests.
 
-**Modified:** none. Middleware already gates the route.
+**Modified:** `frontend/app/mission-control/page.tsx` — adds a "Subscriptions →" link to the new page. Middleware already gates the route.
 
 ## Testing
 
@@ -183,7 +183,7 @@ Unit tests in `frontend/lib/admin/__tests__/subscription-metrics.test.ts` with m
 - Conversion: Y/Z math on a fixed cohort.
 - Section error fallback returns zero values + error string.
 
-Manual verification: load `/mission-control` as the admin account, eyeball numbers against Stripe dashboard.
+Manual verification: load `/mission-control/subscriptions` as the admin account, eyeball numbers against Stripe dashboard.
 
 ## Risks
 

--- a/frontend/app/mission-control/page.tsx
+++ b/frontend/app/mission-control/page.tsx
@@ -40,11 +40,18 @@ export default function MissionControlPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-black text-white">
       <div className="container mx-auto space-y-6 p-6">
-        <div className="space-y-2">
-          <h1 className="font-display text-3xl font-bold tracking-tight">Mission Control</h1>
-          <p className="max-w-3xl text-sm text-gray-400">
-            Live snapshot of model accuracy, prospective evaluation coverage, and point-in-time training readiness.
-          </p>
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="font-display text-3xl font-bold tracking-tight">Mission Control</h1>
+            <p className="max-w-3xl text-sm text-gray-400">
+              Live snapshot of model accuracy, prospective evaluation coverage, and point-in-time training readiness.
+            </p>
+          </div>
+          <Link href="/mission-control/subscriptions">
+            <Button variant="outline" size="sm">
+              Subscriptions →
+            </Button>
+          </Link>
         </div>
 
         <ModelSnapshotDashboard />

--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -1,0 +1,208 @@
+import Link from 'next/link';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { getSubscriptionMetrics } from '@/lib/admin/subscription-metrics';
+
+// Admin gate is enforced by frontend/middleware.ts (ADMIN_ROUTES).
+export const dynamic = 'force-dynamic';
+export const metadata = { robots: { index: false, follow: false } };
+
+function formatDollars(n: number): string {
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default async function SubscriptionsDashboardPage() {
+  const metrics = await getSubscriptionMetrics();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto space-y-8 p-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Link href="/mission-control" className="hover:text-foreground">
+                Mission Control
+              </Link>
+              <span>/</span>
+              <span>Subscriptions</span>
+            </div>
+            <h1 className="font-display text-3xl font-bold tracking-tight">Subscriptions</h1>
+            <p className="text-sm text-muted-foreground">
+              As of {new Date(metrics.generatedAt).toLocaleString('en-US')}
+            </p>
+          </div>
+          <Link href="/mission-control/subscriptions">
+            <Button variant="outline" size="sm">
+              Refresh
+            </Button>
+          </Link>
+        </div>
+
+        {metrics.errors.length > 0 && (
+          <Card variant="accent" className="border-l-destructive">
+            <CardHeader>
+              <CardTitle className="text-destructive">Some data failed to load</CardTitle>
+              <CardDescription>
+                {metrics.errors.length} section{metrics.errors.length === 1 ? '' : 's'} returned an error. The rest of
+                the dashboard reflects what loaded successfully.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                {metrics.errors.map((err, i) => (
+                  <li key={i}>{err}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <KpiCard
+            label="MRR"
+            value={formatDollars(metrics.mrr)}
+            sub={`from ${metrics.activePaid.total} active sub${metrics.activePaid.total === 1 ? '' : 's'}`}
+          />
+          <KpiCard
+            label="Active Paid"
+            value={metrics.activePaid.total.toString()}
+            sub={`${metrics.activePaid.monthly} monthly · ${metrics.activePaid.annual} annual`}
+          />
+          <KpiCard
+            label="Active Trials"
+            value={metrics.trials.total.toString()}
+            sub={metrics.trials.total === 0 ? 'no trials in flight' : 'in flight now'}
+          />
+          <KpiCard
+            label="Trials Ending ≤7d"
+            value={metrics.trials.endingIn7Days.toString()}
+            sub={`${metrics.trials.endingIn3Days} in next 3d`}
+            emphasize={metrics.trials.endingIn7Days > 0}
+          />
+        </div>
+
+        <section className="space-y-3">
+          <div className="flex items-baseline justify-between">
+            <h2 className="font-display text-xl font-semibold">Attention Needed</h2>
+            <span className="text-sm text-muted-foreground">
+              {metrics.pastDue.total} past_due {metrics.pastDue.total === 1 ? 'subscription' : 'subscriptions'}{' '}
+              (excluded from MRR)
+            </span>
+          </div>
+          <Card variant="flat">
+            <CardContent className="p-0">
+              {metrics.pastDue.list.length === 0 ? (
+                <div className="p-6 text-sm text-muted-foreground">No past_due subscriptions. All clear.</div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Customer</TableHead>
+                      <TableHead>Plan</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {metrics.pastDue.list.map((row) => (
+                      <TableRow key={row.id}>
+                        <TableCell>{row.email}</TableCell>
+                        <TableCell className="capitalize">{row.interval === 'year' ? 'Annual' : 'Monthly'}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-baseline justify-between">
+            <h2 className="font-display text-xl font-semibold">Trial Pipeline</h2>
+            <span className="text-sm text-muted-foreground">sorted by soonest end</span>
+          </div>
+          <Card variant="flat">
+            <CardContent className="p-0">
+              {metrics.trials.list.length === 0 ? (
+                <div className="p-6 text-sm text-muted-foreground">No active trials.</div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Customer</TableHead>
+                      <TableHead>Trial ends</TableHead>
+                      <TableHead>Days</TableHead>
+                      <TableHead>Plan</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {metrics.trials.list.map((row) => (
+                      <TableRow key={row.id}>
+                        <TableCell>{row.email}</TableCell>
+                        <TableCell>{formatDate(row.trialEnd)}</TableCell>
+                        <TableCell className={row.daysRemaining <= 3 ? 'font-semibold text-destructive' : ''}>
+                          {row.daysRemaining}
+                        </TableCell>
+                        <TableCell>{row.interval === 'year' ? 'Annual' : 'Monthly'}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="font-display text-xl font-semibold">Conversion · 30-day rolling</h2>
+          <Card variant="flat">
+            <CardContent className="py-6">
+              {metrics.conversion.percent === null ? (
+                <p className="text-sm text-muted-foreground">
+                  Not enough data yet. {metrics.conversion.sample} trial
+                  {metrics.conversion.sample === 1 ? '' : 's'} completed in the cohort window (need ≥5 to compute).
+                </p>
+              ) : (
+                <div className="space-y-1">
+                  <div className="font-display text-4xl font-bold">{metrics.conversion.percent}%</div>
+                  <p className="text-sm text-muted-foreground">
+                    {metrics.conversion.converted} of {metrics.conversion.sample} trials started 31–60 days ago are now
+                    active.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  sub,
+  emphasize = false,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  emphasize?: boolean;
+}) {
+  return (
+    <Card variant={emphasize ? 'primary' : 'default'}>
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="font-display text-3xl">{value}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{sub}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from 'vitest';
+import type Stripe from 'stripe';
+
+vi.mock('server-only', () => ({}));
+
+import {
+  computeMrr,
+  bucketActivePaid,
+  buildTrialPipeline,
+  buildPastDue,
+  computeConversion,
+} from '../subscription-metrics';
+
+const SECONDS_PER_DAY = 86_400;
+
+function makeSub(overrides: {
+  id?: string;
+  status?: Stripe.Subscription.Status;
+  interval?: 'month' | 'year';
+  unitAmount?: number;
+  quantity?: number;
+  trialStart?: number | null;
+  trialEnd?: number | null;
+  email?: string;
+}): Stripe.Subscription {
+  const {
+    id = `sub_${Math.random().toString(36).slice(2)}`,
+    status = 'active',
+    interval = 'month',
+    unitAmount = 699,
+    quantity = 1,
+    trialStart = null,
+    trialEnd = null,
+    email = 'test@example.com',
+  } = overrides;
+  return {
+    id,
+    status,
+    trial_start: trialStart,
+    trial_end: trialEnd,
+    customer: { id: 'cus_x', email, deleted: false } as unknown as Stripe.Customer,
+    items: {
+      data: [
+        {
+          id: 'si_x',
+          quantity,
+          price: {
+            unit_amount: unitAmount,
+            recurring: { interval },
+          },
+        },
+      ],
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+describe('computeMrr', () => {
+  it('sums monthly subs at face value', () => {
+    const subs = [makeSub({ interval: 'month', unitAmount: 699 }), makeSub({ interval: 'month', unitAmount: 1299 })];
+    expect(computeMrr(subs)).toBe(20); // (699 + 1299) / 100 = 19.98 → rounds to 20
+  });
+
+  it('normalizes annual subs to monthly equivalent', () => {
+    const subs = [makeSub({ interval: 'year', unitAmount: 6999 })];
+    // 6999 / 12 = 583.25 cents → 5.83 dollars → rounds to 6
+    expect(computeMrr(subs)).toBe(6);
+  });
+
+  it('mixes monthly and annual correctly', () => {
+    const subs = [
+      makeSub({ interval: 'month', unitAmount: 699 }), // 6.99
+      makeSub({ interval: 'year', unitAmount: 6999 }), // 5.83
+    ];
+    // 699 + (6999/12) = 699 + 583.25 = 1282.25 cents → 12.82 dollars → rounds to 13
+    expect(computeMrr(subs)).toBe(13);
+  });
+
+  it('respects quantity', () => {
+    const subs = [makeSub({ interval: 'month', unitAmount: 699, quantity: 3 })];
+    expect(computeMrr(subs)).toBe(21); // 6.99 * 3 = 20.97 → rounds to 21
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(computeMrr([])).toBe(0);
+  });
+});
+
+describe('bucketActivePaid', () => {
+  it('classifies by interval', () => {
+    const subs = [makeSub({ interval: 'month' }), makeSub({ interval: 'month' }), makeSub({ interval: 'year' })];
+    expect(bucketActivePaid(subs)).toEqual({ total: 3, monthly: 2, annual: 1 });
+  });
+
+  it('handles empty list', () => {
+    expect(bucketActivePaid([])).toEqual({ total: 0, monthly: 0, annual: 0 });
+  });
+});
+
+describe('buildTrialPipeline', () => {
+  const now = 1_700_000_000; // arbitrary fixed second
+
+  it('sorts by soonest trial end', () => {
+    const subs = [
+      makeSub({ id: 'sub_late', trialEnd: now + 5 * SECONDS_PER_DAY }),
+      makeSub({ id: 'sub_soon', trialEnd: now + 1 * SECONDS_PER_DAY }),
+      makeSub({ id: 'sub_mid', trialEnd: now + 3 * SECONDS_PER_DAY }),
+    ];
+    const result = buildTrialPipeline(subs, now);
+    expect(result.list.map((e) => e.id)).toEqual(['sub_soon', 'sub_mid', 'sub_late']);
+  });
+
+  it('endingIn3Days is a subset of endingIn7Days', () => {
+    const subs = [
+      makeSub({ trialEnd: now + 1 * SECONDS_PER_DAY }), // in 1d → in both
+      makeSub({ trialEnd: now + 2 * SECONDS_PER_DAY }), // in 2d → in both
+      makeSub({ trialEnd: now + 5 * SECONDS_PER_DAY }), // in 5d → only ≤7d
+      makeSub({ trialEnd: now + 10 * SECONDS_PER_DAY }), // in 10d → neither
+    ];
+    const result = buildTrialPipeline(subs, now);
+    expect(result.endingIn3Days).toBe(2);
+    expect(result.endingIn7Days).toBe(3);
+    expect(result.endingIn3Days).toBeLessThanOrEqual(result.endingIn7Days);
+  });
+
+  it('skips subs without trial_end', () => {
+    const subs = [makeSub({ trialEnd: null }), makeSub({ trialEnd: now + SECONDS_PER_DAY })];
+    const result = buildTrialPipeline(subs, now);
+    expect(result.list).toHaveLength(1);
+  });
+
+  it('uses customer email', () => {
+    const subs = [makeSub({ email: 'jane@example.com', trialEnd: now + SECONDS_PER_DAY })];
+    expect(buildTrialPipeline(subs, now).list[0].email).toBe('jane@example.com');
+  });
+});
+
+describe('buildPastDue', () => {
+  it('returns total and list with email + interval', () => {
+    const subs = [
+      makeSub({ status: 'past_due', interval: 'month', email: 'a@x.com' }),
+      makeSub({ status: 'past_due', interval: 'year', email: 'b@x.com' }),
+    ];
+    const result = buildPastDue(subs);
+    expect(result.total).toBe(2);
+    expect(result.list[0].email).toBe('a@x.com');
+    expect(result.list[1].interval).toBe('year');
+  });
+
+  it('returns zero for empty list', () => {
+    expect(buildPastDue([])).toEqual({ total: 0, list: [] });
+  });
+});
+
+describe('computeConversion', () => {
+  const now = 1_700_000_000;
+  const day = SECONDS_PER_DAY;
+
+  it('returns null percent when sample < 5', () => {
+    const subs = [
+      makeSub({ status: 'active', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      makeSub({ status: 'canceled', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+    ];
+    const result = computeConversion(subs, now);
+    expect(result.sample).toBe(2);
+    expect(result.percent).toBeNull();
+  });
+
+  it('counts only completed trials in cohort window', () => {
+    const subs = [
+      // In window, completed, active → counts as converted
+      makeSub({ status: 'active', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      makeSub({ status: 'active', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+      makeSub({ status: 'active', trialStart: now - 55 * day, trialEnd: now - 48 * day }),
+      // In window, completed, canceled → counts in sample, not converted
+      makeSub({ status: 'canceled', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      makeSub({ status: 'canceled', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+      // Trial too recent (started < 30d ago) → excluded
+      makeSub({ status: 'trialing', trialStart: now - 5 * day, trialEnd: now + 2 * day }),
+      // Trial older than 60d → excluded
+      makeSub({ status: 'active', trialStart: now - 80 * day, trialEnd: now - 73 * day }),
+      // Trial still in flight (trial_end > now) → excluded
+      makeSub({ status: 'trialing', trialStart: now - 35 * day, trialEnd: now + 1 * day }),
+    ];
+    const result = computeConversion(subs, now);
+    expect(result.sample).toBe(5);
+    expect(result.converted).toBe(3);
+    expect(result.percent).toBe(60); // 3/5 = 60%
+  });
+
+  it('handles zero sample', () => {
+    expect(computeConversion([], now)).toEqual({
+      window: '30d',
+      sample: 0,
+      converted: 0,
+      percent: null,
+    });
+  });
+});

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -1,0 +1,219 @@
+import 'server-only';
+import type Stripe from 'stripe';
+import { stripe } from '@/lib/stripe/server';
+
+export type TrialPipelineEntry = {
+  id: string;
+  email: string;
+  trialEnd: string;
+  daysRemaining: number;
+  interval: 'month' | 'year';
+};
+
+export type PastDueEntry = {
+  id: string;
+  email: string;
+  interval: 'month' | 'year';
+};
+
+export type SubscriptionMetrics = {
+  mrr: number;
+  activePaid: {
+    total: number;
+    monthly: number;
+    annual: number;
+  };
+  trials: {
+    total: number;
+    endingIn3Days: number;
+    endingIn7Days: number;
+    list: TrialPipelineEntry[];
+  };
+  pastDue: {
+    total: number;
+    list: PastDueEntry[];
+  };
+  conversion: {
+    window: '30d';
+    sample: number;
+    converted: number;
+    percent: number | null;
+  };
+  generatedAt: string;
+  errors: string[];
+};
+
+const SECONDS_PER_DAY = 86_400;
+const COHORT_LOOKBACK_DAYS = 60;
+const COHORT_TRIAL_END_THRESHOLD_DAYS = 30;
+const MIN_COHORT_SAMPLE = 5;
+
+function getInterval(sub: Stripe.Subscription): 'month' | 'year' | null {
+  const recurring = sub.items.data[0]?.price?.recurring;
+  if (recurring?.interval === 'month') return 'month';
+  if (recurring?.interval === 'year') return 'year';
+  return null;
+}
+
+function getCustomerEmail(sub: Stripe.Subscription): string {
+  const customer = sub.customer;
+  if (typeof customer === 'string') return customer;
+  if ('deleted' in customer && customer.deleted) return '(deleted customer)';
+  return customer.email ?? '(no email)';
+}
+
+/**
+ * Sum of monthly-equivalent revenue across a list of subscriptions.
+ * Returns whole dollars (Stripe amounts are cents).
+ */
+export function computeMrr(subs: Stripe.Subscription[]): number {
+  let cents = 0;
+  for (const sub of subs) {
+    for (const item of sub.items.data) {
+      const price = item.price;
+      const recurring = price.recurring;
+      if (!recurring || price.unit_amount == null) continue;
+      const quantity = item.quantity ?? 1;
+      const itemMonthly = (price.unit_amount * quantity) / (recurring.interval === 'year' ? 12 : 1);
+      cents += itemMonthly;
+    }
+  }
+  return Math.round(cents / 100);
+}
+
+export function bucketActivePaid(subs: Stripe.Subscription[]): { total: number; monthly: number; annual: number } {
+  let monthly = 0;
+  let annual = 0;
+  for (const sub of subs) {
+    const interval = getInterval(sub);
+    if (interval === 'month') monthly += 1;
+    else if (interval === 'year') annual += 1;
+  }
+  return { total: monthly + annual, monthly, annual };
+}
+
+export function buildTrialPipeline(
+  subs: Stripe.Subscription[],
+  now: number
+): { list: TrialPipelineEntry[]; endingIn3Days: number; endingIn7Days: number } {
+  const list: TrialPipelineEntry[] = [];
+  for (const sub of subs) {
+    if (!sub.trial_end) continue;
+    const interval = getInterval(sub);
+    if (!interval) continue;
+    const daysRemaining = Math.ceil((sub.trial_end - now) / SECONDS_PER_DAY);
+    list.push({
+      id: sub.id,
+      email: getCustomerEmail(sub),
+      trialEnd: new Date(sub.trial_end * 1000).toISOString(),
+      daysRemaining,
+      interval,
+    });
+  }
+  list.sort((a, b) => new Date(a.trialEnd).getTime() - new Date(b.trialEnd).getTime());
+  const endingIn3Days = list.filter((e) => e.daysRemaining <= 3).length;
+  const endingIn7Days = list.filter((e) => e.daysRemaining <= 7).length;
+  return { list, endingIn3Days, endingIn7Days };
+}
+
+export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[]; total: number } {
+  const list: PastDueEntry[] = [];
+  for (const sub of subs) {
+    const interval = getInterval(sub);
+    if (!interval) continue;
+    list.push({
+      id: sub.id,
+      email: getCustomerEmail(sub),
+      interval,
+    });
+  }
+  return { list, total: list.length };
+}
+
+/**
+ * 30-day rolling conversion: of trials whose `trial_start` was 31–60 days ago
+ * AND whose `trial_end` has passed, what % are now `active`?
+ *
+ * Returns null percent when sample < MIN_COHORT_SAMPLE so the UI can show
+ * "not enough data yet".
+ */
+export function computeConversion(
+  subs: Stripe.Subscription[],
+  now: number
+): { window: '30d'; sample: number; converted: number; percent: number | null } {
+  const lookbackStart = now - COHORT_LOOKBACK_DAYS * SECONDS_PER_DAY;
+  const trialEndCutoff = now - COHORT_TRIAL_END_THRESHOLD_DAYS * SECONDS_PER_DAY;
+
+  let sample = 0;
+  let converted = 0;
+  for (const sub of subs) {
+    if (!sub.trial_start || !sub.trial_end) continue;
+    if (sub.trial_start < lookbackStart) continue;
+    if (sub.trial_start >= trialEndCutoff) continue;
+    if (sub.trial_end >= now) continue;
+    sample += 1;
+    if (sub.status === 'active') converted += 1;
+  }
+
+  const percent = sample >= MIN_COHORT_SAMPLE ? Math.round((converted / sample) * 100) : null;
+  return { window: '30d', sample, converted, percent };
+}
+
+async function listAll(params: Stripe.SubscriptionListParams): Promise<Stripe.Subscription[]> {
+  const out: Stripe.Subscription[] = [];
+  for await (const sub of stripe.subscriptions.list({ ...params, limit: 100, expand: ['data.customer'] })) {
+    out.push(sub);
+  }
+  return out;
+}
+
+async function safeList(
+  params: Stripe.SubscriptionListParams,
+  label: string,
+  errors: string[]
+): Promise<Stripe.Subscription[]> {
+  try {
+    return await listAll(params);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`${label}: ${msg}`);
+    return [];
+  }
+}
+
+export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
+  const errors: string[] = [];
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  const [active, trialing, pastDue, cohort] = await Promise.all([
+    safeList({ status: 'active' }, 'active subscriptions', errors),
+    safeList({ status: 'trialing' }, 'trialing subscriptions', errors),
+    safeList({ status: 'past_due' }, 'past_due subscriptions', errors),
+    safeList(
+      { status: 'all', created: { gte: nowSec - COHORT_LOOKBACK_DAYS * SECONDS_PER_DAY } },
+      'conversion cohort',
+      errors
+    ),
+  ]);
+
+  const mrr = computeMrr(active);
+  const activePaid = bucketActivePaid(active);
+  const trialBuckets = buildTrialPipeline(trialing, nowSec);
+  const pastDueOut = buildPastDue(pastDue);
+  const conversion = computeConversion(cohort, nowSec);
+
+  return {
+    mrr,
+    activePaid,
+    trials: {
+      total: trialing.length,
+      endingIn3Days: trialBuckets.endingIn3Days,
+      endingIn7Days: trialBuckets.endingIn7Days,
+      list: trialBuckets.list,
+    },
+    pastDue: pastDueOut,
+    conversion,
+    generatedAt: new Date().toISOString(),
+    errors,
+  };
+}


### PR DESCRIPTION
## Summary
- New internal-only dashboard at `/mission-control/subscriptions` (admin-gated by existing middleware) showing MRR, active paid (monthly/annual split), active trials, trials ending in 3/7 days, trial pipeline table, and 30-day rolling conversion %
- Adds an **Attention Needed** section listing `past_due` subscriptions (count + email + plan); these are explicitly excluded from MRR
- Source of truth is the Stripe API only — no Supabase reads, no schema migrations

## Files
- `frontend/lib/admin/subscription-metrics.ts` — pure math helpers + `getSubscriptionMetrics()` Stripe fetcher with per-section error fallback
- `frontend/app/mission-control/subscriptions/page.tsx` — RSC renderer
- `frontend/lib/admin/__tests__/subscription-metrics.test.ts` — 16 unit tests covering MRR math, bucketing, trial subset invariant, conversion cohort edges, and `null` percent below sample threshold
- `frontend/app/mission-control/page.tsx` — adds "Subscriptions →" link from existing model-accuracy page
- `docs/superpowers/specs/2026-05-01-admin-subscription-dashboard-design.md` — design spec

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] `npx prettier --check` clean on touched files
- [x] `npx vitest run lib/admin/__tests__/subscription-metrics.test.ts` — 16/16 passing
- [ ] Load `/mission-control/subscriptions` as admin in production, eyeball numbers against the Stripe dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)