### PR TITLE
feat(report-card): sync leads to Beehiiv for nurture automation

### DIFF
--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -2,7 +2,7 @@ import { createServerSupabase } from '@/lib/supabase/server';
 import { sendReportCardEmail } from '@/lib/email';
 import { checkRateLimit } from '@/lib/api/rateLimit';
 import { optionalAuth } from '@/lib/api/optionalAuth';
-import { subscribeFreeLead } from '@/lib/beehiiv';
+import { subscribeFreeLead, enrollInAutomation } from '@/lib/beehiiv';
 import { NextRequest, NextResponse } from 'next/server';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { TeamReportCard } from '@/lib/pdf';
@@ -191,7 +191,11 @@ export async function POST(request: NextRequest) {
         if (insertError) console.error('Failed to save report card lead:', insertError);
       });
 
-    // Sync lead to Beehiiv as free-tier subscriber for nurture automation (non-blocking)
+    // Sync lead to Beehiiv as free-tier subscriber for nurture automation (non-blocking).
+    // Then explicitly enroll in the report-card automation so existing subscribers
+    // (newsletter signups, Stripe premium-tier syncs) also enter the sequence — the
+    // create-subscription branch only fires for brand-new emails.
+    const reportCardAutomationId = process.env.BEEHIIV_REPORT_CARD_AUTOMATION_ID;
     subscribeFreeLead(normalizedEmail, {
       teamName: team.team_name,
       clubName: team.club_name,
@@ -199,9 +203,15 @@ export async function POST(request: NextRequest) {
       ageGroup: team.age_group,
       gender: team.gender,
       role: role || null,
-    }).catch((err) => {
-      console.error('Failed to sync report card lead to Beehiiv:', err);
-    });
+    })
+      .then(() => {
+        if (reportCardAutomationId) {
+          return enrollInAutomation(normalizedEmail, reportCardAutomationId);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to sync report card lead to Beehiiv:', err);
+      });
 
     // Send email with PDF attachment (non-blocking)
     const record = `${ranking.total_wins ?? ranking.wins}-${ranking.total_losses ?? ranking.losses}-${ranking.total_draws ?? ranking.draws}`;

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -2,6 +2,7 @@ import { createServerSupabase } from '@/lib/supabase/server';
 import { sendReportCardEmail } from '@/lib/email';
 import { checkRateLimit } from '@/lib/api/rateLimit';
 import { optionalAuth } from '@/lib/api/optionalAuth';
+import { subscribeFreeLead } from '@/lib/beehiiv';
 import { NextRequest, NextResponse } from 'next/server';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { TeamReportCard } from '@/lib/pdf';
@@ -189,6 +190,18 @@ export async function POST(request: NextRequest) {
       .then(({ error: insertError }) => {
         if (insertError) console.error('Failed to save report card lead:', insertError);
       });
+
+    // Sync lead to Beehiiv as free-tier subscriber for nurture automation (non-blocking)
+    subscribeFreeLead(normalizedEmail, {
+      teamName: team.team_name,
+      clubName: team.club_name,
+      state: team.state_code,
+      ageGroup: team.age_group,
+      gender: team.gender,
+      role: role || null,
+    }).catch((err) => {
+      console.error('Failed to sync report card lead to Beehiiv:', err);
+    });
 
     // Send email with PDF attachment (non-blocking)
     const record = `${ranking.total_wins ?? ranking.wins}-${ranking.total_losses ?? ranking.losses}-${ranking.total_draws ?? ranking.draws}`;

--- a/frontend/lib/beehiiv.ts
+++ b/frontend/lib/beehiiv.ts
@@ -192,3 +192,42 @@ export async function subscribeFreeLead(email: string, attrs: ReportCardLeadAttr
     return false;
   }
 }
+
+/**
+ * Enroll an email in a Beehiiv automation via the automation-journey API.
+ *
+ * Works for both new and existing subscribers (a returning newsletter
+ * subscriber filling out the report-card form gets enrolled even though
+ * the create-subscription branch never fires for them).
+ *
+ * The target automation must have an "Add by API" trigger enabled in
+ * Beehiiv. Silently no-ops if API credentials or the automation ID are
+ * not configured.
+ */
+export async function enrollInAutomation(email: string, automationId: string): Promise<boolean> {
+  const { apiKey, pubId } = getConfig();
+  if (!apiKey || !pubId || !automationId) return false;
+
+  try {
+    const resp = await fetch(`${BEEHIIV_API_URL}/publications/${pubId}/automations/${automationId}/journeys`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email }),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.warn(`[beehiiv] Automation enrollment failed (${resp.status}): ${body}`);
+      return false;
+    }
+
+    console.log(`[beehiiv] Enrolled email in automation ${automationId}`);
+    return true;
+  } catch (err) {
+    console.error(`[beehiiv] Error enrolling in automation: ${err}`);
+    return false;
+  }
+}

