### PR TITLE
fix(seo): use existing icon-512.png raster for homepage Organization JSON-LD logo

### DIFF
--- a/frontend/components/StructuredData.tsx
+++ b/frontend/components/StructuredData.tsx
@@ -12,7 +12,7 @@ export function StructuredData() {
     '@type': 'Organization',
     name: 'PitchRank',
     url: BASE_URL,
-    logo: `${BASE_URL}/logos/pitchrank-logo-dark.png`,
+    logo: `${BASE_URL}/logos/icon-512.png`,
     description: 'Data-powered youth soccer team rankings and performance analytics',
     sameAs: PITCHRANK_SAMEAS,
     contactPoint: {


### PR DESCRIPTION
## Summary

The sitewide `Organization` JSON-LD in `StructuredData.tsx` referenced `/logos/pitchrank-logo-dark.png` — a file that does not exist in `frontend/public/logos/`. The URL 404s in production. Switching to the existing `/logos/icon-512.png` (512×512 PNG, raster) fixes both:

1. The 404 on the logo URL itself
2. Google's structured-data spec requirement that `Organization.logo` (when used as an Article publisher) must be raster — already enforced for Article/BlogPosting schemas via `PITCHRANK_PUBLISHER` in PR #718

Surfaced and noted in `.turbo/improvements.md` during the GEO Week 5 author-entity work.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Asset exists (`frontend/public/logos/icon-512.png` is a 512×512 PNG)
- [ ] After deploy: re-run Rich Results Test on `/` — sitewide Organization logo URL should resolve and validate as raster