### PR TITLE
feat(mission-control): track /report-card usage and lead-to-paid conversion

### DIFF
--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -21,6 +21,19 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+function formatRelative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMo = Math.floor(diffDay / 30);
+  return `${diffMo}mo ago`;
+}
+
 export default async function SubscriptionsDashboardPage() {
   const metrics = await getSubscriptionMetrics();
 
@@ -194,6 +207,68 @@ export default async function SubscriptionsDashboardPage() {
                       ` ${metrics.conversion.excluded} test/internal user${metrics.conversion.excluded === 1 ? '' : 's'} excluded.`}
                   </p>
                 </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-baseline justify-between">
+            <h2 className="font-display text-xl font-semibold">Report Card Leads</h2>
+            <span className="text-sm text-muted-foreground">
+              latest {metrics.reportCard.recentLeads.length} of {metrics.reportCard.totalRequests.toLocaleString()}{' '}
+              requests
+            </span>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <KpiCard label="Total Requests" value={metrics.reportCard.totalRequests.toLocaleString()} sub="all time" />
+            <KpiCard
+              label="Unique Emails"
+              value={metrics.reportCard.uniqueEmails.toLocaleString()}
+              sub="distinct addresses"
+            />
+            <KpiCard
+              label="Last 7 Days"
+              value={metrics.reportCard.last7Days.toLocaleString()}
+              sub={`${metrics.reportCard.last30Days.toLocaleString()} in last 30d`}
+            />
+            <KpiCard
+              label="Lead → Paid"
+              value={metrics.reportCard.conversion.percent === null ? '—' : `${metrics.reportCard.conversion.percent}%`}
+              sub={
+                metrics.reportCard.conversion.percent === null
+                  ? `not enough data yet (${metrics.reportCard.conversion.leads} lead${metrics.reportCard.conversion.leads === 1 ? '' : 's'}, need ≥5)`
+                  : `${metrics.reportCard.conversion.converted} of ${metrics.reportCard.conversion.leads} leads now paying${metrics.reportCard.conversion.excluded > 0 ? ` (${metrics.reportCard.conversion.excluded} excluded)` : ''}`
+              }
+            />
+          </div>
+
+          <Card variant="flat">
+            <CardContent className="p-0">
+              {metrics.reportCard.recentLeads.length === 0 ? (
+                <div className="p-6 text-sm text-muted-foreground">No report card requests yet.</div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Team</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>When</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {metrics.reportCard.recentLeads.map((lead) => (
+                      <TableRow key={lead.id}>
+                        <TableCell>{lead.email}</TableCell>
+                        <TableCell>{lead.teamName}</TableCell>
+                        <TableCell className="text-muted-foreground">{lead.role ?? '—'}</TableCell>
+                        <TableCell className="text-muted-foreground">{formatRelative(lead.createdAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               )}
             </CardContent>
           </Card>

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -10,6 +10,7 @@ import {
   buildPastDue,
   computeConversion,
   dedupeEmails,
+  computeLeadConversion,
 } from '../subscription-metrics';
 
 const SECONDS_PER_DAY = 86_400;
@@ -316,5 +317,62 @@ describe('dedupeEmails', () => {
 
   it('returns empty set for empty input', () => {
     expect(dedupeEmails([]).size).toBe(0);
+  });
+});
+
+describe('computeLeadConversion', () => {
+  const excluded = new Set<string>(['internal@pitchrank.io']);
+
+  it('counts leads found in active subs as converted', () => {
+    const leads = new Set(['paid@example.com', 'free@example.com']);
+    const active = [makeSub({ status: 'active', email: 'paid@example.com' })];
+    const result = computeLeadConversion(leads, active, [], excluded);
+    expect(result.leads).toBe(2);
+    expect(result.converted).toBe(1);
+    expect(result.percent).toBeNull(); // sample < 5
+    expect(result.excluded).toBe(0);
+  });
+
+  it('counts leads found in past_due subs as converted', () => {
+    const leads = new Set(['dunning@example.com']);
+    const pastDue = [makeSub({ status: 'past_due', email: 'dunning@example.com' })];
+    const result = computeLeadConversion(leads, [], pastDue, excluded);
+    expect(result.converted).toBe(1);
+  });
+
+  it('returns rounded percent once sample >= 5', () => {
+    const leads = new Set(['a@example.com', 'b@example.com', 'c@example.com', 'd@example.com', 'e@example.com']);
+    const active = [
+      makeSub({ status: 'active', email: 'a@example.com' }),
+      makeSub({ status: 'active', email: 'b@example.com' }),
+    ];
+    const result = computeLeadConversion(leads, active, [], excluded);
+    expect(result.leads).toBe(5);
+    expect(result.converted).toBe(2);
+    expect(result.percent).toBe(40);
+  });
+
+  it('drops excluded emails from both numerator and denominator', () => {
+    const leads = new Set(['internal@pitchrank.io', 'real@example.com']);
+    const active = [
+      makeSub({ status: 'active', email: 'internal@pitchrank.io' }),
+      makeSub({ status: 'active', email: 'real@example.com' }),
+    ];
+    const result = computeLeadConversion(leads, active, [], excluded);
+    expect(result.leads).toBe(1);
+    expect(result.converted).toBe(1);
+    expect(result.excluded).toBe(1);
+  });
+
+  it('matches case-insensitively', () => {
+    const leads = new Set(['mixed@example.com']);
+    const active = [makeSub({ status: 'active', email: 'MIXED@Example.com' })];
+    const result = computeLeadConversion(leads, active, [], excluded);
+    expect(result.converted).toBe(1);
+  });
+
+  it('returns zero/null when no leads', () => {
+    const result = computeLeadConversion(new Set(), [], [], excluded);
+    expect(result).toEqual({ leads: 0, converted: 0, percent: null, excluded: 0 });
   });
 });

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -9,6 +9,7 @@ import {
   buildTrialPipeline,
   buildPastDue,
   computeConversion,
+  dedupeEmails,
 } from '../subscription-metrics';
 
 const SECONDS_PER_DAY = 86_400;
@@ -284,5 +285,36 @@ describe('computeConversion', () => {
     expect(result.sample).toBe(9);
     expect(result.converted).toBe(9);
     expect(result.percent).toBe(100);
+  });
+});
+
+describe('dedupeEmails', () => {
+  it('returns lowercased distinct emails', () => {
+    const result = dedupeEmails(['A@b.com', 'a@B.com', 'c@d.com']);
+    expect(result.size).toBe(2);
+    expect(result.has('a@b.com')).toBe(true);
+    expect(result.has('c@d.com')).toBe(true);
+  });
+
+  it('trims surrounding whitespace', () => {
+    const result = dedupeEmails(['  user@example.com  ', 'user@example.com']);
+    expect(result.size).toBe(1);
+    expect(result.has('user@example.com')).toBe(true);
+  });
+
+  it('skips empty and non-string values', () => {
+    const result = dedupeEmails([
+      '',
+      '   ',
+      'real@example.com',
+      null as unknown as string,
+      undefined as unknown as string,
+    ]);
+    expect(result.size).toBe(1);
+    expect(result.has('real@example.com')).toBe(true);
+  });
+
+  it('returns empty set for empty input', () => {
+    expect(dedupeEmails([]).size).toBe(0);
   });
 });

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -343,7 +343,7 @@ type ReportCardFetchResult = {
  * individually so a single failure degrades that metric (returns 0 / empty)
  * rather than blowing up the dashboard. Failure messages land in `errors`.
  */
-async function _fetchReportCardMetrics(errors: string[]): Promise<ReportCardFetchResult> {
+async function fetchReportCardMetrics(errors: string[]): Promise<ReportCardFetchResult> {
   let supabase: ReturnType<typeof createServiceSupabase>;
   try {
     supabase = createServiceSupabase();
@@ -465,7 +465,7 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
   const errors: string[] = [];
   const nowSec = Math.floor(Date.now() / 1000);
 
-  const [active, trialing, pastDue, cohort] = await Promise.all([
+  const [active, trialing, pastDue, cohort, reportCardData] = await Promise.all([
     safeList({ status: 'active' }, 'active subscriptions', errors),
     safeList({ status: 'trialing' }, 'trialing subscriptions', errors),
     safeList({ status: 'past_due' }, 'past_due subscriptions', errors),
@@ -474,6 +474,7 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
       'conversion cohort',
       errors
     ),
+    fetchReportCardMetrics(errors),
   ]);
 
   const mrr = computeMrr(active);
@@ -481,6 +482,7 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
   const trialBuckets = buildTrialPipeline(trialing, nowSec);
   const pastDueOut = buildPastDue(pastDue);
   const conversion = computeConversion(cohort, nowSec);
+  const leadConversion = computeLeadConversion(reportCardData.uniqueLeadEmails, active, pastDue);
 
   return {
     mrr,
@@ -495,12 +497,12 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
     pastDue: pastDueOut,
     conversion,
     reportCard: {
-      totalRequests: 0,
-      uniqueEmails: 0,
-      last7Days: 0,
-      last30Days: 0,
-      conversion: { leads: 0, converted: 0, percent: null, excluded: 0 },
-      recentLeads: [],
+      totalRequests: reportCardData.totalRequests,
+      uniqueEmails: reportCardData.uniqueLeadEmails.size,
+      last7Days: reportCardData.last7Days,
+      last30Days: reportCardData.last30Days,
+      conversion: leadConversion,
+      recentLeads: reportCardData.recentLeads,
     },
     generatedAt: new Date().toISOString(),
     errors,

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -16,6 +16,28 @@ export type PastDueEntry = {
   interval: 'month' | 'year';
 };
 
+export type ReportCardLead = {
+  id: string;
+  email: string;
+  teamName: string;
+  role: string | null;
+  createdAt: string; // ISO
+};
+
+export type ReportCardMetrics = {
+  totalRequests: number;
+  uniqueEmails: number;
+  last7Days: number;
+  last30Days: number;
+  conversion: {
+    leads: number;
+    converted: number;
+    percent: number | null;
+    excluded: number;
+  };
+  recentLeads: ReportCardLead[];
+};
+
 export type SubscriptionMetrics = {
   mrr: number; // dollars with cents preserved (e.g. 61.25)
   activePaid: {
@@ -41,6 +63,7 @@ export type SubscriptionMetrics = {
     percent: number | null;
     excluded: number; // test/internal users filtered from sample
   };
+  reportCard: ReportCardMetrics;
   generatedAt: string;
   errors: string[];
 };
@@ -272,6 +295,14 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
     },
     pastDue: pastDueOut,
     conversion,
+    reportCard: {
+      totalRequests: 0,
+      uniqueEmails: 0,
+      last7Days: 0,
+      last30Days: 0,
+      conversion: { leads: 0, converted: 0, percent: null, excluded: 0 },
+      recentLeads: [],
+    },
     generatedAt: new Date().toISOString(),
     errors,
   };

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -93,6 +93,21 @@ function getExcludedEmails(): Set<string> {
   return new Set([...HARDCODED_EXCLUDED_EMAILS, ...fromEnv]);
 }
 
+/**
+ * Normalize and deduplicate a list of email strings. Lowercased + trimmed.
+ * Non-string, empty, and whitespace-only values are dropped.
+ */
+export function dedupeEmails(emails: Array<string | null | undefined>): Set<string> {
+  const out = new Set<string>();
+  for (const raw of emails) {
+    if (typeof raw !== 'string') continue;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized.length === 0) continue;
+    out.add(normalized);
+  }
+  return out;
+}
+
 function getInterval(sub: Stripe.Subscription): 'month' | 'year' | null {
   const recurring = sub.items.data[0]?.price?.recurring;
   if (recurring?.interval === 'month') return 'month';

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -108,6 +108,48 @@ export function dedupeEmails(emails: Array<string | null | undefined>): Set<stri
   return out;
 }
 
+/**
+ * Lead → paid conversion. Returns the share of unique lead emails that are
+ * currently paying Stripe customers (active or past_due — past_due means they
+ * paid at least once and a renewal failed).
+ *
+ * Excluded (test/internal) emails are removed from both numerator and
+ * denominator and reported separately. Percent is null when leads <
+ * MIN_COHORT_SAMPLE so the UI can show "not enough data yet".
+ *
+ * Reuses the active + past_due lists already fetched by getSubscriptionMetrics
+ * — no extra Stripe calls.
+ */
+export function computeLeadConversion(
+  leadEmails: Set<string>,
+  activeSubs: Stripe.Subscription[],
+  pastDueSubs: Stripe.Subscription[],
+  excludedEmails: Set<string> = getExcludedEmails()
+): { leads: number; converted: number; percent: number | null; excluded: number } {
+  // Build set of paying emails (lowercased).
+  const paying = new Set<string>();
+  for (const sub of [...activeSubs, ...pastDueSubs]) {
+    const email = getCustomerEmail(sub).toLowerCase();
+    paying.add(email);
+  }
+
+  let leads = 0;
+  let converted = 0;
+  let excluded = 0;
+  for (const raw of leadEmails) {
+    const email = raw.toLowerCase();
+    if (excludedEmails.has(email)) {
+      excluded += 1;
+      continue;
+    }
+    leads += 1;
+    if (paying.has(email)) converted += 1;
+  }
+
+  const percent = leads >= MIN_COHORT_SAMPLE ? Math.round((converted / leads) * 100) : null;
+  return { leads, converted, percent, excluded };
+}
+
 function getInterval(sub: Stripe.Subscription): 'month' | 'year' | null {
   const recurring = sub.items.data[0]?.price?.recurring;
   if (recurring?.interval === 'month') return 'month';

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -323,6 +323,13 @@ async function safeList(
 const REPORT_CARD_PAGE_CAP = 10_000;
 const REPORT_CARD_RECENT_LIMIT = 15;
 
+function formatSupabaseError(e: unknown): string {
+  if (e && typeof e === 'object' && 'message' in e && typeof (e as { message: unknown }).message === 'string') {
+    return (e as { message: string }).message;
+  }
+  return String(e);
+}
+
 type ReportCardFetchResult = {
   totalRequests: number;
   uniqueLeadEmails: Set<string>;
@@ -401,14 +408,14 @@ async function _fetchReportCardMetrics(errors: string[]): Promise<ReportCardFetc
 
   let totalRequests = 0;
   if (totalRes.error) {
-    errors.push(`report card total: ${String(totalRes.error)}`);
+    errors.push(`report card total: ${formatSupabaseError(totalRes.error)}`);
   } else {
     totalRequests = totalRes.count ?? 0;
   }
 
   let uniqueLeadEmails = new Set<string>();
   if (emailsRes.error) {
-    errors.push(`report card unique emails: ${String(emailsRes.error)}`);
+    errors.push(`report card unique emails: ${formatSupabaseError(emailsRes.error)}`);
   } else {
     const rows = (emailsRes.data ?? []) as Array<{ email: string | null }>;
     uniqueLeadEmails = dedupeEmails(rows.map((r) => r.email));
@@ -419,21 +426,21 @@ async function _fetchReportCardMetrics(errors: string[]): Promise<ReportCardFetc
 
   let last7Days = 0;
   if (last7Res.error) {
-    errors.push(`report card last 7d: ${String(last7Res.error)}`);
+    errors.push(`report card last 7d: ${formatSupabaseError(last7Res.error)}`);
   } else {
     last7Days = last7Res.count ?? 0;
   }
 
   let last30Days = 0;
   if (last30Res.error) {
-    errors.push(`report card last 30d: ${String(last30Res.error)}`);
+    errors.push(`report card last 30d: ${formatSupabaseError(last30Res.error)}`);
   } else {
     last30Days = last30Res.count ?? 0;
   }
 
   let recentLeads: ReportCardLead[] = [];
   if (recentRes.error) {
-    errors.push(`report card recent leads: ${String(recentRes.error)}`);
+    errors.push(`report card recent leads: ${formatSupabaseError(recentRes.error)}`);
   } else {
     const rows = (recentRes.data ?? []) as Array<{
       id: string;

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import type Stripe from 'stripe';
 import { stripe } from '@/lib/stripe/server';
+import { createServiceSupabase } from '@/lib/supabase/service';
 
 export type TrialPipelineEntry = {
   id: string;
@@ -317,6 +318,140 @@ async function safeList(
     errors.push(`${label}: ${msg}`);
     return [];
   }
+}
+
+const REPORT_CARD_PAGE_CAP = 10_000;
+const REPORT_CARD_RECENT_LIMIT = 15;
+
+type ReportCardFetchResult = {
+  totalRequests: number;
+  uniqueLeadEmails: Set<string>;
+  last7Days: number;
+  last30Days: number;
+  recentLeads: ReportCardLead[];
+};
+
+/**
+ * Fetch raw report-card lead data from Supabase. Each sub-query is wrapped
+ * individually so a single failure degrades that metric (returns 0 / empty)
+ * rather than blowing up the dashboard. Failure messages land in `errors`.
+ */
+async function _fetchReportCardMetrics(errors: string[]): Promise<ReportCardFetchResult> {
+  let supabase: ReturnType<typeof createServiceSupabase>;
+  try {
+    supabase = createServiceSupabase();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`report card client: ${msg}`);
+    return {
+      totalRequests: 0,
+      uniqueLeadEmails: new Set(),
+      last7Days: 0,
+      last30Days: 0,
+      recentLeads: [],
+    };
+  }
+
+  const now = Date.now();
+  const sevenDaysAgo = new Date(now - 7 * 86_400_000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 86_400_000).toISOString();
+
+  const [totalRes, emailsRes, last7Res, last30Res, recentRes] = await Promise.all([
+    supabase
+      .from('report_card_leads')
+      .select('id', { count: 'exact', head: true })
+      .then(
+        (r) => r,
+        (e) => ({ error: e, count: null }) as { error: unknown; count: null }
+      ),
+    supabase
+      .from('report_card_leads')
+      .select('email')
+      .limit(REPORT_CARD_PAGE_CAP)
+      .then(
+        (r) => r,
+        (e) => ({ error: e, data: null }) as { error: unknown; data: null }
+      ),
+    supabase
+      .from('report_card_leads')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', sevenDaysAgo)
+      .then(
+        (r) => r,
+        (e) => ({ error: e, count: null }) as { error: unknown; count: null }
+      ),
+    supabase
+      .from('report_card_leads')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', thirtyDaysAgo)
+      .then(
+        (r) => r,
+        (e) => ({ error: e, count: null }) as { error: unknown; count: null }
+      ),
+    supabase
+      .from('report_card_leads')
+      .select('id, email, team_name, role, created_at')
+      .order('created_at', { ascending: false })
+      .limit(REPORT_CARD_RECENT_LIMIT)
+      .then(
+        (r) => r,
+        (e) => ({ error: e, data: null }) as { error: unknown; data: null }
+      ),
+  ]);
+
+  let totalRequests = 0;
+  if (totalRes.error) {
+    errors.push(`report card total: ${String(totalRes.error)}`);
+  } else {
+    totalRequests = totalRes.count ?? 0;
+  }
+
+  let uniqueLeadEmails = new Set<string>();
+  if (emailsRes.error) {
+    errors.push(`report card unique emails: ${String(emailsRes.error)}`);
+  } else {
+    const rows = (emailsRes.data ?? []) as Array<{ email: string | null }>;
+    uniqueLeadEmails = dedupeEmails(rows.map((r) => r.email));
+    if (rows.length >= REPORT_CARD_PAGE_CAP) {
+      errors.push(`report card unique emails: hit ${REPORT_CARD_PAGE_CAP}-row cap; count is a lower bound`);
+    }
+  }
+
+  let last7Days = 0;
+  if (last7Res.error) {
+    errors.push(`report card last 7d: ${String(last7Res.error)}`);
+  } else {
+    last7Days = last7Res.count ?? 0;
+  }
+
+  let last30Days = 0;
+  if (last30Res.error) {
+    errors.push(`report card last 30d: ${String(last30Res.error)}`);
+  } else {
+    last30Days = last30Res.count ?? 0;
+  }
+
+  let recentLeads: ReportCardLead[] = [];
+  if (recentRes.error) {
+    errors.push(`report card recent leads: ${String(recentRes.error)}`);
+  } else {
+    const rows = (recentRes.data ?? []) as Array<{
+      id: string;
+      email: string;
+      team_name: string;
+      role: string | null;
+      created_at: string;
+    }>;
+    recentLeads = rows.map((r) => ({
+      id: r.id,
+      email: r.email,
+      teamName: r.team_name,
+      role: r.role,
+      createdAt: r.created_at,
+    }));
+  }
+
+  return { totalRequests, uniqueLeadEmails, last7Days, last30Days, recentLeads };
 }
 
 export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {


### PR DESCRIPTION
Surfaces /report-card usage on /mission-control/subscriptions. Pulls totals, unique emails, last 7d / 30d, and recent leads from `report_card_leads`, plus lead-to-paid conversion by intersecting lead emails with active + past_due Stripe customers (reuses subs already fetched, no extra Stripe calls).

Uses the service-role Supabase client since `report_card_leads` only has an INSERT policy for anon. New helpers (`dedupeEmails`, `computeLeadConversion`) follow the existing testable-helper pattern; 10 unit tests added, suite is 32/32.

Manual check: visit /mission-control/subscriptions and cross-check the KPI values against:

\`\`\`sql
SELECT COUNT(*) AS total,
       COUNT(DISTINCT lower(trim(email))) AS unique_emails,
       COUNT(*) FILTER (WHERE created_at >= now() - interval '7 days')  AS last_7d,
       COUNT(*) FILTER (WHERE created_at >= now() - interval '30 days') AS last_30d
FROM report_card_leads;
\`\`\`

Spec: \`docs/superpowers/specs/2026-05-17-report-card-mission-control-tracking-design.md\`
Plan: \`docs/superpowers/plans/2026-05-17-report-card-mission-control-tracking.md\`