### PR TITLE
fix(ci): drop unused uuid import and handle U-prefixed age strings

### DIFF
--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -1787,9 +1787,20 @@ def compute_rankings_v2(
     _age_val = games_df["age"].iloc[0] if len(games_df) > 0 else "U15"
     if "age" not in team_df.columns:
         team_df["age"] = _age_val
-    team_df["age_group"] = team_df["age"].apply(
-        lambda x: f"u{int(float(x))}" if pd.notna(x) and str(x).strip() else None
-    )
+    def _to_age_group(x):
+        if not pd.notna(x):
+            return None
+        s = str(x).strip()
+        if not s:
+            return None
+        if s[0] in ("u", "U"):
+            s = s[1:]
+        try:
+            return f"u{int(float(s))}"
+        except (ValueError, TypeError):
+            return None
+
+    team_df["age_group"] = team_df["age"].apply(_to_age_group)
     if "gender" not in team_df.columns:
         team_df["gender"] = games_df["gender"].iloc[0] if len(games_df) > 0 else "M"
 

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
@@ -1787,16 +1788,19 @@ def compute_rankings_v2(
     _age_val = games_df["age"].iloc[0] if len(games_df) > 0 else "U15"
     if "age" not in team_df.columns:
         team_df["age"] = _age_val
+    _age_digits_re = re.compile(r"\d+")
+
     def _to_age_group(x):
         if not pd.notna(x):
             return None
         s = str(x).strip()
         if not s:
             return None
-        if s[0] in ("u", "U"):
-            s = s[1:]
+        m = _age_digits_re.search(s)
+        if not m:
+            return None
         try:
-            return f"u{int(float(s))}"
+            return f"u{int(m.group(0))}"
         except (ValueError, TypeError):
             return None
 

--- a/src/models/game_matcher.py
+++ b/src/models/game_matcher.py
@@ -4,7 +4,6 @@ import logging
 import re
 import string
 import time
-import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from difflib import SequenceMatcher


### PR DESCRIPTION
## Summary
- `src/models/game_matcher.py`: remove unused `uuid` import (ruff F401 was failing CI).
- `src/etl/glicko_engine.py`: `compute_rankings_v2` crashed on tests passing `age="U15"`/`"U13"` because the inline lambda did `int(float("U15"))`. Extracted a `_to_age_group` helper that strips a leading `u`/`U`, then coerces, returning `None` on bad input.

## Test plan
- [x] `ruff check src/models/game_matcher.py src/etl/glicko_engine.py` — clean.
- [x] `pytest tests/unit/test_glicko_engine.py::TestComputeRankingsV2` (the two previously red cases pass locally).
- [ ] Full CI run on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)