### PR TITLE
geo: Week 5 dateModified backfill (Shell 2 — 23 blog posts + bump-on-edit convention)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -286,6 +286,15 @@ cn('base-class', condition && 'conditional-class');
 
 ---
 
+## Content Authoring
+
+- Every blog post edit (MDX frontmatter or TSX `BlogPost` object) must bump `modifiedDate` to the current date.
+- Format is ISO-8601 UTC: `'YYYY-MM-DDT00:00:00Z'` (e.g. `'2026-05-04T00:00:00Z'`). Bare `YYYY-MM-DD` triggers Google Rich Results Test "missing timezone" warnings.
+- For new blog posts, set both `date` and `modifiedDate` to the publish date.
+- Convention checked at PR review — no lint rule or pre-commit hook.
+
+---
+
 ## Content Generation
 
 ### llms.txt

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -84,6 +84,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         excerpt={post.excerpt}
         slug={slug}
         date={post.date}
+        modifiedDate={post.modifiedDate}
         readingTime={post.readingTime}
         tags={post.tags}
         image={heroImagePath}

--- a/frontend/components/BlogPostSchema.test.tsx
+++ b/frontend/components/BlogPostSchema.test.tsx
@@ -31,5 +31,20 @@ describe('BlogPostSchema', () => {
     expect(author['@id']).toBe(`${BASE_URL}/authors/pitchrank-team`);
     expect(author.name).toBe('PitchRank Team');
     expect((schema.publisher as { name: string }).name).toBe('PitchRank');
+    expect(schema.dateModified).toBe('2026-04-30');
+  });
+
+  it('uses explicit modifiedDate over the date fallback', () => {
+    const element = BlogPostSchema({
+      title: 'Test Post',
+      excerpt: 'A short excerpt.',
+      slug: 'test-post',
+      date: '2026-02-21',
+      modifiedDate: '2026-04-30T00:00:00Z',
+    });
+    const schema = parseEmittedSchema(element);
+
+    expect(schema.datePublished).toBe('2026-02-21');
+    expect(schema.dateModified).toBe('2026-04-30T00:00:00Z');
   });
 });

