### PR TITLE
feat(report-card): wire internal traffic paths to /report-card

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -47,6 +47,14 @@ export default function Home() {
                 <Link href="/rankings">View Rankings</Link>
               </Button>
               <Button
+                data-testid="cta-report-card"
+                size="lg"
+                asChild
+                className="font-semibold uppercase tracking-wide bg-accent text-primary hover:bg-accent/90"
+              >
+                <Link href="/report-card">Free Team Report Card</Link>
+              </Button>
+              <Button
                 data-testid="cta-methodology"
                 size="lg"
                 variant="outline"

--- a/frontend/app/upgrade/page.tsx
+++ b/frontend/app/upgrade/page.tsx
@@ -413,6 +413,12 @@ function UpgradePageContent() {
           <p className="text-xs text-muted-foreground mt-3">
             7-day free trial. Cancel anytime. No commitment required.
           </p>
+          <p className="text-sm text-muted-foreground mt-6">
+            Not ready?{' '}
+            <Link href="/report-card" className="text-primary font-medium hover:underline">
+              Get a free team report card →
+            </Link>
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -42,6 +42,7 @@ export function Footer() {
       { name: 'Compare Teams', href: '/compare' },
     ],
     Resources: [
+      { name: 'Free Team Report Card', href: '/report-card' },
       { name: 'Methodology', href: '/methodology' },
       { name: 'Blog', href: '/blog' },
     ],


### PR DESCRIPTION
## Summary
The `/report-card` lead-magnet page (shipped in #781, #782, #784) currently has zero internal entry points. This PR adds the three obvious ones so the redesign and Beehiiv pipeline don't ship in a vacuum.

## Changes
- **Homepage hero** — third CTA **"Free Team Report Card"** in electric-yellow (accent), sitting between *View Rankings* (primary white) and *Our Methodology* (outline). Yellow makes the lead magnet the visually loudest button without unseating Rankings as the engagement target.
- **Upgrade page** — soft *"Not ready? Get a free team report card →"* link under the final CTA's small print. Captures parents who scroll the upgrade page without buying — turns a bounce into a lead.
- **Footer Resources column** — "Free Team Report Card" link placed above Methodology and Blog (most-relevant first).

## Out of scope
- One-time newsletter blast announcing the report card to existing Beehiiv subscribers — that's a manual Beehiiv compose, not code
- Paid social / Meta ad campaigns
- OG image refresh for `/report-card` (existing metadata from #781 covers `og:title` / `og:description` / canonical)

## Test plan
- [ ] Vercel preview: homepage hero shows three CTAs, "Free Team Report Card" in yellow, clicks through to `/report-card`
- [ ] Upgrade page: scroll to bottom — "Not ready? Get a free team report card →" link visible under the small print
- [ ] Footer Resources section on any page shows "Free Team Report Card" as the first link
- [ ] Mobile viewport: hero buttons stack cleanly, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)