### PR TITLE
fix(hygiene): strip trailing '*' and "'" from variant tokens

### DIFF
--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -196,6 +196,15 @@ TEAM_COLORS = {
 # Direction/location variants that indicate different teams
 TEAM_DIRECTIONS = {"north", "south", "east", "west", "central"}
 
+# Trailing-marker punctuation stripped from each token before matching against
+# variant/coach/program tables. Must include `'*` so markers like "Blue*" /
+# "Bolts'" don't leak into the variant and cause a phantom mismatch against an
+# otherwise-identical sibling, and `.,` so coach names like "Riedell," parse
+# correctly. Mirrors `_tokenize` in find_fuzzy_duplicate_teams.py and the
+# matching constants in src/utils/team_name_utils.py and
+# src/models/game_matcher.py — keep all four in sync.
+_VARIANT_STRIP_CHARS = "-()[]'*.,"
+
 
 def extract_team_variant(name, club_name: str = ""):
     """Extract team variant (color, direction, coach name, roman numeral) from team name.
@@ -214,21 +223,15 @@ def extract_team_variant(name, club_name: str = ""):
     name_lower = name.lower()
     words = name_lower.split()
 
-    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
-    # don't leak into the variant and cause a phantom mismatch against an
-    # otherwise-identical sibling. Mirrors `_tokenize` in
-    # find_fuzzy_duplicate_teams.py — keep the two in sync.
-    strip_chars = "-()[]'*"
-
     # Check for color ANYWHERE in name (not just at end)
     for word in words:
-        word_clean = word.strip(strip_chars)
+        word_clean = word.strip(_VARIANT_STRIP_CHARS)
         if word_clean in TEAM_COLORS:
             return word_clean
 
     # Check for direction variants (North, South, East, West, Central)
     for word in words:
-        word_clean = word.strip(strip_chars)
+        word_clean = word.strip(_VARIANT_STRIP_CHARS)
         if word_clean in TEAM_DIRECTIONS:
             return word_clean
 
@@ -459,7 +462,7 @@ def extract_team_variant(name, club_name: str = ""):
     # Club tokens are never variants — strip them so duplicates whose stored
     # name omits the club prefix don't produce a phantom variant from a club word.
     if club_name:
-        club_tokens = {w.strip("-()[].,").lower() for w in club_name.replace("-", " ").split()}
+        club_tokens = {w.strip(_VARIANT_STRIP_CHARS).lower() for w in club_name.replace("-", " ").split()}
         _skip_words = _skip_words | (club_tokens - {""})
 
     def _extract_candidate(text):
@@ -468,7 +471,7 @@ def extract_team_variant(name, club_name: str = ""):
         # (each part checked individually against _skip_words)
         text = text.replace("-", " ")
         for word in text.split():
-            w = word.strip("-()[].,").lower()
+            w = word.strip(_VARIANT_STRIP_CHARS).lower()
             if not w or len(w) < 3:
                 continue
             if w in _skip_words:
@@ -671,7 +674,7 @@ def extract_program_tier(name):
         after_age = name[age_end:].strip(" -")
         after_words = after_age.lower().split()
         if after_words:
-            first_word = after_words[0].strip("-()[].,")
+            first_word = after_words[0].strip(_VARIANT_STRIP_CHARS)
             if first_word in SHORT_BRANCH_TOKENS:
                 return first_word
 

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -214,15 +214,21 @@ def extract_team_variant(name, club_name: str = ""):
     name_lower = name.lower()
     words = name_lower.split()
 
+    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
+    # don't leak into the variant and cause a phantom mismatch against an
+    # otherwise-identical sibling. Mirrors `_tokenize` in
+    # find_fuzzy_duplicate_teams.py — keep the two in sync.
+    strip_chars = "-()[]'*"
+
     # Check for color ANYWHERE in name (not just at end)
     for word in words:
-        word_clean = word.strip("-()[]")
+        word_clean = word.strip(strip_chars)
         if word_clean in TEAM_COLORS:
             return word_clean
 
     # Check for direction variants (North, South, East, West, Central)
     for word in words:
-        word_clean = word.strip("-()[]")
+        word_clean = word.strip(strip_chars)
         if word_clean in TEAM_DIRECTIONS:
             return word_clean
 

--- a/src/models/game_matcher.py
+++ b/src/models/game_matcher.py
@@ -273,15 +273,22 @@ def extract_team_variant(name: str) -> Optional[str]:
     name_lower = name.lower()
     words = name_lower.split()
 
+    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
+    # don't leak into the variant and cause a phantom mismatch against an
+    # otherwise-identical sibling. Mirrors `_tokenize` in
+    # src/utils/team_name_utils.py — keep all three extract_team_variant
+    # copies (here, find_queue_matches.py, team_name_utils.py) in sync.
+    strip_chars = "-()[]'*"
+
     # Check for color ANYWHERE in name
     for word in words:
-        word_clean = word.strip("-()[]")
+        word_clean = word.strip(strip_chars)
         if word_clean in TEAM_COLORS:
             return word_clean
 
     # Check for direction variants
     for word in words:
-        word_clean = word.strip("-()[]")
+        word_clean = word.strip(strip_chars)
         if word_clean in TEAM_DIRECTIONS:
             return word_clean
 

--- a/src/models/game_matcher.py
+++ b/src/models/game_matcher.py
@@ -273,12 +273,13 @@ def extract_team_variant(name: str) -> Optional[str]:
     name_lower = name.lower()
     words = name_lower.split()
 
-    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
-    # don't leak into the variant and cause a phantom mismatch against an
-    # otherwise-identical sibling. Mirrors `_tokenize` in
-    # src/utils/team_name_utils.py — keep all three extract_team_variant
-    # copies (here, find_queue_matches.py, team_name_utils.py) in sync.
-    strip_chars = "-()[]'*"
+    # Strip set must include `'*.,` so trailing markers like "Blue*" /
+    # "Bolts'" / "Riedell," don't leak into the variant (color, direction, OR
+    # coach branch below) and cause a phantom mismatch against an otherwise-
+    # identical sibling. Mirrors `_tokenize` in src/utils/team_name_utils.py —
+    # keep all three extract_team_variant copies (here, find_queue_matches.py,
+    # team_name_utils.py) in sync.
+    strip_chars = "-()[]'*.,"
 
     # Check for color ANYWHERE in name
     for word in words:
@@ -314,7 +315,7 @@ def extract_team_variant(name: str) -> Optional[str]:
         after_words = after_age_clean.split()
 
         for word in after_words:
-            word_clean = word.strip("-()[].,").lower()
+            word_clean = word.strip(strip_chars).lower()
             if not word_clean or len(word_clean) < 3:
                 continue
             if word_clean in _NON_COACH_WORDS:

--- a/src/utils/team_name_utils.py
+++ b/src/utils/team_name_utils.py
@@ -571,15 +571,22 @@ def extract_team_variant(name: str) -> Optional[str]:
     name_lower = name.lower()
     words = name_lower.split()
 
+    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
+    # don't leak into the variant and cause a phantom mismatch against an
+    # otherwise-identical sibling. Mirrors `_tokenize` below — keep all three
+    # extract_team_variant copies (here, find_queue_matches.py,
+    # game_matcher.py) in sync.
+    strip_chars = "-()[]'*"
+
     # 1. Color anywhere in name
     for w in words:
-        w_clean = w.strip("-()[]")
+        w_clean = w.strip(strip_chars)
         if w_clean in TEAM_COLORS:
             return w_clean
 
     # 2. Direction
     for w in words:
-        w_clean = w.strip("-()[]")
+        w_clean = w.strip(strip_chars)
         if w_clean in DIRECTION_CANONICAL:
             return DIRECTION_CANONICAL[w_clean]
 

--- a/src/utils/team_name_utils.py
+++ b/src/utils/team_name_utils.py
@@ -571,12 +571,14 @@ def extract_team_variant(name: str) -> Optional[str]:
     name_lower = name.lower()
     words = name_lower.split()
 
-    # Strip set must include `'*` so trailing markers like "Blue*" / "Bolts'"
-    # don't leak into the variant and cause a phantom mismatch against an
-    # otherwise-identical sibling. Mirrors `_tokenize` below — keep all three
+    # Strip set must include `'*.,` so trailing markers like "Blue*" /
+    # "Bolts'" / "Riedell," don't leak into the variant (color, direction, OR
+    # coach branch below — coach_name in extract_distinctions is populated
+    # from this function and a leaked marker breaks the distinction-equality
+    # gate at game-match time). Mirrors `_tokenize` below — keep all three
     # extract_team_variant copies (here, find_queue_matches.py,
     # game_matcher.py) in sync.
-    strip_chars = "-()[]'*"
+    strip_chars = "-()[]'*.,"
 
     # 1. Color anywhere in name
     for w in words:
@@ -608,7 +610,7 @@ def extract_team_variant(name: str) -> Optional[str]:
         # Strip trailing region markers in parens: "(CTX)" → ""
         after_age_clean = re.sub(r"\s*\([^)]+\)\s*$", "", after_age).strip()
         for word in after_age_clean.split():
-            wc = word.strip("-()[].,").lower()
+            wc = word.strip(strip_chars).lower()
             if not wc or len(wc) < 3:
                 continue
             if wc in NON_COACH_WORDS:

--- a/tests/unit/test_game_matcher.py
+++ b/tests/unit/test_game_matcher.py
@@ -49,3 +49,16 @@ class TestExtractTeamVariant:
         """Program names like 'aspire' should not be treated as coach names."""
         result = extract_team_variant("FC Dallas 2014 Aspire")
         assert result is None or result == "aspire"  # aspire is in _PROGRAM_NAMES
+
+    def test_trailing_marker_punctuation_stripped(self):
+        """Trailing markers like '*' or "'" must not leak into the variant.
+
+        Regression for the Skyline duplicate case: 'Skyline - 2015 Blue' and
+        'Skyline - 2015 Blue*' are the same team — both must extract 'blue'.
+        Same parity fix applied to find_queue_matches.extract_team_variant
+        and team_name_utils.extract_team_variant.
+        """
+        assert extract_team_variant("Skyline - 2015 Blue*") == "blue"
+        assert extract_team_variant("FC Dallas 2014 Blue*") == "blue"
+        assert extract_team_variant("Select North*") == "north"
+        assert extract_team_variant("Rush South'") == "south"

--- a/tests/unit/test_game_matcher.py
+++ b/tests/unit/test_game_matcher.py
@@ -62,3 +62,18 @@ class TestExtractTeamVariant:
         assert extract_team_variant("FC Dallas 2014 Blue*") == "blue"
         assert extract_team_variant("Select North*") == "north"
         assert extract_team_variant("Rush South'") == "south"
+
+    def test_coach_name_trailing_markers_stripped(self):
+        """Trailing markers must also be stripped in the coach-name branch.
+
+        Regression: the color/direction loops were patched first but the
+        coach branch kept its own strip literal that excluded `'*` —
+        'Atletico Dallas 15G Riedell*' would extract 'riedell*' while the
+        unmarked sibling extracted 'riedell', leaving them as distinct
+        coach_name values in extract_distinctions and blocking the merge.
+        """
+        assert extract_team_variant("Atletico Dallas 15G Riedell*") == "riedell"
+        assert extract_team_variant("Atletico Dallas 15G Riedell'") == "riedell"
+        assert extract_team_variant("FC Dynamo 2014 Davis,") == "davis"
+        # And the unmarked sibling must still match identically.
+        assert extract_team_variant("Atletico Dallas 15G Riedell") == "riedell"


### PR DESCRIPTION
## Summary
- Weekly Data Hygiene's fuzzy-merge step (Step 3) was missing obvious duplicates like `Skyline - 2015 Blue` vs `Skyline - 2015 Blue*` because `extract_team_variant` only stripped `-()[]`, while `_tokenize` strips `()[]'*`. Trailing `*` leaked into the variant (`"blue*"`), and `score_team_pair`'s variant-equality gate short-circuited to `None`.
- Three copies of `extract_team_variant` exist (`scripts/find_queue_matches.py`, `src/models/game_matcher.py`, `src/utils/team_name_utils.py`) — all had the same bug. All three now use `strip_chars = "-()[]'*"` and reference each other to catch future drift.
- Added a regression test in `tests/unit/test_game_matcher.py` covering `*` and `'` trailing markers.

Confirmed locally: the three duplicate pairs the user found by hand this week (Skyline `Blue*`, plus two unrelated cases) — Skyline now scores 1.0 and would auto-merge on next Tuesday's run. The other two pairs (`IP-NUFC U10 2015` and `Stars` vs `Stars 2015`) are blocked by separate issues in `_should_skip_pair` (multi-cohort age tokens; generic-without-year skip), tracked for a follow-up.

## Test plan
- [x] `python -m pytest tests/unit/test_game_matcher.py -q` — 10 passed
- [x] Re-ran `score_team_pair` on the failing pair — `Skyline Blue` vs `Skyline Blue*` now returns `1.0` (was `None`)
- [x] Regression: `FC Dallas 2014 Blue` vs `FC Dallas 2014 Gold` and `Select North` vs `Select South` still return `None` (real variant differences preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)