--- a/frontend/lib/beehiiv.ts
+++ b/frontend/lib/beehiiv.ts
@@ -108,3 +108,87 @@ export async function tagSubscriber(email: string): Promise<boolean> {
 export async function untagSubscriber(email: string): Promise<boolean> {
   return setSubscriberTier(email, 'free');
 }
+
+export interface ReportCardLeadAttrs {
+  teamName?: string | null;
+  clubName?: string | null;
+  state?: string | null;
+  ageGroup?: string | null;
+  gender?: string | null;
+  role?: string | null;
+}
+
+/**
+ * Subscribe a report-card lead to Beehiiv as a free-tier subscriber.
+ *
+ * Sets utm_source=report-card and custom fields so the welcome automation
+ * can branch on source and personalize Day 2+ emails with team details.
+ * Creates the subscriber if missing; updates their custom fields if they
+ * already exist (returning visitor).
+ */
+export async function subscribeFreeLead(email: string, attrs: ReportCardLeadAttrs = {}): Promise<boolean> {
+  const { apiKey, pubId } = getConfig();
+  if (!apiKey || !pubId) {
+    console.warn('[beehiiv] API key or publication ID not configured, skipping report-card sync');
+    return false;
+  }
+
+  const customFields = [
+    { name: 'source', value: 'report-card' },
+    { name: 'team_name', value: attrs.teamName ?? '' },
+    { name: 'club_name', value: attrs.clubName ?? '' },
+    { name: 'state', value: attrs.state ?? '' },
+    { name: 'age_group', value: attrs.ageGroup ?? '' },
+    { name: 'gender', value: attrs.gender ?? '' },
+    { name: 'role', value: attrs.role ?? '' },
+  ].filter((f) => f.value !== '');
+
+  try {
+    const subscriberId = await findSubscriberId(email);
+
+    if (subscriberId) {
+      const resp = await fetch(`${BEEHIIV_API_URL}/publications/${pubId}/subscriptions/${subscriberId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ custom_fields: customFields }),
+      });
+
+      if (!resp.ok) {
+        const body = await resp.text();
+        console.warn(`[beehiiv] Report-card custom fields update failed (${resp.status}): ${body}`);
+        return false;
+      }
+    } else {
+      const resp = await fetch(`${BEEHIIV_API_URL}/publications/${pubId}/subscriptions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email,
+          tier: 'free',
+          utm_source: 'report-card',
+          reactivate_existing: false,
+          send_welcome_email: false,
+          custom_fields: customFields,
+        }),
+      });
+
+      if (!resp.ok) {
+        const body = await resp.text();
+        console.warn(`[beehiiv] Report-card subscribe failed (${resp.status}): ${body}`);
+        return false;
+      }
+    }
+
+    console.log(`[beehiiv] Synced report-card lead (${attrs.teamName ?? 'unknown team'})`);
+    return true;
+  } catch (err) {
+    console.error(`[beehiiv] Error syncing report-card lead: ${err}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
The `/report-card` form captures leads to Supabase but never adds them to Beehiiv — so the 7-email nurture sequence drafted in `campaigns/free-team-report-card/emails/` has had nothing to trigger off. This is the smallest unlock: a free-tier Beehiiv subscribe call alongside the existing Supabase insert and Resend Day-0 delivery email.

## Changes
- **New** `subscribeFreeLead(email, attrs)` in `frontend/lib/beehiiv.ts`
  - Creates subscriber with `tier: 'free'`, `utm_source: 'report-card'`
  - Custom fields: `source`, `team_name`, `club_name`, `state`, `age_group`, `gender`, `role` — for Beehiiv automation branching + email personalization
  - Updates custom fields on existing subscribers (returning visitors don't get re-subscribed)
  - Silently no-ops if `BEEHIIV_API_KEY` / `BEEHIIV_PUBLICATION_ID` env vars are missing
- **Wired** into `frontend/app/api/reports/team-card/route.ts` as a non-blocking call, mirroring the existing Supabase insert + Resend send pattern

## What this enables
Configure a Beehiiv automation that triggers on `subscribers added with utm_source=report-card` and the existing drafted Day 2 → Day 14 nurture emails will fire. Email content can branch on the custom fields (e.g., "Other teams in {{state}}'s {{age_group}} {{gender}} group...").

## What is *not* in this PR
- No UI changes
- No changes to Stripe webhook premium-tier sync (`tagSubscriber` / `untagSubscriber` untouched)
- Beehiiv automation itself — that's a configuration task in the Beehiiv UI, not code
- The page redesign + filter-gated team search — separate follow-up PR

## Test plan
- [ ] Set `BEEHIIV_API_KEY` and `BEEHIIV_PUBLICATION_ID` in env (already set in prod for the premium sync)
- [ ] Submit a real report-card request via `/report-card`
- [ ] Verify subscriber appears in Beehiiv with `tier=free`, `utm_source=report-card`, and custom fields populated with the team's name/state/age_group/gender
- [ ] Re-submit with the same email — verify custom fields update without creating a duplicate
- [ ] Submit with `BEEHIIV_API_KEY` unset locally — verify the Resend email + Supabase insert still succeed (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)