### PR TITLE
feat: in-product "Something seems off?" feedback widget

### DIFF
--- a/frontend/app/api/feedback/__tests__/route.test.ts
+++ b/frontend/app/api/feedback/__tests__/route.test.ts
@@ -166,4 +166,99 @@ describe('POST /api/feedback', () => {
     await POST(makeRequest(validBody));
     expect(mockSendFeedback.mock.calls[0][0].ipMasked).toBe('203.0.113.x');
   });
+
+  it('400 when the JSON body is literal null', async () => {
+    const req = new Request('http://localhost/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '203.0.113.42' },
+      body: 'null',
+    }) as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when context.pathname is missing', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        context: { openedAt: VALID_OPENED, submittedAt: VALID_SUBMITTED },
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when timestamps fail to parse', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        context: {
+          pathname: '/teams/abc',
+          openedAt: 'not-a-date',
+          submittedAt: 'also-not-a-date',
+        },
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('500 when the Supabase auth lookup throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetUser.mockRejectedValue(new Error('supabase unreachable'));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('masks IPv6 addresses by dropping the last segment', async () => {
+    const req = new Request('http://localhost/api/feedback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-forwarded-for': '2001:db8:abcd:1234:5678:9abc:def0:1111',
+      },
+      body: JSON.stringify(validBody),
+    }) as NextRequest;
+    await POST(req);
+    expect(mockSendFeedback).toHaveBeenCalled();
+    const masked = mockSendFeedback.mock.calls[0][0].ipMasked;
+    // Last segment replaced with 'x'.
+    expect(masked.endsWith(':x')).toBe(true);
+    expect(masked.startsWith('2001:db8:')).toBe(true);
+  });
+
+  it('returns "masked" for IPs that are neither IPv4 nor IPv6', async () => {
+    const req = new Request('http://localhost/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-forwarded-for': 'garbage' },
+      body: JSON.stringify(validBody),
+    }) as NextRequest;
+    await POST(req);
+    expect(mockSendFeedback.mock.calls[0][0].ipMasked).toBe('masked');
+  });
+
+  it('demotes signed-in user with null email to anonymous and warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-no-email', email: null } },
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ ...validBody, email: 'fallback@example.com' }));
+
+    expect(res.status).toBe(200);
+    expect(mockSendFeedback).toHaveBeenCalledOnce();
+    expect(mockSendFeedback.mock.calls[0][0].identity).toEqual({
+      kind: 'anonymous',
+      email: 'fallback@example.com',
+    });
+    expect(warnSpy).toHaveBeenCalledWith('[feedback] signed-in user has no email; treating as anonymous', {
+      userId: 'user-no-email',
+    });
+
+    warnSpy.mockRestore();
+  });
 });

