### PR TITLE
feat(team-page): Clutch Factor card — W-L splits by goal differential

### DIFF
--- a/frontend/app/api/teams/[teamId]/clutch/route.ts
+++ b/frontend/app/api/teams/[teamId]/clutch/route.ts
@@ -46,11 +46,13 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
 
     const { data: games, error: gamesError } = await supabase
       .from('games')
-      .select('home_team_master_id, away_team_master_id, home_score, away_score')
+      .select('home_team_master_id, away_team_master_id, home_score, away_score, game_date')
       .or(orConditions)
       .eq('is_excluded', false)
       .not('home_score', 'is', null)
-      .not('away_score', 'is', null);
+      .not('away_score', 'is', null)
+      .order('game_date', { ascending: false })
+      .limit(30);
 
     if (gamesError) {
       console.error('Error fetching games for clutch factor:', gamesError);

--- a/frontend/app/api/teams/[teamId]/clutch/route.ts
+++ b/frontend/app/api/teams/[teamId]/clutch/route.ts
@@ -1,0 +1,107 @@
+import { requirePremium } from '@/lib/api/requirePremium';
+import { NextResponse } from 'next/server';
+
+/**
+ * GET /api/teams/[teamId]/clutch
+ *
+ * Returns the team's record in close vs. blowout games, bucketed by goal
+ * differential. Draws (margin 0) are excluded — clutch implies a result.
+ * Premium-only endpoint.
+ */
+export async function GET(req: Request, { params }: { params: Promise<{ teamId: string }> }) {
+  try {
+    const { teamId } = await params;
+    const auth = await requirePremium();
+    if (auth.error) return auth.error;
+    const { supabase } = auth;
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(teamId)) {
+      return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
+    }
+
+    // Resolve merged team IDs so games stored under deprecated IDs are included
+    // (mirrors /api/insights/[teamId]).
+    const { data: incomingMerge } = await supabase
+      .from('team_merge_map')
+      .select('canonical_team_id')
+      .eq('deprecated_team_id', teamId)
+      .maybeSingle();
+    const canonicalTeamId = (incomingMerge as { canonical_team_id?: string } | null)?.canonical_team_id ?? teamId;
+
+    const { data: mergedTeams } = await supabase
+      .from('team_merge_map')
+      .select('deprecated_team_id')
+      .eq('canonical_team_id', canonicalTeamId);
+
+    const teamIdsToQuery = new Set<string>([canonicalTeamId, teamId]);
+    ((mergedTeams || []) as { deprecated_team_id: string | null }[]).forEach((m) => {
+      if (m.deprecated_team_id) teamIdsToQuery.add(m.deprecated_team_id);
+    });
+    const teamIdList = Array.from(teamIdsToQuery);
+
+    const orConditions = teamIdList
+      .map((tid) => `home_team_master_id.eq.${tid},away_team_master_id.eq.${tid}`)
+      .join(',');
+
+    const { data: games, error: gamesError } = await supabase
+      .from('games')
+      .select('home_team_master_id, away_team_master_id, home_score, away_score')
+      .or(orConditions)
+      .eq('is_excluded', false)
+      .not('home_score', 'is', null)
+      .not('away_score', 'is', null);
+
+    if (gamesError) {
+      console.error('Error fetching games for clutch factor:', gamesError);
+      return NextResponse.json({ error: 'Failed to load games' }, { status: 500 });
+    }
+
+    type GameRow = {
+      home_team_master_id: string | null;
+      away_team_master_id: string | null;
+      home_score: number | null;
+      away_score: number | null;
+    };
+
+    const buckets = {
+      oneGoal: { wins: 0, losses: 0 },
+      twoGoal: { wins: 0, losses: 0 },
+      threePlus: { wins: 0, losses: 0 },
+    };
+
+    ((games || []) as GameRow[]).forEach((game) => {
+      if (game.home_score === null || game.away_score === null) return;
+      const isHome = game.home_team_master_id !== null && teamIdsToQuery.has(game.home_team_master_id);
+      const teamScore = isHome ? game.home_score : game.away_score;
+      const oppScore = isHome ? game.away_score : game.home_score;
+      const margin = Math.abs(teamScore - oppScore);
+      if (margin === 0) return;
+
+      const bucket = margin === 1 ? buckets.oneGoal : margin === 2 ? buckets.twoGoal : buckets.threePlus;
+      if (teamScore > oppScore) {
+        bucket.wins++;
+      } else {
+        bucket.losses++;
+      }
+    });
+
+    const toLine = (b: { wins: number; losses: number }) => {
+      const total = b.wins + b.losses;
+      return {
+        wins: b.wins,
+        losses: b.losses,
+        winPct: total > 0 ? b.wins / total : null,
+      };
+    };
+
+    return NextResponse.json({
+      oneGoal: toLine(buckets.oneGoal),
+      twoGoal: toLine(buckets.twoGoal),
+      threePlus: toLine(buckets.threePlus),
+    });
+  } catch (error) {
+    console.error('Clutch factor error:', error);
+    return NextResponse.json({ error: 'Failed to compute clutch factor' }, { status: 500 });
+  }
+}

