### PR TITLE
test(stripe): add route tests for sync and portal endpoints

### DIFF
--- a/frontend/app/api/stripe/portal/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/portal/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetUser, mockFrom, mockPortalSessionsCreate } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockPortalSessionsCreate: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/stripe/server', () => ({
+  stripe: {
+    billingPortal: { sessions: { create: mockPortalSessionsCreate } },
+  },
+}));
+
+import { POST } from '../route';
+
+function profileChain(final: { data?: unknown; error?: unknown }) {
+  const single = vi.fn().mockResolvedValue(final);
+  const eq = vi.fn(() => ({ single }));
+  const select = vi.fn(() => ({ eq }));
+  return { select };
+}
+
+describe('POST /api/stripe/portal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://pitchrank.io';
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await POST();
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when profile has no stripe_customer_id', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: null }, error: null }));
+
+    const res = await POST();
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'No billing account found' });
+  });
+
+  it('returns 400 when profile lookup errors', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockFrom.mockReturnValue(profileChain({ data: null, error: { message: 'boom' } }));
+
+    const res = await POST();
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'No billing account found' });
+  });
+
+  it('keys the portal session off the user own stripe_customer_id', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null }));
+    mockPortalSessionsCreate.mockResolvedValue({ url: 'https://billing.stripe.com/session/abc' });
+
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: 'https://billing.stripe.com/session/abc' });
+    // Critical regression guard: the customer passed to Stripe MUST be the one we
+    // looked up by user.id — never a value derived from request body. Wrong filter
+    // here = billing-account leak.
+    expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
+      customer: 'cus_user-1',
+      return_url: 'https://pitchrank.io/watchlist',
+    });
+  });
+
+  it('returns 500 on Stripe error without leaking details', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null }));
+    mockPortalSessionsCreate.mockRejectedValue(new Error('Stripe is down: req_xyz'));
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create portal session');
+  });
+});

