### PR TITLE
fix(rankings): compute rank_change_7d against rank_in_cohort_final on both sides

### DIFF
--- a/scripts/backfill_prediction_feature_history.py
+++ b/scripts/backfill_prediction_feature_history.py
@@ -152,7 +152,7 @@ async def replay_prediction_snapshot(
         merge_resolver=merge_resolver,
         use_glicko=use_glicko,
         persist_game_residuals=False,
-        calculate_rank_changes=False,
+        calculate_rank_changes_enabled=False,
         save_snapshot=False,
     )
 

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -49,7 +49,6 @@ class RankingContext:
     save_snapshot: bool = True
     persist_game_residuals: bool = True
     persist_game_explainability: bool = True
-    calculate_rank_changes: bool = True
     # Instrumentation
     timing_report: Optional[Any] = None
     pass_label: Optional[str] = None
@@ -1951,7 +1950,6 @@ async def compute_rankings_with_ml(
     save_snapshot = ctx.save_snapshot
     persist_game_residuals = ctx.persist_game_residuals
     persist_game_explainability = ctx.persist_game_explainability
-    calculate_rank_changes_enabled = ctx.calculate_rank_changes
     global_strength_map = ctx.global_strength_map
     merge_version = ctx.merge_version
     team_state_map = ctx.team_state_map
@@ -2246,24 +2244,16 @@ async def compute_rankings_with_ml(
                 after = ps_max_after_ml.get((age, gender), 0)
                 logger.debug(f"  {age} {gender}: pre-ML={before:.3f}, post-ML={after:.3f}, diff={after - before:+.3f}")
 
-    # Calculate rank changes using historical snapshots (7d and 30d)
-    if calculate_rank_changes_enabled:
-        logger.info("📊 Calculating rank changes from historical data...")
-        with _section(timing_report, "rank_changes"):
-            teams_with_ml = await calculate_rank_changes(
-                supabase_client=supabase_client,
-                current_rankings_df=teams_with_ml,
-                reference_date=snapshot_date,
-            )
-    else:
-        for column in [
-            "rank_change_7d",
-            "rank_change_30d",
-            "rank_change_state_7d",
-            "rank_change_state_30d",
-        ]:
-            if column not in teams_with_ml.columns:
-                teams_with_ml[column] = None
+    # Rank-change columns are populated later in compute_all_cohorts; init here so
+    # solo callers of this function still see the columns on the returned DataFrame.
+    for column in [
+        "rank_change_7d",
+        "rank_change_30d",
+        "rank_change_state_7d",
+        "rank_change_state_30d",
+    ]:
+        if column not in teams_with_ml.columns:
+            teams_with_ml[column] = None
 
     # Save current rankings as a snapshot for future rank change calculations
     # (Skip if save_snapshot=False, e.g., when called from compute_all_cohorts)
@@ -2372,7 +2362,7 @@ async def compute_all_cohorts(
     use_glicko: bool = True,  # True = Glicko-2 engine, False = legacy v53e engine
     persist_game_residuals: bool = True,
     persist_game_explainability: bool = True,
-    calculate_rank_changes: bool = True,
+    calculate_rank_changes_enabled: bool = True,
     save_snapshot: bool = True,
 ) -> Dict[str, pd.DataFrame]:
     """
@@ -2527,7 +2517,6 @@ async def compute_all_cohorts(
                 use_glicko=use_glicko,
                 persist_game_residuals=persist_game_residuals,
                 persist_game_explainability=persist_game_explainability,
-                calculate_rank_changes=calculate_rank_changes,
             ),
         )
         pass1_tasks.append(task)
@@ -2598,7 +2587,6 @@ async def compute_all_cohorts(
                 initial_ratings=pass1_glicko_ratings.get(i) if use_glicko else None,
                 persist_game_residuals=persist_game_residuals,
                 persist_game_explainability=persist_game_explainability,
-                calculate_rank_changes=calculate_rank_changes,
             ),
         )
         pass2_tasks.append(task)
@@ -3172,6 +3160,17 @@ async def compute_all_cohorts(
                         )
                         teams_combined.loc[ranks.index, "rank_in_cohort_final"] = ranks
                     logger.info(f"  Published rank_in_cohort_final computed for {active_mask.sum()} Active teams")
+
+                # Compute rank-change deltas inside the rank_in_cohort_final guard so both
+                # sides of the diff resolve to the published final rank, not rank_in_cohort_ml.
+                if calculate_rank_changes_enabled:
+                    logger.info("📊 Calculating rank changes from historical data...")
+                    with _section(timing_report, "rank_changes"):
+                        teams_combined = await calculate_rank_changes(
+                            supabase_client=supabase_client,
+                            current_rankings_df=teams_combined,
+                            reference_date=_normalize_snapshot_date(today),
+                        )
 
             # === Anchor integrity sample (top 3 per age group) ===
             if "power_score_true" in teams_combined.columns:

--- a/tests/unit/test_glicko_sos_role.py
+++ b/tests/unit/test_glicko_sos_role.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import numpy as np
 import pandas as pd
@@ -404,7 +405,6 @@ async def test_compute_all_cohorts_can_skip_snapshot_and_rank_change_side_effect
             {
                 "pass_label": pass_label,
                 "persist_game_residuals": ctx.persist_game_residuals if ctx else None,
-                "calculate_rank_changes": ctx.calculate_rank_changes if ctx else None,
                 "save_snapshot": ctx.save_snapshot if ctx else None,
             }
         )
@@ -423,9 +423,12 @@ async def test_compute_all_cohorts_can_skip_snapshot_and_rank_change_side_effect
         save_calls["prediction"] += 1
         return None
 
+    rank_change_spy = AsyncMock()
+
     monkeypatch.setattr(calculator, "compute_rankings_with_ml", fake_compute_rankings_with_ml)
     monkeypatch.setattr(calculator, "save_ranking_snapshot", fake_save_ranking_snapshot)
     monkeypatch.setattr(calculator, "_save_prediction_feature_snapshot_safe", fake_save_prediction_feature_snapshot)
+    monkeypatch.setattr(calculator, "calculate_rank_changes", rank_change_spy)
 
     games = pd.DataFrame(
         _make_game_pair("A", "B", 2, 1, "2026-03-01", age="14")
@@ -438,15 +441,15 @@ async def test_compute_all_cohorts_can_skip_snapshot_and_rank_change_side_effect
         fetch_from_supabase=False,
         use_glicko=True,
         persist_game_residuals=False,
-        calculate_rank_changes=False,
+        calculate_rank_changes_enabled=False,
         save_snapshot=False,
     )
 
     assert not result["teams"].empty
     assert save_calls == {"ranking": 0, "prediction": 0}
+    rank_change_spy.assert_not_called()
     assert len(calls) == 4
     assert all(call["persist_game_residuals"] is False for call in calls)
-    assert all(call["calculate_rank_changes"] is False for call in calls)
     assert all(call["save_snapshot"] is False for call in calls)
     assert "same_age_games" in result["teams"].columns
     assert "publication_cap_rank" in result["teams"].columns
@@ -671,7 +674,7 @@ async def test_compute_all_cohorts_merges_game_explainability_and_threads_flag(m
         fetch_from_supabase=False,
         use_glicko=True,
         persist_game_explainability=False,
-        calculate_rank_changes=False,
+        calculate_rank_changes_enabled=False,
         save_snapshot=False,
     )
 

--- a/tests/unit/test_ranking_history_relocation.py
+++ b/tests/unit/test_ranking_history_relocation.py
@@ -1,0 +1,269 @@
+"""
+Regression tests for the rank_change_7d apples-to-oranges bug.
+
+Before the fix, calculate_rank_changes ran in compute_rankings_with_ml on a
+DataFrame that did NOT yet have rank_in_cohort_final populated, so the "current"
+side fell back to rank_in_cohort_ml while the historical side (read from
+ranking_history) resolved to rank_in_cohort_final — producing impossible deltas
+like #1 ↓16 for top-of-cohort teams.
+
+The fix relocates the call into compute_all_cohorts after rank_in_cohort_final
+is set. Live bug shape: Illinois Magic FC 2014 (u12 male) had
+rank_in_cohort_final=1, rank_in_cohort_ml=23, historical 7d ago = 7. Correct
+delta is 7 - 1 = +6. The bug produced 7 - 23 = -16.
+"""
+
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+from src.rankings import calculator, ranking_history
+
+
+@pytest.mark.asyncio
+async def test_rank_change_uses_rank_in_cohort_final_not_ml(monkeypatch):
+    """rank_change_7d must use rank_in_cohort_final on the current side."""
+    team_a = "00000000-0000-0000-0000-00000000000a"
+    team_b = "00000000-0000-0000-0000-00000000000b"
+
+    current_df = pd.DataFrame(
+        {
+            "team_id": [team_a, team_b],
+            "age_group": ["u12", "u12"],
+            "gender": ["male", "male"],
+            "rank_in_cohort_final": pd.array([1, 5], dtype="Int64"),
+            "rank_in_cohort_ml": pd.array([23, 7], dtype="Int64"),
+            "rank_in_cohort": pd.array([44, 10], dtype="Int64"),
+            "state_code": ["IL", "IL"],
+            "power_score_final": [0.845, 0.700],
+            "status": ["Active", "Active"],
+        }
+    )
+
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_ranks",
+        AsyncMock(side_effect=[{team_a: 7, team_b: 9}, {}]),
+    )
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_state_ranks",
+        AsyncMock(side_effect=[{}, {}]),
+    )
+
+    result = await ranking_history.calculate_rank_changes(
+        supabase_client=None,
+        current_rankings_df=current_df,
+    )
+
+    # team_a: 7 - 1 = +6 (bug would have produced 7 - 23 = -16)
+    assert result.loc[result["team_id"] == team_a, "rank_change_7d"].iloc[0] == 6, (
+        "rank_change_7d for team_a must use rank_in_cohort_final (=1), not "
+        "rank_in_cohort_ml (=23). Got -16 means the bug is back."
+    )
+    # team_b: 9 - 5 = +4
+    assert result.loc[result["team_id"] == team_b, "rank_change_7d"].iloc[0] == 4
+    assert pd.isna(result.loc[result["team_id"] == team_a, "rank_change_30d"].iloc[0])
+
+
+@pytest.mark.asyncio
+async def test_rank_change_falls_back_to_ml_when_final_is_na(monkeypatch):
+    """3-level fallback (final → ml → cohort) is preserved for pre-migration/Inactive teams."""
+    team_a = "00000000-0000-0000-0000-00000000000a"
+
+    # rank_in_cohort_final is NA (Inactive team or pre-migration row); fallback
+    # to rank_in_cohort_ml=23. Historical also has only ml available (final=NA).
+    current_df = pd.DataFrame(
+        {
+            "team_id": [team_a],
+            "age_group": ["u12"],
+            "gender": ["male"],
+            "rank_in_cohort_final": pd.array([pd.NA], dtype="Int64"),
+            "rank_in_cohort_ml": pd.array([23], dtype="Int64"),
+            "rank_in_cohort": pd.array([44], dtype="Int64"),
+            "state_code": ["IL"],
+            "power_score_final": [0.700],
+            "status": ["Inactive"],
+        }
+    )
+
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_ranks",
+        AsyncMock(side_effect=[{team_a: 30}, {}]),
+    )
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_state_ranks",
+        AsyncMock(side_effect=[{}, {}]),
+    )
+
+    result = await ranking_history.calculate_rank_changes(
+        supabase_client=None,
+        current_rankings_df=current_df,
+    )
+
+    # final=NA → fallback to ml=23 for current; historical=30 → 30 - 23 = +7
+    assert result.loc[result["team_id"] == team_a, "rank_change_7d"].iloc[0] == 7
+
+
+@pytest.mark.asyncio
+async def test_state_rank_change_uses_current_state_rank(monkeypatch):
+    """State-rank delta uses the current state rank computed from power_score_final."""
+    team_a = "00000000-0000-0000-0000-00000000000a"
+    team_b = "00000000-0000-0000-0000-00000000000b"
+
+    # Both teams in IL. power_score_final orders A > B → A is state rank 1, B is 2.
+    current_df = pd.DataFrame(
+        {
+            "team_id": [team_a, team_b],
+            "age_group": ["u12", "u12"],
+            "gender": ["male", "male"],
+            "rank_in_cohort_final": pd.array([1, 5], dtype="Int64"),
+            "rank_in_cohort_ml": pd.array([1, 5], dtype="Int64"),
+            "rank_in_cohort": pd.array([1, 5], dtype="Int64"),
+            "state_code": ["IL", "IL"],
+            "power_score_final": [0.845, 0.700],
+            "status": ["Active", "Active"],
+        }
+    )
+
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_ranks",
+        AsyncMock(side_effect=[{}, {}]),
+    )
+    monkeypatch.setattr(
+        ranking_history,
+        "get_historical_state_ranks",
+        AsyncMock(side_effect=[{team_a: 3, team_b: 4}, {}]),
+    )
+
+    result = await ranking_history.calculate_rank_changes(
+        supabase_client=None,
+        current_rankings_df=current_df,
+    )
+
+    # team_a: current state rank 1, historical 3 → 3 - 1 = +2
+    assert result.loc[result["team_id"] == team_a, "rank_change_state_7d"].iloc[0] == 2
+    # team_b: current state rank 2, historical 4 → 4 - 2 = +2
+    assert result.loc[result["team_id"] == team_b, "rank_change_state_7d"].iloc[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_compute_all_cohorts_invokes_calculate_rank_changes_after_final_rank(monkeypatch):
+    """Integration: the relocated call runs against teams_combined with rank_in_cohort_final populated."""
+    captured: dict = {}
+
+    async def fake_calculate_rank_changes(supabase_client, current_rankings_df, reference_date=None):
+        captured["call_count"] = captured.get("call_count", 0) + 1
+        captured["has_final_column"] = "rank_in_cohort_final" in current_rankings_df.columns
+        captured["final_values"] = current_rankings_df["rank_in_cohort_final"].tolist()
+        current_rankings_df["rank_change_7d"] = 0
+        current_rankings_df["rank_change_30d"] = 0
+        current_rankings_df["rank_change_state_7d"] = 0
+        current_rankings_df["rank_change_state_30d"] = 0
+        return current_rankings_df
+
+    monkeypatch.setattr(calculator, "calculate_rank_changes", fake_calculate_rank_changes)
+
+    # Stub compute_rankings_with_ml to return a minimal teams DataFrame so
+    # compute_all_cohorts can finish without touching the real engine.
+    async def fake_compute_rankings_with_ml(
+        supabase_client,
+        games_df,
+        today,
+        v53_cfg=None,
+        layer13_cfg=None,
+        fetch_from_supabase=False,
+        lookback_days=365,
+        provider_filter=None,
+        ctx=None,
+    ):
+        age = str(games_df["age"].iloc[0])
+        rows = [
+            {
+                "team_id": f"team-{age}-{tid}",
+                "age": age,
+                "age_num": int(age),
+                "gender": "male",
+                "mu": 1500.0 + i * 10,
+                "sigma": 80.0,
+                "volatility": 0.06,
+                "abs_strength": 0.5,
+                "sos_norm": 0.50,
+                "powerscore_adj": 0.50,
+                "powerscore_ml": 0.50,
+                "power_score_true": 0.50 + i * 0.05,
+                "power_score_final": 0.50 + i * 0.05,
+                "status": "Active",
+            }
+            for i, tid in enumerate(["A", "B"])
+        ]
+        return {
+            "teams": pd.DataFrame(rows),
+            "games_used": games_df.copy(),
+            "pre_sos_state": {"legacy": age},
+        }
+
+    async def fake_save(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(calculator, "compute_rankings_with_ml", fake_compute_rankings_with_ml)
+    monkeypatch.setattr(calculator, "save_ranking_snapshot", fake_save)
+    monkeypatch.setattr(calculator, "_save_prediction_feature_snapshot_safe", fake_save)
+
+    games = pd.DataFrame(
+        [
+            {
+                "team_id": "A",
+                "opp_id": "B",
+                "gf": 2,
+                "ga": 1,
+                "date": pd.Timestamp("2026-03-01"),
+                "age": "14",
+                "gender": "male",
+                "opp_age": "14",
+                "opp_gender": "male",
+            },
+            {
+                "team_id": "B",
+                "opp_id": "A",
+                "gf": 1,
+                "ga": 2,
+                "date": pd.Timestamp("2026-03-01"),
+                "age": "14",
+                "gender": "male",
+                "opp_age": "14",
+                "opp_gender": "male",
+            },
+        ]
+    )
+
+    class _DummySupabase:
+        def __init__(self):
+            self.client = None
+
+    await calculator.compute_all_cohorts(
+        supabase_client=_DummySupabase(),
+        games_df=games,
+        fetch_from_supabase=False,
+        use_glicko=True,
+        calculate_rank_changes_enabled=True,
+        save_snapshot=False,
+    )
+
+    assert captured.get("call_count") == 1, (
+        f"calculate_rank_changes must be awaited exactly once at the compute_all_cohorts "
+        f"layer, got {captured.get('call_count')}. Per-cohort invocations would mean the "
+        f"relocation has regressed."
+    )
+    assert captured["has_final_column"], (
+        "calculate_rank_changes must receive a DataFrame with rank_in_cohort_final populated. "
+        "Missing column means the call was relocated to before the final-rank publication step."
+    )
+    assert any(v is not pd.NA for v in captured["final_values"]), (
+        "rank_in_cohort_final must contain at least one non-NA value when "
+        "calculate_rank_changes runs (the published rank for Active teams)."
+    )


### PR DESCRIPTION
## Summary

Top-of-cohort teams were rendering as `#1 ↓16` because `calculate_rank_changes` ran inside `compute_rankings_with_ml`, before `rank_in_cohort_final` is populated. Current rank fell back to `rank_in_cohort_ml` (e.g. 23) while the historical snapshot resolved to `rank_in_cohort_final` (e.g. 7), producing `7 − 23 = -16` on the same row that gets republished as `#1` by the later final-rank pass. Trigger case: Illinois Magic FC 2014 (u12 male).

## Changes

- Moved `calculate_rank_changes` into `compute_all_cohorts`, inside the `if "power_score_true" in teams_combined.columns:` guard, after the `rank_in_cohort_final` block. Both sides of the delta now resolve to the published final rank.
- Renamed the `compute_all_cohorts` parameter `calculate_rank_changes` → `calculate_rank_changes_enabled` to stop shadowing the imported function. Updated the matching kwarg in `scripts/backfill_prediction_feature_history.py` and `tests/unit/test_glicko_sos_role.py`.
- Replaced the per-cohort branch in `compute_rankings_with_ml` with an unconditional `None` scaffold so solo callers still see the four `rank_change_*` columns. Dropped the now-dead `RankingContext.calculate_rank_changes` field and the two forwards.
- Added `tests/unit/test_ranking_history_relocation.py`: the bug-shape regression (final=1, ml=23, hist=7 → +6), the `final=NA` fallback path, the state-rank delta path, and an integration test asserting the relocated call fires exactly once with `rank_in_cohort_final` populated. Tightened the False-branch test in `test_glicko_sos_role.py` with `spy.assert_not_called()`.

## Scope

Forward-only. Existing rows in `rankings_full` self-correct on the next ranking job; historical `ranking_history.rank_change_*` rows are not backfilled (30-day chart will catch up as snapshots roll forward).

## Test plan

- [x] `pytest tests/unit/test_ranking_history_relocation.py tests/unit/test_ranking_history_na_safety.py tests/unit/test_glicko_sos_role.py` — 26 pass
- [x] `ruff check` clean on all four touched files
- [ ] After the first post-deploy ranking job: `SELECT team_id, rank_in_cohort_final, rank_change_7d FROM rankings_full WHERE team_id = '36d80476-f198-4b2c-bdf6-ac5a52dbf99f'` → expect `rank_change_7d >= 0` (was `-16`)
- [ ] After first post-deploy run: `SELECT COUNT(*) FROM rankings_full WHERE rank_in_cohort_final = 1 AND rank_change_7d < 0` → expect 0