### PR TITLE
fix(rank-trend): hide Glicko-2 engine cutover window from history chart

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1201,6 +1201,11 @@ export const api = {
 
     if (!data || data.length === 0) return [];
 
+    // Exclude the Glicko-2 engine cutover window (Apr 1–10, 2026) — transient
+    // ranks during this period are noise from the engine swap, not real movement.
+    const ENGINE_CUTOVER_START = '2026-04-01';
+    const ENGINE_CUTOVER_END = '2026-04-10';
+
     // Filter to only Monday snapshots (day 1) and dedupe by week
     const seen = new Set<string>();
     const points: RankHistoryPoint[] = [];
@@ -1211,6 +1216,10 @@ export const api = {
       rank_in_cohort_ml: number | null;
       rank_in_cohort_final: number | null;
     }>) {
+      if (row.snapshot_date >= ENGINE_CUTOVER_START && row.snapshot_date <= ENGINE_CUTOVER_END) {
+        continue;
+      }
+
       // Find the Monday of this snapshot's week
       const d = new Date(row.snapshot_date + 'T00:00:00');
       const day = d.getUTCDay(); // 0=Sun, 1=Mon, ...


### PR DESCRIPTION
## Summary
- Skip rank-history snapshots between 2026-04-01 and 2026-04-10 in the rank trend chart
- Avoids surfacing transient ranks produced during the Glicko-2 engine swap as real movement

## Test plan
- [ ] Open a team detail page for a team with snapshots spanning April 2026 and confirm the chart skips the cutover week
- [ ] Confirm pre-Apr-1 and post-Apr-10 points still appear and connect cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)