### PR TITLE
feat(frontend): roll out composeTeamDisplay to infographics + UnknownOpponentLink

### DIFF
--- a/frontend/components/UnknownOpponentLink.tsx
+++ b/frontend/components/UnknownOpponentLink.tsx
@@ -24,6 +24,7 @@ import type { RankingRow } from '@/types/RankingRow';
 import type { GameWithTeams } from '@/lib/types';
 import { formatGameDate } from '@/lib/dateUtils';
 import { AGE_GROUPS_ALL, formatGender } from '@/lib/constants';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface UnknownOpponentLinkProps {
   game: GameWithTeams;
@@ -240,7 +241,7 @@ export function UnknownOpponentLink({
 
   const handleSelectTeam = (team: RankingRow) => {
     setSelectedTeam(team);
-    setSearchQuery(team.team_name);
+    setSearchQuery(composeTeamDisplay(team));
     setIsSearchOpen(false);
     setSelectedIndex(0);
   };
@@ -533,29 +534,32 @@ export function UnknownOpponentLink({
                         </div>
                       ) : (
                         <div className="space-y-1">
-                          {filteredTeams.map((team, index) => (
-                            <button
-                              key={team.team_id_master}
-                              onClick={() => handleSelectTeam(team)}
-                              className={`w-full text-left p-2 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary ${
-                                index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
-                              }`}
-                              aria-label={`Select ${team.team_name}`}
-                            >
-                              <div className="font-medium">{highlightMatch(team.team_name, deferredSearchQuery)}</div>
-                              <div className="text-xs text-muted-foreground">
-                                {team.club_name && <span>{highlightMatch(team.club_name, deferredSearchQuery)}</span>}
-                                {team.state && (
-                                  <span className={team.club_name ? ' • ' : ''}>{team.state.toUpperCase()}</span>
-                                )}
-                                {team.age != null && team.gender && (
-                                  <span className={team.club_name || team.state ? ' • ' : ''}>
-                                    U{team.age} {formatGender(team.gender)}
-                                  </span>
-                                )}
-                              </div>
-                            </button>
-                          ))}
+                          {filteredTeams.map((team, index) => {
+                            const displayName = composeTeamDisplay(team);
+                            return (
+                              <button
+                                key={team.team_id_master}
+                                onClick={() => handleSelectTeam(team)}
+                                className={`w-full text-left p-2 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary ${
+                                  index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
+                                }`}
+                                aria-label={`Select ${displayName}`}
+                              >
+                                <div className="font-medium">{highlightMatch(displayName, deferredSearchQuery)}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {team.club_name && <span>{highlightMatch(team.club_name, deferredSearchQuery)}</span>}
+                                  {team.state && (
+                                    <span className={team.club_name ? ' • ' : ''}>{team.state.toUpperCase()}</span>
+                                  )}
+                                  {team.age != null && team.gender && (
+                                    <span className={team.club_name || team.state ? ' • ' : ''}>
+                                      U{team.age} {formatGender(team.gender)}
+                                    </span>
+                                  )}
+                                </div>
+                              </button>
+                            );
+                          })}
                         </div>
                       )}
                     </CardContent>
@@ -672,7 +676,7 @@ export function UnknownOpponentLink({
               <div className="flex items-start gap-2">
                 <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
                 <div>
-                  <p className="font-medium text-green-800 dark:text-green-200">{selectedTeam.team_name}</p>
+                  <p className="font-medium text-green-800 dark:text-green-200">{composeTeamDisplay(selectedTeam)}</p>
                   <p className="text-green-600 dark:text-green-300 text-xs">
                     {selectedTeam.club_name && `${selectedTeam.club_name} • `}
                     {selectedTeam.state?.toUpperCase()}

--- a/frontend/components/infographics/BiggestMoversPreview.tsx
+++ b/frontend/components/infographics/BiggestMoversPreview.tsx
@@ -3,6 +3,7 @@
 import React, { forwardRef } from 'react';
 import { InfographicWrapper, Platform, BRAND_COLORS, PLATFORM_DIMENSIONS } from './InfographicWrapper';
 import type { RankingRow } from '@/types/RankingRow';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface MoverTeam extends RankingRow {
   change: number;
@@ -80,7 +81,7 @@ export const BiggestMoversPreview = forwardRef<HTMLDivElement, BiggestMoversPrev
               whiteSpace: 'nowrap',
             }}
           >
-            {team.team_name}
+            {composeTeamDisplay(team)}
           </div>
           <div
             style={{

--- a/frontend/components/infographics/HeadToHeadPreview.tsx
+++ b/frontend/components/infographics/HeadToHeadPreview.tsx
@@ -6,6 +6,7 @@ import type { TeamWithRanking } from '@/lib/types';
 import type { RankingRow } from '@/types/RankingRow';
 import { predictMatch } from '@/lib/matchPredictor';
 import type { Game } from '@/lib/types';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface TeamCardProps {
   team: RankingRow;
@@ -53,7 +54,7 @@ function TeamCard({ team, rank, side, rankSize, teamNameSize, smallTextSize, max
           whiteSpace: 'nowrap',
         }}
       >
-        {team.team_name}
+        {composeTeamDisplay(team)}
       </div>
       <div
         style={{

--- a/frontend/components/infographics/StateChampionsPreview.tsx
+++ b/frontend/components/infographics/StateChampionsPreview.tsx
@@ -3,6 +3,7 @@
 import React, { forwardRef } from 'react';
 import { InfographicWrapper, Platform, BRAND_COLORS, PLATFORM_DIMENSIONS } from './InfographicWrapper';
 import type { RankingRow } from '@/types/RankingRow';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface StateChampion {
   state: string;
@@ -185,7 +186,7 @@ export const StateChampionsPreview = forwardRef<HTMLDivElement, StateChampionsPr
                     maxHeight: `${teamNameSize * 2.4}px`,
                   }}
                 >
-                  {champion.team.team_name}
+                  {composeTeamDisplay(champion.team)}
                 </div>
 
                 {/* Power Score */}

--- a/frontend/components/infographics/TeamSpotlightPreview.tsx
+++ b/frontend/components/infographics/TeamSpotlightPreview.tsx
@@ -3,6 +3,7 @@
 import React, { forwardRef } from 'react';
 import { InfographicWrapper, Platform, BRAND_COLORS, PLATFORM_DIMENSIONS } from './InfographicWrapper';
 import type { RankingRow } from '@/types/RankingRow';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface TeamSpotlightPreviewProps {
   team: RankingRow & { rank?: number };
@@ -168,7 +169,7 @@ export const TeamSpotlightPreview = forwardRef<HTMLDivElement, TeamSpotlightPrev
               whiteSpace: 'nowrap',
             }}
           >
-            {team.team_name}
+            {composeTeamDisplay(team)}
           </div>
 
           {/* Club & Location */}

--- a/frontend/components/infographics/Top10Infographic.tsx
+++ b/frontend/components/infographics/Top10Infographic.tsx
@@ -3,6 +3,7 @@
 import React, { forwardRef } from 'react';
 import { InfographicWrapper, Platform, BRAND_COLORS, PLATFORM_DIMENSIONS } from './InfographicWrapper';
 import type { RankingRow } from '@/types/RankingRow';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface Top10InfographicProps {
   teams: RankingRow[];
@@ -261,7 +262,7 @@ function RankingRowItem({ rank, team, rankSize, teamNameSize, statsSize, isVerti
             lineHeight: 1.2,
           }}
         >
-          {team.team_name}
+          {composeTeamDisplay(team)}
         </div>
         <div
           style={{

--- a/frontend/components/infographics/canvasRenderer.ts
+++ b/frontend/components/infographics/canvasRenderer.ts
@@ -1,5 +1,6 @@
 import type { RankingRow } from '@/types/RankingRow';
 import { PLATFORM_DIMENSIONS, BRAND_COLORS, Platform } from './InfographicWrapper';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface RenderOptions {
   teams: RankingRow[];
@@ -191,7 +192,7 @@ export async function renderInfographicToCanvas(options: RenderOptions): Promise
     ctx.font = `600 ${teamNameSize}px Oswald, "Arial Black", sans-serif`;
 
     // Truncate team name if too long
-    let teamName = team.team_name.toUpperCase();
+    let teamName = composeTeamDisplay(team).toUpperCase();
     const maxTeamWidth = dimensions.width - teamInfoX - 180;
     while (ctx.measureText(teamName).width > maxTeamWidth && teamName.length > 10) {
       teamName = teamName.slice(0, -4) + '...';

--- a/frontend/components/infographics/headToHeadRenderer.ts
+++ b/frontend/components/infographics/headToHeadRenderer.ts
@@ -3,6 +3,7 @@ import type { RankingRow } from '@/types/RankingRow';
 import { PLATFORM_DIMENSIONS, BRAND_COLORS, Platform } from './InfographicWrapper';
 import { predictMatch } from '@/lib/matchPredictor';
 import type { Game } from '@/lib/types';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface HeadToHeadOptions {
   team1: RankingRow & { rank?: number };
@@ -149,7 +150,7 @@ export async function renderHeadToHeadToCanvas(options: HeadToHeadOptions): Prom
   ctx.fillStyle = BRAND_COLORS.brightWhite;
   ctx.font = `700 ${teamNameSize}px Oswald, "Arial Black", sans-serif`;
 
-  let team1Name = team1.team_name.toUpperCase();
+  let team1Name = composeTeamDisplay(team1).toUpperCase();
   const maxNameWidth = centerX - padding - 80;
   while (ctx.measureText(team1Name).width > maxNameWidth && team1Name.length > 8) {
     team1Name = team1Name.slice(0, -4) + '...';
@@ -178,7 +179,7 @@ export async function renderHeadToHeadToCanvas(options: HeadToHeadOptions): Prom
   ctx.fillStyle = BRAND_COLORS.brightWhite;
   ctx.font = `700 ${teamNameSize}px Oswald, "Arial Black", sans-serif`;
 
-  let team2Name = team2.team_name.toUpperCase();
+  let team2Name = composeTeamDisplay(team2).toUpperCase();
   while (ctx.measureText(team2Name).width > maxNameWidth && team2Name.length > 8) {
     team2Name = team2Name.slice(0, -4) + '...';
   }

--- a/frontend/components/infographics/rankingMoversRenderer.ts
+++ b/frontend/components/infographics/rankingMoversRenderer.ts
@@ -1,5 +1,6 @@
 import type { RankingRow } from '@/types/RankingRow';
 import { PLATFORM_DIMENSIONS, BRAND_COLORS, Platform } from './InfographicWrapper';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface RankingMoversOptions {
   climbers: Array<RankingRow & { change: number; rank?: number }>;
@@ -149,7 +150,7 @@ export async function renderRankingMoversToCanvas(options: RankingMoversOptions)
     ctx.fillStyle = BRAND_COLORS.brightWhite;
     ctx.font = `600 ${teamNameSize}px Oswald, "Arial Black", sans-serif`;
 
-    let name = team.team_name.toUpperCase();
+    let name = composeTeamDisplay(team).toUpperCase();
     const maxNameWidth = width - (textX - x) - 60;
     while (ctx.measureText(name).width > maxNameWidth && name.length > 8) {
       name = name.slice(0, -4) + '...';

--- a/frontend/components/infographics/stateChampionsRenderer.ts
+++ b/frontend/components/infographics/stateChampionsRenderer.ts
@@ -1,5 +1,6 @@
 import type { RankingRow } from '@/types/RankingRow';
 import { PLATFORM_DIMENSIONS, BRAND_COLORS, Platform } from './InfographicWrapper';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface StateChampionsOptions {
   champions: Array<{ state: string; team: RankingRow }>;
@@ -150,7 +151,7 @@ export async function renderStateChampionsToCanvas(options: StateChampionsOption
     // Team name (truncated)
     ctx.fillStyle = BRAND_COLORS.brightWhite;
     ctx.font = `600 ${teamNameSize}px "DM Sans", Arial, sans-serif`;
-    let teamName = champ.team.team_name.toUpperCase();
+    let teamName = composeTeamDisplay(champ.team).toUpperCase();
     const maxNameWidth = cardWidth - 20;
     while (ctx.measureText(teamName).width > maxNameWidth && teamName.length > 8) {
       teamName = teamName.slice(0, -4) + '...';

--- a/frontend/components/infographics/teamSpotlightRenderer.ts
+++ b/frontend/components/infographics/teamSpotlightRenderer.ts
@@ -1,5 +1,6 @@
 import type { RankingRow } from '@/types/RankingRow';
 import { PLATFORM_DIMENSIONS, BRAND_COLORS, Platform } from './InfographicWrapper';
+import { composeTeamDisplay } from '@/lib/utils';
 
 interface TeamSpotlightOptions {
   team: RankingRow & { rank?: number };
@@ -126,7 +127,7 @@ export async function renderTeamSpotlightToCanvas(options: TeamSpotlightOptions)
   ctx.textBaseline = 'top';
 
   // Truncate if needed
-  let teamName = team.team_name.toUpperCase();
+  let teamName = composeTeamDisplay(team).toUpperCase();
   const maxWidth = dimensions.width - padding * 2;
   while (ctx.measureText(teamName).width > maxWidth && teamName.length > 10) {
     teamName = teamName.slice(0, -4) + '...';


### PR DESCRIPTION
## Summary

Follow-up to #722. Adopts `composeTeamDisplay` in the surfaces deferred from that PR: 5 infographic preview components (HeadToHeadPreview, Top10Infographic, StateChampionsPreview, BiggestMoversPreview, TeamSpotlightPreview), their 5 canvas renderer scripts, and `UnknownOpponentLink`. Render-only diff. Modular11 short-circuit preserved (helper still returns raw `team_name` when `has_modular11_alias === true`).

`UnknownOpponentLink` dropdown row uses `const displayName = composeTeamDisplay(team)` reused for the aria-label and `highlightMatch` arg, mirroring `RecentMovers.tsx`. Filter/sort sites at `:220, :226-227` deliberately stay on raw text (`searchable_name || team_name`).

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors, 1 pre-existing unrelated warning
- `npm run test`: 23 files / 115 tests pass
- Smoke deferred to manual dev-server check below

## Test plan

- [ ] `/infographics`: pick a non-Modular11 row whose existing rankings table label visibly differs from raw `team_name` (must show both a league suffix AND a distinction token, e.g. "ECNL White"). Render each of the 5 infographic types and confirm:
  - [ ] On-page Preview shows the composed label
  - [ ] Generated PNG shows the same composed label (canvas truncation operates on composed string)
- [ ] **Modular11 spot-check (regression-most-critical)**: MLS Next U15 cohort renders raw `team_name` in both preview and generated image. `tsc` cannot catch missing `has_modular11_alias` plumbing.
- [ ] Edge case: a team with `club_name = null` falls back to raw `team_name` without truncation regression.
- [ ] `UnknownOpponentLink` (premium-gated team detail page with unknown opponent):
  - [ ] Dropdown rows show composed labels
  - [ ] `aria-label` reads "Select {composed label}"
  - [ ] Clicking a row populates the search input + green confirmation panel with the composed label
  - [ ] Re-typing a fragment of raw `team_name` still finds the same team (filter at `:220` matches `searchable_name || team_name`)

Plan: `.turbo/plans/compose-team-display-rollout.md` (gitignored)