### PR TITLE
fix(rankings): SECURITY DEFINER on RPCs to bypass team_alias_map RLS

### DIFF
--- a/supabase/migrations/20260505100000_rankings_rpcs_security_definer.sql
+++ b/supabase/migrations/20260505100000_rankings_rpcs_security_definer.sql
@@ -1,0 +1,23 @@
+-- Make get_national_rankings and get_state_rankings run as SECURITY DEFINER.
+--
+-- The previous migration (20260505000000) added an EXISTS subquery on
+-- team_alias_map to compute has_modular11_alias. team_alias_map carries
+-- a permissive RLS deny-all policy for anon/authenticated (see migration
+-- 20240215000000_add_row_level_security.sql), so when the RPC was called
+-- from the API route as the anon role the EXISTS lookup blew up at
+-- execute time and the route returned 500 "Failed to fetch state rankings".
+--
+-- Switching the functions to SECURITY DEFINER makes them run as the
+-- function owner (postgres), which sees through the RLS policy. This
+-- doesn't expose any new data to the anon caller — the function still
+-- returns only ranking rows; has_modular11_alias is just a boolean.
+-- search_path is pinned to public + pg_temp to neutralize the standard
+-- SECURITY DEFINER + search_path injection risk.
+
+ALTER FUNCTION get_national_rankings(TEXT, TEXT, INT, INT)
+  SECURITY DEFINER
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION get_state_rankings(TEXT, TEXT, TEXT, INT, INT)
+  SECURITY DEFINER
+  SET search_path = public, pg_temp;


### PR DESCRIPTION
## Summary

Production state and national rankings APIs were returning 500 `Failed to fetch state rankings` after PR #722 merged.

Root cause: PR #722 added an EXISTS subquery on `team_alias_map` inside both rankings RPCs to compute `has_modular11_alias`. `team_alias_map` has an RLS `team_alias_map_deny_all` policy (migration 20240215000000:250) that denies all access to `anon` and `authenticated`. The API route runs as anon → EXISTS subquery errors at execute time → route returns 500.

## Fix

`ALTER FUNCTION ... SECURITY DEFINER` on both RPCs so they run as the function owner (postgres). Owner sees through RLS. `search_path` pinned to `public, pg_temp` to neutralize the standard SECURITY DEFINER injection risk.

No new data is exposed to anon — `has_modular11_alias` is a boolean (modular11 alias exists yes/no), not alias details.

## Test plan

After applying the migration, verify:
```sql
SELECT proname, prosecdef FROM pg_proc WHERE proname IN ('get_national_rankings', 'get_state_rankings');
-- Both prosecdef should be true

SELECT count(*) FROM get_state_rankings('AZ', '14', 'M', 100, 0);
-- Should return >0
```

Then load `/rankings/state/AZ?age=u14&gender=male` — should populate.