### PR TITLE
fix(gotsport): API-first canonical team_id resolution + alias-map pollution audit

### DIFF
--- a/.claude/skills/scraper-patterns.skill.md
+++ b/.claude/skills/scraper-patterns.skill.md
@@ -46,6 +46,60 @@ time.sleep(1.0)
 time.sleep(random.uniform(0.1, 2.5))
 ```
 
+## GotSport Endpoint Quirks
+
+GotSport event pages expose three different schedule URLs with very different
+contents. Pick the right one for the event type, or you will silently miss
+games.
+
+### Per-group page (`/schedules?group={X}`)
+
+- One big match table per page, columns: `Match # | Time | Home Team | Results | Away Team | Location | Division`.
+- Tournament-style events: shows played + upcoming. Parser-friendly. Default walk target.
+- League/season events (NPL, CCL, ECNL season brackets): shows **upcoming fixtures only**. Played history is NOT here. The "Results" column is `-` for every visible row.
+
+### Per-group results page (`/results?group={X}`)
+
+- Round-robin standings matrix (NxN team grid). Cells contain `2-0`, `3-1`, `-`, etc.
+- **No per-game dates, no venues, no match IDs** — useless to the existing `_parse_games_from_schedule_page` parser.
+- Do not try to add this as a parser target.
+
+### Per-team page (`/schedules?team={REGISTRATION_ID}`)
+
+- One `<table>` per match for the team's full event schedule (past + future).
+- Same 7-column layout as the per-group page, so the existing parser handles each table without changes.
+- **Required for league/season events** — this is the only endpoint that surfaces played history with real dates.
+- **Must use the registration ID, not the API team ID.** `/schedules?team={api_id}` redirects to `home.gotsport.com/login/`. Registration IDs come from the `team={\d+}` query param in per-group page hrefs (also accumulated in `api_team_id_cache` after the per-group walk).
+- **No longer exposes `rankings.gotsport.com/teams/{api_id}` or `system.gotsport.com/teams/{api_id}` anchor links** as of 2026-05-01. The legacy HTML-scraping strategies in `_resolve_api_team_id_from_event_page` (rankings link parse, `/teams/{id}` link parse, JS `team_id` parse) are dead — the only team-id-bearing link on the page is `/matches_export?team={reg_id}`, which is the registration ID, not the API ID. Use the JSON API instead (next subsection).
+
+### API endpoint (`/api/v1/teams/{id}/matches?past=true`)
+
+- Source of truth for canonical team_id resolution. **Not CAPTCHA-protected** (verified 2026-05-01) even on events whose HTML pages are CAPTCHA-gated.
+- Status-based classifier:
+  - `200` + non-empty list → `{id}` is a valid API team ID. Each match has `homeTeam.team_id` (canonical), `home_team_reg_id` (per-event registration), and the away mirrors. Match the queried `{id}` against `home_team_reg_id` / `away_team_reg_id` to pick the right canonical `team_id`.
+  - `200` + non-empty list with NO self-match → conservatively treat as unresolved. Promoting `{id}` would risk re-injecting a registration ID into `team_alias_map` as if it were canonical.
+  - `200` + empty list → ambiguous (brand-new team, or stale id). Treat as unresolved.
+  - `404` → `{id}` is a registration ID, not an API team ID. Deterministic.
+- Resolver lives at `src/scrapers/gotsport.py:_resolve_api_team_id_from_event_page` and routes through the module-level `_zenrows_get` helper. ZenRows uses basic proxy (`js_render=false`) since this is a JSON endpoint — ~1 credit per call vs ~25 with JS render.
+
+### HTML-CAPTCHA failure vs API-resolution failure
+
+These are different failure modes with different telemetry surfaces:
+
+- **HTML CAPTCHA** (event main page, per-team schedule page): `_fetch_event_page` raises `EventCaptchaGatedError` and `_write_captcha_artifact` writes `reports/<event_key>/intake/captcha_challenge.json`. Operators can replay these via a future CAPTCHA-solver integration.
+- **API resolution failure** (4xx/5xx/timeout from `_resolve_api_team_id_from_event_page`): the resolver returns `None`, the parser drops the row, and `scrape_games_from_schedule_pages` increments `self._last_resolution_metrics["dropped_unresolved"]`. The per-event summary JSON (`data/raw/new_events_*_summary.json`) carries `teams_resolved` / `teams_unresolved` / `games_dropped_unresolved`. **No `captcha_challenge.json` is written for API failures** — the API isn't CAPTCHA-protected, so non-200 means a different class of failure (registration ID, gotsport API outage, ZenRows budget exhausted). Look at `_last_resolution_metrics["dropped_unresolved"]` and the workflow logs, not at `reports/<event_key>/intake/`.
+
+### Walking pattern in `scrape_games_from_schedule_pages`
+
+1. Per-group walk first (always — populates `api_team_id_cache` keyed by reg_id).
+2. Per-team walk second, iterating `api_team_id_cache.keys()` and calling the same parser.
+3. Validator dedup (`provider:date:sorted_team_ids`) collapses the home/away duplicates.
+4. Disable per-team walk with `GOTSPORT_SKIP_PER_TEAM_WALK=1`. Cap with `GOTSPORT_MAX_TEAM_PAGES` (default 200).
+
+### Tournament vs season-event runtime
+
+Per-team walk roughly 5x's the HTTP request count vs per-group walk alone (~96 team pages vs ~20 group pages for a typical event). Stays well under the 3-hour workflow timeout but will exceed the `GOTSPORT_EVENT_TIMEOUT=240s` warn-only threshold for some events.
+
 ## Request Pattern
 
 ### Standard Request

