### PR TITLE
fix(hygiene): correct U18/U19 collapse in fix-age-year-discrepancies workflow

### DIFF
--- a/scripts/fix_team_age_groups.py
+++ b/scripts/fix_team_age_groups.py
@@ -38,8 +38,12 @@ def calculate_age_group(birth_year: int) -> str:
 
     Formula: age_group = CURRENT_YEAR - birth_year + 1
     Season year rolls over on Aug 1.
+    U18 is merged into U19 to match the canonical AGE_GROUPS keyset
+    (config/settings.py) and team_name_utils.canonicalize_age_group.
     """
     age = CURRENT_YEAR - birth_year + 1
+    if age == 18:
+        age = 19
     if 7 <= age <= 19:
         return f"u{age}"
     return None
@@ -50,20 +54,24 @@ def extract_birth_year(team_name: str) -> int:
 
     Handles multiple formats:
     - Single year: "Team 2014" → 2014
-    - Two years with slash: "Team 2013/2014" → 2013 (use older/first year)
-    - Two years with dash: "Team 2009-2010" → 2009 (use older/first year)
-    - Two years after letter: "B2013/2014" → 2013 (use older/first year)
+    - Two years with slash: "Team 2013/2014" → 2013 (older/primary cohort)
+    - Two years with dash: "Team 2009-2010" → 2009 (older/primary cohort)
+    - Two years after letter: "B2013/2014" → 2013 (older/primary cohort)
+
+    PitchRank business rule (per Dallas, 2026-05-01): for dual-age teams
+    we always take the OLDER cohort — older birth year (smaller number) for
+    year pairs, higher U-age for U-age pairs. Both forms refer to the
+    same older players. So 2012/2013 → 2012 (= U14), and u10/u11 → u11.
 
     Returns the birth year if found and valid, None otherwise.
     """
     # First, check for two-year patterns like "2013/2014" or "2009-2010" or "B2013/2014"
-    # Use the FIRST (older) year in these cases
     # Note: Using (?<![0-9]) instead of \b to allow patterns like "B2013/2014"
     two_year_match = re.search(r"(?<![0-9])(20\d{2})[/-](20\d{2})(?![0-9])", team_name)
     if two_year_match:
         year1 = int(two_year_match.group(1))
         year2 = int(two_year_match.group(2))
-        # Use the older (smaller) year
+        # Use the older (smaller) year — primary cohort per business rule
         year = min(year1, year2)
         if 2005 <= year <= 2018:
             return year
@@ -75,7 +83,7 @@ def extract_birth_year(team_name: str) -> int:
         year2_short = int(short_year_match.group(2))
         # Convert short year to full year (e.g., 14 -> 2014)
         year2 = 2000 + year2_short
-        # Use the older (smaller) year
+        # Use the older (smaller) year — primary cohort per business rule
         year = min(year1, year2)
         if 2005 <= year <= 2018:
             return year

--- a/scripts/normalize_team_names.py
+++ b/scripts/normalize_team_names.py
@@ -157,7 +157,10 @@ def normalize_team_name(team_name: str, club_name: str = None) -> str:
             result_tokens.append(parsed_age)
             continue
 
-        # Handle combined age patterns like '15/16B' - take oldest year
+        # Handle combined age patterns like '15/16B' - take older (smaller) year.
+        # PitchRank business rule: dual-age teams classify as the OLDER cohort
+        # (older birth year for year pairs, higher U-age for U-age pairs — both
+        # refer to the same older players). So '15/16 → 2015 (= U11).
         slash_match = re.match(r"^(\d{2})/(\d{2})([BbGgMmFf])?$", clean_token)
         if slash_match and age_found is None:
             y1, y2 = int(slash_match.group(1)), int(slash_match.group(2))


### PR DESCRIPTION
## Summary

The Tuesday `Fix Age Year Discrepancies` hygiene workflow had a single correctness bug: its embedded `calculate_age_group()` returned `u18` for 2008-born teams, but PitchRank's canonical `AGE_GROUPS` (`config/settings.py:91-101`) merges U18 into U19. Result: every workflow run was silently flipping ~4,777 correctly-tagged `u19` teams down to non-canonical `u18`.

This PR adds the U18→U19 collapse to match the canonical helper at `src/utils/team_name_utils.py:530-531`. Also documents the dual-age business rule in both scripts so future edits don't drift again.

## Changes

- `scripts/fix_team_age_groups.py:36-89`
  - `calculate_age_group()` now collapses U18 → U19
  - `extract_birth_year()` docstring documents the older-cohort rule (logic unchanged; `min` was already correct)
- `scripts/normalize_team_names.py:160-170`
  - Slash-token branch comment now correctly states the rule (logic unchanged)

## Validation

Local dry run against prod DB before this PR:

| Run | Mismatch count | Shape |
|---|---|---|
| Pre-fix | 4,783 (count includes the 4,777 u18→u19 + 6 u20→u19/u17→u19 edge cases that were also broken) | All cases the canonical helper would have caught |
| Post-fix | 4,777 | 100% `u18 → u19` — zero spurious changes |

All 18 self-test cases pass, including:
- Single-year: 2015→u11, 2014→u12, 2013→u13, 2012→u14, 2011→u15, 2010→u16, 2009→u17, 2008→u19, 2007→u19
- Dual-age (older cohort wins): `Raymond Rams U14 2012-13`→u14, `HJR U15 Elite 2011-14`→u15, `2012/2013`→u14, `Cannon High 2008-2012`→u19

## Test plan

- [x] Dry run matches expectations (4,777 u18→u19 only)
- [x] Self-tests pass for all canonical and dual-age forms
- [ ] Run workflow with `dry_run=true` from the Actions tab post-merge to confirm CI behavior
- [ ] First scheduled Tuesday run: spot-check `logs/step2_fix_age.log` artifact

## Notes

- Workflow YAML (`.github/workflows/fix-age-year-discrepancies.yml`) is unchanged — it just shells out to the two scripts.
- `src/utils/team_name_utils.py:503-512` (canonical helper, slash dual-age branch) still uses `max` for `'10/11`-style 2-digit tokens, contradicting the older-cohort business rule. Out of scope here; flagged in `gotcha_slash_age_tokens.md` for a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)