--- a/frontend/app/api/feedback/__tests__/route.test.ts
+++ b/frontend/app/api/feedback/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const { mockSendFeedback, mockCheckRateLimit, mockGetUser } = vi.hoisted(() => ({
+  mockSendFeedback: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendFeedbackEmail: mockSendFeedback,
+}));
+
+vi.mock('@/lib/api/rateLimit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: async () => ({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+import { POST } from '../route';
+
+const VALID_OPENED = '2026-05-06T18:00:00.000Z';
+const VALID_SUBMITTED = '2026-05-06T18:00:05.000Z'; // 5s after open
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/feedback', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '203.0.113.42',
+    },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+const validBody = {
+  category: 'rankings-wrong',
+  message: 'My team is ranked too low for sure',
+  context: {
+    pathname: '/teams/abc-u14-boys',
+    openedAt: VALID_OPENED,
+    submittedAt: VALID_SUBMITTED,
+  },
+};
+
+describe('POST /api/feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
+    mockSendFeedback.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+  });
+
+  it('200s on a valid signed-in submission and dispatches email', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'coach@example.com' } },
+      error: null,
+    });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSendFeedback).toHaveBeenCalledTimes(1);
+    const sent = mockSendFeedback.mock.calls[0][0];
+    expect(sent.identity).toEqual({ kind: 'signed-in', userId: 'user-1', email: 'coach@example.com' });
+  });
+
+  it('200s on a valid anonymous submission with replyTo email', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: 'anon@example.com' }));
+    expect(res.status).toBe(200);
+    expect(mockSendFeedback).toHaveBeenCalledOnce();
+    const sent = mockSendFeedback.mock.calls[0][0];
+    expect(sent.identity).toEqual({ kind: 'anonymous', email: 'anon@example.com' });
+  });
+
+  it('200s on a valid anonymous submission with no email', async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockSendFeedback).toHaveBeenCalledOnce();
+    expect(mockSendFeedback.mock.calls[0][0].identity).toEqual({ kind: 'anonymous' });
+  });
+
+  it('400 when category is missing', async () => {
+    const { category: _category, ...rest } = validBody;
+    const res = await POST(makeRequest(rest));
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when category is unknown', async () => {
+    const res = await POST(makeRequest({ ...validBody, category: 'something-else' }));
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when message is too short', async () => {
+    const res = await POST(makeRequest({ ...validBody, message: 'short' }));
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when message exceeds 2000 chars', async () => {
+    const res = await POST(makeRequest({ ...validBody, message: 'a'.repeat(2001) }));
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('400 when an anonymous email is malformed', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('200 (silent) but does not send when honeypot is filled', async () => {
+    const res = await POST(makeRequest({ ...validBody, website: 'http://spam.example' }));
+    expect(res.status).toBe(200);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('200 (silent) but does not send when min-time floor is violated', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        context: {
+          ...validBody.context,
+          submittedAt: '2026-05-06T18:00:01.000Z', // only 1s after open
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('429 when rate limit denies', async () => {
+    mockCheckRateLimit.mockReturnValue(false);
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('502 when sendFeedbackEmail returns false', async () => {
+    mockSendFeedback.mockResolvedValue(false);
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(502);
+  });
+
+  it('400 on malformed JSON body', async () => {
+    const req = new Request('http://localhost/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '203.0.113.42' },
+      body: '{not valid',
+    }) as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('masks the IP last octet in the dispatched payload', async () => {
+    await POST(makeRequest(validBody));
+    expect(mockSendFeedback.mock.calls[0][0].ipMasked).toBe('203.0.113.x');
+  });
+});

--- a/frontend/app/api/feedback/route.ts
+++ b/frontend/app/api/feedback/route.ts
@@ -62,6 +62,10 @@ export async function POST(request: NextRequest) {
     if (parsed.error) return parsed.error;
     const body = parsed.data;
 
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return bad('Invalid request body');
+    }
+
     // Honeypot — silent accept, do not send.
     if (typeof body.website === 'string' && body.website.length > 0) {
       return NextResponse.json({ ok: true });
@@ -117,9 +121,17 @@ export async function POST(request: NextRequest) {
     const { data: userResult } = await supabase.auth.getUser();
     const sessionUser = userResult?.user ?? null;
 
-    const identity: FeedbackIdentity = sessionUser?.email
-      ? { kind: 'signed-in', userId: sessionUser.id, email: sessionUser.email }
-      : { kind: 'anonymous', ...(anonymousEmail ? { email: anonymousEmail } : {}) };
+    let identity: FeedbackIdentity;
+    if (sessionUser?.email) {
+      identity = { kind: 'signed-in', userId: sessionUser.id, email: sessionUser.email };
+    } else {
+      if (sessionUser) {
+        console.warn('[feedback] signed-in user has no email; treating as anonymous', {
+          userId: sessionUser.id,
+        });
+      }
+      identity = { kind: 'anonymous', ...(anonymousEmail ? { email: anonymousEmail } : {}) };
+    }
 
     // Optional context fields (typed as unknown above; coerce safely)
     const referrer = isStringWithLen(ctx.referrer, 0, MAX_TEXT_FIELD) ? ctx.referrer : undefined;
@@ -160,6 +172,7 @@ export async function POST(request: NextRequest) {
         scope: 'feedback',
         category,
         identity: identity.kind === 'signed-in' ? identity.userId : 'anonymous',
+        sessionUserId: sessionUser?.id ?? null,
         pathname: ctx.pathname,
         outcome: 'sent',
       })

--- a/frontend/app/api/feedback/route.ts
+++ b/frontend/app/api/feedback/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { parseJsonBody } from '@/lib/api/parseJsonBody';
+import { checkRateLimit } from '@/lib/api/rateLimit';
+import { createServerSupabase } from '@/lib/supabase/server';
+import { sendFeedbackEmail, type FeedbackCategory, type FeedbackIdentity } from '@/lib/email';
+
+const VALID_CATEGORIES: readonly FeedbackCategory[] = [
+  'cant-find-team',
+  'rankings-wrong',
+  'wrong-games',
+  'bug',
+  'other',
+] as const;
+
+const MIN_MESSAGE = 10;
+const MAX_MESSAGE = 2000;
+const MAX_PATHNAME = 512;
+const MAX_TEXT_FIELD = 512;
+const MIN_DWELL_MS = 2000;
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface IncomingBody {
+  category?: unknown;
+  message?: unknown;
+  email?: unknown;
+  website?: unknown;
+  context?: {
+    pathname?: unknown;
+    referrer?: unknown;
+    userAgent?: unknown;
+    viewport?: { w?: unknown; h?: unknown };
+    openedAt?: unknown;
+    submittedAt?: unknown;
+  };
+}
+
+function bad(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+function maskIp(ip: string): string {
+  if (ip === 'unknown') return 'unknown';
+  const parts = ip.split('.');
+  if (parts.length === 4) return `${parts[0]}.${parts[1]}.${parts[2]}.x`;
+  // IPv6 or other: drop the last segment
+  const v6 = ip.split(':');
+  if (v6.length > 1) return v6.slice(0, -1).concat('x').join(':');
+  return 'masked';
+}
+
+function isStringWithLen(v: unknown, min: number, max: number): v is string {
+  return typeof v === 'string' && v.length >= min && v.length <= max;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+
+    const parsed = await parseJsonBody<IncomingBody>(request);
+    if (parsed.error) return parsed.error;
+    const body = parsed.data;
+
+    // Honeypot — silent accept, do not send.
+    if (typeof body.website === 'string' && body.website.length > 0) {
+      return NextResponse.json({ ok: true });
+    }
+
+    // Category
+    if (typeof body.category !== 'string' || !VALID_CATEGORIES.includes(body.category as FeedbackCategory)) {
+      return bad('Invalid category');
+    }
+    const category = body.category as FeedbackCategory;
+
+    // Message
+    if (typeof body.message !== 'string') return bad('Message is required');
+    const message = body.message.trim();
+    if (message.length < MIN_MESSAGE) return bad(`Message must be at least ${MIN_MESSAGE} characters`);
+    if (message.length > MAX_MESSAGE) return bad(`Message must be at most ${MAX_MESSAGE} characters`);
+
+    // Optional anonymous email
+    let anonymousEmail: string | undefined;
+    if (body.email !== undefined && body.email !== null && body.email !== '') {
+      if (typeof body.email !== 'string' || !EMAIL_REGEX.test(body.email)) {
+        return bad('Email is not valid');
+      }
+      anonymousEmail = body.email.trim();
+    }
+
+    // Context
+    const ctx = body.context;
+    if (!ctx || typeof ctx !== 'object') return bad('Context is required');
+    if (!isStringWithLen(ctx.pathname, 1, MAX_PATHNAME)) return bad('Invalid pathname');
+    if (!isStringWithLen(ctx.openedAt, 1, 64)) return bad('Invalid openedAt');
+    if (!isStringWithLen(ctx.submittedAt, 1, 64)) return bad('Invalid submittedAt');
+
+    const openedAtMs = Date.parse(ctx.openedAt);
+    const submittedAtMs = Date.parse(ctx.submittedAt);
+    if (Number.isNaN(openedAtMs) || Number.isNaN(submittedAtMs)) return bad('Invalid timestamps');
+
+    // Min-time floor — silent accept, do not send.
+    if (submittedAtMs - openedAtMs < MIN_DWELL_MS) {
+      return NextResponse.json({ ok: true });
+    }
+
+    // Rate limit by IP
+    if (!checkRateLimit(ip, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+      return NextResponse.json(
+        { error: 'rate_limited' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)) } }
+      );
+    }
+
+    // Identify caller via server session
+    const supabase = await createServerSupabase();
+    const { data: userResult } = await supabase.auth.getUser();
+    const sessionUser = userResult?.user ?? null;
+
+    const identity: FeedbackIdentity = sessionUser?.email
+      ? { kind: 'signed-in', userId: sessionUser.id, email: sessionUser.email }
+      : { kind: 'anonymous', ...(anonymousEmail ? { email: anonymousEmail } : {}) };
+
+    // Optional context fields (typed as unknown above; coerce safely)
+    const referrer = isStringWithLen(ctx.referrer, 0, MAX_TEXT_FIELD) ? ctx.referrer : undefined;
+    const userAgent = isStringWithLen(ctx.userAgent, 0, MAX_TEXT_FIELD) ? ctx.userAgent : undefined;
+    let viewport: { w: number; h: number } | undefined;
+    if (
+      ctx.viewport &&
+      typeof ctx.viewport.w === 'number' &&
+      typeof ctx.viewport.h === 'number' &&
+      ctx.viewport.w > 0 &&
+      ctx.viewport.h > 0
+    ) {
+      viewport = { w: Math.floor(ctx.viewport.w), h: Math.floor(ctx.viewport.h) };
+    }
+
+    // NOTE: openedAt is captured for the min-time floor but is intentionally NOT
+    // included in the email context — sendFeedbackEmail's FeedbackContext does not have it.
+    const ok = await sendFeedbackEmail({
+      category,
+      message,
+      identity,
+      context: {
+        pathname: ctx.pathname,
+        referrer,
+        userAgent,
+        viewport,
+        submittedAt: ctx.submittedAt,
+      },
+      ipMasked: maskIp(ip),
+    });
+
+    if (!ok) {
+      return NextResponse.json({ error: 'send_failed' }, { status: 502 });
+    }
+
+    console.log(
+      JSON.stringify({
+        scope: 'feedback',
+        category,
+        identity: identity.kind === 'signed-in' ? identity.userId : 'anonymous',
+        pathname: ctx.pathname,
+        outcome: 'sent',
+      })
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('[feedback] Unexpected error:', err);
+    return NextResponse.json({ error: 'send_failed' }, { status: 500 });
+  }
+}

--- a/frontend/components/FeedbackModal.tsx
+++ b/frontend/components/FeedbackModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 import {
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useUser } from '@/hooks/useUser';
 
@@ -36,6 +37,9 @@ const PLACEHOLDERS: Record<Category, string> = {
 
 const MIN_MESSAGE = 10;
 const MAX_MESSAGE = 2000;
+
+const TEXTAREA_CLASSES =
+  'flex w-full min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
 
 interface FeedbackModalProps {
   open: boolean;
@@ -103,10 +107,6 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
       }
 
       setStatus('success');
-      setCategory('');
-      setMessage('');
-      setEmail('');
-      setWebsite('');
     } catch {
       setStatus('error');
     }
@@ -140,9 +140,7 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
       )}
 
       <div className="space-y-1.5">
-        <label htmlFor="feedback-category" className="text-sm font-medium">
-          Category
-        </label>
+        <Label htmlFor="feedback-category">Category</Label>
         <Select value={category} onValueChange={(v) => setCategory(v as Category)}>
           <SelectTrigger id="feedback-category" data-testid="feedback-category">
             <SelectValue placeholder="Select one…" />
@@ -158,19 +156,16 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
       </div>
 
       <div className="space-y-1.5">
-        <label htmlFor="feedback-message" className="text-sm font-medium">
-          What&apos;s happening?
-        </label>
+        <Label htmlFor="feedback-message">What&apos;s happening?</Label>
         <textarea
           id="feedback-message"
           data-testid="feedback-message"
-          className="flex w-full min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          className={TEXTAREA_CLASSES}
           placeholder={placeholder}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           rows={5}
           maxLength={MAX_MESSAGE}
-          autoFocus
         />
         <p className="text-xs text-muted-foreground">
           {message.trim().length} / {MAX_MESSAGE}
@@ -179,9 +174,9 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
 
       {!hasUser && (
         <div className="space-y-1.5">
-          <label htmlFor="feedback-email" className="text-sm font-medium">
+          <Label htmlFor="feedback-email">
             Email <span className="text-muted-foreground font-normal">(optional)</span>
-          </label>
+          </Label>
           <Input
             id="feedback-email"
             data-testid="feedback-email"
@@ -199,7 +194,6 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
 
       {/* Honeypot — must remain hidden and not focusable */}
       <div
-        aria-hidden="true"
         style={{
           position: 'absolute',
           left: '-9999px',
@@ -222,7 +216,7 @@ function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUse
       </div>
 
       <DialogFooter>
-        <Button type="button" variant="ghost" onClick={onClose}>
+        <Button type="button" variant="outline" onClick={onClose}>
           Cancel
         </Button>
         <Button type="submit" disabled={!canSubmit || status === 'submitting'} data-testid="feedback-submit">
@@ -257,6 +251,8 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 
   const formKey = `${pathname ?? ''}:${openCount}`;
 
+  const onClose = useCallback(() => onOpenChange(false), [onOpenChange]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[480px]" data-testid="feedback-modal">
@@ -265,7 +261,7 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
           <DialogDescription>Tell us what you&apos;re seeing — we read every report.</DialogDescription>
         </DialogHeader>
 
-        <FeedbackForm key={formKey} pathname={pathname ?? ''} hasUser={!!user} onClose={() => onOpenChange(false)} />
+        <FeedbackForm key={formKey} pathname={pathname ?? ''} hasUser={!!user} onClose={onClose} />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/components/FeedbackModal.tsx
+++ b/frontend/components/FeedbackModal.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useUser } from '@/hooks/useUser';
+
+type Category = 'cant-find-team' | 'rankings-wrong' | 'wrong-games' | 'bug' | 'other';
+
+const CATEGORY_OPTIONS: Array<{ value: Category; label: string }> = [
+  { value: 'cant-find-team', label: "I can't find my team" },
+  { value: 'rankings-wrong', label: 'Rankings look wrong' },
+  { value: 'wrong-games', label: 'Wrong games attached to a team' },
+  { value: 'bug', label: 'Bug or broken page' },
+  { value: 'other', label: 'Other' },
+];
+
+const PLACEHOLDERS: Record<Category, string> = {
+  'cant-find-team': 'Club name, age group, gender, state — anything that helps us find them.',
+  'rankings-wrong': 'Which team, and what looks off about their ranking?',
+  'wrong-games': "Which team's game list looks wrong, and which game(s)?",
+  bug: 'What did you click, and what happened vs what you expected?',
+  other: "Tell us what's on your mind.",
+};
+
+const MIN_MESSAGE = 10;
+const MAX_MESSAGE = 2000;
+
+interface FeedbackModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error' | 'rate_limited';
+
+/**
+ * Inner form is mounted with a fresh `key` on each open and on each pathname
+ * change, so all local state (category, message, email, status) resets via
+ * remount instead of via setState-in-effect.
+ */
+function FeedbackForm({ pathname, hasUser, onClose }: { pathname: string; hasUser: boolean; onClose: () => void }) {
+  const [category, setCategory] = useState<Category | ''>('');
+  const [message, setMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [website, setWebsite] = useState(''); // honeypot
+  const [status, setStatus] = useState<Status>('idle');
+  const openedAtRef = useRef<string>(new Date().toISOString());
+
+  // Auto-close 4s after success — this is a legitimate external sync (timer).
+  useEffect(() => {
+    if (status !== 'success') return;
+    const t = setTimeout(onClose, 4000);
+    return () => clearTimeout(t);
+  }, [status, onClose]);
+
+  const canSubmit = useMemo(
+    () => category !== '' && message.trim().length >= MIN_MESSAGE && message.length <= MAX_MESSAGE,
+    [category, message]
+  );
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit || status === 'submitting') return;
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          category,
+          message: message.trim(),
+          ...(hasUser ? {} : email.trim() ? { email: email.trim() } : {}),
+          ...(website ? { website } : {}),
+          context: {
+            pathname,
+            referrer: typeof document !== 'undefined' ? document.referrer : undefined,
+            userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+            viewport: typeof window !== 'undefined' ? { w: window.innerWidth, h: window.innerHeight } : undefined,
+            openedAt: openedAtRef.current,
+            submittedAt: new Date().toISOString(),
+          },
+        }),
+      });
+
+      if (res.status === 429) {
+        setStatus('rate_limited');
+        return;
+      }
+      if (!res.ok) {
+        setStatus('error');
+        return;
+      }
+
+      setStatus('success');
+      setCategory('');
+      setMessage('');
+      setEmail('');
+      setWebsite('');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  const placeholder = category ? PLACEHOLDERS[category] : 'Tell us what you saw…';
+
+  if (status === 'success') {
+    return (
+      <div
+        className="rounded-md border border-green-300 bg-green-50 p-4 text-sm text-green-900"
+        role="status"
+        aria-live="polite"
+      >
+        Thanks — we got it.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      {status === 'error' && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900" role="alert">
+          Couldn&apos;t send right now. Try again, or email pitchrankio@gmail.com.
+        </div>
+      )}
+      {status === 'rate_limited' && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900" role="alert">
+          You&apos;ve sent a few already — give it an hour and try again.
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <label htmlFor="feedback-category" className="text-sm font-medium">
+          Category
+        </label>
+        <Select value={category} onValueChange={(v) => setCategory(v as Category)}>
+          <SelectTrigger id="feedback-category" data-testid="feedback-category">
+            <SelectValue placeholder="Select one…" />
+          </SelectTrigger>
+          <SelectContent>
+            {CATEGORY_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="feedback-message" className="text-sm font-medium">
+          What&apos;s happening?
+        </label>
+        <textarea
+          id="feedback-message"
+          data-testid="feedback-message"
+          className="flex w-full min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder={placeholder}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={5}
+          maxLength={MAX_MESSAGE}
+          autoFocus
+        />
+        <p className="text-xs text-muted-foreground">
+          {message.trim().length} / {MAX_MESSAGE}
+        </p>
+      </div>
+
+      {!hasUser && (
+        <div className="space-y-1.5">
+          <label htmlFor="feedback-email" className="text-sm font-medium">
+            Email <span className="text-muted-foreground font-normal">(optional)</span>
+          </label>
+          <Input
+            id="feedback-email"
+            data-testid="feedback-email"
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+          />
+          <p className="text-xs text-muted-foreground">
+            So we can reply if we have questions. We won&apos;t add you to anything.
+          </p>
+        </div>
+      )}
+
+      {/* Honeypot — must remain hidden and not focusable */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          top: 'auto',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+        }}
+      >
+        <label htmlFor="feedback-website">Website</label>
+        <input
+          id="feedback-website"
+          name="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit || status === 'submitting'} data-testid="feedback-submit">
+          {status === 'submitting' ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Sending…
+            </>
+          ) : (
+            'Send'
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
+  const pathname = usePathname();
+  const { user } = useUser();
+
+  // Bumps each time the modal transitions to open; combined with pathname,
+  // forms a stable key that remounts the inner form (resetting all its state).
+  // Uses the "store information from previous renders" pattern with useState
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders).
+  const [prevOpen, setPrevOpen] = useState(open);
+  const [openCount, setOpenCount] = useState(0);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setOpenCount((c) => c + 1);
+  }
+
+  const formKey = `${pathname ?? ''}:${openCount}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]" data-testid="feedback-modal">
+        <DialogHeader>
+          <DialogTitle>Something seems off?</DialogTitle>
+          <DialogDescription>Tell us what you&apos;re seeing — we read every report.</DialogDescription>
+        </DialogHeader>
+
+        <FeedbackForm key={formKey} pathname={pathname ?? ''} hasUser={!!user} onClose={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/FeedbackTrigger.tsx
+++ b/frontend/components/FeedbackTrigger.tsx
@@ -26,7 +26,6 @@ export function FeedbackTrigger() {
         title="Something seems off?"
         onClick={() => setOpen(true)}
         data-testid="feedback-trigger"
-        className="min-w-[44px] min-h-[44px]"
       >
         <HelpCircle className="h-5 w-5" />
       </Button>

--- a/frontend/components/FeedbackTrigger.tsx
+++ b/frontend/components/FeedbackTrigger.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { HelpCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { FeedbackModal } from './FeedbackModal';
+
+const HIDDEN_PREFIXES = ['/embed', '/login', '/signup'];
+
+export function FeedbackTrigger() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  if (pathname && HIDDEN_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Report an issue"
+        title="Something seems off?"
+        onClick={() => setOpen(true)}
+        data-testid="feedback-trigger"
+        className="min-w-[44px] min-h-[44px]"
+      >
+        <HelpCircle className="h-5 w-5" />
+      </Button>
+      <FeedbackModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/frontend/components/Navigation.tsx
+++ b/frontend/components/Navigation.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Menu, X, Star, User, LogOut, LogIn } from 'lucide-react';
 import { GlobalSearch } from './GlobalSearch';
+import { FeedbackTrigger } from './FeedbackTrigger';
 import { Button } from './ui/button';
 import { useUser } from '@/hooks/useUser';
 
@@ -114,6 +115,8 @@ export function Navigation() {
             Blog
           </Link>
 
+          <FeedbackTrigger />
+
           {/* Auth Section */}
           {!isLoading && (
             <>
@@ -146,11 +149,12 @@ export function Navigation() {
           )}
         </nav>
 
-        {/* Mobile: Search + Menu Button */}
+        {/* Mobile: Search + Feedback + Menu Button */}
         <div className="flex lg:hidden items-center gap-2 sm:gap-3">
           <div className="flex-1 min-w-0">
             <GlobalSearch />
           </div>
+          <FeedbackTrigger />
           <Button
             variant="ghost"
             size="icon"

--- a/frontend/lib/email/__tests__/feedback.test.ts
+++ b/frontend/lib/email/__tests__/feedback.test.ts
@@ -20,7 +20,6 @@ const baseInput = {
     userAgent: 'Mozilla/5.0',
     viewport: { w: 1280, h: 800 },
     submittedAt: '2026-05-06T18:42:00.000Z',
-    openedAt: '2026-05-06T18:41:30.000Z',
   },
   ipMasked: '192.168.1.x',
 };
@@ -46,22 +45,33 @@ describe('sendFeedbackEmail', () => {
     expect(subject).toContain('My U14 team is ranked too low');
   });
 
-  it('truncates long messages in subject to 60 chars', async () => {
+  it('truncates long messages in subject to 60 chars + ellipsis', async () => {
     const longMsg = 'a'.repeat(200);
     await sendFeedbackEmail({ ...baseInput, message: longMsg });
     const subject = mockSend.mock.calls[0][0].subject;
-    const tail = subject.split('—').pop()!.trim();
-    expect(tail.length).toBeLessThanOrEqual(63); // 60 + ellipsis
+
+    // Subject must end with the ellipsis when truncation occurs.
+    expect(subject.endsWith('…')).toBe(true);
+    // Exactly 60 'a's followed by the ellipsis, not 59 and not 61.
+    expect(subject).toContain(`${CATEGORY_LABELS['rankings-wrong']} — ${'a'.repeat(60)}…`);
+    expect(subject).not.toContain('a'.repeat(61) + '…');
   });
 
-  it('escapes HTML in the user message body', async () => {
-    const dangerous = '<script>alert(1)</script><img onerror=x src=y>';
+  it('escapes HTML in the user message body (all five entities)', async () => {
+    const dangerous = `<script>alert(1)</script><img onerror=x src=y> & " '`;
     await sendFeedbackEmail({ ...baseInput, message: dangerous });
     const html = mockSend.mock.calls[0][0].html;
+
+    // None of the raw injection vectors should appear.
     expect(html).not.toContain('<script>');
     expect(html).not.toContain('<img onerror');
+
+    // All five entity escapes should be present.
     expect(html).toContain('&lt;script&gt;');
     expect(html).toContain('&lt;img onerror=x src=y&gt;');
+    expect(html).toContain('&amp;');
+    expect(html).toContain('&quot;');
+    expect(html).toContain('&#39;');
   });
 
   it('sets replyTo to user.email for signed-in submitters', async () => {

--- a/frontend/lib/email/__tests__/feedback.test.ts
+++ b/frontend/lib/email/__tests__/feedback.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+}));
+
+vi.mock('../resend', () => ({
+  resend: { emails: { send: mockSend } },
+}));
+
+import { sendFeedbackEmail, CATEGORY_LABELS } from '../feedback';
+
+const baseInput = {
+  category: 'rankings-wrong' as const,
+  message: 'My U14 team is ranked too low',
+  identity: { kind: 'signed-in' as const, userId: 'user-123', email: 'coach@example.com' },
+  context: {
+    pathname: '/teams/abc-u14-boys',
+    referrer: 'https://google.com',
+    userAgent: 'Mozilla/5.0',
+    viewport: { w: 1280, h: 800 },
+    submittedAt: '2026-05-06T18:42:00.000Z',
+    openedAt: '2026-05-06T18:41:30.000Z',
+  },
+  ipMasked: '192.168.1.x',
+};
+
+describe('sendFeedbackEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({ data: { id: 'email-id' }, error: null });
+  });
+
+  it('sends from feedback@mail.pitchrank.io to pitchrankio@gmail.com', async () => {
+    await sendFeedbackEmail(baseInput);
+    const call = mockSend.mock.calls[0][0];
+    expect(call.from).toBe('PitchRank <feedback@mail.pitchrank.io>');
+    expect(call.to).toBe('pitchrankio@gmail.com');
+  });
+
+  it('subject contains category label and message snippet', async () => {
+    await sendFeedbackEmail(baseInput);
+    const subject = mockSend.mock.calls[0][0].subject;
+    expect(subject).toContain('[PitchRank Feedback]');
+    expect(subject).toContain(CATEGORY_LABELS['rankings-wrong']);
+    expect(subject).toContain('My U14 team is ranked too low');
+  });
+
+  it('truncates long messages in subject to 60 chars', async () => {
+    const longMsg = 'a'.repeat(200);
+    await sendFeedbackEmail({ ...baseInput, message: longMsg });
+    const subject = mockSend.mock.calls[0][0].subject;
+    const tail = subject.split('—').pop()!.trim();
+    expect(tail.length).toBeLessThanOrEqual(63); // 60 + ellipsis
+  });
+
+  it('escapes HTML in the user message body', async () => {
+    const dangerous = '<script>alert(1)</script><img onerror=x src=y>';
+    await sendFeedbackEmail({ ...baseInput, message: dangerous });
+    const html = mockSend.mock.calls[0][0].html;
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img onerror');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;img onerror=x src=y&gt;');
+  });
+
+  it('sets replyTo to user.email for signed-in submitters', async () => {
+    await sendFeedbackEmail(baseInput);
+    expect(mockSend.mock.calls[0][0].replyTo).toBe('coach@example.com');
+  });
+
+  it('sets replyTo to anonymous email when provided', async () => {
+    await sendFeedbackEmail({
+      ...baseInput,
+      identity: { kind: 'anonymous', email: 'anon@example.com' },
+    });
+    expect(mockSend.mock.calls[0][0].replyTo).toBe('anon@example.com');
+  });
+
+  it('omits replyTo when anonymous with no email', async () => {
+    await sendFeedbackEmail({
+      ...baseInput,
+      identity: { kind: 'anonymous' },
+    });
+    expect(mockSend.mock.calls[0][0].replyTo).toBeUndefined();
+  });
+
+  it('returns false and does not throw when resend is null', async () => {
+    vi.resetModules();
+    vi.doMock('../resend', () => ({ resend: null }));
+    const { sendFeedbackEmail: localSend } = await import('../feedback');
+    const result = await localSend(baseInput);
+    expect(result).toBe(false);
+  });
+
+  it('returns true on successful send', async () => {
+    const result = await sendFeedbackEmail(baseInput);
+    expect(result).toBe(true);
+  });
+});

--- a/frontend/lib/email/feedback.ts
+++ b/frontend/lib/email/feedback.ts
@@ -20,7 +20,6 @@ export interface FeedbackContext {
   userAgent?: string;
   viewport?: { w: number; h: number };
   submittedAt: string;
-  openedAt: string;
 }
 
 export interface SendFeedbackEmailInput {
@@ -57,7 +56,6 @@ function buildFromLine(identity: FeedbackIdentity): string {
 }
 
 function pickReplyTo(identity: FeedbackIdentity): string | undefined {
-  if (identity.kind === 'signed-in') return identity.email;
   return identity.email;
 }
 

--- a/frontend/lib/email/feedback.ts
+++ b/frontend/lib/email/feedback.ts
@@ -1,0 +1,151 @@
+import { resend } from './resend';
+
+export type FeedbackCategory = 'cant-find-team' | 'rankings-wrong' | 'wrong-games' | 'bug' | 'other';
+
+export const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  'cant-find-team': "Can't find my team",
+  'rankings-wrong': 'Rankings look wrong',
+  'wrong-games': 'Wrong games attached',
+  bug: 'Bug or broken page',
+  other: 'Other',
+};
+
+export type FeedbackIdentity =
+  | { kind: 'signed-in'; userId: string; email: string }
+  | { kind: 'anonymous'; email?: string };
+
+export interface FeedbackContext {
+  pathname: string;
+  referrer?: string;
+  userAgent?: string;
+  viewport?: { w: number; h: number };
+  submittedAt: string;
+  openedAt: string;
+}
+
+export interface SendFeedbackEmailInput {
+  category: FeedbackCategory;
+  message: string;
+  identity: FeedbackIdentity;
+  context: FeedbackContext;
+  ipMasked: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function truncateForSubject(s: string, max = 60): string {
+  const oneLine = s.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= max ? oneLine : oneLine.slice(0, max) + '…';
+}
+
+function buildSubject(category: FeedbackCategory, message: string): string {
+  return `[PitchRank Feedback] ${CATEGORY_LABELS[category]} — ${truncateForSubject(message)}`;
+}
+
+function buildFromLine(identity: FeedbackIdentity): string {
+  if (identity.kind === 'signed-in') {
+    return `${identity.email} (signed-in user, id=${identity.userId})`;
+  }
+  return identity.email ? `${identity.email} (anonymous)` : 'anonymous (no email provided)';
+}
+
+function pickReplyTo(identity: FeedbackIdentity): string | undefined {
+  if (identity.kind === 'signed-in') return identity.email;
+  return identity.email;
+}
+
+function buildHtml(input: SendFeedbackEmailInput): string {
+  const { category, message, identity, context, ipMasked } = input;
+  const safeMessage = escapeHtml(message);
+  const safeFrom = escapeHtml(buildFromLine(identity));
+  const safePath = escapeHtml(context.pathname);
+  const safeRef = escapeHtml(context.referrer ?? '(none)');
+  const safeUa = escapeHtml(context.userAgent ?? '(none)');
+  const vp = context.viewport ? `${context.viewport.w}×${context.viewport.h}` : '(unknown)';
+
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a1a1a; max-width: 640px; margin: 0 auto; padding: 20px;">
+  <div style="background-color: #0B5345; padding: 16px 24px; border-radius: 8px 8px 0 0;">
+    <h1 style="color: #F4D03F; margin: 0; font-size: 20px; letter-spacing: 2px;">PITCHRANK FEEDBACK</h1>
+  </div>
+  <div style="background-color: #f9fafb; padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+    <table style="width:100%; font-size: 14px; margin-bottom: 16px;">
+      <tr><td style="padding: 4px 12px 4px 0; color:#6b7280;">Category:</td><td><strong>${CATEGORY_LABELS[category]}</strong></td></tr>
+      <tr><td style="padding: 4px 12px 4px 0; color:#6b7280;">From:</td><td>${safeFrom}</td></tr>
+      <tr><td style="padding: 4px 12px 4px 0; color:#6b7280;">Page:</td><td><code>${safePath}</code></td></tr>
+      <tr><td style="padding: 4px 12px 4px 0; color:#6b7280;">Submitted:</td><td>${escapeHtml(context.submittedAt)}</td></tr>
+    </table>
+    <div style="background:#fff; border:1px solid #e5e7eb; border-radius:6px; padding:16px; font-family: ui-monospace, Menlo, Consolas, monospace; white-space: pre-wrap; word-break: break-word; font-size: 13px; line-height: 1.5;">${safeMessage}</div>
+    <hr style="border:none; border-top:1px solid #e5e7eb; margin: 24px 0;">
+    <table style="width:100%; font-size: 12px; color:#9ca3af;">
+      <tr><td style="padding: 2px 12px 2px 0;">Referrer:</td><td>${safeRef}</td></tr>
+      <tr><td style="padding: 2px 12px 2px 0;">Viewport:</td><td>${vp}</td></tr>
+      <tr><td style="padding: 2px 12px 2px 0;">User-Agent:</td><td>${safeUa}</td></tr>
+      <tr><td style="padding: 2px 12px 2px 0;">IP:</td><td><code>${escapeHtml(ipMasked)}</code></td></tr>
+    </table>
+  </div>
+</body></html>`;
+}
+
+function buildText(input: SendFeedbackEmailInput): string {
+  const { category, message, identity, context, ipMasked } = input;
+  return [
+    `PITCHRANK FEEDBACK`,
+    ``,
+    `Category:  ${CATEGORY_LABELS[category]}`,
+    `From:      ${buildFromLine(identity)}`,
+    `Page:      ${context.pathname}`,
+    `Submitted: ${context.submittedAt}`,
+    ``,
+    `--- Message ---`,
+    message,
+    `---------------`,
+    ``,
+    `Referrer:   ${context.referrer ?? '(none)'}`,
+    `Viewport:   ${context.viewport ? `${context.viewport.w}x${context.viewport.h}` : '(unknown)'}`,
+    `User-Agent: ${context.userAgent ?? '(none)'}`,
+    `IP:         ${ipMasked}`,
+  ].join('\n');
+}
+
+/**
+ * Send a feedback report email. Returns true on success, false on failure
+ * (including when Resend is not configured). Does not throw.
+ */
+export async function sendFeedbackEmail(input: SendFeedbackEmailInput): Promise<boolean> {
+  if (!resend) {
+    console.warn('Resend not configured - skipping feedback email');
+    return false;
+  }
+
+  const replyTo = pickReplyTo(input.identity);
+
+  try {
+    const { error } = await resend.emails.send({
+      from: 'PitchRank <feedback@mail.pitchrank.io>',
+      to: 'pitchrankio@gmail.com',
+      subject: buildSubject(input.category, input.message),
+      html: buildHtml(input),
+      text: buildText(input),
+      ...(replyTo ? { replyTo } : {}),
+    });
+
+    if (error) {
+      console.error('Failed to send feedback email:', error);
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    console.error('Error sending feedback email:', err);
+    return false;
+  }
+}

--- a/frontend/lib/email/index.ts
+++ b/frontend/lib/email/index.ts
@@ -2,3 +2,5 @@ export { resend } from './resend';
 export { sendWelcomeEmail } from './welcome';
 export { sendPasswordSetupEmail } from './password-setup';
 export { sendReportCardEmail } from './report-card';
+export { sendFeedbackEmail } from './feedback';
+export type { FeedbackCategory, FeedbackIdentity, FeedbackContext, SendFeedbackEmailInput } from './feedback';


### PR DESCRIPTION
## Summary

- Adds a `?` icon to the global navigation that opens a categorized feedback modal — users (signed-in or anonymous) can submit reports across 5 categories (can't find team, rankings wrong, wrong games, bug, other).
- Submissions email to `pitchrankio@gmail.com` via existing Resend infra. New `feedback@mail.pitchrank.io` sender; `replyTo` is the submitter's email when known so Reply in Gmail goes back to them.
- Anti-bot: honeypot field + 2s min-time floor + 5/hour IP rate-limit. No CAPTCHA, no DB. Identity is server-derived (Supabase session); the optional anonymous email field is only used for replyTo, never trusted as identity.

## What's new

- `frontend/lib/email/feedback.ts` — `sendFeedbackEmail` builder, mirrors `welcome.ts`/`report-card.ts` pattern (HTML escaping, plain-text fallback, null-resend guard, returns boolean)
- `frontend/app/api/feedback/route.ts` — `POST` handler with manual validation (matching the project's existing newsletter-route style; no zod)
- `frontend/components/FeedbackModal.tsx` — Radix Dialog form, formKey-based remount on open/route-change (avoids React 19's `set-state-in-effect` lint)
- `frontend/components/FeedbackTrigger.tsx` — `?` icon button, suppressed on `/embed`, `/login`, `/signup`
- `frontend/components/Navigation.tsx` — mounts the trigger in both desktop and mobile clusters

## Out of scope (parking lot)

No DB persistence, no admin review page, no Telegram/Slack/GitHub-issue routing, no CAPTCHA, no smart category preselect, no auto-parsing of pathname. See `docs/superpowers/specs/2026-05-06-something-seems-off-feedback-design.md` for full rationale.

## Test plan

- [x] Unit tests for email builder (9): subject shape + truncation, HTML escaping (all 5 entities), replyTo branches, null-resend guard, success path
- [x] Route tests (21): valid signed-in/anonymous, all validation 400s, honeypot/min-time silent 200s, rate-limit 429, send_failed 502, IPv4/IPv6/garbage IP masking, null body 400, Supabase throws 500, signed-in-with-no-email demote
- [x] Typecheck clean, ESLint clean
- [x] Manual smoke on Vercel preview: trigger appears, modal opens, validation gates, submit succeeds, email lands at `pitchrankio@gmail.com` from `feedback@mail.pitchrank.io`

## Deployment notes

- `RESEND_API_KEY` was missing from all Vercel envs before this PR — added to Production, Preview, Development as part of getting the smoke test green. The key was pasted in the Claude Code session transcript and should be rotated post-merge.
- Existing email features (`welcome.ts`, `password-setup.ts`, `report-card.ts`) were silently no-op in production for the same reason; they will start working once this is merged.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-06-something-seems-off-feedback-design.md`
- Plan: `docs/superpowers/plans/2026-05-06-something-seems-off-feedback.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)