### PR TITLE
fix(audit-script): use review_status='pending' for DB constraint compliance

### DIFF
--- a/scripts/audit_polluted_gotsport_aliases.py
+++ b/scripts/audit_polluted_gotsport_aliases.py
@@ -19,7 +19,7 @@ GotSport JSON API at `/api/v1/teams/{id}/matches?past=true`:
     - 404 → `registration_id` (quarantine candidate).
     - 5xx / network error / non-list JSON → `unknown_<reason>` (skip).
 
-Quarantine action sets `review_status='needs_review'`. Rows are not deleted —
+Quarantine action sets `review_status='pending'`. Rows are not deleted —
 the audit trail and the master team mapping are preserved so a future operator
 can either re-approve or merge.
 
@@ -263,12 +263,12 @@ def main(args: argparse.Namespace) -> None:
         print("\nNothing to quarantine.")
         return
 
-    print(f"\nUpdating {len(quarantine_candidates)} aliases to review_status='needs_review'...")
+    print(f"\nUpdating {len(quarantine_candidates)} aliases to review_status='pending'...")
     updated_count = 0
     error_count = 0
     for row in quarantine_candidates:
         try:
-            supabase.table("team_alias_map").update({"review_status": "needs_review"}).eq("id", row["id"]).execute()
+            supabase.table("team_alias_map").update({"review_status": "pending"}).eq("id", row["id"]).execute()
             updated_count += 1
             if updated_count % 100 == 0:
                 print(f"  Updated {updated_count}/{len(quarantine_candidates)}...")
@@ -290,10 +290,10 @@ def main(args: argparse.Namespace) -> None:
             supabase.table("team_alias_map").select("id,review_status").in_("id", batch).execute()
         )
         for record in verify_result.data or []:
-            if record.get("review_status") == "needs_review":
+            if record.get("review_status") == "pending":
                 verified_review += 1
 
-    print(f"Verified {verified_review}/{len(quarantine_candidates)} now have review_status='needs_review'")
+    print(f"Verified {verified_review}/{len(quarantine_candidates)} now have review_status='pending'")
 
 
 def _default_output_path() -> str:


### PR DESCRIPTION
## Summary

The audit script merged in #713 used \`review_status='needs_review'\` for quarantining polluted gotsport aliases, but the \`team_alias_map.review_status\` CHECK constraint only allows \`('pending', 'approved', 'rejected', 'new_team')\` per \`supabase/migrations/20240101000000_initial_schema.sql:113\`. Running \`--apply\` errored on all 112 candidates with constraint violation 23514.

Switching to \`'pending'\` is the semantic match — removes rows from \`_match_by_provider_id\`'s active pool (which requires \`review_status='approved'\` at \`src/models/game_matcher.py:902\`) without making a permanent rejection.

## Test plan

- [x] Ran \`--apply\` against the live DB after this fix: 112/112 rows updated successfully, verification re-read confirms all now have \`review_status='pending'\`. Historical pollution from the gotsport bug is now cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)