--- a/frontend/components/ClutchFactorCard.tsx
+++ b/frontend/components/ClutchFactorCard.tsx
@@ -102,7 +102,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
         <CardHeader className="pb-3">
           <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
             <Flame className="h-4 w-4" />
-            Clutch Factor
+            Clutch Factor (last 30 games)
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -118,7 +118,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
         <CardHeader className="pb-3">
           <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
             <Flame className="h-4 w-4" />
-            Clutch Factor
+            Clutch Factor (last 30 games)
           </CardTitle>
           <CardDescription>Record in close vs. blowout games</CardDescription>
         </CardHeader>
@@ -163,7 +163,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
         <CardHeader className="pb-3">
           <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
             <Flame className="h-4 w-4" />
-            Clutch Factor
+            Clutch Factor (last 30 games)
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -179,7 +179,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
         <CardHeader className="pb-3">
           <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
             <Flame className="h-4 w-4" />
-            Clutch Factor
+            Clutch Factor (last 30 games)
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -204,7 +204,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
         <CardHeader className="pb-3">
           <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
             <Flame className="h-4 w-4" />
-            Clutch Factor
+            Clutch Factor (last 30 games)
           </CardTitle>
           <CardDescription>Record in close vs. blowout games</CardDescription>
         </CardHeader>
@@ -220,7 +220,7 @@ export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
       <CardHeader className="pb-3">
         <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
           <Flame className="h-4 w-4 text-primary" />
-          Clutch Factor
+          Clutch Factor (last 30 games)
           <Tooltip>
             <TooltipTrigger asChild>
               <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />

