### PR TITLE
fix(search): restore disambiguator + age in global search dropdown

### DIFF
--- a/frontend/components/GlobalSearch.tsx
+++ b/frontend/components/GlobalSearch.tsx
@@ -235,31 +235,38 @@ export function GlobalSearch() {
               </div>
             ) : (
               <div id="global-search-results" role="listbox" className="space-y-1" ref={listRef}>
-                {searchResults.map((team, index) => (
-                  <button
-                    key={team.team_id_master}
-                    role="option"
-                    aria-selected={index === selectedIndex}
-                    onClick={() => handleSelect(team)}
-                    className={`w-full text-left p-3 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary min-h-[44px] ${
-                      index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
-                    }`}
-                    aria-label={`Select ${composeTeamDisplay(team)}`}
-                  >
-                    <div className="font-medium truncate">
-                      {highlightMatch(composeTeamDisplay(team), deferredSearchQuery)}
-                    </div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      {team.state && <span>{team.state.toUpperCase()}</span>}
-                      {team.rank_in_cohort_final && <span> • Rank #{team.rank_in_cohort_final}</span>}
-                      {team.age != null && team.gender && (
-                        <span className={team.state || team.rank_in_cohort_final ? ' • ' : ''}>
-                          {formatGender(team.gender)}
-                        </span>
+                {searchResults.map((team, index) => {
+                  const composed = composeTeamDisplay(team);
+                  const showRawName = !!team.team_name && team.team_name !== composed;
+                  return (
+                    <button
+                      key={team.team_id_master}
+                      role="option"
+                      aria-selected={index === selectedIndex}
+                      onClick={() => handleSelect(team)}
+                      className={`w-full text-left p-3 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary min-h-[44px] ${
+                        index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
+                      }`}
+                      aria-label={`Select ${composed}${showRawName ? ` (${team.team_name})` : ''}`}
+                    >
+                      <div className="font-medium truncate">{highlightMatch(composed, deferredSearchQuery)}</div>
+                      {showRawName && (
+                        <div className="text-xs text-muted-foreground truncate">
+                          {highlightMatch(team.team_name, deferredSearchQuery)}
+                        </div>
                       )}
-                    </div>
-                  </button>
-                ))}
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {team.state && <span>{team.state.toUpperCase()}</span>}
+                        {team.rank_in_cohort_final && <span> • Rank #{team.rank_in_cohort_final}</span>}
+                        {team.age != null && team.gender && (
+                          <span className={team.state || team.rank_in_cohort_final ? ' • ' : ''}>
+                            U{team.age} {formatGender(team.gender)}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
               </div>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary

PR #722 swapped the global-search dropdown's primary line from raw `team_name` to `composeTeamDisplay`, and dropped `U{age}` from the subline. That formatting works on `/rankings` (where age is already a URL filter) but the global nav search has no filter — so a live query just confirmed that **~60% of teams (93,644 of 155,711)** collapsed into duplicate-display rows with no visible age. Worst case: `Legends FC (ca)` rendered identically across **43** different teams.

This PR restores the per-row identifying info without giving up the cleanup #722 was after.

## Changes (1 file, +31 / −24)

`frontend/components/GlobalSearch.tsx`:
- Add a muted secondary line with `team_name` when it differs from `composeTeamDisplay(team)`. Suppressed when they match (no double row, no MLS Next regression).
- Re-add `U{team.age}` to the metadata subline next to gender.
- Both lines run through `highlightMatch`, so queries against tokens that only live in `team_name` (coach names, birth years, squad letters) are visibly highlighted.
- `aria-label` includes both forms when they differ for screen readers.

## Verified in browser

Spun up local dev and tested with Playwright snapshots of the dropdown:
- `Solar SC` — 8 results, each composed line + raw `team_name` + `U{age} {gender}` visible.
- `Hernandez` — coach-name search now visibly highlights the match in the secondary line.
- `Cedar Stars` — the three `Cedar Stars Academy - Bergen GA` rows that previously rendered identically are now distinguished by birth year (2007/2009/2010) on the secondary line.
- `Phoenix Rising AD` — MLS Next teams render with secondary `team_name` as expected (see follow-up below).

## Follow-up (separate PR)

`fetchModular11TeamIds` in `useTeamSearch.ts` returns an empty Set under the anonymous Supabase key — so the `has_modular11_alias` short-circuit added in #722 has been silently no-op since merge. No console warning fires because zero rows is not an `error`. This PR is strictly better for those teams (raw `team_name` now appears as the secondary line), but the short-circuit itself needs an RLS / data-fetch fix.

## Test plan
- [ ] Open the homepage on a deploy preview, type "Solar SC" — confirm each row shows composed + raw + age/gender
- [ ] Type a coach name (e.g. "Hernandez", "Romero") — confirm highlighting on the secondary line
- [ ] Confirm dropdown still closes / navigates correctly on click and Enter