### PR TITLE
fix(watchlist): resolve deprecated team_ids, switch SOS to rank, add form strip

### DIFF
--- a/frontend/app/api/watchlist/route.ts
+++ b/frontend/app/api/watchlist/route.ts
@@ -16,6 +16,8 @@ export interface WatchlistTeam {
   rank_in_state_final: number | null;
   power_score_final: number | null;
   sos_norm: number | null;
+  sos_rank_state: number | null;
+  sos_rank_national: number | null;
   // Deltas
   rank_change_7d: number | null;
   rank_change_30d: number | null;
@@ -29,6 +31,7 @@ export interface WatchlistTeam {
   // Recent activity
   new_games_count: number;
   last_game_date: string | null;
+  last_5_results: ('W' | 'L' | 'D')[]; // Oldest-first for left-to-right timeline display
   // Added to watchlist
   watchlist_added_at: string;
 }
@@ -128,6 +131,7 @@ export async function GET() {
     type StateRankRow = {
       team_id_master: string;
       rank_in_state_final: number | null;
+      sos_rank_state: number | null;
     };
 
     type RankingRow = {
@@ -140,6 +144,8 @@ export async function GET() {
       rank_in_cohort_final: number | null;
       power_score_final: number | null;
       sos_norm: number | null;
+      sos_rank_state: number | null;
+      sos_rank_national: number | null;
       rank_change_7d: number | null;
       rank_change_30d: number | null;
       wins: number | null;
@@ -163,10 +169,42 @@ export async function GET() {
       });
     }
 
-    // Get team IDs
+    // Get team IDs (may include deprecated team_id_masters from before merges).
+    // Resolve to canonical via team_merge_map so rankings/state queries hit the
+    // canonical row — otherwise the watchlist card shows stale pre-merge data
+    // while the team page (which redirects deprecated → canonical) shows current data.
     const typedItems = items as WatchlistItem[];
-    const teamIds = typedItems.map((item: WatchlistItem) => item.team_id_master);
-    const itemMap = new Map(typedItems.map((item: WatchlistItem) => [item.team_id_master, item.created_at]));
+    const originalIds = typedItems.map((item: WatchlistItem) => item.team_id_master);
+
+    const { data: mergeData, error: mergeError } = await supabase
+      .from('team_merge_map')
+      .select('deprecated_team_id, canonical_team_id')
+      .in('deprecated_team_id', originalIds);
+
+    if (mergeError) {
+      console.error('[Watchlist API] Error fetching merge map:', mergeError);
+    }
+
+    const canonicalByDeprecated = new Map<string, string>(
+      ((mergeData || []) as { deprecated_team_id: string; canonical_team_id: string }[]).map((m) => [
+        m.deprecated_team_id,
+        m.canonical_team_id,
+      ])
+    );
+
+    const resolveId = (id: string) => canonicalByDeprecated.get(id) ?? id;
+    const teamIds = Array.from(new Set(originalIds.map(resolveId)));
+
+    // Key itemMap by canonical id so the response carries the canonical team_id_master.
+    // If both the deprecated and canonical IDs are in the watchlist, keep the earliest added_at.
+    const itemMap = new Map<string, string>();
+    for (const item of typedItems) {
+      const canonical = resolveId(item.team_id_master);
+      const existing = itemMap.get(canonical);
+      if (!existing || item.created_at < existing) {
+        itemMap.set(canonical, item.created_at);
+      }
+    }
 
     // Guard against empty teamIds array
     if (teamIds.length === 0) {
@@ -213,7 +251,7 @@ export async function GET() {
     // Fetch state rankings for state rank (with status filter)
     const { data: stateRankingsData, error: stateRankingsError } = await supabase
       .from('state_rankings_view')
-      .select('team_id_master, rank_in_state_final')
+      .select('team_id_master, rank_in_state_final, sos_rank_state')
       .in('team_id_master', teamIds)
       .in('status', ['Active', 'Not Enough Ranked Games']);
 
@@ -226,6 +264,9 @@ export async function GET() {
         sr.team_id_master,
         sr.rank_in_state_final,
       ])
+    );
+    const sosRankStateMap = new Map(
+      ((stateRankingsData || []) as StateRankRow[]).map((sr: StateRankRow) => [sr.team_id_master, sr.sos_rank_state])
     );
 
     // Calculate new games count (last 7 days) for each team
@@ -332,6 +373,64 @@ export async function GET() {
       }
     }
 
+    // Compute last 5 game results (W/L/D) per team for the form strip.
+    // Overshoot the limit so the per-team top-5 survives the home/away merge + dedupe.
+    const formLimit = teamIds.length * 12;
+    const [formHomeResult, formAwayResult] = await Promise.all([
+      supabase
+        .from('games')
+        .select('home_team_master_id, away_team_master_id, home_score, away_score, game_date')
+        .in('home_team_master_id', teamIds)
+        .eq('is_excluded', false)
+        .not('home_score', 'is', null)
+        .not('away_score', 'is', null)
+        .order('game_date', { ascending: false })
+        .limit(formLimit),
+      supabase
+        .from('games')
+        .select('home_team_master_id, away_team_master_id, home_score, away_score, game_date')
+        .in('away_team_master_id', teamIds)
+        .eq('is_excluded', false)
+        .not('home_score', 'is', null)
+        .not('away_score', 'is', null)
+        .order('game_date', { ascending: false })
+        .limit(formLimit),
+    ]);
+
+    const formGamesRaw = [...(formHomeResult.data || []), ...(formAwayResult.data || [])];
+    const formSeen = new Set<string>();
+    const formGames = formGamesRaw
+      .filter((g) => {
+        const key = `${g.home_team_master_id}|${g.away_team_master_id}|${g.game_date}`;
+        if (formSeen.has(key)) return false;
+        formSeen.add(key);
+        return true;
+      })
+      .sort((a, b) => (b.game_date > a.game_date ? 1 : b.game_date < a.game_date ? -1 : 0));
+
+    // Walk most-recent-first; take 5 per team; then reverse so the array is oldest-first.
+    const formByTeam = new Map<string, ('W' | 'L' | 'D')[]>();
+    const teamIdSet = new Set(teamIds);
+    for (const game of formGames) {
+      const homeId = game.home_team_master_id;
+      const awayId = game.away_team_master_id;
+      for (const teamId of [homeId, awayId]) {
+        if (!teamId || !teamIdSet.has(teamId)) continue;
+        const list = formByTeam.get(teamId) ?? [];
+        if (list.length >= 5) continue;
+        const isHome = teamId === homeId;
+        const myScore = isHome ? game.home_score : game.away_score;
+        const opScore = isHome ? game.away_score : game.home_score;
+        if (myScore == null || opScore == null) continue;
+        const result: 'W' | 'L' | 'D' = myScore > opScore ? 'W' : myScore < opScore ? 'L' : 'D';
+        list.push(result);
+        formByTeam.set(teamId, list);
+      }
+    }
+    for (const [id, results] of formByTeam) {
+      formByTeam.set(id, results.reverse());
+    }
+
     // Define type for team data from teams table
     type TeamRow = {
       team_id_master: string;
@@ -382,6 +481,8 @@ export async function GET() {
         rank_in_state_final: stateRankMap.get(team.team_id_master) ?? null,
         power_score_final: ranking?.power_score_final ?? null,
         sos_norm: ranking?.sos_norm ?? null,
+        sos_rank_state: sosRankStateMap.get(team.team_id_master) ?? ranking?.sos_rank_state ?? null,
+        sos_rank_national: ranking?.sos_rank_national ?? null,
         rank_change_7d: ranking?.rank_change_7d ?? null,
         rank_change_30d: ranking?.rank_change_30d ?? null,
         wins: ranking?.wins || 0,
@@ -392,6 +493,7 @@ export async function GET() {
         win_percentage: ranking?.win_percentage ?? null,
         new_games_count: newGamesMap.get(team.team_id_master) || 0,
         last_game_date: lastGameMap.get(team.team_id_master) || null,
+        last_5_results: formByTeam.get(team.team_id_master) ?? [],
         watchlist_added_at: itemMap.get(team.team_id_master) || '',
       };
     });

--- a/frontend/app/watchlist/page.tsx
+++ b/frontend/app/watchlist/page.tsx
@@ -24,7 +24,7 @@ import {
 } from 'lucide-react';
 import { fetchWatchlist, removeFromSupabaseWatchlist, initWatchlist } from '@/lib/watchlist';
 import type { WatchlistResponse } from '@/app/api/watchlist/route';
-import { formatPowerScore, formatSOSIndex, cn } from '@/lib/utils';
+import { formatPowerScore, cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -585,15 +585,36 @@ export default function WatchlistPage() {
                         </div>
                         <div className="text-center p-2 bg-muted/50 rounded-lg">
                           <p className="text-xs text-muted-foreground uppercase tracking-wide">SOS</p>
-                          <p className="font-mono font-semibold text-sm">{formatSOSIndex(team.sos_norm)}</p>
+                          <p className="font-mono font-semibold text-sm">
+                            {team.sos_rank_national ? `#${team.sos_rank_national}` : '—'}
+                          </p>
                         </div>
                         <div className="text-center p-2 bg-muted/50 rounded-lg">
-                          <p className="text-xs text-muted-foreground uppercase tracking-wide">Record</p>
+                          <p className="text-xs text-muted-foreground uppercase tracking-wide">Ranked Record</p>
                           <p className="font-mono font-semibold text-sm">
                             {team.wins}-{team.losses}-{team.draws}
                           </p>
                         </div>
                       </div>
+
+                      {/* Form (last 5 games, oldest left → newest right) */}
+                      {team.last_5_results.length > 0 && (
+                        <div className="flex items-center justify-center gap-1.5 mb-4">
+                          <span className="text-[10px] text-muted-foreground uppercase tracking-wide mr-1">Form</span>
+                          {team.last_5_results.map((r, i) => (
+                            <span
+                              key={i}
+                              className={cn(
+                                'inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-bold text-white',
+                                r === 'W' ? 'bg-green-500' : r === 'L' ? 'bg-red-500' : 'bg-gray-400'
+                              )}
+                              title={r === 'W' ? 'Win' : r === 'L' ? 'Loss' : 'Draw'}
+                            >
+                              {r}
+                            </span>
+                          ))}
+                        </div>
+                      )}
 
                       {/* Actions */}
                       <div className="flex items-center justify-between pt-3 border-t">


### PR DESCRIPTION
## Summary
- Resolve deprecated `team_id_master` values through `team_merge_map` in `/api/watchlist` so the card hits the same canonical `rankings_view` row the team page renders. The team page already redirects deprecated → canonical at `app/teams/[id]/page.tsx:140-144`, which is why the two surfaces showed different ranks / SOS / record for the same team (e.g. card showed rank 53 / 25-2-3 / SOS 99.9 while the team page showed #5 / 27-4-3 / National SOS #26).
- Switch the watchlist card's SOS cell from the 0–100 SOS index (`formatSOSIndex(sos_norm)`) to `#{sos_rank_national}` so the metric matches what the team header shows.
- Rename the card's record cell to **Ranked Record** so the wins/losses/draws figure (ranked-games window) is distinguishable from the team header's total record.
- Add a last-5 W/L/D **Form** strip beneath the stats grid (oldest-left). Filters `is_excluded = false` and ignores rows without scores.

## Test plan
- [ ] Log in as a premium user with a watchlist that includes a team whose `team_id_master` is deprecated (e.g. the Philadelphia Union Juniors U12 case). Confirm rank / PowerScore / SOS on the card now match the canonical team's team-detail page.
- [ ] Verify the "View" link from the watchlist card lands directly on the canonical team page (no redirect).
- [ ] Confirm the SOS cell renders `#N` and matches the team header's "National SOS" value.
- [ ] Confirm the record cell label reads "Ranked Record" and the value still matches the ranked-games window.
- [ ] Confirm the Form strip renders up to 5 dots (W = green, L = red, D = gray), oldest on the left.
- [ ] Sanity-check a team with fewer than 5 completed games — strip renders the available results only.
- [ ] Sanity-check a team with `is_excluded` (futsal) games — those should not appear in the form strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)