### PR TITLE
fix(team-page): unbreak admin aliases dropdown + rename feedback modal title

### DIFF
--- a/frontend/app/api/team-aliases/[teamId]/route.ts
+++ b/frontend/app/api/team-aliases/[teamId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { requireAdmin } from '@/lib/supabase/admin';
+import { createServiceSupabase } from '@/lib/supabase/service';
 
 /**
  * Get all aliases for a team from team_alias_map
@@ -13,15 +13,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const { teamId } = await params;
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseAnonKey) {
-      console.error('[team-aliases] Missing environment variables');
-      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+    // team_alias_map has a deny-all RLS policy for anon/authenticated roles;
+    // service-role bypass is required to read it. Auth is already gated by requireAdmin().
+    const supabase = createServiceSupabase();
 
     // Fetch all aliases for this team with provider info
     // Include division field for MLS NEXT HD/AD differentiation

--- a/frontend/components/FeedbackModal.tsx
+++ b/frontend/components/FeedbackModal.tsx
@@ -257,7 +257,7 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[480px]" data-testid="feedback-modal">
         <DialogHeader>
-          <DialogTitle>Something seems off?</DialogTitle>
+          <DialogTitle>Feedback/Questions</DialogTitle>
           <DialogDescription>Tell us what you&apos;re seeing — we read every report.</DialogDescription>
         </DialogHeader>
 

--- a/frontend/components/FeedbackTrigger.tsx
+++ b/frontend/components/FeedbackTrigger.tsx
@@ -22,8 +22,8 @@ export function FeedbackTrigger() {
         type="button"
         variant="ghost"
         size="icon"
-        aria-label="Report an issue"
-        title="Something seems off?"
+        aria-label="Feedback or questions"
+        title="Feedback/Questions"
         onClick={() => setOpen(true)}
         data-testid="feedback-trigger"
       >

--- a/frontend/components/TeamHeader.tsx
+++ b/frontend/components/TeamHeader.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/lib/watchlist';
 import type { WatchlistResponse } from '@/app/api/watchlist/route';
 import { formatPowerScore } from '@/lib/utils';
-import { useUser, hasPremiumAccess } from '@/hooks/useUser';
+import { useUser, hasPremiumAccess, hasAdminAccess } from '@/hooks/useUser';
 import { ShareButtons } from '@/components/ShareButtons';
 import { NotificationBell } from '@/components/NotificationBell';
 import { TeamSchema } from '@/components/TeamSchema';
@@ -60,6 +60,7 @@ export function TeamHeader({ teamId }: TeamHeaderProps) {
   // Wait for user loading to complete before determining premium status
   // This prevents race conditions where profile is null during initial load
   const isPremium = !userLoading && hasPremiumAccess(profile);
+  const isAdmin = !userLoading && hasAdminAccess(profile);
 
   const [watched, setWatched] = useState(false);
   const [isToggling, setIsToggling] = useState(false);
@@ -284,20 +285,26 @@ export function TeamHeader({ teamId }: TeamHeaderProps) {
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <div className="relative">
-                <button
-                  onClick={() => setAliasesOpen(!aliasesOpen)}
-                  className="flex items-center gap-1.5 text-xl sm:text-2xl md:text-3xl font-display font-bold uppercase text-primary-foreground tracking-wide hover:text-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
-                  aria-label="View team aliases"
-                  aria-expanded={aliasesOpen}
-                >
-                  {team.team_name}
-                  <ChevronDown
-                    className={`h-4 w-4 sm:h-5 sm:w-5 opacity-70 transition-transform ${aliasesOpen ? 'rotate-180' : ''}`}
-                  />
-                </button>
+                {isAdmin ? (
+                  <button
+                    onClick={() => setAliasesOpen(!aliasesOpen)}
+                    className="flex items-center gap-1.5 text-xl sm:text-2xl md:text-3xl font-display font-bold uppercase text-primary-foreground tracking-wide hover:text-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
+                    aria-label="View team aliases"
+                    aria-expanded={aliasesOpen}
+                  >
+                    {team.team_name}
+                    <ChevronDown
+                      className={`h-4 w-4 sm:h-5 sm:w-5 opacity-70 transition-transform ${aliasesOpen ? 'rotate-180' : ''}`}
+                    />
+                  </button>
+                ) : (
+                  <div className="text-xl sm:text-2xl md:text-3xl font-display font-bold uppercase text-primary-foreground tracking-wide">
+                    {team.team_name}
+                  </div>
+                )}
 
-                {/* Aliases Dropdown */}
-                {aliasesOpen && (
+                {/* Aliases Dropdown (admin-only) */}
+                {isAdmin && aliasesOpen && (
                   <>
                     {/* Backdrop to close dropdown when clicking outside */}
                     <div className="fixed inset-0 z-40" onClick={() => setAliasesOpen(false)} />


### PR DESCRIPTION
## Summary

- **Aliases dropdown was always empty.** The `/api/team-aliases/[teamId]` route reads `team_alias_map` with the anon Supabase key, but the table has a `team_alias_map_deny_all` RLS policy that returns `false` for both `anon` and `authenticated` roles. PostgREST silently returned `[]` for every caller, including admins. Swapped to `createServiceSupabase()` (auth still gated by `requireAdmin()`).
- **Hid the dropdown trigger from non-admins** in `TeamHeader.tsx`. Non-admins can't read the data anyway; the affordance only led to "No aliases found". Trigger now renders the team name as plain text for them.
- **Renamed feedback widget title** from "Something seems off?" to "Feedback/Questions" — modal `DialogTitle` and trigger tooltip + `aria-label`.

## Why the aliases bug was silent

`requireAdmin()` gated callers correctly. The route then constructed a *fresh* anon-key client and queried `team_alias_map`; the RLS policy redacted all rows. No error, just an empty array — so the dropdown showed "No aliases found" for every team, every user, forever.

Data sanity: `team_alias_map` currently has 175,679 approved rows. Top team has 13 aliases. The join column (`team_id_master`) and `review_status='approved'` filter are correct.

## Test plan

- [ ] Hard refresh a team page while signed in as admin (e.g. `/teams/c4aed802-03a8-4f19-a841-7b95417421f0` — WUFA 2012, 13 aliases) → chevron renders, dropdown lists providers.
- [ ] Sign in as a free/premium (non-admin) user → team name renders without a chevron, no clickable affordance.
- [ ] Open the feedback widget (HelpCircle button) → modal title reads "Feedback/Questions"; tooltip on the button matches.
- [ ] `npx tsc --noEmit` (already verified locally — clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)