### PR TITLE
fix(scrape-games): pass --repo to gh in chain dispatcher

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -359,6 +359,10 @@ jobs:
           fi
 
           echo "Dispatching next chain link (chain_remaining=$NEXT_REMAINING)"
+          # --repo is required because this job has no checkout step; without
+          # it `gh` looks for a local git repo and exits with
+          # `fatal: not a git repository`.
           gh workflow run scrape-games.yml \
+            --repo "${GITHUB_REPOSITORY}" \
             --ref "${GITHUB_REF_NAME}" \
             -f chain_remaining="$NEXT_REMAINING"


### PR DESCRIPTION
## Summary

First chain seed (run 25683249094) failed in the finalize job with:
```
Dispatching next chain link (chain_remaining=4)
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `finalize` job in #737 has no checkout step (it only runs the dispatcher), so `gh workflow run` couldn't auto-detect the repo. Fix: pass `--repo \"\\"` explicitly.

## Test plan
- [ ] Re-dispatch chain manually after merge; verify finalize step succeeds and next link queues