### PR TITLE
fix(insights): state-cohort query column name (state, not state_code)

### DIFF
--- a/frontend/app/api/insights/[teamId]/route.ts
+++ b/frontend/app/api/insights/[teamId]/route.ts
@@ -203,7 +203,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
         .select('team_id_master, power_score_final')
         .eq('age', ranking.age)
         .eq('gender', ranking.gender)
-        .eq('state_code', team.state_code)
+        .eq('state', team.state_code)
         .eq('status', 'Active')
         .order('power_score_final', { ascending: false });
 


### PR DESCRIPTION
## Summary

Follow-up fix that didn't make it into the PR #744 squash merge (committed ~40 min after merge).

`rankings_view` exposes the state column as `state` (value example `'WI'`), but PR #744's state-cohort query in `app/api/insights/[teamId]/route.ts` used `.eq('state_code', team.state_code)` against the view. That returned Postgres error `42703 column "rankings_view.state_code" does not exist`, which the existing error-swallow pattern silently caught — so \`stateCohort\` was \`null\` for every team site-wide, and the state-leaderboard persona trait never fired.

After this fix: Rush Union Wisconsin 2012 Premier (\`d21d8035-...\`) gets the **"#2 in WI U14 Girls"** trait line instead of falling through to "Top 2% nationally". 17 Active WI U14 F teams, ranked by \`power_score_final\`.

## Test plan

- [x] tsc clean
- [x] 20 lib/insights tests still green
- [x] Verified live: querying \`rankings_view\` with \`.eq('state', 'WI').eq('age', 14).eq('gender', 'F').eq('status', 'Active')\` returns 17 rows; target team at index 1 (rank 2)
- [ ] Smoke: open Rush Union team page after merge + deploy; confirm trait line reads "#2 in WI U14 Girls"

## Notes

Single-character fix: \`state_code\` → \`state\` on line 206 of \`app/api/insights/[teamId]/route.ts\`. The argument value (\`team.state_code\`) is still pulled from the \`teams\` table where the column IS \`state_code\` — only the rankings_view side uses the shorter name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)