--- a/frontend/content/blog-posts.tsx
+++ b/frontend/content/blog-posts.tsx
@@ -32,6 +32,7 @@ export const blogPosts: BlogPost[] = [
       "Confused by youth soccer rankings? This guide breaks down how different ranking systems work, what your team's ranking actually means, and which systems parents should trust.",
     author: 'PitchRank Team',
     date: '2026-03-05',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '8 min read',
     tags: ['Rankings', 'Educational', 'Parents', 'Decision Making'],
     content: (
@@ -422,6 +423,7 @@ export const blogPosts: BlogPost[] = [
       "Everything parents need to know about youth soccer rankings—what they are, how they work, and why they matter for your child's development and club selection.",
     author: 'PitchRank Team',
     date: '2026-03-02',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '9 min read',
     tags: ['Rankings', 'Parents', 'Club Selection'],
     content: (
@@ -907,6 +909,7 @@ export const blogPosts: BlogPost[] = [
       "Discover the algorithm methodology behind PitchRank's youth soccer rankings and why our power scores are more accurate than traditional ranking systems.",
     author: 'PitchRank Team',
     date: '2025-02-04',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '8 min read',
     tags: ['Algorithm', 'Methodology', 'Rankings'],
     content: (
@@ -1199,6 +1202,7 @@ export const blogPosts: BlogPost[] = [
       'Find where your California club ranks among 15,693 teams. LA Galaxy, San Diego Surf, Beach FC and more — rated weekly by PowerScore. Free.',
     author: 'PitchRank Team',
     date: '2026-02-21',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '9 min read',
     tags: ['California', 'Youth Soccer', 'Rankings', 'Parent Guide'],
     content: (
@@ -1875,6 +1879,7 @@ export const blogPosts: BlogPost[] = [
       'Find where your Texas club ranks among 9,457 teams. FC Dallas, Solar SC, and more — rated weekly by PowerScore from real game results. Free.',
     author: 'PitchRank Team',
     date: '2026-03-14',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '10 min read',
     tags: ['Texas', 'Youth Soccer', 'Rankings', 'Parent Guide'],
     content: (
@@ -2569,6 +2574,7 @@ export const blogPosts: BlogPost[] = [
       'Find youth soccer team rankings in every state. The only platform with comprehensive 50-state rankings powered by a 13-layer algorithm. California, Texas, Florida, and more.',
     author: 'PitchRank Team',
     date: '2026-03-12',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '12 min read',
     tags: ['Youth Soccer', 'Rankings', 'State Rankings', 'Parent Guide', '50 States'],
     content: (
@@ -2884,6 +2890,7 @@ export const blogPosts: BlogPost[] = [
       "PowerScore is PitchRank's 0–1 team strength rating: 13 layers, 50% strength of schedule, updated weekly. Here's how it works and how to read your team's number.",
     author: 'PitchRank Team',
     date: '2026-03-18',
+    modifiedDate: '2026-04-30T00:00:00Z',
     readingTime: '11 min read',
     tags: ['PowerScore', 'Rankings', 'Educational', 'Methodology'],
     content: (

--- a/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/arizona-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'arizona-youth-soccer-rankings-guide'
 excerpt: "Confused about Arizona soccer rankings? Here's what every parent needs to know about youth soccer team rankings in AZ, from Phoenix to Tucson."
 author: 'PitchRank Team'
 date: '2026-02-21'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '8 min read'
 tags: ['Arizona', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'colorado-youth-soccer-rankings-guide'
 excerpt: 'Find where your Colorado club ranks. Rapids Youth, Real Colorado, Colorado Storm and more — rated by PowerScore from real game results. Free rankings updated every Monday.'
 author: 'PitchRank Team'
 date: '2026-04-08'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['Colorado', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/florida-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'florida-youth-soccer-rankings-guide'
 excerpt: "Florida has 5,300+ ranked youth soccer teams — 3rd most in the country. Here's what every parent needs to know about rankings, from Miami to Jacksonville."
 author: 'PitchRank Team'
 date: '2026-04-09'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['Florida', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/georgia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/georgia-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'georgia-youth-soccer-rankings-guide'
 excerpt: 'Find where your GA youth soccer club ranks among 789 teams. Concorde Fire, UFA, NASA Tophat, Southern Soccer Academy, Gwinnett SA and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-29'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Georgia', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/illinois-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/illinois-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'illinois-youth-soccer-rankings-guide'
 excerpt: 'Find where your IL youth soccer club ranks among 1,284 teams. Sockers FC, Metro Alliance, Chicago Fire Youth, Central Illinois United and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-30'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Illinois', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/maryland-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'maryland-youth-soccer-rankings-guide'
 excerpt: 'Find where your MD youth soccer club ranks among 1,500+ teams. Bethesda SC, Coppermine, Maryland United, Pipeline and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-28'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Maryland', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/michigan-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'michigan-youth-soccer-rankings-guide'
 excerpt: 'Find where your Michigan club ranks among thousands of teams. Michigan Hawks, Vardar, DCFC and more — rated by PowerScore from real game results. Free rankings updated every Monday.'
 author: 'PitchRank Team'
 date: '2026-04-08'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['Michigan', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-jersey-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'new-jersey-youth-soccer-rankings-guide'
 excerpt: 'Find where your NJ club ranks among thousands of teams. PDA, STA, Match Fit Academy, FC Copa and more — rated by PowerScore from real game results. Free rankings updated every Monday.'
 author: 'PitchRank Team'
 date: '2026-04-11'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['New Jersey', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/new-york-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'new-york-youth-soccer-rankings-guide'
 excerpt: 'Find where your NY youth soccer club ranks among 3,600+ teams. Manhattan SC, SUSA FC, WNY Flash, Long Island SC and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-28'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['New York', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/north-carolina-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'north-carolina-youth-soccer-rankings-guide'
 excerpt: 'Find where your NC youth soccer club ranks among 2,600+ teams. Charlotte SA, NCFC, Wake FC and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-11'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['North Carolina', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/ohio-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/ohio-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'ohio-youth-soccer-rankings-guide'
 excerpt: 'Find where your OH youth soccer club ranks among 2,650 teams. Cincinnati United Premier, Club Ohio, Columbus Force, Cleveland Force and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-30'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Ohio', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
+++ b/frontend/content/blog/pa-u10-boys-soccer-rankings.mdx
@@ -4,6 +4,7 @@ slug: 'pa-u10-boys-soccer-rankings'
 excerpt: 'The top 25 U10 boys soccer teams in Pennsylvania, ranked by PowerScore. FC DELCO, Philadelphia Union SWAG, Pittsburgh Riverhounds — see where your team stands.'
 author: 'PitchRank Team'
 date: '2026-04-15'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '6 min read'
 tags: ['Pennsylvania', 'U10', 'Boys Soccer', 'Rankings', 'FC DELCO', 'Philadelphia Union']
 keywords:

--- a/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/pennsylvania-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'pennsylvania-youth-soccer-rankings-guide'
 excerpt: 'Pennsylvania youth soccer rankings guide: EDP, EPYSA explained. See where PA clubs rank by PowerScore. Updated weekly. Free for parents.'
 author: 'PitchRank Team'
 date: '2026-04-15'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '11 min read'
 tags: ['Pennsylvania', 'Youth Soccer', 'Rankings', 'Parent Guide', 'EDP', 'EPYSA']
 keywords:

--- a/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
+++ b/frontend/content/blog/virginia-youth-soccer-rankings-guide.mdx
@@ -4,6 +4,7 @@ slug: 'virginia-youth-soccer-rankings-guide'
 excerpt: 'Find where your VA youth soccer club ranks among 1,500+ teams. Beach FC, Richmond United, Arlington Soccer, Loudoun and more — rated weekly by PowerScore. Free.'
 author: 'PitchRank Team'
 date: '2026-04-28'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Virginia', 'Youth Soccer', 'Rankings', 'Parent Guide']
 keywords:

--- a/frontend/content/blog/what-predicts-winning-beyond-goals.mdx
+++ b/frontend/content/blog/what-predicts-winning-beyond-goals.mdx
@@ -4,6 +4,7 @@ slug: 'what-predicts-winning-beyond-goals'
 excerpt: 'Goals scored alone predict only 47% of outcomes — barely better than a coin flip. After analyzing 700,000+ youth soccer games, we found the real predictors of team quality. The answer might surprise you.'
 author: 'PitchRank Team'
 date: '2026-03-16'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '9 min read'
 tags: ['Data', 'Rankings', 'Methodology', 'Youth Soccer', 'Analysis']
 keywords:

--- a/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
+++ b/frontend/content/blog/youth-soccer-age-group-change-2026-2027.mdx
@@ -4,6 +4,7 @@ slug: 'youth-soccer-age-group-change-2026-2027'
 excerpt: "Youth soccer is switching from birth-year to school-year age groups starting fall 2026. Here's exactly how it works, who it affects, and what to do before tryouts."
 author: 'PitchRank Team'
 date: '2026-04-06'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Youth Soccer', 'Age Groups', 'Tryouts', 'Parent Guide', '2026-2027']
 keywords:

--- a/frontend/content/blog/youth-soccer-levels-explained.mdx
+++ b/frontend/content/blog/youth-soccer-levels-explained.mdx
@@ -4,6 +4,7 @@ slug: 'youth-soccer-levels-explained'
 excerpt: 'A plain-English guide to the levels of youth soccer in the US — ECNL, MLS NEXT, GA, NPL, ECNL Regional, National League, state premier, and travel/rec. What each is, how they fit together, and what it actually means for your kid.'
 author: 'PitchRank Team'
 date: '2026-04-29'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '11 min read'
 tags: ['Youth Soccer', 'ECNL', 'MLS NEXT', 'Parent Guide', 'Club Soccer']
 keywords:

--- a/frontend/content/blog/youth-soccer-tryouts-2026.mdx
+++ b/frontend/content/blog/youth-soccer-tryouts-2026.mdx
@@ -4,6 +4,7 @@ slug: 'youth-soccer-tryouts-2026'
 excerpt: 'Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch.'
 author: 'PitchRank Team'
 date: '2026-04-07'
+modifiedDate: '2026-04-30T00:00:00Z'
 readingTime: '10 min read'
 tags: ['Youth Soccer', 'Tryouts', 'Parent Guide', 'Club Soccer', '2026-2027']
 keywords:

--- a/frontend/lib/blog.tsx
+++ b/frontend/lib/blog.tsx
@@ -9,6 +9,7 @@ export interface BlogPost {
   excerpt: string;
   content: React.ReactNode | string;
   date: string;
+  modifiedDate?: string;
   author: string;
   readingTime?: string;
   tags?: string[];
@@ -31,6 +32,7 @@ function parseMarkdownFile(file: string): BlogPost {
     excerpt: data.excerpt || '',
     content,
     date: data.date ? String(data.date) : '1970-01-01',
+    modifiedDate: data.modifiedDate,
     author: data.author || 'PitchRank Team',
     readingTime: data.readingTime,
     tags: data.tags,


### PR DESCRIPTION
## Summary

- Backfills `modifiedDate: '2026-04-30T00:00:00Z'` (ISO-8601 UTC) on all 25 existing blog posts: 18 MDX in `frontend/content/blog/` and 7 TSX `BlogPost` objects in `frontend/content/blog-posts.tsx`. The original spec called for 23; two pillars were added since drafting.
- Threads `modifiedDate?: string` through the `BlogPost` interface, `parseMarkdownFile`, and the `<BlogPostSchema>` call site at `app/blog/[slug]/page.tsx`. The schema component already accepted the prop, so no edit there.
- Adds a new `## Content Authoring` section to `frontend/CLAUDE.md` (between SEO and Performance) documenting the bump-on-edit convention: every blog post edit must bump `modifiedDate` to the current date in ISO-8601 UTC form. Convention checked at PR review, no lint rule.
- Two unit tests on `BlogPostSchema`: explicit `modifiedDate` override + `dateModified` fallback assertion.

## Why

Princeton GEO research measured roughly 3x AI-engine citation rate for content edited within ~60 days. Before this change, every blog post emitted `dateModified=datePublished` via the existing `BlogPostSchema:47` `modifiedDate || date` fallback, which kills the recency signal across all 25 posts.

Format choice (`'2026-04-30T00:00:00Z'`) follows the precedent set in Shell 1 at `app/methodology/page.tsx:43`. Bare `YYYY-MM-DD` triggers Google Rich Results Test "missing timezone" warnings.

## Test plan

- [x] `cd frontend && npm run typecheck` clean
- [x] `cd frontend && npm test` 117/117 (includes the two new BlogPostSchema cases)
- [x] `cd frontend && npm run build` exit 0
- [x] Smoke check on prerendered HTML: `dateModified="2026-04-30T00:00:00Z"` confirmed on 25/25 blog posts with distinct `datePublished` per post
- [ ] Verify Google Rich Results Test on a sample blog URL after merge to confirm no "missing timezone" warnings

## Coordination

Sibling PR for Shell 3 lands concurrently from `C:/pitchrank-geo-week5-shell3`. Shell 3 also touches `frontend/CLAUDE.md` in a different section (R8b vs this PR's R8a/Content Authoring) so trivial conflict only if both merge in the same window.