### PR TITLE
chore(dashboard): default sidebar to Team Merge Manager

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -244,23 +244,25 @@ def _load_rankings_view_age_state_status():
 
 # Sidebar navigation
 st.sidebar.title("Navigation")
+_nav_options = [
+    "📋 Review Queue",
+    "👥 Age Groups",
+    "📈 Database Import Stats",
+    "🆕 New Accounts",
+    "🧩 Unknown Opponent Review",
+    "🗺️ State Coverage",
+    "📍 Missing State Codes",
+    "🔀 Team Merge Manager",
+    "✏️ Manual Team Edit",
+    "🔎 Team Discovery Review",
+    "🛡️ Due Diligence Review",
+    "📸 Instagram Review",
+    "🚫 Game Exclusion Manager"
+]
 section = st.sidebar.radio(
     "Select Section",
-    [
-        "📋 Review Queue",
-        "👥 Age Groups",
-        "📈 Database Import Stats",
-        "🆕 New Accounts",
-        "🧩 Unknown Opponent Review",
-        "🗺️ State Coverage",
-        "📍 Missing State Codes",
-        "🔀 Team Merge Manager",
-        "✏️ Manual Team Edit",
-        "🔎 Team Discovery Review",
-        "🛡️ Due Diligence Review",
-        "📸 Instagram Review",
-        "🚫 Game Exclusion Manager"
-    ]
+    _nav_options,
+    index=_nav_options.index("🔀 Team Merge Manager"),
 )
 
 # Helper functions for fuzzy matching


### PR DESCRIPTION
## Summary
- Hosted dashboard at pitchrank-configdashboard.streamlit.app was landing on Review Queue, which runs uncached Supabase queries on render and is slow to open.
- Make Team Merge Manager the default sidebar selection. Review Queue is unchanged — just one click away.

## Test plan
- [ ] Merge, wait for Streamlit Cloud to redeploy, confirm app opens on Team Merge Manager
- [ ] Click into Review Queue and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)