### PR TITLE
fix(dashboard): show league in Manual Team Edit

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4099,7 +4099,8 @@ elif section == "✏️ Manual Team Edit":
                         select_fields = (
                             'team_id_master, provider_team_id, team_name, club_name, '
                             'age_group, gender, state_code, birth_year, is_deprecated, '
-                            'created_at, updated_at, last_scraped_at, state, provider_id'
+                            'created_at, updated_at, last_scraped_at, state, provider_id, '
+                            'league, distinction, team_name_original'
                         )
 
                         # Search by ID first (exact match) - highest priority


### PR DESCRIPTION
Streamlit's Manual Team Edit form was showing `(Unaffiliated)` for every team because the search query at `dashboard.py:4099` didn't `SELECT` the `league` column. The form would call `team.get('league', '') or ''`, which always evaluated to `''`, so the league dropdown fell back to index 0 (Unaffiliated) regardless of the actual DB value.

Adds `league`, `distinction`, and `team_name_original` to the select so the form reflects the real values.

## Test plan
- [ ] Open Streamlit dashboard, go to Manual Team Edit
- [ ] Search a known ECNL team (e.g. Minnesota Thunder ECNL 2009, id `4474f852-6602-4b52-96f9-18c3a99e8b8f`)
- [ ] Verify League dropdown shows `ECNL` (not `(Unaffiliated)`)