### PR TITLE
fix(rankings): canonicalize age_group to 'u{N}' in ranking_history

### DIFF
--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -1787,7 +1787,9 @@ def compute_rankings_v2(
     _age_val = games_df["age"].iloc[0] if len(games_df) > 0 else "U15"
     if "age" not in team_df.columns:
         team_df["age"] = _age_val
-    team_df["age_group"] = team_df["age"]
+    team_df["age_group"] = team_df["age"].apply(
+        lambda x: f"u{int(float(x))}" if pd.notna(x) and str(x).strip() else None
+    )
     if "gender" not in team_df.columns:
         team_df["gender"] = games_df["gender"].iloc[0] if len(games_df) > 0 else "M"
 

--- a/src/rankings/ranking_history.py
+++ b/src/rankings/ranking_history.py
@@ -24,6 +24,30 @@ def _compute_state_ranks(df: pd.DataFrame, active_mask: "pd.Series[bool]", score
     return active_subset.groupby(["state_code", "age_group", "gender"]).cumcount() + 1
 
 
+def _canonicalize_age_group(value) -> str:
+    """Coerce age_group to canonical 'u{N}' form. Returns '' for missing/unparseable input.
+
+    Upstream callers may pass numeric strings ("14"), capitalized ("U14"),
+    or the canonical form ("u14"); all flatten to "u14".
+    """
+    if pd.isna(value):
+        return ""
+    digits = "".join(ch for ch in str(value).strip().lower() if ch.isdigit())
+    return f"u{int(digits)}" if digits else ""
+
+
+def _apply_age_group_canonicalization(df: pd.DataFrame) -> None:
+    """Canonicalize df['age_group'] in place, deriving from 'age' when needed."""
+    if "age_group" in df.columns:
+        df["age_group"] = df["age_group"].apply(_canonicalize_age_group)
+        if "age" in df.columns:
+            empty = df["age_group"].eq("")
+            if empty.any():
+                df.loc[empty, "age_group"] = df.loc[empty, "age"].apply(_canonicalize_age_group)
+    elif "age" in df.columns:
+        df["age_group"] = df["age"].apply(_canonicalize_age_group)
+
+
 async def save_ranking_snapshot(
     supabase_client, rankings_df: pd.DataFrame, snapshot_date: Optional[date] = None
 ) -> int:
@@ -57,10 +81,11 @@ async def save_ranking_snapshot(
     # Make a copy to avoid modifying original DataFrame
     df = rankings_df.copy()
 
-    # Derive age_group from 'age' field if not already present
-    if "age_group" not in df.columns or df["age_group"].isna().all():
-        if "age" in df.columns:
-            df["age_group"] = df["age"].apply(lambda x: f"u{int(float(x))}" if pd.notna(x) else "")
+    # Canonicalize age_group to 'u{N}' form before any downstream use.
+    # Upstream callers (e.g. Glicko engine) may set this to a bare numeric
+    # string ("14"); canonicalizing here keeps ranking_history consistent
+    # with rankings_full and the teams table.
+    _apply_age_group_canonicalization(df)
 
     # Calculate state ranks within each (state_code, age_group, gender) cohort
     # Only Active teams get state ranks — consistent with state_rankings_view
@@ -471,11 +496,8 @@ async def calculate_rank_changes(
     # This matches the logic in save_ranking_snapshot()
     has_state_data = "state_code" in current_rankings_df.columns and "power_score_final" in current_rankings_df.columns
     if has_state_data:
-        # Derive age_group from 'age' field if not already present
         df = current_rankings_df.copy()
-        if "age_group" not in df.columns or df["age_group"].isna().all():
-            if "age" in df.columns:
-                df["age_group"] = df["age"].apply(lambda x: f"u{int(float(x))}" if pd.notna(x) else "")
+        _apply_age_group_canonicalization(df)
 
         # Use power_score_final to match save_ranking_snapshot() — both must use
         # the same score column to avoid phantom rank changes


### PR DESCRIPTION
## Summary
- `ranking_history` rows written since 2026-04-01 stored `age_group` as bare numeric strings (`"14"`) instead of the canonical `"u14"` form
- Root cause: `glicko_engine.compute_rankings_v2` assigned `team_df["age_group"] = team_df["age"]` directly (introduced by commit `e5c5ed7e5` on 2026-04-01)
- `ranking_history.save_ranking_snapshot` only derived the `"u{N}"` form when `age_group` was missing/all-NaN, so the bad value flowed through
- `rankings_full` was unaffected — `data_adapter.v53e_to_rankings_full_format` re-derives `age_group` on its write path

## Fix
Two layers (defense in depth):

1. **`src/etl/glicko_engine.py`**: emit canonical `"u{N}"` at the source
2. **`src/rankings/ranking_history.py`**: always canonicalize on write via shared `_canonicalize_age_group` / `_apply_age_group_canonicalization` helpers (used by both `save_ranking_snapshot` and `calculate_rank_changes`)

## Blast radius (existing dirty rows)
~3.2M rows in `ranking_history` from Apr 1 → May 11 carry bare `"14"`-style values. Survey of consumers:

- Frontend `getRankHistory` (rank chart): filters by `team_id` only — unaffected
- `get_historical_ranks` / `get_historical_state_ranks`: filter by `team_id` — unaffected
- `scripts/movy_report.py`: self-joins `ranking_history` on `age_group` across snapshots — silently dropped teams during Apr 1–30 (format flip window); self-healed once both sides went stale
- `rankings_full`: clean

Backfill is optional and not part of this PR. ~16K rows for `(age_group=10, snapshot_date=2026-05-11)` were canonicalized during investigation.

## Test plan
- [ ] Verify next ranking cron run writes `u{N}` form (check `SELECT DISTINCT age_group FROM ranking_history WHERE snapshot_date = <next-run-date>`)
- [ ] Confirm `rankings_full` still writes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)