### PR TITLE
fix(mission-control): trial pipeline tweaks + MRR cents + conversion accuracy

### DIFF
--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -9,7 +9,12 @@ export const dynamic = 'force-dynamic';
 export const metadata = { robots: { index: false, follow: false } };
 
 function formatDollars(n: number): string {
-  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+  return n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 function formatDate(iso: string): string {
@@ -76,7 +81,13 @@ export default async function SubscriptionsDashboardPage() {
           <KpiCard
             label="Active Trials"
             value={metrics.trials.total.toString()}
-            sub={metrics.trials.total === 0 ? 'no trials in flight' : 'in flight now'}
+            sub={
+              metrics.trials.canceledPending > 0
+                ? `+${metrics.trials.canceledPending} canceled (won't renew)`
+                : metrics.trials.total === 0
+                  ? 'no trials in flight'
+                  : 'in flight now'
+            }
           />
           <KpiCard
             label="Trials Ending ≤7d"
@@ -123,7 +134,10 @@ export default async function SubscriptionsDashboardPage() {
         <section className="space-y-3">
           <div className="flex items-baseline justify-between">
             <h2 className="font-display text-xl font-semibold">Trial Pipeline</h2>
-            <span className="text-sm text-muted-foreground">sorted by soonest end</span>
+            <span className="text-sm text-muted-foreground">
+              sorted by soonest end · canceled trials hidden
+              {metrics.trials.canceledPending > 0 && ` (${metrics.trials.canceledPending} not shown)`}
+            </span>
           </div>
           <Card variant="flat">
             <CardContent className="p-0">
@@ -170,8 +184,8 @@ export default async function SubscriptionsDashboardPage() {
                 <div className="space-y-1">
                   <div className="font-display text-4xl font-bold">{metrics.conversion.percent}%</div>
                   <p className="text-sm text-muted-foreground">
-                    {metrics.conversion.converted} of {metrics.conversion.sample} trials started 31–60 days ago are now
-                    active.
+                    {metrics.conversion.converted} of {metrics.conversion.sample} trials started 31–60 days ago paid at
+                    least once (active or past_due). Trials still in flight are excluded.
                   </p>
                 </div>
               )}

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -22,6 +22,7 @@ function makeSub(overrides: {
   trialStart?: number | null;
   trialEnd?: number | null;
   email?: string;
+  cancelAtPeriodEnd?: boolean;
 }): Stripe.Subscription {
   const {
     id = `sub_${Math.random().toString(36).slice(2)}`,
@@ -32,12 +33,14 @@ function makeSub(overrides: {
     trialStart = null,
     trialEnd = null,
     email = 'test@example.com',
+    cancelAtPeriodEnd = false,
   } = overrides;
   return {
     id,
     status,
     trial_start: trialStart,
     trial_end: trialEnd,
+    cancel_at_period_end: cancelAtPeriodEnd,
     customer: { id: 'cus_x', email, deleted: false } as unknown as Stripe.Customer,
     items: {
       data: [
@@ -55,33 +58,41 @@ function makeSub(overrides: {
 }
 
 describe('computeMrr', () => {
-  it('sums monthly subs at face value', () => {
+  it('sums monthly subs preserving cents', () => {
     const subs = [makeSub({ interval: 'month', unitAmount: 699 }), makeSub({ interval: 'month', unitAmount: 1299 })];
-    expect(computeMrr(subs)).toBe(20); // (699 + 1299) / 100 = 19.98 → rounds to 20
+    expect(computeMrr(subs)).toBe(19.98); // 699 + 1299 = 1998 cents → 19.98 dollars
   });
 
-  it('normalizes annual subs to monthly equivalent', () => {
+  it('normalizes annual subs to monthly equivalent with cents', () => {
     const subs = [makeSub({ interval: 'year', unitAmount: 6999 })];
-    // 6999 / 12 = 583.25 cents → 5.83 dollars → rounds to 6
-    expect(computeMrr(subs)).toBe(6);
+    // 6999 / 12 = 583.25 cents → rounds to nearest cent → 5.83 dollars
+    expect(computeMrr(subs)).toBe(5.83);
   });
 
   it('mixes monthly and annual correctly', () => {
     const subs = [
-      makeSub({ interval: 'month', unitAmount: 699 }), // 6.99
-      makeSub({ interval: 'year', unitAmount: 6999 }), // 5.83
+      makeSub({ interval: 'month', unitAmount: 699 }), // 699 cents
+      makeSub({ interval: 'year', unitAmount: 6999 }), // 583.25 cents
     ];
-    // 699 + (6999/12) = 699 + 583.25 = 1282.25 cents → 12.82 dollars → rounds to 13
-    expect(computeMrr(subs)).toBe(13);
+    // 699 + 583.25 = 1282.25 cents → rounds to 1282 cents → 12.82 dollars
+    expect(computeMrr(subs)).toBe(12.82);
   });
 
   it('respects quantity', () => {
     const subs = [makeSub({ interval: 'month', unitAmount: 699, quantity: 3 })];
-    expect(computeMrr(subs)).toBe(21); // 6.99 * 3 = 20.97 → rounds to 21
+    expect(computeMrr(subs)).toBe(20.97); // 6.99 * 3
   });
 
   it('returns 0 for an empty list', () => {
     expect(computeMrr([])).toBe(0);
+  });
+
+  it('rounds half-cent up', () => {
+    // 6999 / 12 = 583.25 cents → rounds to 583 cents (banker would round, but Math.round half-up)
+    // Pick a value that lands exactly on .5 cents to verify behavior
+    const subs = [makeSub({ interval: 'year', unitAmount: 12 * 199 + 6 })]; // 12*199 + 6 = 2394 → /12 = 199.5 cents
+    // 199.5 → Math.round → 200 cents → 2.00 dollars
+    expect(computeMrr(subs)).toBe(2);
   });
 });
 
@@ -107,6 +118,7 @@ describe('buildTrialPipeline', () => {
     ];
     const result = buildTrialPipeline(subs, now);
     expect(result.list.map((e) => e.id)).toEqual(['sub_soon', 'sub_mid', 'sub_late']);
+    expect(result.activeTotal).toBe(3);
   });
 
   it('endingIn3Days is a subset of endingIn7Days', () => {
@@ -131,6 +143,33 @@ describe('buildTrialPipeline', () => {
   it('uses customer email', () => {
     const subs = [makeSub({ email: 'jane@example.com', trialEnd: now + SECONDS_PER_DAY })];
     expect(buildTrialPipeline(subs, now).list[0].email).toBe('jane@example.com');
+  });
+
+  it('hides trials marked cancel_at_period_end and counts them separately', () => {
+    const subs = [
+      // active trial — included
+      makeSub({ id: 'sub_active', trialEnd: now + 2 * SECONDS_PER_DAY }),
+      // canceled trial — hidden but counted
+      makeSub({
+        id: 'sub_canceled_a',
+        trialEnd: now + 1 * SECONDS_PER_DAY,
+        cancelAtPeriodEnd: true,
+        email: 'colvillem@gmail.com',
+      }),
+      makeSub({
+        id: 'sub_canceled_b',
+        trialEnd: now + 3 * SECONDS_PER_DAY,
+        cancelAtPeriodEnd: true,
+        email: 'ronald.warzoha@gmail.com',
+      }),
+    ];
+    const result = buildTrialPipeline(subs, now);
+    expect(result.activeTotal).toBe(1);
+    expect(result.canceledPending).toBe(2);
+    expect(result.list.map((e) => e.id)).toEqual(['sub_active']);
+    // canceled trials must not affect ending buckets
+    expect(result.endingIn3Days).toBe(1);
+    expect(result.endingIn7Days).toBe(1);
   });
 });
 
@@ -165,26 +204,28 @@ describe('computeConversion', () => {
     expect(result.percent).toBeNull();
   });
 
-  it('counts only completed trials in cohort window', () => {
+  it('counts active and past_due as converted; excludes still-in-flight and out-of-window', () => {
     const subs = [
-      // In window, completed, active → counts as converted
+      // In window, completed, active → converted
       makeSub({ status: 'active', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
       makeSub({ status: 'active', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
       makeSub({ status: 'active', trialStart: now - 55 * day, trialEnd: now - 48 * day }),
-      // In window, completed, canceled → counts in sample, not converted
+      // In window, completed, past_due → converted (paid at least once, now in dunning)
+      makeSub({ status: 'past_due', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      // In window, completed, canceled → in sample, not converted
       makeSub({ status: 'canceled', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
       makeSub({ status: 'canceled', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
       // Trial too recent (started < 30d ago) → excluded
       makeSub({ status: 'trialing', trialStart: now - 5 * day, trialEnd: now + 2 * day }),
       // Trial older than 60d → excluded
       makeSub({ status: 'active', trialStart: now - 80 * day, trialEnd: now - 73 * day }),
-      // Trial still in flight (trial_end > now) → excluded
+      // Trial still in flight (trial_end > now) → excluded — does not penalize conversion
       makeSub({ status: 'trialing', trialStart: now - 35 * day, trialEnd: now + 1 * day }),
     ];
     const result = computeConversion(subs, now);
-    expect(result.sample).toBe(5);
-    expect(result.converted).toBe(3);
-    expect(result.percent).toBe(60); // 3/5 = 60%
+    expect(result.sample).toBe(6);
+    expect(result.converted).toBe(4);
+    expect(result.percent).toBe(67); // 4/6 = 66.67% → rounds to 67
   });
 
   it('handles zero sample', () => {

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -17,14 +17,15 @@ export type PastDueEntry = {
 };
 
 export type SubscriptionMetrics = {
-  mrr: number;
+  mrr: number; // dollars with cents preserved (e.g. 61.25)
   activePaid: {
     total: number;
     monthly: number;
     annual: number;
   };
   trials: {
-    total: number;
+    total: number; // active trials only — excludes those marked cancel_at_period_end
+    canceledPending: number; // trialing + cancel_at_period_end (won't renew)
     endingIn3Days: number;
     endingIn7Days: number;
     list: TrialPipelineEntry[];
@@ -64,7 +65,7 @@ function getCustomerEmail(sub: Stripe.Subscription): string {
 
 /**
  * Sum of monthly-equivalent revenue across a list of subscriptions.
- * Returns whole dollars (Stripe amounts are cents).
+ * Returns dollars with cents preserved (e.g. 61.25), rounded to the nearest cent.
  */
 export function computeMrr(subs: Stripe.Subscription[]): number {
   let cents = 0;
@@ -78,7 +79,7 @@ export function computeMrr(subs: Stripe.Subscription[]): number {
       cents += itemMonthly;
     }
   }
-  return Math.round(cents / 100);
+  return Math.round(cents) / 100;
 }
 
 export function bucketActivePaid(subs: Stripe.Subscription[]): { total: number; monthly: number; annual: number } {
@@ -92,13 +93,32 @@ export function bucketActivePaid(subs: Stripe.Subscription[]): { total: number; 
   return { total: monthly + annual, monthly, annual };
 }
 
+/**
+ * Build the trial pipeline view. Excludes trials the user has already
+ * canceled (cancel_at_period_end=true on a trialing sub) — those won't
+ * convert and shouldn't show up as actionable in the dashboard.
+ *
+ * Returns both the actionable count (`activeTotal`) and the canceled-pending
+ * count for transparency.
+ */
 export function buildTrialPipeline(
   subs: Stripe.Subscription[],
   now: number
-): { list: TrialPipelineEntry[]; endingIn3Days: number; endingIn7Days: number } {
+): {
+  list: TrialPipelineEntry[];
+  activeTotal: number;
+  canceledPending: number;
+  endingIn3Days: number;
+  endingIn7Days: number;
+} {
   const list: TrialPipelineEntry[] = [];
+  let canceledPending = 0;
   for (const sub of subs) {
     if (!sub.trial_end) continue;
+    if (sub.cancel_at_period_end) {
+      canceledPending += 1;
+      continue;
+    }
     const interval = getInterval(sub);
     if (!interval) continue;
     const daysRemaining = Math.ceil((sub.trial_end - now) / SECONDS_PER_DAY);
@@ -113,7 +133,7 @@ export function buildTrialPipeline(
   list.sort((a, b) => new Date(a.trialEnd).getTime() - new Date(b.trialEnd).getTime());
   const endingIn3Days = list.filter((e) => e.daysRemaining <= 3).length;
   const endingIn7Days = list.filter((e) => e.daysRemaining <= 7).length;
-  return { list, endingIn3Days, endingIn7Days };
+  return { list, activeTotal: list.length, canceledPending, endingIn3Days, endingIn7Days };
 }
 
 export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[]; total: number } {
@@ -132,7 +152,17 @@ export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[
 
 /**
  * 30-day rolling conversion: of trials whose `trial_start` was 31–60 days ago
- * AND whose `trial_end` has passed, what % are now `active`?
+ * AND whose `trial_end` has passed, what % paid at least once?
+ *
+ * "Paid at least once" = current status is `active` OR `past_due`. past_due
+ * means the first invoice was paid and a subsequent renewal failed — they
+ * still converted, they're just in dunning now. Excluding them would
+ * understate the true conversion rate.
+ *
+ * Trials still in flight (trial_end >= now) are excluded — including them
+ * would penalize conversion for users who haven't had a chance to convert
+ * yet. The trial_start cutoff at 30d ago guarantees this is impossible
+ * for typical trial lengths, but we keep the explicit filter for safety.
  *
  * Returns null percent when sample < MIN_COHORT_SAMPLE so the UI can show
  * "not enough data yet".
@@ -152,7 +182,7 @@ export function computeConversion(
     if (sub.trial_start >= trialEndCutoff) continue;
     if (sub.trial_end >= now) continue;
     sample += 1;
-    if (sub.status === 'active') converted += 1;
+    if (sub.status === 'active' || sub.status === 'past_due') converted += 1;
   }
 
   const percent = sample >= MIN_COHORT_SAMPLE ? Math.round((converted / sample) * 100) : null;
@@ -206,7 +236,8 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
     mrr,
     activePaid,
     trials: {
-      total: trialing.length,
+      total: trialBuckets.activeTotal,
+      canceledPending: trialBuckets.canceledPending,
       endingIn3Days: trialBuckets.endingIn3Days,
       endingIn7Days: trialBuckets.endingIn7Days,
       list: trialBuckets.list,


### PR DESCRIPTION
## Summary
Three small refinements to the subscription dashboard from PR #705:

1. **Hide canceled trials from the pipeline.** When a user cancels mid-trial via the Customer Portal, Stripe keeps `status='trialing'` but flips `cancel_at_period_end=true`. Those won't convert and shouldn't show up as actionable in the pipeline table or the ending-soon counts. They're still surfaced as a separate count under the Active Trials KPI (e.g. "+2 canceled (won't renew)") so nothing is hidden silently.

2. **Tighten conversion math.** Counts `active` OR `past_due` as converted — `past_due` means the first invoice was paid and a subsequent renewal failed, so they did convert. Excluding them understates the true conversion rate. Also keeps the explicit `trial_end < now` filter so trials still in flight never penalize the percentage.

3. **MRR with 2 decimals.** Preserves cents in the math (`Math.round(cents) / 100`) and renders as `$61.25` instead of `$61`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` / `npx prettier --check` clean on touched files
- [x] `npx vitest run` — 18/18 passing (added test for canceled-trial hiding using the two example emails the user flagged, and for past_due in the conversion numerator)
- [ ] Reload \`/mission-control/subscriptions\` and verify Colvillem & Ronald no longer appear in the pipeline; MRR shows two decimals

🤖 Generated with [Claude Code](https://claude.com/claude-code)