### PR TITLE
revert(rankings): show raw team_name in rankings table + global search

### DIFF
--- a/frontend/components/GlobalSearch.tsx
+++ b/frontend/components/GlobalSearch.tsx
@@ -12,7 +12,6 @@ import { useTeamSearch } from '@/hooks/useTeamSearch';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackSearchUsed, trackSearchResultClicked } from '@/lib/events';
 import { formatGender } from '@/lib/constants';
-import { composeTeamDisplay } from '@/lib/utils';
 
 /**
  * Escape special regex characters in a string
@@ -236,8 +235,6 @@ export function GlobalSearch() {
             ) : (
               <div id="global-search-results" role="listbox" className="space-y-1" ref={listRef}>
                 {searchResults.map((team, index) => {
-                  const composed = composeTeamDisplay(team);
-                  const showRawName = !!team.team_name && team.team_name !== composed;
                   return (
                     <button
                       key={team.team_id_master}
@@ -247,14 +244,9 @@ export function GlobalSearch() {
                       className={`w-full text-left p-3 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary min-h-[44px] ${
                         index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
                       }`}
-                      aria-label={`Select ${composed}${showRawName ? ` (${team.team_name})` : ''}`}
+                      aria-label={`Select ${team.team_name}`}
                     >
-                      <div className="font-medium truncate">{highlightMatch(composed, deferredSearchQuery)}</div>
-                      {showRawName && (
-                        <div className="text-xs text-muted-foreground truncate">
-                          {highlightMatch(team.team_name, deferredSearchQuery)}
-                        </div>
-                      )}
+                      <div className="font-medium truncate">{highlightMatch(team.team_name, deferredSearchQuery)}</div>
                       <div className="text-xs text-muted-foreground mt-1">
                         {team.state && <span>{team.state.toUpperCase()}</span>}
                         {team.rank_in_cohort_final && <span> • Rank #{team.rank_in_cohort_final}</span>}

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -10,7 +10,7 @@ import { usePrefetchTeam } from '@/lib/hooks';
 import Link from 'next/link';
 import { ArrowUp, ArrowDown, ArrowUpDown, ChevronRight } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatPowerScore, composeTeamDisplay } from '@/lib/utils';
+import { formatPowerScore } from '@/lib/utils';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackRankingsViewed, trackSortUsed, trackTeamRowClicked } from '@/lib/events';
 import { RankingsSchema } from '@/components/RankingsSchema';
@@ -130,8 +130,8 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
           bValue = getDisplayRank(b) ?? Infinity;
           break;
         case 'team':
-          aValue = composeTeamDisplay(a).toLowerCase();
-          bValue = composeTeamDisplay(b).toLowerCase();
+          aValue = a.team_name.toLowerCase();
+          bValue = b.team_name.toLowerCase();
           break;
         case 'powerScore':
           aValue = a.power_score_final ?? 0;
@@ -295,7 +295,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     .filter((team) => getDisplayRank(team) != null)
     .slice(0, 10)
     .map((team) => ({
-      teamName: composeTeamDisplay(team),
+      teamName: team.team_name,
       clubName: team.club_name ?? undefined,
       rank: getDisplayRank(team)!,
       powerScore: team.power_score_final ?? undefined,
@@ -515,7 +515,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                           </div>
                           <div className="px-1.5 sm:px-4 py-2 sm:py-3 min-w-0 overflow-hidden">
                             <span className="font-medium text-primary group-hover:text-primary/80 transition-colors duration-300 text-xs sm:text-sm truncate block w-full">
-                              {composeTeamDisplay(team)}
+                              {team.team_name}
                             </span>
                             {(team.club_name || team.state) && (
                               <div className="text-xs sm:text-sm text-muted-foreground truncate w-full">


### PR DESCRIPTION
## Summary
Reverts the user-facing display half of #722 on two surfaces:

- **RankingsTable** renders `team.team_name` directly (not `composeTeamDisplay`); the team-column sort key and `RankingsSchema` JSON-LD also use the raw name. The `{club} • {STATE}` subline is retained.
- **GlobalSearch** dropdown renders raw `team_name` only (drops the composed-line / raw-secondary pairing).

Search behavior is unchanged: `useTeamSearch.searchable_name` is a superset that still includes the raw `team_name` token, so users can type either form to find a team.

RPC projections (`get_national_rankings`, `get_state_rankings`) and Compare / TeamSelector / RecentMovers / infographics / UnknownOpponentLink keep using `composeTeamDisplay` — only the two surfaces above are reverted.

## Test plan
- [ ] Rankings table shows the raw `team_name` instead of the composed `club + age + league + distinction` line
- [ ] Sorting the team column orders by raw `team_name`
- [ ] Global search dropdown lists raw team names
- [ ] Typing the composed form (e.g. "Rebels ECNL Black") still finds the team
- [ ] Typing the raw form still finds the team
- [ ] Compare flow, TeamSelector, RecentMovers, infographics unchanged