--- a/.github/workflows/auto-gotsport-event-scrape.yml
+++ b/.github/workflows/auto-gotsport-event-scrape.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Run GotSport Event Scraper
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          # Intentional aliasing: one secret feeds two env-var names because
+          # different scripts read different keys for the same value (see
+          # memory note gotcha_supabase_key_env_mismatch.md). DO NOT collapse.
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          ZENROWS_API_KEY: ${{ secrets.ZENROWS_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}
           # Performance settings - balanced for speed + completeness
           GOTSPORT_DELAY_MIN: '0.1'

--- a/.github/workflows/auto-gotsport-upcoming-event-scrape.yml
+++ b/.github/workflows/auto-gotsport-upcoming-event-scrape.yml
@@ -49,8 +49,12 @@ jobs:
       - name: Run upcoming event fixture scraper
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          # Intentional aliasing: one secret feeds two env-var names because
+          # different scripts read different keys for the same value (see
+          # memory note gotcha_supabase_key_env_mismatch.md). DO NOT collapse.
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          ZENROWS_API_KEY: ${{ secrets.ZENROWS_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}
           GOTSPORT_DELAY_MIN: "0.1"
           GOTSPORT_DELAY_MAX: "0.2"

--- a/scripts/audit_polluted_gotsport_aliases.py
+++ b/scripts/audit_polluted_gotsport_aliases.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Audit and quarantine GotSport team_alias_map rows polluted with registration IDs.
+
+Some GotSport `team_alias_map` rows with `match_method='fuzzy_auto'` were
+created by an earlier scraper bug that shipped per-event registration IDs as
+`provider_team_id` when the canonical API team ID could not be resolved.
+Registration IDs are not stable cross-event; treating them as canonical lets a
+future event recycle the same numeric reg_id for a different team and silently
+mis-route via the alias map.
+
+This script validates each fuzzy_auto row's `provider_team_id` against the
+GotSport JSON API at `/api/v1/teams/{id}/matches?past=true`:
+
+    - 200 + match list contains row's `provider_team_id` as a `home_team_reg_id`
+      or `away_team_reg_id` → `valid_api_id_self_match` (canonical, keep).
+    - 200 + non-empty list with NO self-match → `valid_api_id_no_self_match`
+      (suspect; default action: quarantine, override with --keep-no-self-match).
+    - 200 + empty list → `ambiguous` (don't quarantine, log for manual review).
+    - 404 → `registration_id` (quarantine candidate).
+    - 5xx / network error / non-list JSON → `unknown_<reason>` (skip).
+
+Quarantine action sets `review_status='needs_review'`. Rows are not deleted —
+the audit trail and the master team mapping are preserved so a future operator
+can either re-approve or merge.
+
+Usage:
+    python scripts/audit_polluted_gotsport_aliases.py                    # dry-run, all rows
+    python scripts/audit_polluted_gotsport_aliases.py --limit 50         # dry-run, sample
+    python scripts/audit_polluted_gotsport_aliases.py --apply            # mutate
+    python scripts/audit_polluted_gotsport_aliases.py --apply --keep-no-self-match
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+import requests  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
+
+# Module-level helper from the same scraper module so the audit doesn't need
+# a full GotsportScraper instance (whose __init__ does a Supabase providers
+# round-trip and other heavyweight setup).
+from src.scrapers.gotsport import _zenrows_get  # noqa: E402
+from supabase import create_client  # noqa: E402
+
+# Load environment variables (mirrors maintain_gotsport_direct_id_aliases.py:30-34)
+env_local = Path(".env.local")
+if env_local.exists():
+    load_dotenv(env_local, override=True)
+else:
+    load_dotenv()
+
+supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY"))
+
+
+CSV_COLUMNS = (
+    "id",
+    "provider_id",
+    "provider_team_id",
+    "team_id_master",
+    "match_method",
+    "review_status",
+    "api_status_code",
+    "api_match_count",
+    "self_match_found",
+    "verdict",
+    "decision_at",
+)
+
+
+def get_gotsport_provider_id() -> str:
+    """Look up GotSport provider UUID from providers table."""
+    result = supabase.table("providers").select("id").eq("code", "gotsport").execute()
+    if not result.data:
+        raise ValueError("GotSport provider not found in providers table")
+    return result.data[0]["id"]
+
+
+def fetch_fuzzy_auto_aliases(provider_id: str, limit: int | None) -> list[dict]:
+    """Paginate through team_alias_map for the provider's fuzzy_auto + approved rows."""
+    rows: list[dict] = []
+    page_size = 1000
+    offset = 0
+
+    while True:
+        result = (
+            supabase.table("team_alias_map")
+            .select("id,provider_id,provider_team_id,team_id_master,match_method,review_status")
+            .eq("provider_id", provider_id)
+            .eq("match_method", "fuzzy_auto")
+            .eq("review_status", "approved")
+            .not_.is_("provider_team_id", "null")
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+
+        if not result.data:
+            break
+        rows.extend(result.data)
+        if limit is not None and len(rows) >= limit:
+            return rows[:limit]
+        if len(result.data) < page_size:
+            break
+        offset += page_size
+
+    return rows
+
+
+def classify_alias(
+    session: requests.Session,
+    api_key: str | None,
+    provider_team_id: str,
+) -> tuple[int | None, int, bool, str]:
+    """Validate a single alias against the GotSport API.
+
+    Returns ``(api_status_code, api_match_count, self_match_found, verdict)``.
+    Mirrors the resolver branches in src/scrapers/gotsport.py:_resolve_api_team_id_from_event_page.
+    """
+    api_url = f"https://system.gotsport.com/api/v1/teams/{provider_team_id}/matches?past=true"
+
+    try:
+        response = _zenrows_get(session, api_key, api_url, timeout=10, delay_min=0.1, delay_max=0.3)
+    except requests.RequestException as e:
+        return (None, 0, False, f"unknown_{type(e).__name__}")
+
+    status = response.status_code
+    if status == 404:
+        return (status, 0, False, "registration_id")
+    if status != 200:
+        return (status, 0, False, f"unknown_status_{status}")
+
+    try:
+        body = response.json()
+    except (ValueError, AttributeError):
+        return (status, 0, False, "unknown_non_json_body")
+
+    if not isinstance(body, list):
+        return (status, 0, False, "unknown_non_list_body")
+
+    if not body:
+        return (status, 0, False, "ambiguous")
+
+    # Self-match is on homeTeam.team_id / awayTeam.team_id (verified live
+    # 2026-05-01 — the gotsport API endpoint only accepts api_team_ids and
+    # always returns matches where the queried id is one of the teams).
+    # Reg_id fields in the response are the per-match registration IDs of
+    # both teams, NOT the queried team's reg_id.
+    target = str(provider_team_id)
+    self_match = False
+    for match in body:
+        if not isinstance(match, dict):
+            continue
+        home_tid = str((match.get("homeTeam") or {}).get("team_id"))
+        away_tid = str((match.get("awayTeam") or {}).get("team_id"))
+        if home_tid == target or away_tid == target:
+            self_match = True
+            break
+
+    if self_match:
+        return (status, len(body), True, "valid_api_id_self_match")
+    return (status, len(body), False, "valid_api_id_no_self_match")
+
+
+def write_csv(report_rows: list[dict], output_path: Path) -> None:
+    """Write report to CSV with explicit column ordering."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for row in report_rows:
+            writer.writerow({col: row.get(col, "") for col in CSV_COLUMNS})
+
+
+def main(args: argparse.Namespace) -> None:
+    print("=" * 80)
+    print("GotSport Polluted Alias Audit")
+    print("=" * 80)
+
+    if not args.apply:
+        print("\nDRY RUN MODE - No DB changes will be made (use --apply to mutate)\n")
+
+    api_key = os.getenv("ZENROWS_API_KEY")
+    if not api_key:
+        print("WARNING: ZENROWS_API_KEY not set; calls will go direct to gotsport (risk of IP blocking)")
+
+    provider_id = get_gotsport_provider_id()
+    print(f"GotSport provider_id: {provider_id}")
+
+    print("Fetching fuzzy_auto + approved aliases...")
+    aliases = fetch_fuzzy_auto_aliases(provider_id, args.limit)
+    print(f"Retrieved {len(aliases)} aliases for validation")
+
+    if not aliases:
+        print("\nNothing to audit.")
+        write_csv([], Path(args.output or _default_output_path()))
+        return
+
+    session = requests.Session()
+    session.headers.update(
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            )
+        }
+    )
+
+    decision_at = datetime.utcnow().isoformat() + "Z"
+    report_rows: list[dict] = []
+    for idx, alias in enumerate(aliases, start=1):
+        provider_team_id = alias["provider_team_id"]
+        status, match_count, self_match, verdict = classify_alias(session, api_key, provider_team_id)
+
+        report_rows.append(
+            {
+                "id": alias["id"],
+                "provider_id": alias["provider_id"],
+                "provider_team_id": provider_team_id,
+                "team_id_master": alias.get("team_id_master") or "",
+                "match_method": alias["match_method"],
+                "review_status": alias["review_status"],
+                "api_status_code": status if status is not None else "",
+                "api_match_count": match_count,
+                "self_match_found": self_match,
+                "verdict": verdict,
+                "decision_at": decision_at,
+            }
+        )
+
+        if idx % 50 == 0 or idx == len(aliases):
+            print(f"  Validated {idx}/{len(aliases)}...")
+
+    output_path = Path(args.output or _default_output_path())
+    write_csv(report_rows, output_path)
+
+    verdict_counts = Counter(row["verdict"] for row in report_rows)
+
+    quarantine_verdicts = {"registration_id"}
+    if not args.keep_no_self_match:
+        quarantine_verdicts.add("valid_api_id_no_self_match")
+
+    quarantine_candidates = [r for r in report_rows if r["verdict"] in quarantine_verdicts]
+
+    print("\nVerdict counts:")
+    for verdict, count in sorted(verdict_counts.items()):
+        print(f"  {verdict:<35s} {count:>6d}")
+    print(f"\nQuarantine candidates: {len(quarantine_candidates)}")
+    print(f"Report CSV: {output_path}")
+
+    if not args.apply:
+        print("\nDRY RUN — no DB changes made. Re-run with --apply to mutate.")
+        return
+
+    if not quarantine_candidates:
+        print("\nNothing to quarantine.")
+        return
+
+    print(f"\nUpdating {len(quarantine_candidates)} aliases to review_status='needs_review'...")
+    updated_count = 0
+    error_count = 0
+    for row in quarantine_candidates:
+        try:
+            supabase.table("team_alias_map").update({"review_status": "needs_review"}).eq("id", row["id"]).execute()
+            updated_count += 1
+            if updated_count % 100 == 0:
+                print(f"  Updated {updated_count}/{len(quarantine_candidates)}...")
+        except Exception as e:
+            print(f"  Error updating alias {row['id']}: {e}")
+            error_count += 1
+
+    print(f"\nUpdated {updated_count} aliases")
+    if error_count:
+        print(f"Errors: {error_count}")
+
+    # Verification re-read (mirrors maintain_gotsport_direct_id_aliases.py:132-152)
+    print("\nVerifying updates...")
+    quarantined_ids = [row["id"] for row in quarantine_candidates]
+    verified_review = 0
+    for i in range(0, len(quarantined_ids), 100):
+        batch = quarantined_ids[i : i + 100]
+        verify_result = (
+            supabase.table("team_alias_map").select("id,review_status").in_("id", batch).execute()
+        )
+        for record in verify_result.data or []:
+            if record.get("review_status") == "needs_review":
+                verified_review += 1
+
+    print(f"Verified {verified_review}/{len(quarantine_candidates)} now have review_status='needs_review'")
+
+
+def _default_output_path() -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"data/exports/audit_polluted_gotsport_aliases_{timestamp}.csv"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Audit and quarantine polluted GotSport team_alias_map rows")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate DB: set review_status='needs_review' on quarantine candidates. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max rows to validate (for testing on a subset).",
+    )
+    parser.add_argument(
+        "--keep-no-self-match",
+        action="store_true",
+        help=(
+            "Do NOT quarantine rows with verdict='valid_api_id_no_self_match' (the suspect "
+            "bucket). Default behavior quarantines them. Off-by-default flag for the "
+            "operator who has independent evidence the no-self-match bucket is safe."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=f"CSV output path. Default: {_default_output_path()}",
+    )
+    main(parser.parse_args())

--- a/scripts/scrape_new_gotsport_events.py
+++ b/scripts/scrape_new_gotsport_events.py
@@ -914,6 +914,7 @@ def scrape_new_events(
                 # Scrape games directly from schedule pages (FAST PATH)
                 # This is more reliable than extract_event_teams and avoids redundant HTTP requests
                 games = scraper.scrape_games_from_schedule_pages(event_id, event_name=event_name, since_date=since_date)
+                metrics = getattr(scraper, "_last_resolution_metrics", {}) or {}
 
                 event_elapsed = (datetime.now() - event_start_time).total_seconds()
 
@@ -934,6 +935,9 @@ def scrape_new_events(
                             "teams_count": teams_count,
                             "games_count": len(games),
                             "status": "success",
+                            "teams_resolved": metrics.get("resolved", 0),
+                            "teams_unresolved": metrics.get("unresolved", 0),
+                            "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                         }
                     )
                     all_games.extend(games)
@@ -950,12 +954,19 @@ def scrape_new_events(
                             "teams_count": 0,
                             "games_count": 0,
                             "status": "no_games",
+                            "teams_resolved": metrics.get("resolved", 0),
+                            "teams_unresolved": metrics.get("unresolved", 0),
+                            "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                         }
                     )
                     console.print(f"  [yellow]⚠️  {event_name}: No games found ({event_elapsed:.1f}s)[/yellow]")
 
             except Exception as e:
                 logger.error(f"Error scraping event {event_id}: {e}")
+                # Best-effort metrics — _last_resolution_metrics may be from
+                # this event's partial run (CAPTCHA gate, network error) or
+                # from a prior event if the exception fired before stash.
+                metrics = getattr(scraper, "_last_resolution_metrics", {}) or {}
                 event_results.append(
                     {
                         "event_id": event_id,
@@ -964,6 +975,9 @@ def scrape_new_events(
                         "games_count": 0,
                         "status": "error",
                         "error": str(e),
+                        "teams_resolved": metrics.get("resolved", 0),
+                        "teams_unresolved": metrics.get("unresolved", 0),
+                        "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                     }
                 )
                 console.print(f"  [red]Error scraping {event_name}: {e}[/red]")

--- a/scripts/scrape_upcoming_gotsport_events.py
+++ b/scripts/scrape_upcoming_gotsport_events.py
@@ -943,6 +943,7 @@ def scrape_upcoming_events(
                 # Scrape games directly from schedule pages (FAST PATH)
                 # This is more reliable than extract_event_teams and avoids redundant HTTP requests
                 games = scraper.scrape_games_from_schedule_pages(event_id, event_name=event_name, since_date=since_date)
+                metrics = getattr(scraper, "_last_resolution_metrics", {}) or {}
                 games = filter_games_to_window(games, window_start, window_end)
 
                 event_elapsed = (datetime.now() - event_start_time).total_seconds()
@@ -964,6 +965,9 @@ def scrape_upcoming_events(
                             "teams_count": teams_count,
                             "games_count": len(games),
                             "status": "success",
+                            "teams_resolved": metrics.get("resolved", 0),
+                            "teams_unresolved": metrics.get("unresolved", 0),
+                            "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                         }
                     )
                     all_games.extend(games)
@@ -980,6 +984,9 @@ def scrape_upcoming_events(
                             "teams_count": 0,
                             "games_count": 0,
                             "status": "no_games",
+                            "teams_resolved": metrics.get("resolved", 0),
+                            "teams_unresolved": metrics.get("unresolved", 0),
+                            "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                         }
                     )
                     console.print(
@@ -988,6 +995,7 @@ def scrape_upcoming_events(
 
             except Exception as e:
                 logger.error(f"Error scraping event {event_id}: {e}")
+                metrics = getattr(scraper, "_last_resolution_metrics", {}) or {}
                 event_results.append(
                     {
                         "event_id": event_id,
@@ -996,6 +1004,9 @@ def scrape_upcoming_events(
                         "games_count": 0,
                         "status": "error",
                         "error": str(e),
+                        "teams_resolved": metrics.get("resolved", 0),
+                        "teams_unresolved": metrics.get("unresolved", 0),
+                        "games_dropped_unresolved": metrics.get("dropped_unresolved", 0),
                     }
                 )
                 console.print(f"  [red]Error scraping {event_name}: {e}[/red]")

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -751,6 +751,48 @@ def _extract_captcha_signals(response: requests.Response, fallback_target_url: s
     )
 
 
+def _zenrows_get(
+    session: requests.Session,
+    api_key: Optional[str],
+    url: str,
+    *,
+    timeout: int,
+    delay_min: float = 0.0,
+    delay_max: float = 0.0,
+) -> requests.Response:
+    """Route a GET through ZenRows when ``api_key`` is set, else direct.
+
+    Module-level so callers can use it without instantiating ``GotsportScraper``
+    (whose ``__init__`` performs a Supabase ``providers`` lookup and other
+    heavyweight setup). The class-level ``_fetch_json_via_zenrows`` shim
+    forwards production calls here with the scraper's session + delay config.
+
+    ``timeout`` is honored on both branches — unlike ``_make_zenrows_request``
+    (line 1298) which hard-codes ``timeout=self.timeout`` regardless of caller
+    intent.
+
+    Post-call jitter mirrors ``_subpage_fetcher`` (line 3037-3038): sleep AFTER
+    the response so the rate limit applies to the gap before the next request,
+    not the latency of this one.
+    """
+    if api_key:
+        zenrows_params = {
+            "apikey": api_key,
+            "url": url,
+            "js_render": "false",
+            "premium_proxy": "true",
+            "proxy_country": "us",
+        }
+        response = session.get("https://api.zenrows.com/v1/", params=zenrows_params, timeout=timeout)
+    else:
+        response = session.get(url, timeout=timeout)
+
+    if delay_min > 0 or delay_max > 0:
+        time.sleep(random.uniform(delay_min, delay_max))
+
+    return response
+
+
 def extract_event_teams_by_bracket_from_soup(soup: BeautifulSoup, event_id: str) -> Dict[str, List[EventTeam]]:
     """Pure-parse counterpart to ``GotsportScraper.extract_event_teams_by_bracket``.
 
@@ -1226,6 +1268,15 @@ class GotsportScraper(ProviderScraper):
         # stale candidates from a prior run don't leak.
         self._matcher_cache: dict[tuple, list[dict[str, Any]]] = {}
 
+        # Per-call resolution metrics from the most recent scrape_games_from_schedule_pages
+        # invocation. Callers (scripts/scrape_new_gotsport_events.py,
+        # scripts/scrape_upcoming_gotsport_events.py) read this immediately
+        # after the call to populate the per-event summary JSON. Per-instance,
+        # not per-call — invocations are sequential per the existing per-event
+        # loops (verified via grep 2026-05-01). Concurrent calls on a single
+        # instance would race; document this if parallelism is added.
+        self._last_resolution_metrics: dict[str, int] = {}
+
         logger.info(
             f"Initialized GotsportScraper "
             f"(skip_team_id_resolution={skip_team_id_resolution}, "
@@ -1296,6 +1347,27 @@ class GotsportScraper(ProviderScraper):
             "proxy_country": "us",
         }
         return self.session.get(zenrows_url, params=zenrows_params, timeout=self.timeout)
+
+    def _fetch_json_via_zenrows(self, url: str, *, timeout: Optional[int] = None) -> requests.Response:
+        """Route a JSON GET through ZenRows when configured, else direct session.
+
+        Class-level shim forwarding to the module-level ``_zenrows_get`` helper.
+        Used by ``_resolve_api_team_id_from_event_page`` (and any future API
+        consumer) so the production scrape carries the configured rate-limit
+        jitter without each call site re-implementing the if/else.
+
+        Unlike ``_make_zenrows_request``, the caller's ``timeout`` argument is
+        honored — passing ``timeout=10`` actually applies a 10s budget instead
+        of being silently overridden by ``self.timeout``.
+        """
+        return _zenrows_get(
+            self.session,
+            self.zenrows_api_key,
+            url,
+            timeout=timeout if timeout is not None else self.timeout,
+            delay_min=self.delay_min,
+            delay_max=self.delay_max,
+        )
 
     def _fetch_event_page(self, event_id: str) -> requests.Response:
         """Fetch the top-level event URL with unified CAPTCHA detection.
@@ -1821,113 +1893,118 @@ class GotsportScraper(ProviderScraper):
         self, event_id: str, registration_id: str, team_name: Optional[str] = None
     ) -> Optional[str]:
         """
-        Resolve GotSport API team ID from event registration ID by following the team's event page.
+        Resolve canonical GotSport API team ID from a per-event registration ID.
 
-        Uses multiple strategies:
-        1. Look for rankings link on team's event schedule page
-        2. Look for direct /teams/{id} links (API team IDs)
-        3. Look for team_id in JavaScript/JSON data on the page
-        4. Try the GotSport API directly with the registration ID (it might work)
+        Calls the gotsport public JSON API at ``/api/v1/teams/{id}/matches?past=true``
+        via ZenRows (when configured). The API is NOT CAPTCHA-protected (verified
+        2026-05-01) and serves as the source of truth after gotsport removed
+        ``rankings.gotsport.com/teams/{api_id}`` links from per-team profile
+        pages — the legacy HTML-scraping strategies (rankings link parse,
+        ``/teams/{id}`` link parse, JS ``team_id`` parse) are dead.
+
+        Resolution outcomes (verified live 2026-05-01):
+
+        - ``200`` + match list where ``homeTeam.team_id == registration_id`` (or
+          ``awayTeam.team_id``) for at least one match → return
+          ``str(registration_id)``. The queried id WAS itself an API team id
+          (the schedule page ``team=`` query param is sometimes the api_id, not
+          the reg_id, despite docs to the contrary).
+        - ``200`` + non-empty list with NO ``homeTeam.team_id`` / ``awayTeam.team_id``
+          self-match → return ``None``. Conservative; defensive against a
+          malformed API response.
+        - ``200`` + empty list → ``None`` (brand-new team, or stale id).
+        - ``404`` → ``None`` (the queried id is a registration id, not an API
+          team id — the API endpoint only accepts api_ids, verified live).
+        - 4xx/5xx/timeout → ``None`` (don't promote on uncertainty).
+
+        NOTE: ``home_team_reg_id`` / ``away_team_reg_id`` in the response are
+        per-event registration IDs of EACH team in the match. They are NOT the
+        queried team's reg_id (the API endpoint doesn't accept reg_ids in the
+        first place — they all 404). Self-match is on ``team_id`` fields only.
 
         Args:
-            event_id: GotSport event ID
-            registration_id: Event registration ID (from schedule page links)
-            team_name: Optional team name for logging
+            event_id: GotSport event ID (kept for signature compatibility; not
+                used by the API path — the API endpoint is per-team, not per-event).
+            registration_id: Event registration ID (from schedule page links).
+            team_name: Optional team name for logging.
 
         Returns:
-            API team ID if found, None otherwise
+            Canonical API team ID as a string when resolvable; ``None`` otherwise.
         """
+        api_url = f"https://system.gotsport.com/api/v1/teams/{registration_id}/matches?past=true"
+        log_label = team_name or registration_id
+
         try:
-            # Step 1: Go to team's event page
-            team_event_url = f"{self.EVENT_BASE}/{event_id}/schedules?team={registration_id}"
-            response = self.session.get(team_event_url, timeout=self.timeout)
-            response.raise_for_status()
+            response = self._fetch_json_via_zenrows(api_url, timeout=10)
 
-            soup = BeautifulSoup(response.text, "html.parser")
+            if response.status_code == 404:
+                logger.debug(
+                    f"API 404 for team {log_label} (reg_id={registration_id}) — "
+                    f"id is a registration ID, not an API team ID"
+                )
+                return None
 
-            # Strategy 1: Find "view rankings" link (most reliable)
-            rankings_links = soup.find_all("a", href=re.compile(r"rankings\.gotsport\.com/teams/\d+", re.I))
+            if response.status_code != 200:
+                logger.warning(
+                    f"API status {response.status_code} for team {log_label} "
+                    f"(reg_id={registration_id}); treating as unresolved"
+                )
+                return None
 
-            if not rankings_links:
-                # Try alternative patterns - might be in text like "View Rankings"
-                all_links = soup.find_all("a", href=True)
-                for link in all_links:
-                    href = link.get("href", "")
-                    if "rankings" in href.lower() and "/teams/" in href:
-                        rankings_links.append(link)
-                        break
+            matches = response.json()
+            if not isinstance(matches, list):
+                logger.warning(
+                    f"API returned non-list body for team {log_label} "
+                    f"(reg_id={registration_id}); treating as unresolved"
+                )
+                return None
 
-            for link in rankings_links:
-                href = link.get("href", "")
-                # Extract team ID from rankings URL: rankings.gotsport.com/teams/{id}
-                match = re.search(r"rankings\.gotsport\.com/teams/(\d+)", href, re.I)
-                if match:
-                    api_team_id = match.group(1)
+            if not matches:
+                logger.info(
+                    f"API returned empty match list for team {log_label} "
+                    f"(reg_id={registration_id}); ambiguous — treating as unresolved"
+                )
+                return None
+
+            queried_str = str(registration_id)
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                home_team = match.get("homeTeam") or {}
+                away_team = match.get("awayTeam") or {}
+                if str(home_team.get("team_id")) == queried_str or str(away_team.get("team_id")) == queried_str:
                     logger.debug(
-                        f"Resolved API team ID {api_team_id} from rankings link for {team_name or registration_id}"
+                        f"Resolved API team ID {queried_str} from self-match "
+                        f"for {log_label}"
                     )
-                    return api_team_id
+                    return queried_str
 
-            # Strategy 2: Look for direct /teams/{id} links (API team IDs, not event registration)
-            # These are links to the team's main page, not event-specific pages
-            team_links = soup.find_all("a", href=re.compile(r"system\.gotsport\.com/teams/\d+", re.I))
-            for link in team_links:
-                href = link.get("href", "")
-                match = re.search(r"/teams/(\d+)", href)
-                if match:
-                    api_team_id = match.group(1)
-                    # Validate this is an API team ID (not the same as registration_id)
-                    if api_team_id != registration_id:
-                        logger.debug(
-                            f"Resolved API team ID {api_team_id} from system.gotsport.com "
-                            f"link for {team_name or registration_id}"
-                        )
-                        return api_team_id
-
-            # Strategy 3: Look for team_id in JavaScript/JSON data on the page
-            scripts = soup.find_all("script")
-            for script in scripts:
-                if script.string:
-                    # Look for patterns like "team_id": 123456 or team_id = 123456
-                    patterns = [
-                        r'"team_id"\s*:\s*(\d+)',
-                        r"'team_id'\s*:\s*(\d+)",
-                        r"team_id\s*=\s*(\d+)",
-                        r'"rankings_team_id"\s*:\s*(\d+)',
-                        r'"api_team_id"\s*:\s*(\d+)',
-                    ]
-                    for pattern in patterns:
-                        matches = re.findall(pattern, script.string, re.IGNORECASE)
-                        for api_team_id in matches:
-                            # Validate it's different from registration_id (likely the API team ID)
-                            if api_team_id != registration_id and len(api_team_id) >= 5:
-                                logger.debug(
-                                    f"Resolved API team ID {api_team_id} from script data "
-                                    f"for {team_name or registration_id}"
-                                )
-                                return api_team_id
-
-            # Strategy 4: Try the GotSport API directly with the registration ID
-            # Some registration IDs might actually be valid API team IDs
-            try:
-                api_url = f"https://system.gotsport.com/api/v1/teams/{registration_id}/matches"
-                api_response = self.session.get(api_url, params={"past": "true"}, timeout=10)
-                if api_response.status_code == 200:
-                    # The registration ID is also a valid API team ID!
-                    logger.debug(
-                        f"Registration ID {registration_id} is a valid API team ID for {team_name or registration_id}"
-                    )
-                    return registration_id
-            except Exception:
-                pass  # API call failed, continue
-
-            logger.debug(
-                f"No API team ID found for team {team_name or registration_id} (registration_id={registration_id})"
+            # 200 + non-empty + no self-match — treat as unresolved. The API
+            # contract is "matches for the queried team" so every match
+            # SHOULD have queried_str as homeTeam.team_id or awayTeam.team_id.
+            # No self-match means a malformed response or contract drift;
+            # don't promote on uncertainty.
+            first = matches[0] if isinstance(matches[0], dict) else {}
+            logger.warning(
+                f"API returned matches but none have queried id={registration_id} as "
+                f"home/away team_id for {log_label}; treating as unresolved "
+                f"(first match home_tid={(first.get('homeTeam') or {}).get('team_id')}, "
+                f"away_tid={(first.get('awayTeam') or {}).get('team_id')})"
             )
             return None
 
-        except Exception as e:
-            logger.debug(f"Error resolving API team ID from event page for {team_name or registration_id}: {e}")
+        except (
+            requests.RequestException,
+            json.JSONDecodeError,
+            KeyError,
+            ValueError,
+            TypeError,
+            AttributeError,
+        ) as e:
+            logger.warning(
+                f"Error resolving API team ID for {log_label} "
+                f"(reg_id={registration_id}): {type(e).__name__}: {e}"
+            )
             return None
 
     def scrape_games_from_schedule_pages(
@@ -1945,6 +2022,14 @@ class GotsportScraper(ProviderScraper):
             List of GameData objects from schedule pages
         """
         games: List[GameData] = []
+        # Mutable single-element list shared across both walks' parser calls so
+        # _parse_games_from_schedule_page can increment without changing its
+        # tuple-return contract. See plan Step 3 for the rationale.
+        drop_counter: List[int] = [0]
+        # Stash empty metrics up front so callers reading after an early-exit
+        # path (CAPTCHA re-raise, exception) see a sane shape, not stale data
+        # from a prior event.
+        self._last_resolution_metrics = {"resolved": 0, "unresolved": 0, "dropped_unresolved": 0}
 
         logger.info(f"Scraping games from schedule pages for event {event_id}")
 
@@ -2070,6 +2155,7 @@ class GotsportScraper(ProviderScraper):
                         teams_by_name,
                         api_team_id_cache,
                         registration_to_api,
+                        drop_counter=drop_counter,
                     )
                     games.extend(schedule_games)
                     logger.debug(
@@ -2116,6 +2202,7 @@ class GotsportScraper(ProviderScraper):
                             teams_by_name,
                             api_team_id_cache,
                             registration_to_api,
+                            drop_counter=drop_counter,
                         )
                         games.extend(team_games)
                         if page_delay > 0:
@@ -2133,18 +2220,33 @@ class GotsportScraper(ProviderScraper):
             unresolved_count = sum(1 for v in api_team_id_cache.values() if v is None)
             logger.info(f"Total games scraped from schedule pages: {len(games)}")
             logger.info(
-                f"Team ID resolution: {resolved_count} resolved, {unresolved_count} unresolved (using registration IDs)"
+                f"Team ID resolution: {resolved_count} resolved, {unresolved_count} unresolved"
             )
+            logger.info(f"Games dropped (unresolved teams): {drop_counter[0]}")
             if unresolved_count > 0:
                 logger.warning(
-                    "Some teams used registration IDs instead of API team IDs - these may not match in the database"
+                    f"{unresolved_count} teams could not be resolved to canonical API team IDs; "
+                    f"games involving them were dropped (count={drop_counter[0]})"
                 )
+            self._last_resolution_metrics = {
+                "resolved": resolved_count,
+                "unresolved": unresolved_count,
+                "dropped_unresolved": drop_counter[0],
+            }
         except EventCaptchaGatedError:
             # CAPTCHA is a retryable state — surface to caller so the event
-            # is not marked scraped and the artifact is preserved.
+            # is not marked scraped and the artifact is preserved. Metrics
+            # remain at the early-exit defaults (zeros) set above.
             raise
         except Exception as e:
             logger.error(f"Error scraping games from schedule pages: {e}")
+            # Stash whatever drop_counter accumulated before the exception so
+            # callers see partial metrics rather than zeros.
+            self._last_resolution_metrics = {
+                "resolved": 0,
+                "unresolved": 0,
+                "dropped_unresolved": drop_counter[0],
+            }
 
         return games
 
@@ -2157,8 +2259,18 @@ class GotsportScraper(ProviderScraper):
         teams_by_name: Optional[Dict[str, str]] = None,
         api_team_id_cache: Optional[Dict[str, Optional[str]]] = None,
         registration_to_api: Optional[Dict[str, str]] = None,
+        drop_counter: Optional[List[int]] = None,
     ) -> List[GameData]:
-        """Parse games from a single schedule page"""
+        """Parse games from a single schedule page.
+
+        ``drop_counter`` is a single-element mutable list — when provided,
+        ``drop_counter[0]`` is incremented for each game row dropped because
+        either home or away team failed all 5 resolution priorities and would
+        have shipped a registration ID as ``provider_team_id`` (the bug fixed
+        by removing the line 2283/2329 reg_id fallback). The caller in
+        ``scrape_games_from_schedule_pages`` owns the list so totals
+        accumulate across the per-group + per-team walks for a single event.
+        """
         if api_team_id_cache is None:
             api_team_id_cache = {}
         if teams_by_name is None:
@@ -2268,20 +2380,26 @@ class GotsportScraper(ProviderScraper):
                                             home_team_id = reg_id
                                             api_team_id_cache[reg_id] = reg_id
                                         else:
-                                            # Priority 4: Resolve API team ID by following the team's event page (SLOW!)
+                                            # Priority 4: Resolve API team ID via the gotsport public JSON API
                                             home_team_id = self._resolve_api_team_id_from_event_page(
                                                 event_id, reg_id, home_team_name
                                             )
                                             api_team_id_cache[reg_id] = home_team_id
+                                            # Propagate the resolved (reg_id → api_id) mapping so
+                                            # subsequent rows on this OR the per-team walk pass
+                                            # hit Priority 1 instead of re-resolving.
+                                            if home_team_id:
+                                                registration_to_api[reg_id] = home_team_id
 
                                         if not home_team_id:
                                             # Priority 5: Fallback to name-based mapping
                                             if teams_by_name and home_team_name:
                                                 normalized_name = " ".join(home_team_name.split()).lower()
                                                 home_team_id = teams_by_name.get(normalized_name)
-                                            # Last resort: use registration ID
-                                            if not home_team_id:
-                                                home_team_id = reg_id
+                                            # If still unresolved, leave home_team_id = None.
+                                            # Do NOT fall back to reg_id — that pollutes
+                                            # team_alias_map with registration IDs treated as
+                                            # canonical provider_team_ids.
 
                         # Extract away team
                         away_cell = cells[away_col] if away_col is not None and away_col < len(cells) else None
@@ -2314,22 +2432,38 @@ class GotsportScraper(ProviderScraper):
                                             away_team_id = reg_id
                                             api_team_id_cache[reg_id] = reg_id
                                         else:
-                                            # Priority 4: Resolve API team ID by following the team's event page (SLOW!)
+                                            # Priority 4: Resolve API team ID via the gotsport public JSON API
                                             away_team_id = self._resolve_api_team_id_from_event_page(
                                                 event_id, reg_id, away_team_name
                                             )
                                             api_team_id_cache[reg_id] = away_team_id
+                                            # Propagate the resolved (reg_id → api_id) mapping so
+                                            # subsequent rows on this OR the per-team walk pass
+                                            # hit Priority 1 instead of re-resolving.
+                                            if away_team_id:
+                                                registration_to_api[reg_id] = away_team_id
 
                                         if not away_team_id:
                                             # Priority 5: Fallback to name-based mapping
                                             if teams_by_name and away_team_name:
                                                 normalized_name = " ".join(away_team_name.split()).lower()
                                                 away_team_id = teams_by_name.get(normalized_name)
-                                            # Last resort: use registration ID
-                                            if not away_team_id:
-                                                away_team_id = reg_id
+                                            # If still unresolved, leave away_team_id = None.
+                                            # Do NOT fall back to reg_id — that pollutes
+                                            # team_alias_map with registration IDs treated as
+                                            # canonical provider_team_ids.
 
                         if not home_team_name or not away_team_name:
+                            continue
+
+                        # Drop the row if either team's provider ID couldn't be resolved
+                        # to a real API team_id. Shipping the row with home_team_id/away_team_id
+                        # = None would force downstream to write a registration ID into
+                        # team_alias_map (the bug we're fixing). Counter is observed in
+                        # scrape_games_from_schedule_pages → self._last_resolution_metrics.
+                        if not home_team_id or not away_team_id:
+                            if drop_counter is not None:
+                                drop_counter[0] += 1
                             continue
 
                         # Extract score

--- a/tests/unit/test_gotsport_parser_drop_counter.py
+++ b/tests/unit/test_gotsport_parser_drop_counter.py
@@ -1,0 +1,127 @@
+"""Unit tests for the drop counter in ``_parse_games_from_schedule_page``.
+
+Verifies plan Step 3 contract: rows where home or away team can't be resolved
+to a real API team ID are dropped (never shipped with reg_id as
+``provider_team_id``), and ``drop_counter[0]`` is incremented for each drop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.scrapers.gotsport import GotsportScraper
+
+# Three games:
+#   1. Both teams have direct /teams/{api_id} hrefs → resolves cleanly, ships.
+#   2. Home has reg_id (Priority-4 path returns None), away resolves cleanly → drops.
+#   3. Both have reg_ids that resolve to None → drops.
+THREE_GAME_HTML = """
+<html><body>
+<table>
+  <thead>
+    <tr>
+      <th>Match #</th>
+      <th>Time</th>
+      <th>Home Team</th>
+      <th>Results</th>
+      <th>Away Team</th>
+      <th>Location</th>
+      <th>Division</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>Nov 28, 2025 4:00 PM HST</td>
+      <td><a href="https://system.gotsport.com/teams/100001">Resolved Home FC</a></td>
+      <td>2 - 1</td>
+      <td><a href="https://system.gotsport.com/teams/100002">Resolved Away FC</a></td>
+      <td>Field 1</td>
+      <td>U14B</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>Nov 28, 2025 5:00 PM HST</td>
+      <td><a href="/org_event/events/123/schedules?team=900001">Unresolved Home FC</a></td>
+      <td>3 - 0</td>
+      <td><a href="https://system.gotsport.com/teams/100002">Resolved Away FC</a></td>
+      <td>Field 2</td>
+      <td>U14B</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>Nov 28, 2025 6:00 PM HST</td>
+      <td><a href="/org_event/events/123/schedules?team=900003">Unresolved Home FC 2</a></td>
+      <td>1 - 1</td>
+      <td><a href="/org_event/events/123/schedules?team=900004">Unresolved Away FC</a></td>
+      <td>Field 3</td>
+      <td>U14B</td>
+    </tr>
+  </tbody>
+</table>
+</body></html>
+"""
+
+
+def _make_scraper_with_html(html: str):
+    """Build a barebones scraper instance via __new__ so __init__'s heavy setup
+    (Supabase providers lookup, nested scraper init) is skipped. Set only the
+    attrs the parser path reads."""
+    scraper = GotsportScraper.__new__(GotsportScraper)
+    response = MagicMock()
+    response.text = html
+    response.raise_for_status.return_value = None
+
+    session = MagicMock()
+    session.get.return_value = response
+
+    scraper.session = session
+    scraper.timeout = 30
+    scraper.skip_team_id_resolution = False
+    scraper.provider_code = "gotsport"
+    # Resolver always returns None to exercise the drop path
+    scraper._resolve_api_team_id_from_event_page = MagicMock(return_value=None)
+    return scraper
+
+
+def test_parser_drops_rows_with_unresolved_teams_and_increments_counter():
+    scraper = _make_scraper_with_html(THREE_GAME_HTML)
+    drop_counter = [0]
+
+    games = scraper._parse_games_from_schedule_page(
+        schedule_url="https://system.gotsport.com/org_event/events/123/schedules?group=1",
+        event_id="123",
+        event_name="Test Event",
+        since_date=None,
+        teams_by_name={},
+        api_team_id_cache={},
+        registration_to_api={},
+        drop_counter=drop_counter,
+    )
+
+    # Game 1 ships from BOTH home and away perspectives (the parser emits two
+    # GameData rows per match — see lines 2479+ in gotsport.py). Games 2 and 3
+    # drop entirely.
+    assert len(games) == 2, f"Expected 2 GameData rows (game 1 home + away), got {len(games)}: {games}"
+    assert drop_counter[0] == 2, f"Expected drop_counter == 2, got {drop_counter[0]}"
+
+    # Both shipped rows should reference resolved API team IDs (100001/100002),
+    # never registration IDs.
+    for game in games:
+        assert game.team_id in {"100001", "100002"}, f"Unexpected team_id leaked: {game.team_id}"
+        assert game.opponent_id in {"100001", "100002"}, f"Unexpected opponent_id leaked: {game.opponent_id}"
+
+
+def test_parser_drop_counter_optional():
+    """Calling without drop_counter must not crash — defaults to None and skips increment."""
+    scraper = _make_scraper_with_html(THREE_GAME_HTML)
+    games = scraper._parse_games_from_schedule_page(
+        schedule_url="https://system.gotsport.com/org_event/events/123/schedules?group=1",
+        event_id="123",
+        event_name="Test Event",
+        since_date=None,
+        teams_by_name={},
+        api_team_id_cache={},
+        registration_to_api={},
+    )
+    assert len(games) == 2

--- a/tests/unit/test_resolve_api_team_id_from_event_page.py
+++ b/tests/unit/test_resolve_api_team_id_from_event_page.py
@@ -1,0 +1,171 @@
+"""Unit tests for ``GotsportScraper._resolve_api_team_id_from_event_page``.
+
+Verifies the post-2026-05-01 API-first contract documented in
+``src/scrapers/gotsport.py``. The resolver MUST return ``None`` on no-self-match
+— promoting the queried id to a canonical API team_id was the bug this rewrite
+fixed.
+
+Self-match is on ``homeTeam.team_id`` / ``awayTeam.team_id``, NOT on
+``home_team_reg_id`` / ``away_team_reg_id`` — the gotsport API endpoint only
+accepts api_team_ids (verified live 2026-05-01: a known reg_id returns 404).
+The reg_id fields in match records are the per-event registrations of BOTH
+teams; they're not the queried team's reg_id.
+
+Tests stub ``_fetch_json_via_zenrows`` instead of constructing a full
+``GotsportScraper`` so the heavyweight ``__init__`` (Supabase ``providers``
+round-trip, nested scraper init) doesn't run.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from src.scrapers.gotsport import GotsportScraper
+
+
+def _make_response(status_code: int, body: Any = None, raises_json: bool = False) -> MagicMock:
+    """Build a fake ``requests.Response`` covering the surface the resolver reads."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    if raises_json:
+        response.json.side_effect = json.JSONDecodeError("expecting value", "", 0)
+    else:
+        response.json.return_value = body
+    return response
+
+
+def _resolver(response_or_exc: Any):
+    """Build a barebones scraper stand-in with a stubbed _fetch_json_via_zenrows."""
+    scraper = MagicMock(spec=GotsportScraper)
+    if isinstance(response_or_exc, Exception):
+        scraper._fetch_json_via_zenrows.side_effect = response_or_exc
+    else:
+        scraper._fetch_json_via_zenrows.return_value = response_or_exc
+    # Bind the real resolver so it operates on our stub
+    scraper._resolve_api_team_id_from_event_page = (
+        GotsportScraper._resolve_api_team_id_from_event_page.__get__(scraper, GotsportScraper)
+    )
+    return scraper
+
+
+class TestResolveApiTeamIdFromEventPage:
+    def test_self_match_on_away_team_id_returns_queried_id(self):
+        # Schedule page link `team=255164` is the API team_id; API returns
+        # matches where 255164 IS awayTeam.team_id.
+        body = [
+            {
+                "home_team_reg_id": 3714464,
+                "away_team_reg_id": 3714466,
+                "homeTeam": {"team_id": 630656},
+                "awayTeam": {"team_id": 255164},
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "255164", "Away FC") == "255164"
+
+    def test_self_match_on_home_team_id_returns_queried_id(self):
+        body = [
+            {
+                "home_team_reg_id": 3714464,
+                "away_team_reg_id": 3714466,
+                "homeTeam": {"team_id": 630656},
+                "awayTeam": {"team_id": 255164},
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "630656", "Home FC") == "630656"
+
+    def test_no_self_match_returns_none(self):
+        # 200 OK but the queried id doesn't appear as home/away team_id in any
+        # match — defensive against malformed response. Must NOT promote the
+        # queried id (that's the bug this rewrite fixed).
+        body = [
+            {
+                "home_team_reg_id": 111,
+                "away_team_reg_id": 222,
+                "homeTeam": {"team_id": 333},
+                "awayTeam": {"team_id": 444},
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "999999", "Some FC") is None
+
+    def test_reg_id_self_match_does_not_count(self):
+        # If the queried id matches a home_team_reg_id or away_team_reg_id but
+        # NOT a homeTeam.team_id / awayTeam.team_id, treat as no self-match.
+        # (This case shouldn't happen in practice — reg_ids 404 — but the
+        # resolver must not be tricked into promoting a reg_id by stale data.)
+        body = [
+            {
+                "home_team_reg_id": 3714466,  # numeric coincidence with queried id
+                "away_team_reg_id": 222,
+                "homeTeam": {"team_id": 100001},
+                "awayTeam": {"team_id": 100002},
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "3714466", "Reg ID FC") is None
+
+    def test_empty_list_returns_none(self):
+        scraper = _resolver(_make_response(200, []))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    def test_404_returns_none(self):
+        # Verified live 2026-05-01: querying a reg_id returns 404. This is
+        # the deterministic registration-vs-api-id classifier.
+        scraper = _resolver(_make_response(404))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "3714466", None) is None
+
+    def test_500_returns_none(self):
+        scraper = _resolver(_make_response(500))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    def test_network_error_returns_none(self):
+        scraper = _resolver(requests.ConnectionError("boom"))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    def test_malformed_json_returns_none(self):
+        # response.json() raising JSONDecodeError is in the resolver's
+        # exception tuple — must not propagate.
+        scraper = _resolver(_make_response(200, raises_json=True))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    def test_match_with_none_team_ids_returns_none(self):
+        # Defensive: a partial-write match record where homeTeam/awayTeam
+        # team_id is None must not crash the resolver via str(None) coercion.
+        body = [
+            {
+                "homeTeam": {"team_id": None},
+                "awayTeam": {"team_id": None},
+                "home_team_reg_id": 111,
+                "away_team_reg_id": 222,
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    def test_non_list_body_returns_none(self):
+        # API contract drift: gotsport returns a wrapper dict instead of a
+        # list. Resolver must treat as unresolved.
+        scraper = _resolver(_make_response(200, {"matches": []}))
+        assert scraper._resolve_api_team_id_from_event_page("e1", "12345", None) is None
+
+    @pytest.mark.parametrize("queried_id", ["255164", 255164])
+    def test_str_coercion_on_both_sides(self, queried_id):
+        # Both sides of the team_id comparison are str-coerced so a numeric
+        # API response value matches a string call-site argument.
+        body = [
+            {
+                "homeTeam": {"team_id": 255164},  # int from API
+                "awayTeam": {"team_id": 444},
+                "home_team_reg_id": 999,
+                "away_team_reg_id": 998,
+            }
+        ]
+        scraper = _resolver(_make_response(200, body))
+        assert scraper._resolve_api_team_id_from_event_page("e1", str(queried_id), None) == "255164"


### PR DESCRIPTION
## Summary

- Replace the HTML-scraping team_id resolver with a direct call to gotsport's public JSON API (`/api/v1/teams/{id}/matches?past=true`) routed through ZenRows. The HTML pages are CAPTCHA-blocked (reCAPTCHA v3 rolled out April 2026) and no longer expose `rankings.gotsport.com/teams/{api_id}` links, making the legacy resolver dead code on most events. The API endpoint is not CAPTCHA-protected (verified live 2026-05-01) and provides a deterministic 200/404 classifier for canonical-vs-registration ID.
- Refuse to ship registration IDs as `provider_team_id`. Schedule parser now drops rows where either team can't be resolved to a real API team_id; per-event drop counts surface in `data/raw/{new,upcoming}_events_*_summary.json` via a new `_last_resolution_metrics` instance stash. This stops `team_alias_map` from accumulating `match_method='fuzzy_auto'` rows keyed on per-event reg IDs.
- New `scripts/audit_polluted_gotsport_aliases.py` audits historical fuzzy_auto gotsport aliases against the API and quarantines reg_id rows by setting `review_status='needs_review'` (no deletes — preserves audit trail). Default is dry-run; `--apply` mutates.

## Why this works

Live ZenRows + gotsport API testing during planning proved the original direction (route HTML resolver through ZenRows premium) wrong on two fronts: premium proxy + JS render still returns the verify_captchas page, AND the per-team profile pages no longer contain `rankings.gotsport.com/teams/{id}` anchors. Pivoted mid-plan to API-first resolution. The plan is at `.turbo/plans/gotsport-direct-match-fix.md`.

## Prerequisites before merge

- [ ] **`ZENROWS_API_KEY` repo secret** must exist (Settings → Secrets and variables → Actions → New repository secret). Without it, `self.use_zenrows = bool(os.getenv("ZENROWS_API_KEY"))` evaluates False and every team falls through as unresolved/dropped.

## Test plan

- [x] Static checks: `python -m py_compile` + `ruff check` clean on all 4 changed scripts and 2 new test files.
- [x] Unit tests: 13 cases for the resolver (self-match, 404, 500, malformed JSON, str-coercion, defensive None handling) + 2 cases for the parser drop counter. **15 passed.**
- [x] Live ZenRows JSON shape verification: HTTP 200, 24 matches, schema matches the resolver's expectations.
- [x] Live end-to-end resolver: API team_id `255164` → `"255164"` (resolved); registration ID `3714466` → `None` (correctly refused).
- [ ] **After merge:** trigger `auto-gotsport-event-scrape.yml` manually via `gh workflow run`. Inspect the `data/raw/new_events_*_summary.json` artifact — each event row should have `teams_resolved`, `teams_unresolved`, `games_dropped_unresolved` keys.
- [ ] **After merge:** dry-run the audit script to see how polluted the existing alias map is: `python scripts/audit_polluted_gotsport_aliases.py --limit 50`. Re-run with `--apply` once the dry-run output looks right.
- [ ] Query Supabase 24h after the next workflow run: `SELECT COUNT(*) FROM team_alias_map WHERE provider_id = '<gotsport_id>' AND match_method = 'fuzzy_auto' AND created_at > NOW() - INTERVAL '1 day';` — should be 0 or near-0 (no new fuzzy_auto aliases keyed on reg IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)