--- a/frontend/app/api/stripe/portal/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/portal/__tests__/route.test.ts
@@ -28,11 +28,17 @@ vi.mock('@/lib/stripe/server', () => ({
 
 import { POST } from '../route';
 
+/**
+ * Build a chainable supabase mock that records the filter args (column/value)
+ * so tests can assert the lookup is keyed correctly. Returns the supabase-shaped
+ * `client` for use with `mockFrom.mockReturnValue(...)`, plus the underlying
+ * spies for assertions.
+ */
 function profileChain(final: { data?: unknown; error?: unknown }) {
   const single = vi.fn().mockResolvedValue(final);
   const eq = vi.fn(() => ({ single }));
   const select = vi.fn(() => ({ eq }));
-  return { select };
+  return { client: { select }, select, eq, single };
 }
 
 describe('POST /api/stripe/portal', () => {
@@ -51,7 +57,8 @@ describe('POST /api/stripe/portal', () => {
 
   it('returns 400 when profile has no stripe_customer_id', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
-    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: null }, error: null }));
+    const chain = profileChain({ data: { stripe_customer_id: null }, error: null });
+    mockFrom.mockReturnValue(chain.client);
 
     const res = await POST();
 
@@ -61,7 +68,8 @@ describe('POST /api/stripe/portal', () => {
 
   it('returns 400 when profile lookup errors', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
-    mockFrom.mockReturnValue(profileChain({ data: null, error: { message: 'boom' } }));
+    const chain = profileChain({ data: null, error: { message: 'boom' } });
+    mockFrom.mockReturnValue(chain.client);
 
     const res = await POST();
 
@@ -71,16 +79,22 @@ describe('POST /api/stripe/portal', () => {
 
   it('keys the portal session off the user own stripe_customer_id', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
-    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null }));
+    const chain = profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null });
+    mockFrom.mockReturnValue(chain.client);
     mockPortalSessionsCreate.mockResolvedValue({ url: 'https://billing.stripe.com/session/abc' });
 
     const res = await POST();
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ url: 'https://billing.stripe.com/session/abc' });
+
     // Critical regression guard: the customer passed to Stripe MUST be the one we
-    // looked up by user.id — never a value derived from request body. Wrong filter
-    // here = billing-account leak.
+    // looked up by `user.id` — never a value derived from request body or any
+    // other column. Wrong table, wrong filter column, or wrong filter value here
+    // = billing-account leak (returning another user's portal session).
+    expect(mockFrom).toHaveBeenCalledWith('user_profiles');
+    expect(chain.select).toHaveBeenCalledWith('stripe_customer_id');
+    expect(chain.eq).toHaveBeenCalledWith('id', 'user-1');
     expect(mockPortalSessionsCreate).toHaveBeenCalledWith({
       customer: 'cus_user-1',
       return_url: 'https://pitchrank.io/watchlist',
@@ -89,7 +103,8 @@ describe('POST /api/stripe/portal', () => {
 
   it('returns 500 on Stripe error without leaking details', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
-    mockFrom.mockReturnValue(profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null }));
+    const chain = profileChain({ data: { stripe_customer_id: 'cus_user-1' }, error: null });
+    mockFrom.mockReturnValue(chain.client);
     mockPortalSessionsCreate.mockRejectedValue(new Error('Stripe is down: req_xyz'));
 
     const res = await POST();

--- a/frontend/app/api/stripe/sync/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/sync/__tests__/route.test.ts
@@ -48,15 +48,29 @@ function makeRequest(body: unknown): Request {
   });
 }
 
-// Helper to build a chainable supabase query mock that returns the given final value
-function chain(final: { data?: unknown; error?: unknown }) {
+/**
+ * Build a chainable supabase SELECT mock that records the filter args
+ * (column/value pair) so tests can assert the lookup is keyed correctly.
+ * Returns the supabase-shaped `client` plus the underlying spies.
+ *
+ * Supports both `.single()` and `.maybeSingle()` terminators.
+ */
+function selectChain(final: { data?: unknown; error?: unknown }) {
   const single = vi.fn().mockResolvedValue(final);
   const maybeSingle = vi.fn().mockResolvedValue(final);
-  const eq2 = vi.fn(() => ({ single, maybeSingle }));
-  const eq1 = vi.fn(() => ({ single, maybeSingle, eq: eq2 }));
-  const select = vi.fn(() => ({ eq: eq1 }));
-  const update = vi.fn(() => ({ eq: vi.fn().mockResolvedValue(final) }));
-  return { select, update, eq: eq1 };
+  const eq = vi.fn(() => ({ single, maybeSingle }));
+  const select = vi.fn(() => ({ eq }));
+  return { client: { select }, select, eq, single, maybeSingle };
+}
+
+/**
+ * Build a chainable supabase UPDATE mock that records the filter args.
+ * The route pattern is `.from(table).update(updates).eq(column, value)`.
+ */
+function updateChain(final: { error?: unknown } = { error: null }) {
+  const eq = vi.fn().mockResolvedValue(final);
+  const update = vi.fn(() => ({ eq }));
+  return { client: { update }, update, eq };
 }
 
 describe('POST /api/stripe/sync', () => {
@@ -112,12 +126,19 @@ describe('POST /api/stripe/sync', () => {
       subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
       metadata: {},
     });
-    mockServerFrom.mockReturnValue(chain({ data: { stripe_customer_id: 'cus_real' }, error: null }));
+    const chain = selectChain({ data: { stripe_customer_id: 'cus_real' }, error: null });
+    mockServerFrom.mockReturnValue(chain.client);
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual({ error: 'Session does not belong to you' });
+
+    // Ownership check must look up the profile by user.id, never by anything
+    // attacker-controlled. Wrong filter column here = anyone can claim any
+    // checkout session.
+    expect(mockServerFrom).toHaveBeenCalledWith('user_profiles');
+    expect(chain.eq).toHaveBeenCalledWith('id', 'user-real');
   });
 
   it('authenticated: returns 403 when profile has no customer_id (cannot verify)', async () => {
@@ -127,13 +148,15 @@ describe('POST /api/stripe/sync', () => {
       subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
       metadata: {},
     });
-    mockServerFrom.mockReturnValue(chain({ data: { stripe_customer_id: null }, error: null }));
+    const chain = selectChain({ data: { stripe_customer_id: null }, error: null });
+    mockServerFrom.mockReturnValue(chain.client);
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toMatch(/cannot verify/i);
+    expect(chain.eq).toHaveBeenCalledWith('id', 'user-real');
   });
 
   it('authenticated: syncs profile by user.id when metadata matches', async () => {
@@ -143,15 +166,20 @@ describe('POST /api/stripe/sync', () => {
       subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
       metadata: { supabase_user_id: 'user-real' },
     });
-    const updateEq = vi.fn().mockResolvedValue({ error: null });
-    mockServerFrom.mockReturnValue({ update: vi.fn(() => ({ eq: updateEq })) });
+    const update = updateChain({ error: null });
+    mockServerFrom.mockReturnValue(update.client);
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ synced: true, plan: 'premium', status: 'active' });
-    expect(updateEq).toHaveBeenCalledWith('id', 'user-real');
+
+    // Critical: must update the profile keyed by user.id from the verified
+    // session, never by stripe_customer_id directly (otherwise a forged session
+    // pointing at another user's customer_id would mutate that user's row).
+    expect(mockServerFrom).toHaveBeenCalledWith('user_profiles');
+    expect(update.eq).toHaveBeenCalledWith('id', 'user-real');
   });
 
   it('anonymous: returns 202 when no profile exists yet (webhook pending)', async () => {
@@ -160,13 +188,21 @@ describe('POST /api/stripe/sync', () => {
       customer: 'cus_anon',
       subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
     });
-    mockAdminFrom.mockReturnValue(chain({ data: null, error: null }));
+    const chain = selectChain({ data: null, error: null });
+    mockAdminFrom.mockReturnValue(chain.client);
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_anon' }));
 
     expect(res.status).toBe(202);
     const body = await res.json();
     expect(body).toMatchObject({ synced: false });
+
+    // Anonymous-path lookup MUST be keyed by stripe_customer_id from the
+    // verified Stripe session, never by anything client-supplied. Wrong column
+    // here = account-linking regression (e.g., looking up by email could
+    // attach a payment to the wrong account).
+    expect(mockAdminFrom).toHaveBeenCalledWith('user_profiles');
+    expect(chain.eq).toHaveBeenCalledWith('stripe_customer_id', 'cus_anon');
   });
 
   it('anonymous: syncs by stripe_customer_id when profile exists', async () => {
@@ -175,17 +211,23 @@ describe('POST /api/stripe/sync', () => {
       customer: 'cus_anon',
       subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
     });
-    // First call (lookup) returns profile; second call (update) returns success
-    const updateEq = vi.fn().mockResolvedValue({ error: null });
-    const lookupChain = chain({ data: { id: 'profile-99' }, error: null });
-    mockAdminFrom.mockReturnValueOnce(lookupChain).mockReturnValueOnce({ update: vi.fn(() => ({ eq: updateEq })) });
+    const lookup = selectChain({ data: { id: 'profile-99' }, error: null });
+    const update = updateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(lookup.client) // first call: SELECT to find profile
+      .mockReturnValueOnce(update.client); // second call: UPDATE that profile
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_anon' }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ synced: true, plan: 'premium', status: 'active' });
-    expect(updateEq).toHaveBeenCalledWith('id', 'profile-99');
+
+    // Lookup keyed by stripe_customer_id from Stripe (not client input).
+    expect(lookup.eq).toHaveBeenCalledWith('stripe_customer_id', 'cus_anon');
+    // Then update by the resolved profile.id — NOT by stripe_customer_id again
+    // (which would update any row sharing that customer_id, not just this profile).
+    expect(update.eq).toHaveBeenCalledWith('id', 'profile-99');
   });
 
   it('returns 500 on unexpected Stripe error', async () => {

--- a/frontend/app/api/stripe/sync/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/sync/__tests__/route.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted mock fns so they're available inside vi.mock factories
+const { mockGetUser, mockServerFrom, mockAdminFrom, mockSessionsRetrieve, mockSubscriptionsRetrieve } = vi.hoisted(
+  () => ({
+    mockGetUser: vi.fn(),
+    mockServerFrom: vi.fn(),
+    mockAdminFrom: vi.fn(),
+    mockSessionsRetrieve: vi.fn(),
+    mockSubscriptionsRetrieve: vi.fn(),
+  })
+);
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  }),
+}));
+
+vi.mock('@/lib/supabase/service', () => ({
+  getSupabaseAdmin: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock('@/lib/stripe/server', () => ({
+  stripe: {
+    checkout: { sessions: { retrieve: mockSessionsRetrieve } },
+    subscriptions: { retrieve: mockSubscriptionsRetrieve },
+  },
+  extractPeriodEnd: vi.fn(() => '2026-12-31T00:00:00.000Z'),
+  mapStatusToPlan: vi.fn((status: string) => (status === 'active' ? 'premium' : 'free')),
+}));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/stripe/sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// Helper to build a chainable supabase query mock that returns the given final value
+function chain(final: { data?: unknown; error?: unknown }) {
+  const single = vi.fn().mockResolvedValue(final);
+  const maybeSingle = vi.fn().mockResolvedValue(final);
+  const eq2 = vi.fn(() => ({ single, maybeSingle }));
+  const eq1 = vi.fn(() => ({ single, maybeSingle, eq: eq2 }));
+  const select = vi.fn(() => ({ eq: eq1 }));
+  const update = vi.fn(() => ({ eq: vi.fn().mockResolvedValue(final) }));
+  return { select, update, eq: eq1 };
+}
+
+describe('POST /api/stripe/sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when sessionId is missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Missing session_id' });
+  });
+
+  it('returns 400 when sessionId is not a string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const res = await POST(makeRequest({ sessionId: 123 }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when session has no subscription', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockResolvedValue({ customer: 'cus_123', subscription: null });
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Session has no subscription' });
+  });
+
+  it('authenticated: returns 403 when session metadata user does not match', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_123',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+      metadata: { supabase_user_id: 'user-attacker' },
+    });
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Session does not belong to you' });
+  });
+
+  it('authenticated: returns 403 when no metadata and customer_id mismatch on profile', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_attacker',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+      metadata: {},
+    });
+    mockServerFrom.mockReturnValue(chain({ data: { stripe_customer_id: 'cus_real' }, error: null }));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Session does not belong to you' });
+  });
+
+  it('authenticated: returns 403 when profile has no customer_id (cannot verify)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_123',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+      metadata: {},
+    });
+    mockServerFrom.mockReturnValue(chain({ data: { stripe_customer_id: null }, error: null }));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/cannot verify/i);
+  });
+
+  it('authenticated: syncs profile by user.id when metadata matches', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_123',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+      metadata: { supabase_user_id: 'user-real' },
+    });
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    mockServerFrom.mockReturnValue({ update: vi.fn(() => ({ eq: updateEq })) });
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ synced: true, plan: 'premium', status: 'active' });
+    expect(updateEq).toHaveBeenCalledWith('id', 'user-real');
+  });
+
+  it('anonymous: returns 202 when no profile exists yet (webhook pending)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_anon',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+    });
+    mockAdminFrom.mockReturnValue(chain({ data: null, error: null }));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_anon' }));
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body).toMatchObject({ synced: false });
+  });
+
+  it('anonymous: syncs by stripe_customer_id when profile exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockResolvedValue({
+      customer: 'cus_anon',
+      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+    });
+    // First call (lookup) returns profile; second call (update) returns success
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const lookupChain = chain({ data: { id: 'profile-99' }, error: null });
+    mockAdminFrom.mockReturnValueOnce(lookupChain).mockReturnValueOnce({ update: vi.fn(() => ({ eq: updateEq })) });
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_anon' }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ synced: true, plan: 'premium', status: 'active' });
+    expect(updateEq).toHaveBeenCalledWith('id', 'profile-99');
+  });
+
+  it('returns 500 on unexpected Stripe error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockRejectedValue(new Error('Stripe down'));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
Both routes sit on the revenue path and write/read `user_profiles.stripe_customer_id`/`plan` — neither had any test coverage. Adds 15 new test cases following the same `vi.hoisted` + mock pattern as the existing `webhook` and `checkout` suites.

## `stripe/sync` coverage (10 tests)
- 400 on missing/non-string sessionId
- 400 when session has no subscription
- Authenticated path: 403 when metadata `supabase_user_id` mismatches
- Authenticated path: 403 when no metadata + `customer_id` mismatch on profile
- Authenticated path: 403 when profile has no `customer_id` (cannot verify)
- Authenticated path: 200 + sync when metadata matches
- Anonymous path: 202 when no profile yet (webhook pending)
- Anonymous path: 200 + sync when profile exists, keyed by `customer_id`
- 500 on unexpected Stripe error

## `stripe/portal` coverage (5 tests)
- 401 when not authenticated
- 400 when profile has no `stripe_customer_id`
- 400 when profile lookup errors
- 200 + portal URL — **regression guard asserts `customer` passed to Stripe is the one looked up by `user.id`** (wrong filter = billing-account leak, the original audit P0 risk)
- 500 with generic message on Stripe error (no leaked details)

## Test plan
- [x] All 183 tests pass locally (was 168 before this PR)
- [x] `tsc --noEmit` clean
- [ ] CI typecheck + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)