### PR TITLE
fix(mission-control): conversion now counts every completed trial

### DIFF
--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -172,13 +172,14 @@ export default async function SubscriptionsDashboardPage() {
         </section>
 
         <section className="space-y-3">
-          <h2 className="font-display text-xl font-semibold">Conversion · 30-day rolling</h2>
+          <h2 className="font-display text-xl font-semibold">Conversion · last {metrics.conversion.windowDays} days</h2>
           <Card variant="flat">
             <CardContent className="py-6">
               {metrics.conversion.percent === null ? (
                 <p className="text-sm text-muted-foreground">
-                  Not enough data yet. {metrics.conversion.sample} trial
-                  {metrics.conversion.sample === 1 ? '' : 's'} completed in the cohort window (need ≥5 to compute).
+                  Not enough data yet. {metrics.conversion.sample} completed trial
+                  {metrics.conversion.sample === 1 ? '' : 's'} in the last {metrics.conversion.windowDays} days (need ≥5
+                  to compute).
                   {metrics.conversion.excluded > 0 &&
                     ` ${metrics.conversion.excluded} test/internal user${metrics.conversion.excluded === 1 ? '' : 's'} excluded.`}
                 </p>
@@ -186,8 +187,9 @@ export default async function SubscriptionsDashboardPage() {
                 <div className="space-y-1">
                   <div className="font-display text-4xl font-bold">{metrics.conversion.percent}%</div>
                   <p className="text-sm text-muted-foreground">
-                    {metrics.conversion.converted} of {metrics.conversion.sample} trials started 31–60 days ago paid at
-                    least once (active or past_due). Trials still in flight are excluded.
+                    {metrics.conversion.converted} of {metrics.conversion.sample} completed trials in the last{' '}
+                    {metrics.conversion.windowDays} days are now paying (active or past_due). Trials still in flight are
+                    excluded.
                     {metrics.conversion.excluded > 0 &&
                       ` ${metrics.conversion.excluded} test/internal user${metrics.conversion.excluded === 1 ? '' : 's'} excluded.`}
                   </p>

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -196,41 +196,44 @@ describe('computeConversion', () => {
 
   it('returns null percent when sample < 5', () => {
     const subs = [
-      makeSub({ status: 'active', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      makeSub({ status: 'canceled', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
+      makeSub({ status: 'active', trialEnd: now - 7 * day }),
+      makeSub({ status: 'canceled', trialEnd: now - 7 * day }),
     ];
     const result = computeConversion(subs, now);
     expect(result.sample).toBe(2);
     expect(result.percent).toBeNull();
   });
 
-  it('counts active and past_due as converted; excludes still-in-flight and out-of-window', () => {
+  it('counts active and past_due as converted; trial-end-in-future is excluded', () => {
     const subs = [
-      // In window, completed, active → converted
-      makeSub({ status: 'active', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      makeSub({ status: 'active', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
-      makeSub({ status: 'active', trialStart: now - 55 * day, trialEnd: now - 48 * day }),
-      // In window, completed, past_due → converted (paid at least once, now in dunning)
-      makeSub({ status: 'past_due', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      // In window, completed, canceled → in sample, not converted
-      makeSub({ status: 'canceled', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      makeSub({ status: 'canceled', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
-      // Trial too recent (started < 30d ago) → excluded
-      makeSub({ status: 'trialing', trialStart: now - 5 * day, trialEnd: now + 2 * day }),
-      // Trial older than 60d → excluded
-      makeSub({ status: 'active', trialStart: now - 80 * day, trialEnd: now - 73 * day }),
-      // Trial still in flight (trial_end > now) → excluded — does not penalize conversion
-      makeSub({ status: 'trialing', trialStart: now - 35 * day, trialEnd: now + 1 * day }),
+      // Recent conversions (trial just ended) — these were the bug: previously excluded
+      makeSub({ status: 'active', trialEnd: now - 1 * day }),
+      makeSub({ status: 'active', trialEnd: now - 3 * day }),
+      makeSub({ status: 'active', trialEnd: now - 10 * day }),
+      // past_due — paid at least once, currently in dunning → converted
+      makeSub({ status: 'past_due', trialEnd: now - 5 * day }),
+      // canceled after trial — counts in sample, not converted
+      makeSub({ status: 'canceled', trialEnd: now - 5 * day }),
+      makeSub({ status: 'canceled', trialEnd: now - 20 * day }),
+      // Trial still in flight — excluded so it doesn't penalize conversion
+      makeSub({ status: 'trialing', trialEnd: now + 2 * day }),
+      // No trial at all — excluded (can't measure trial conversion on a non-trial sub)
+      makeSub({ status: 'active', trialEnd: null }),
     ];
     const result = computeConversion(subs, now);
     expect(result.sample).toBe(6);
     expect(result.converted).toBe(4);
-    expect(result.percent).toBe(67); // 4/6 = 66.67% → rounds to 67
+    expect(result.percent).toBe(67); // 4/6 = 66.67% → 67
+  });
+
+  it('reports the windowDays passed by caller', () => {
+    const result = computeConversion([], now, undefined, 90);
+    expect(result.windowDays).toBe(90);
   });
 
   it('handles zero sample', () => {
     expect(computeConversion([], now)).toEqual({
-      window: '30d',
+      windowDays: expect.any(Number),
       sample: 0,
       converted: 0,
       percent: null,
@@ -247,24 +250,14 @@ describe('computeConversion', () => {
     ]);
     const subs = [
       // Real cohort: 5 users, 4 converted → 80%
-      makeSub({ status: 'active', email: 'a@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      makeSub({ status: 'active', email: 'b@example.com', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
-      makeSub({ status: 'active', email: 'c@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      makeSub({ status: 'active', email: 'd@example.com', trialStart: now - 50 * day, trialEnd: now - 43 * day }),
-      makeSub({ status: 'canceled', email: 'e@example.com', trialStart: now - 45 * day, trialEnd: now - 38 * day }),
-      // Test users in the same cohort window — must NOT be in sample
-      makeSub({
-        status: 'canceled',
-        email: 'cartermheidt@gmail.com',
-        trialStart: now - 45 * day,
-        trialEnd: now - 38 * day,
-      }),
-      makeSub({
-        status: 'canceled',
-        email: 'dallasheidt@gmail.com',
-        trialStart: now - 50 * day,
-        trialEnd: now - 43 * day,
-      }),
+      makeSub({ status: 'active', email: 'a@example.com', trialEnd: now - 5 * day }),
+      makeSub({ status: 'active', email: 'b@example.com', trialEnd: now - 5 * day }),
+      makeSub({ status: 'active', email: 'c@example.com', trialEnd: now - 5 * day }),
+      makeSub({ status: 'active', email: 'd@example.com', trialEnd: now - 5 * day }),
+      makeSub({ status: 'canceled', email: 'e@example.com', trialEnd: now - 5 * day }),
+      // Test users — must NOT be in sample
+      makeSub({ status: 'canceled', email: 'cartermheidt@gmail.com', trialEnd: now - 5 * day }),
+      makeSub({ status: 'canceled', email: 'dallasheidt@gmail.com', trialEnd: now - 5 * day }),
     ];
     const result = computeConversion(subs, now, excluded);
     expect(result.sample).toBe(5);
@@ -275,16 +268,21 @@ describe('computeConversion', () => {
 
   it('email match is case-insensitive', () => {
     const excluded = new Set(['dallasheidt@gmail.com']);
-    const subs = [
-      makeSub({
-        status: 'canceled',
-        email: 'DallasHeidt@Gmail.com',
-        trialStart: now - 45 * day,
-        trialEnd: now - 38 * day,
-      }),
-    ];
+    const subs = [makeSub({ status: 'canceled', email: 'DallasHeidt@Gmail.com', trialEnd: now - 5 * day })];
     const result = computeConversion(subs, now, excluded);
     expect(result.sample).toBe(0);
     expect(result.excluded).toBe(1);
+  });
+
+  it('regression: a 7-day trial that started 10 days ago and converted IS counted', () => {
+    // This was the reported bug: the old logic required trial_start to be 31-60d ago,
+    // so a recently-converted trial (typical case for a young business) was dropped.
+    const subs = Array.from({ length: 9 }, (_, i) =>
+      makeSub({ status: 'active', email: `user${i}@example.com`, trialEnd: now - 3 * day })
+    );
+    const result = computeConversion(subs, now);
+    expect(result.sample).toBe(9);
+    expect(result.converted).toBe(9);
+    expect(result.percent).toBe(100);
   });
 });

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -35,7 +35,7 @@ export type SubscriptionMetrics = {
     list: PastDueEntry[];
   };
   conversion: {
-    window: '30d';
+    windowDays: number; // size of the lookback window
     sample: number;
     converted: number;
     percent: number | null;
@@ -46,8 +46,7 @@ export type SubscriptionMetrics = {
 };
 
 const SECONDS_PER_DAY = 86_400;
-const COHORT_LOOKBACK_DAYS = 60;
-const COHORT_TRIAL_END_THRESHOLD_DAYS = 30;
+const COHORT_LOOKBACK_DAYS = 90;
 const MIN_COHORT_SAMPLE = 5;
 
 /**
@@ -173,18 +172,23 @@ export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[
 }
 
 /**
- * 30-day rolling conversion: of trials whose `trial_start` was 31–60 days ago
- * AND whose `trial_end` has passed, what % paid at least once?
+ * Trial conversion: of trials that have ENDED in the lookback window, what
+ * percentage are now paying customers?
  *
- * "Paid at least once" = current status is `active` OR `past_due`. past_due
+ * Cohort (denominator): every subscription with a `trial_end` in the past.
+ * The list is bounded by what the caller fetched from Stripe (typically the
+ * last 90 days of subscription creations), which is reflected in
+ * `windowDays`.
+ *
+ * Converted (numerator): current status is `active` OR `past_due`. past_due
  * means the first invoice was paid and a subsequent renewal failed — they
- * still converted, they're just in dunning now. Excluding them would
- * understate the true conversion rate.
+ * still converted, they're just in dunning now.
  *
- * Trials still in flight (trial_end >= now) are excluded — including them
- * would penalize conversion for users who haven't had a chance to convert
- * yet. The trial_start cutoff at 30d ago guarantees this is impossible
- * for typical trial lengths, but we keep the explicit filter for safety.
+ * Trials still in flight (`trial_end >= now`) are excluded so they don't
+ * penalize the percentage before they've had a chance to convert.
+ *
+ * Internal/test emails are excluded from both numerator and denominator and
+ * counted separately.
  *
  * Returns null percent when sample < MIN_COHORT_SAMPLE so the UI can show
  * "not enough data yet".
@@ -192,19 +196,15 @@ export function buildPastDue(subs: Stripe.Subscription[]): { list: PastDueEntry[
 export function computeConversion(
   subs: Stripe.Subscription[],
   now: number,
-  excludedEmails: Set<string> = getExcludedEmails()
-): { window: '30d'; sample: number; converted: number; percent: number | null; excluded: number } {
-  const lookbackStart = now - COHORT_LOOKBACK_DAYS * SECONDS_PER_DAY;
-  const trialEndCutoff = now - COHORT_TRIAL_END_THRESHOLD_DAYS * SECONDS_PER_DAY;
-
+  excludedEmails: Set<string> = getExcludedEmails(),
+  windowDays: number = COHORT_LOOKBACK_DAYS
+): { windowDays: number; sample: number; converted: number; percent: number | null; excluded: number } {
   let sample = 0;
   let converted = 0;
   let excluded = 0;
   for (const sub of subs) {
-    if (!sub.trial_start || !sub.trial_end) continue;
-    if (sub.trial_start < lookbackStart) continue;
-    if (sub.trial_start >= trialEndCutoff) continue;
-    if (sub.trial_end >= now) continue;
+    if (!sub.trial_end) continue; // never had a trial → not part of "did the trial convert?"
+    if (sub.trial_end >= now) continue; // trial still in flight
     if (excludedEmails.has(getCustomerEmail(sub).toLowerCase())) {
       excluded += 1;
       continue;
@@ -214,7 +214,7 @@ export function computeConversion(
   }
 
   const percent = sample >= MIN_COHORT_SAMPLE ? Math.round((converted / sample) * 100) : null;
-  return { window: '30d', sample, converted, percent, excluded };
+  return { windowDays, sample, converted, percent, excluded };
 }
 
 async function listAll(params: Stripe.SubscriptionListParams): Promise<Stripe.Subscription[]> {


### PR DESCRIPTION
## Summary
**The bug**: previous conversion logic required \`trial_start\` to be 31–60 days ago. With Stripe's 7-day default trial, every recently-converted user (started 10d ago, paid 3d ago) was excluded as "too recent." For a young business with most subs created in the last 30 days, the cohort was effectively empty and the dashboard reported "not enough data" even though 9 subs were paying.

**The fix**: drop the artificial 30-day buffer. Cohort is now every subscription whose trial has ended in the lookback window. Window widened from 60 → 90 days. Numerator unchanged (active OR past_due). Email exclusion unchanged. Trials still in flight remain excluded.

## Changes
- \`computeConversion\`: removed \`trial_start ∈ [60d, 30d]\` filter; now just checks \`trial_end < now\`
- \`SubscriptionMetrics.conversion.window\` → \`windowDays: number\` (surfaced in UI as "last N days")
- Default window: 60d → 90d
- UI heading: "Conversion · 30-day rolling" → "Conversion · last 90 days"
- Body copy: "trials started 31–60 days ago paid at least once" → "completed trials in the last 90 days are now paying"

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` / \`npx prettier --check\` clean
- [x] \`npx vitest run\` — 22/22 passing including a regression test for the exact reported case (9 subs with trial_end 3d ago should yield 100%)
- [ ] Reload \`/mission-control/subscriptions\` — conversion should show a real %, no longer "not enough data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)