--- a/frontend/components/ClutchFactorCard.tsx
+++ b/frontend/components/ClutchFactorCard.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { ChartSkeleton } from '@/components/ui/skeletons';
+import { Flame, Lock, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useUser, hasPremiumAccess } from '@/hooks/useUser';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { trackPaywallImpression, trackPaywallUpgradeClicked } from '@/lib/events';
+
+interface ClutchFactorCardProps {
+  teamId: string;
+}
+
+interface ClutchBucket {
+  wins: number;
+  losses: number;
+  winPct: number | null;
+}
+
+interface ClutchResponse {
+  oneGoal: ClutchBucket;
+  twoGoal: ClutchBucket;
+  threePlus: ClutchBucket;
+}
+
+const BUCKETS: Array<{ key: keyof ClutchResponse; label: string }> = [
+  { key: 'oneGoal', label: '1-Goal Games' },
+  { key: 'twoGoal', label: '2-Goal Games' },
+  { key: 'threePlus', label: '3+ Goal Games' },
+];
+
+function formatPct(winPct: number | null): string {
+  if (winPct === null) return '—';
+  return `${Math.round(winPct * 100)}%`;
+}
+
+function pctColor(winPct: number | null): string {
+  if (winPct === null) return 'text-muted-foreground';
+  if (winPct >= 0.7) return 'text-green-600 dark:text-green-400';
+  if (winPct >= 0.5) return 'text-blue-600 dark:text-blue-400';
+  if (winPct >= 0.3) return 'text-amber-600 dark:text-amber-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+/**
+ * Clutch Factor card — team's W-L and win % bucketed by goal differential
+ * (1-goal, 2-goal, 3+ goal). Ties are excluded. Premium-only.
+ */
+export function ClutchFactorCard({ teamId }: ClutchFactorCardProps) {
+  const { profile, isLoading: userLoading } = useUser();
+  const [data, setData] = useState<ClutchResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isPremium = hasPremiumAccess(profile);
+
+  const fetchData = useCallback(async () => {
+    if (!isPremium) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/teams/${teamId}/clutch`);
+      const body = await response.json();
+
+      if (!response.ok) {
+        throw new Error(body.error || 'Failed to fetch clutch factor');
+      }
+
+      setData(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load clutch factor');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [teamId, isPremium]);
+
+  useEffect(() => {
+    if (isPremium && teamId) {
+      fetchData();
+    }
+  }, [isPremium, teamId, fetchData]);
+
+  useEffect(() => {
+    if (!isPremium && !userLoading) {
+      trackPaywallImpression({
+        feature: 'clutch_factor',
+        location: 'team_detail_page',
+        team_id: teamId,
+      });
+    }
+  }, [isPremium, userLoading, teamId]);
+
+  if (userLoading) {
+    return (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <Flame className="h-4 w-4" />
+            Clutch Factor
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartSkeleton height={60} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!isPremium) {
+    return (
+      <Card className="border-l-4 border-l-amber-500/50 overflow-hidden">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <Flame className="h-4 w-4" />
+            Clutch Factor
+          </CardTitle>
+          <CardDescription>Record in close vs. blowout games</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="relative">
+            <div className="blur-sm pointer-events-none select-none space-y-2" aria-hidden="true">
+              {BUCKETS.map((b) => (
+                <div key={b.key} className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">{b.label}</span>
+                  <span className="font-mono font-semibold">8–4 (67%)</span>
+                </div>
+              ))}
+            </div>
+            <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/60 backdrop-blur-[1px]">
+              <Lock className="h-5 w-5 text-muted-foreground mb-2" />
+              <p className="text-xs text-muted-foreground mb-2">Unlock clutch-game splits</p>
+              <Link
+                href={`/upgrade?source=clutch_factor&team=${teamId}`}
+                onClick={() =>
+                  trackPaywallUpgradeClicked({
+                    feature: 'clutch_factor',
+                    location: 'team_detail_page',
+                    team_id: teamId,
+                  })
+                }
+              >
+                <Button size="sm" className="text-xs">
+                  <Lock className="w-3 h-3 mr-1" />
+                  Upgrade to Unlock
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Card className="border-l-4 border-l-primary">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <Flame className="h-4 w-4" />
+            Clutch Factor
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ChartSkeleton height={80} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-l-4 border-l-destructive/50">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <Flame className="h-4 w-4" />
+            Clutch Factor
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground text-center py-2">Unable to load clutch factor</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalGames = data
+    ? data.oneGoal.wins +
+      data.oneGoal.losses +
+      data.twoGoal.wins +
+      data.twoGoal.losses +
+      data.threePlus.wins +
+      data.threePlus.losses
+    : 0;
+
+  if (!data || totalGames === 0) {
+    return (
+      <Card className="border-l-4 border-l-muted">
+        <CardHeader className="pb-3">
+          <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+            <Flame className="h-4 w-4" />
+            Clutch Factor
+          </CardTitle>
+          <CardDescription>Record in close vs. blowout games</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground text-center py-2">No decided games yet</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-l-4 border-l-primary">
+      <CardHeader className="pb-3">
+        <CardTitle className="font-display uppercase tracking-wide text-base flex items-center gap-2">
+          <Flame className="h-4 w-4 text-primary" />
+          Clutch Factor
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent side="right" className="max-w-[280px]">
+              <p className="font-semibold mb-1">Clutch Factor</p>
+              <p className="text-xs">
+                Wins and losses split by goal differential. Draws are excluded. A strong record in 1-goal games suggests
+                a team that closes out tight matches; a weak one suggests they fade when it matters.
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </CardTitle>
+        <CardDescription>Record in close vs. blowout games</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {BUCKETS.map(({ key, label }) => {
+          const bucket = data[key];
+          const total = bucket.wins + bucket.losses;
+          return (
+            <div key={key} className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">{label}</span>
+              <div className="flex items-center gap-2 font-mono">
+                <span className="font-semibold tabular-nums">
+                  {bucket.wins}–{bucket.losses}
+                </span>
+                <span className={cn('text-xs font-medium tabular-nums w-10 text-right', pctColor(bucket.winPct))}>
+                  {total > 0 ? formatPct(bucket.winPct) : '—'}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/TeamPageShell.tsx
+++ b/frontend/components/TeamPageShell.tsx
@@ -27,6 +27,11 @@ const LazyTeamInsightsCard = dynamic(
   { ssr: true, loading: () => <div className="h-40 animate-pulse bg-muted rounded-lg" /> }
 );
 
+const LazyClutchFactorCard = dynamic(
+  () => import('@/components/ClutchFactorCard').then((mod) => ({ default: mod.ClutchFactorCard })),
+  { ssr: true, loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> }
+);
+
 const LazyRankHistoryChart = dynamic(
   () => import('@/components/RankHistoryChart').then((mod) => ({ default: mod.RankHistoryChart })),
   { ssr: true, loading: () => <div className="h-[240px] animate-pulse bg-muted rounded-lg" /> }
@@ -137,6 +142,9 @@ export function TeamPageShell({ id }: TeamPageShellProps) {
               </SectionErrorBoundary>
               <SectionErrorBoundary fallbackTitle="Failed to load insights.">
                 <LazyTeamInsightsCard teamId={id} />
+              </SectionErrorBoundary>
+              <SectionErrorBoundary fallbackTitle="Failed to load clutch factor.">
+                <LazyClutchFactorCard teamId={id} />
               </SectionErrorBoundary>
             </div>
           </div>


### PR DESCRIPTION
## Summary

New premium-only card on the team detail page, stacked directly below Team Insights. Shows the team's record (wins–losses and win %) in the **last 30 scored, non-excluded games**, bucketed by goal differential:

- 1-Goal games
- 2-Goal games
- 3+ Goal games

Draws are excluded — clutch implies a result. Numbers surface team archetypes that other cards miss (e.g., "Flat Track Bully" reads as weak in 1-goal games + dominant in 3+ goal games).

## Implementation

- New route `GET /api/teams/[teamId]/clutch` — premium-gated via `requirePremium`, resolves merged team IDs through `team_merge_map` so games scraped under deprecated IDs are counted (mirrors `/api/insights/[teamId]`). Orders by `game_date desc` and limits to 30.
- New client component `ClutchFactorCard` — mirrors `TeamInsightsCard`'s premium-gating pattern (skeleton / paywall teaser / error / empty / data states).
- Wired into `TeamPageShell` via `dynamic()` lazy import + `SectionErrorBoundary`, slotted after `LazyTeamInsightsCard`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint --no-fix` clean on changed files
- [x] Anonymous `GET /api/teams/<uuid>/clutch` → 401 (premium gate enforced)
- [x] Anonymous `GET /teams/<id>` → 200 → redirects to `/upgrade` (upstream premium gate intact, new card doesn't crash SSR)
- [x] Bucketing math validated against live DB for a known team (Atletico Dallas 2016, 30-game window: 2-3 / 7-4 / 10-1)
- [ ] Logged-in premium browser smoke test — card renders below Team Insights with live numbers
- [ ] Mobile layout check on team detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)