### PR TITLE
geo: Week 5 author entity (Shell 1 — Organization JSON-LD + /authors/pitchrank-team)

### DIFF
--- a/frontend/app/authors/pitchrank-team/page.tsx
+++ b/frontend/app/authors/pitchrank-team/page.tsx
@@ -1,0 +1,71 @@
+import { PageHeader } from '@/components/PageHeader';
+import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
+import { AuthorEntitySchema } from '@/components/AuthorEntitySchema';
+import type { Metadata } from 'next';
+import { BASE_URL, PITCHRANK_TEAM_AUTHOR_PATH } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'PitchRank Team',
+  description:
+    'Meet the PitchRank Team — the people behind the youth soccer ranking platform that publishes weekly rankings, methodology, and guides for U10–U19 teams across all 50 states.',
+  alternates: {
+    canonical: `${BASE_URL}${PITCHRANK_TEAM_AUTHOR_PATH}`,
+  },
+  openGraph: {
+    title: 'PitchRank Team | PitchRank',
+    description:
+      'Meet the PitchRank Team — the people behind PitchRank.io and the rankings, methodology, and guides published on the site.',
+    url: `${BASE_URL}${PITCHRANK_TEAM_AUTHOR_PATH}`,
+    siteName: 'PitchRank',
+    type: 'website',
+    images: [
+      {
+        url: '/logos/pitchrank-wordmark.svg',
+        width: 1200,
+        height: 630,
+        alt: 'PitchRank Team',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'PitchRank Team | PitchRank',
+    description: 'The team behind PitchRank.io youth soccer rankings, methodology, and guides.',
+    images: ['/logos/pitchrank-wordmark.svg'],
+  },
+};
+
+export default function PitchRankTeamPage() {
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <BreadcrumbSchema items={[{ name: 'PitchRank Team', href: PITCHRANK_TEAM_AUTHOR_PATH }]} />
+      <AuthorEntitySchema />
+      <PageHeader
+        title="PitchRank Team"
+        description="The team behind PitchRank's youth soccer rankings, methodology, and guides."
+        showBackButton
+        backHref="/"
+      />
+
+      <div className="max-w-4xl mx-auto">
+        <div className="space-y-6">
+          <p className="text-muted-foreground leading-relaxed">
+            PitchRank is built by a small team focused on bringing transparent, data-first rankings to youth soccer. We
+            collect verified game results, run them through a rating engine that weighs opponent quality, schedule
+            strength, and recent form, then publish weekly rankings for every age group across all 50 states.
+          </p>
+          <p className="text-muted-foreground leading-relaxed">
+            The platform combines a core rating algorithm with a machine-learning layer that flags teams trending up or
+            down based on performance versus expectations. Rankings refresh every Monday morning so coaches, parents,
+            and players see how their team stacks up against the rest of the country — not just their local league.
+          </p>
+          <p className="text-muted-foreground leading-relaxed">
+            The PitchRank Team writes the methodology, blog, and state guides published on this site. We are based in
+            Arizona and built the platform after years of frustration with the lack of objective, cross-state
+            comparisons in youth club soccer.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -84,7 +84,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         excerpt={post.excerpt}
         slug={slug}
         date={post.date}
-        author={post.author}
         readingTime={post.readingTime}
         tags={post.tags}
         image={heroImagePath}

--- a/frontend/app/methodology/page.tsx
+++ b/frontend/app/methodology/page.tsx
@@ -1,6 +1,7 @@
 import { PageHeader } from '@/components/PageHeader';
 import { MethodologySection } from '@/components/MethodologySection';
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
+import { MethodologySchema } from '@/components/MethodologySchema';
 import type { Metadata } from 'next';
 import { BASE_URL } from '@/lib/constants';
 
@@ -39,6 +40,7 @@ export default function MethodologyPage() {
   return (
     <div className="container mx-auto py-8 px-4">
       <BreadcrumbSchema items={[{ name: 'Methodology', href: '/methodology' }]} />
+      <MethodologySchema datePublished="2026-04-30" dateModified="2026-04-30" />
       <PageHeader
         title="Ranking Methodology"
         description="Understanding how PitchRank calculates team rankings and power scores"

--- a/frontend/app/methodology/page.tsx
+++ b/frontend/app/methodology/page.tsx
@@ -40,7 +40,7 @@ export default function MethodologyPage() {
   return (
     <div className="container mx-auto py-8 px-4">
       <BreadcrumbSchema items={[{ name: 'Methodology', href: '/methodology' }]} />
-      <MethodologySchema datePublished="2026-04-30" dateModified="2026-04-30" />
+      <MethodologySchema datePublished="2026-04-30T00:00:00Z" dateModified="2026-04-30T00:00:00Z" />
       <PageHeader
         title="Ranking Methodology"
         description="Understanding how PitchRank calculates team rankings and power scores"

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { US_STATES, AGE_GROUPS, BASE_URL_WWW } from '@/lib/constants';
+import { US_STATES, AGE_GROUPS, BASE_URL_WWW, PITCHRANK_TEAM_AUTHOR_PATH } from '@/lib/constants';
 import { getAllBlogSlugs } from '@/lib/blog';
 
 /**
@@ -48,6 +48,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.7,
+    },
+    {
+      url: `${baseUrl}${PITCHRANK_TEAM_AUTHOR_PATH}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.4,
     },
   ];
 

--- a/frontend/components/AuthorEntitySchema.tsx
+++ b/frontend/components/AuthorEntitySchema.tsx
@@ -1,0 +1,19 @@
+import { PITCHRANK_TEAM_AUTHOR } from '@/lib/constants';
+import { safeJsonLd } from '@/lib/schema-utils';
+
+/**
+ * Self-referential Organization JSON-LD for the /authors/pitchrank-team page.
+ * Adds a top-level @context so the entity validates standalone; other consumers
+ * (BlogPostSchema, MethodologySchema) embed PITCHRANK_TEAM_AUTHOR as a nested
+ * `author` value where the parent schema already supplies @context.
+ */
+export function AuthorEntitySchema() {
+  const schema = {
+    '@context': 'https://schema.org',
+    ...PITCHRANK_TEAM_AUTHOR,
+  };
+
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(schema) }} />;
+}
+
+export default AuthorEntitySchema;

--- a/frontend/components/BlogPostSchema.test.tsx
+++ b/frontend/components/BlogPostSchema.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { BlogPostSchema } from './BlogPostSchema';
+import { BASE_URL } from '@/lib/constants';
+
+interface JsonLdScriptElement {
+  props: {
+    type: string;
+    dangerouslySetInnerHTML: { __html: string };
+  };
+}
+
+function parseEmittedSchema(element: unknown): Record<string, unknown> {
+  const html = (element as JsonLdScriptElement).props.dangerouslySetInnerHTML.__html;
+  return JSON.parse(html.replace(/\\u003c/g, '<'));
+}
+
+describe('BlogPostSchema', () => {
+  it('emits BlogPosting schema with PitchRank Team Organization author', () => {
+    const element = BlogPostSchema({
+      title: 'Test Post',
+      excerpt: 'A short excerpt.',
+      slug: 'test-post',
+      date: '2026-04-30',
+    });
+    const schema = parseEmittedSchema(element);
+
+    expect(schema['@type']).toBe('BlogPosting');
+    expect(schema.url).toBe(`${BASE_URL}/blog/test-post`);
+    const author = schema.author as { '@type': string; '@id': string; name: string };
+    expect(author['@type']).toBe('Organization');
+    expect(author['@id']).toBe(`${BASE_URL}/authors/pitchrank-team`);
+    expect(author.name).toBe('PitchRank Team');
+    expect((schema.publisher as { name: string }).name).toBe('PitchRank');
+  });
+});

--- a/frontend/components/BlogPostSchema.tsx
+++ b/frontend/components/BlogPostSchema.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BASE_URL } from '@/lib/constants';
+import { BASE_URL, PITCHRANK_PUBLISHER, PITCHRANK_TEAM_AUTHOR } from '@/lib/constants';
 import { safeJsonLd } from '@/lib/schema-utils';
 
 interface BlogPostSchemaProps {
@@ -7,7 +7,6 @@ interface BlogPostSchemaProps {
   excerpt: string;
   slug: string;
   date: string;
-  author: string;
   readingTime?: string;
   tags?: string[];
   modifiedDate?: string;
@@ -25,7 +24,6 @@ export function BlogPostSchema({
   excerpt,
   slug,
   date,
-  author,
   readingTime,
   tags,
   modifiedDate,
@@ -47,18 +45,8 @@ export function BlogPostSchema({
     url: postUrl,
     datePublished: date,
     dateModified: modifiedDate || date,
-    author: {
-      '@type': 'Person',
-      name: author,
-    },
-    publisher: {
-      '@type': 'Organization',
-      name: 'PitchRank',
-      logo: {
-        '@type': 'ImageObject',
-        url: `${BASE_URL}/logos/pitchrank-wordmark.svg`,
-      },
-    },
+    author: PITCHRANK_TEAM_AUTHOR,
+    publisher: PITCHRANK_PUBLISHER,
     image: imageUrl,
     mainEntityOfPage: {
       '@type': 'WebPage',

--- a/frontend/components/MethodologySchema.test.tsx
+++ b/frontend/components/MethodologySchema.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { MethodologySchema } from './MethodologySchema';
+import { BASE_URL } from '@/lib/constants';
+
+interface JsonLdScriptElement {
+  props: {
+    type: string;
+    dangerouslySetInnerHTML: { __html: string };
+  };
+}
+
+function parseEmittedSchema(element: unknown): Record<string, unknown> {
+  const html = (element as JsonLdScriptElement).props.dangerouslySetInnerHTML.__html;
+  return JSON.parse(html.replace(/\\u003c/g, '<'));
+}
+
+describe('MethodologySchema', () => {
+  it('emits Article schema with PitchRank Team author and the supplied dates', () => {
+    const element = MethodologySchema({ datePublished: '2026-04-30', dateModified: '2026-05-01' });
+    const schema = parseEmittedSchema(element);
+
+    expect(schema['@type']).toBe('Article');
+    expect((schema.author as { '@id': string })['@id']).toBe(`${BASE_URL}/authors/pitchrank-team`);
+    expect(schema.datePublished).toBe('2026-04-30');
+    expect(schema.dateModified).toBe('2026-05-01');
+    expect((schema.publisher as { name: string }).name).toBe('PitchRank');
+  });
+});

--- a/frontend/components/MethodologySchema.tsx
+++ b/frontend/components/MethodologySchema.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { BASE_URL, PITCHRANK_PUBLISHER, PITCHRANK_TEAM_AUTHOR } from '@/lib/constants';
+import { safeJsonLd } from '@/lib/schema-utils';
+
+interface MethodologySchemaProps {
+  datePublished: string;
+  dateModified: string;
+}
+
+/** /methodology has no visible byline, so the JSON-LD author entity is the only attribution signal for AI engines. */
+export function MethodologySchema({ datePublished, dateModified }: MethodologySchemaProps) {
+  const pageUrl = `${BASE_URL}/methodology`;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'PitchRank Ranking Methodology',
+    description:
+      'How PitchRank calculates youth soccer team rankings and PowerScores using opponent quality, schedule strength, and machine-learning trend detection.',
+    url: pageUrl,
+    datePublished,
+    dateModified,
+    author: PITCHRANK_TEAM_AUTHOR,
+    publisher: PITCHRANK_PUBLISHER,
+    image: `${BASE_URL}/opengraph-image.png`,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': pageUrl,
+    },
+  };
+
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(schema) }} />;
+}
+
+export default MethodologySchema;

--- a/frontend/components/StructuredData.tsx
+++ b/frontend/components/StructuredData.tsx
@@ -1,4 +1,4 @@
-import { BASE_URL } from '@/lib/constants';
+import { BASE_URL, PITCHRANK_SAMEAS } from '@/lib/constants';
 import { safeJsonLd } from '@/lib/schema-utils';
 
 /**
@@ -14,12 +14,7 @@ export function StructuredData() {
     url: BASE_URL,
     logo: `${BASE_URL}/logos/pitchrank-logo-dark.png`,
     description: 'Data-powered youth soccer team rankings and performance analytics',
-    sameAs: [
-      'https://twitter.com/pitchrank',
-      'https://instagram.com/pitchrank',
-      'https://facebook.com/pitchrank',
-      'https://linkedin.com/company/pitchrank',
-    ],
+    sameAs: PITCHRANK_SAMEAS,
     contactPoint: {
       '@type': 'ContactPoint',
       contactType: 'Customer Support',

--- a/frontend/content/blog-posts.tsx
+++ b/frontend/content/blog-posts.tsx
@@ -2882,7 +2882,7 @@ export const blogPosts: BlogPost[] = [
     title: 'What is PowerScore in Youth Soccer? The Complete Guide',
     excerpt:
       "PowerScore is PitchRank's 0–1 team strength rating: 13 layers, 50% strength of schedule, updated weekly. Here's how it works and how to read your team's number.",
-    author: 'PitchRank',
+    author: 'PitchRank Team',
     date: '2026-03-18',
     readingTime: '11 min read',
     tags: ['PowerScore', 'Rankings', 'Educational', 'Methodology'],

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -66,6 +66,50 @@ export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.pitchra
  */
 export const BASE_URL_WWW = BASE_URL.includes('://www.') ? BASE_URL : BASE_URL.replace('https://', 'https://www.');
 
+// --- Brand / Author ---
+
+/** Canonical site path for the PitchRank Team author entity. */
+export const PITCHRANK_TEAM_AUTHOR_PATH = '/authors/pitchrank-team' as const;
+
+/**
+ * External profiles linked from PitchRank's Schema.org Organization entities.
+ * Shared by the homepage Organization (StructuredData.tsx) and the PitchRank Team
+ * author entity (PITCHRANK_TEAM_AUTHOR) so both stay in sync.
+ */
+export const PITCHRANK_SAMEAS = [
+  'https://twitter.com/pitchrank',
+  'https://instagram.com/pitchrank',
+  'https://facebook.com/pitchrank',
+  'https://linkedin.com/company/pitchrank',
+] as const;
+
+/**
+ * Author entity for PitchRank-published content. Used as the JSON-LD `author`
+ * value in BlogPosting and Article schemas, and as the self-referential
+ * Organization schema rendered on PITCHRANK_TEAM_AUTHOR_PATH.
+ */
+export const PITCHRANK_TEAM_AUTHOR = {
+  '@type': 'Organization',
+  '@id': `${BASE_URL}${PITCHRANK_TEAM_AUTHOR_PATH}`,
+  name: 'PitchRank Team',
+  url: `${BASE_URL}${PITCHRANK_TEAM_AUTHOR_PATH}`,
+  sameAs: PITCHRANK_SAMEAS,
+} as const;
+
+/**
+ * Publisher entity used inside Article / BlogPosting schemas.
+ * Logo is a square raster (512×512 PNG); Google's structured-data spec rejects
+ * SVG / vector logos for `publisher.logo` on Article schemas.
+ */
+export const PITCHRANK_PUBLISHER = {
+  '@type': 'Organization',
+  name: 'PitchRank',
+  logo: {
+    '@type': 'ImageObject',
+    url: `${BASE_URL}/logos/icon-512.png`,
+  },
+} as const;
+
 // --- Age Groups ---
 
 /** Standard ranked age groups (excludes u18 which has no rankings cohort). */


### PR DESCRIPTION
## Summary

- Every authored page now emits an `Organization`-shaped `author` in JSON-LD, pointing at a real entity URL with `sameAs` linkage. Clears the GEO audit's no-author auto-cap (max score 60).
- New `/authors/pitchrank-team` page hosts the entity. Sitewide Organization in `StructuredData.tsx` shares the same `sameAs` array via the new `PITCHRANK_SAMEAS` constant. Author page renders via a new `AuthorEntitySchema` component to keep JSON-LD inside `components/*Schema.tsx`.
- `BlogPostSchema.tsx` swapped `Person` author to `PITCHRANK_TEAM_AUTHOR`. Methodology page gets a new `Article` schema with the same author entity. No visible bylines added (matches the /rankings rule).
- Centralized publisher in `PITCHRANK_PUBLISHER` (raster PNG via `/logos/icon-512.png`); fixes the SVG-logo Google rejects on Article publishers. Sitewide Organization in `StructuredData.tsx` still references the pre-existing broken `pitchrank-logo-dark.png`; tracked in `.turbo/improvements.md`.
- TSX outlier author at `blog-posts.tsx:2885` normalized from `'PitchRank'` to `'PitchRank Team'`. Dead `author` prop dropped from `BlogPostSchema` after the schema stopped consuming it.

Covers Shell 1 of `.turbo/specs/geo-week5-foundations.md` (R1, R2, R3, R5, R6). Shells 2 (dateModified backfill) and 3 (llms.txt generator) remain.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` clean, `/authors/pitchrank-team` registered as static route
- [x] `vitest run` 114/114 (includes new `MethodologySchema.test.tsx` and `BlogPostSchema.test.tsx`)
- [x] Local smoke: view-source on `/`, `/methodology`, `/authors/pitchrank-team`, and a sample blog post. All four JSON-LD shapes correct, `sameAs` intact, dates render, sitewide Organization unchanged
- [x] `/sitemap.xml` includes new author URL
- [ ] Validate all four schemas at https://search.google.com/test/rich-results before merge