### PR TITLE
fix(mission-control): exclude test/internal users from conversion %

### DIFF
--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -179,6 +179,8 @@ export default async function SubscriptionsDashboardPage() {
                 <p className="text-sm text-muted-foreground">
                   Not enough data yet. {metrics.conversion.sample} trial
                   {metrics.conversion.sample === 1 ? '' : 's'} completed in the cohort window (need ≥5 to compute).
+                  {metrics.conversion.excluded > 0 &&
+                    ` ${metrics.conversion.excluded} test/internal user${metrics.conversion.excluded === 1 ? '' : 's'} excluded.`}
                 </p>
               ) : (
                 <div className="space-y-1">
@@ -186,6 +188,8 @@ export default async function SubscriptionsDashboardPage() {
                   <p className="text-sm text-muted-foreground">
                     {metrics.conversion.converted} of {metrics.conversion.sample} trials started 31–60 days ago paid at
                     least once (active or past_due). Trials still in flight are excluded.
+                    {metrics.conversion.excluded > 0 &&
+                      ` ${metrics.conversion.excluded} test/internal user${metrics.conversion.excluded === 1 ? '' : 's'} excluded.`}
                   </p>
                 </div>
               )}

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -234,6 +234,57 @@ describe('computeConversion', () => {
       sample: 0,
       converted: 0,
       percent: null,
+      excluded: 0,
     });
+  });
+
+  it('excludes test/internal users from the cohort and counts them separately', () => {
+    const excluded = new Set([
+      'cartermheidt@gmail.com',
+      'brooksheidt@gmail.com',
+      'dallasheidt@gmail.com',
+      'dallas@rightsideuplending.com',
+    ]);
+    const subs = [
+      // Real cohort: 5 users, 4 converted → 80%
+      makeSub({ status: 'active', email: 'a@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      makeSub({ status: 'active', email: 'b@example.com', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+      makeSub({ status: 'active', email: 'c@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      makeSub({ status: 'active', email: 'd@example.com', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+      makeSub({ status: 'canceled', email: 'e@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
+      // Test users in the same cohort window — must NOT be in sample
+      makeSub({
+        status: 'canceled',
+        email: 'cartermheidt@gmail.com',
+        trialStart: now - 45 * day,
+        trialEnd: now - 38 * day,
+      }),
+      makeSub({
+        status: 'canceled',
+        email: 'dallasheidt@gmail.com',
+        trialStart: now - 50 * day,
+        trialEnd: now - 43 * day,
+      }),
+    ];
+    const result = computeConversion(subs, now, excluded);
+    expect(result.sample).toBe(5);
+    expect(result.converted).toBe(4);
+    expect(result.percent).toBe(80);
+    expect(result.excluded).toBe(2);
+  });
+
+  it('email match is case-insensitive', () => {
+    const excluded = new Set(['dallasheidt@gmail.com']);
+    const subs = [
+      makeSub({
+        status: 'canceled',
+        email: 'DallasHeidt@Gmail.com',
+        trialStart: now - 45 * day,
+        trialEnd: now - 38 * day,
+      }),
+    ];
+    const result = computeConversion(subs, now, excluded);
+    expect(result.sample).toBe(0);
+    expect(result.excluded).toBe(1);
   });
 });

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -39,6 +39,7 @@ export type SubscriptionMetrics = {
     sample: number;
     converted: number;
     percent: number | null;
+    excluded: number; // test/internal users filtered from sample
   };
   generatedAt: string;
   errors: string[];
@@ -48,6 +49,27 @@ const SECONDS_PER_DAY = 86_400;
 const COHORT_LOOKBACK_DAYS = 60;
 const COHORT_TRIAL_END_THRESHOLD_DAYS = 30;
 const MIN_COHORT_SAMPLE = 5;
+
+/**
+ * Internal/test users whose subscriptions skew dashboard math (especially
+ * conversion %). Compared case-insensitively. Add via env var
+ * `ADMIN_DASHBOARD_EXCLUDED_EMAILS` (comma-separated) to extend at runtime
+ * without a deploy.
+ */
+const HARDCODED_EXCLUDED_EMAILS = new Set([
+  'cartermheidt@gmail.com',
+  'brooksheidt@gmail.com',
+  'dallasheidt@gmail.com',
+  'dallas@rightsideuplending.com',
+]);
+
+function getExcludedEmails(): Set<string> {
+  const fromEnv = (process.env.ADMIN_DASHBOARD_EXCLUDED_EMAILS ?? '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  return new Set([...HARDCODED_EXCLUDED_EMAILS, ...fromEnv]);
+}
 
 function getInterval(sub: Stripe.Subscription): 'month' | 'year' | null {
   const recurring = sub.items.data[0]?.price?.recurring;
@@ -169,24 +191,30 @@ export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[
  */
 export function computeConversion(
   subs: Stripe.Subscription[],
-  now: number
-): { window: '30d'; sample: number; converted: number; percent: number | null } {
+  now: number,
+  excludedEmails: Set<string> = getExcludedEmails()
+): { window: '30d'; sample: number; converted: number; percent: number | null; excluded: number } {
   const lookbackStart = now - COHORT_LOOKBACK_DAYS * SECONDS_PER_DAY;
   const trialEndCutoff = now - COHORT_TRIAL_END_THRESHOLD_DAYS * SECONDS_PER_DAY;
 
   let sample = 0;
   let converted = 0;
+  let excluded = 0;
   for (const sub of subs) {
     if (!sub.trial_start || !sub.trial_end) continue;
     if (sub.trial_start < lookbackStart) continue;
     if (sub.trial_start >= trialEndCutoff) continue;
     if (sub.trial_end >= now) continue;
+    if (excludedEmails.has(getCustomerEmail(sub).toLowerCase())) {
+      excluded += 1;
+      continue;
+    }
     sample += 1;
     if (sub.status === 'active' || sub.status === 'past_due') converted += 1;
   }
 
   const percent = sample >= MIN_COHORT_SAMPLE ? Math.round((converted / sample) * 100) : null;
-  return { window: '30d', sample, converted, percent };
+  return { window: '30d', sample, converted, percent, excluded };
 }
 
 async function listAll(params: Stripe.SubscriptionListParams): Promise<Stripe.Subscription[]> {


### PR DESCRIPTION
## Summary
Conversion % was including 4 known test/family accounts (Dallas, Carter, Brooks Heidt + dallas@rightsideuplending.com) that never converted, artificially deflating the rate.

- Adds a baked-in deny-list filtering them out of both the cohort numerator and denominator
- Match is case-insensitive
- Extensible at runtime via \`ADMIN_DASHBOARD_EXCLUDED_EMAILS\` env var (comma-separated) without a deploy
- Excluded count is surfaced in the conversion copy ("N test/internal users excluded") — nothing hidden silently

## Scope
Only conversion % is filtered. MRR, active paid, trials, and past_due intentionally still include these users. Easy to extend later if needed.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` / \`npx prettier --check\` clean
- [x] \`npx vitest run\` — 20/20 passing (added 2 tests covering email exclusion + case-insensitive match)
- [ ] Reload \`/mission-control/subscriptions\` and verify conversion % moves up; copy shows "N test/internal users excluded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)