### PR TITLE
feat(beehiiv): auto-enroll into lifecycle automations via webhook (no segment lag)

### DIFF
--- a/docs/superpowers/specs/2026-05-17-lifecycle-automation-flow.md
+++ b/docs/superpowers/specs/2026-05-17-lifecycle-automation-flow.md
@@ -98,6 +98,33 @@ Plus two utility automations not on the main graph:
 - **Dunning / Update Card** — trigger: `lifecycle becomes past_due`. 3 emails over Stripe's ~21-day retry window. Exits on `lifecycle becomes paid`.
 - **Cancellation Save** — trigger: `lifecycle becomes canceling`. 1-2 emails before period ends. Exits on `lifecycle becomes paid`.
 
+### How triggers actually fire (implementation note)
+
+Beehiiv on Scale plan does NOT recalculate dynamic segments in real time
+(refreshes once daily). Segment-based triggers would delay Trial Onboarding's
+Email 1 by up to 24h — unacceptable for a 7-day trial. Instead, every
+lifecycle automation uses the **`Added by API`** trigger, and the Stripe
+webhook calls Beehiiv's automation-enrollment endpoint directly the moment
+state transitions, giving sub-second routing latency.
+
+Each lifecycle state maps to a Vercel env var holding the automation ID:
+
+| lifecycle | env var | required? |
+|---|---|---|
+| `lead` | `BEEHIIV_REPORT_CARD_AUTOMATION_ID` | already set |
+| `free_drip` | `BEEHIIV_FREE_DRIP_AUTOMATION_ID` | set when Non-Premium Drip is built |
+| `trialing` | `BEEHIIV_TRIAL_AUTOMATION_ID` | set when Trial Onboarding is built |
+| `past_due` | `BEEHIIV_DUNNING_AUTOMATION_ID` | set when Dunning is built |
+| `canceling` | `BEEHIIV_CANCELING_AUTOMATION_ID` | set when Cancellation Save is built |
+| `paid` | `BEEHIIV_PAID_AUTOMATION_ID` | set when Paid Drip is built |
+| `trial_canceled` | `BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID` | set when Trial Cancel Drip is built |
+| `paid_canceled` | `BEEHIIV_PAID_CANCEL_AUTOMATION_ID` | set when Paid Win-Back is built |
+
+The webhook's `enrollInLifecycleAutomation()` helper reads `LIFECYCLE_AUTOMATION_ENV[lifecycle]` and no-ops when the env var is unset — so new automations come online by setting an env var, no code change required.
+
+Per-step `Conditions` on every Send Email node (filter: `lifecycle is <state>`)
+remain the in-flight gate that skips subscribers whose state changes mid-sequence.
+
 ## 5. Gaps from prior sketch — addressed here
 
 | # | Gap | Solution |

--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/stripe/server', () => ({
     },
     customers: {
       retrieve: vi.fn().mockResolvedValue({ id: 'cus_123', email: 'test@example.com' }),
+      update: vi.fn().mockResolvedValue({ id: 'cus_123' }),
     },
   },
   WEBHOOK_EVENTS: {
@@ -40,6 +41,7 @@ vi.mock('@/lib/beehiiv', () => ({
   tagSubscriber: vi.fn().mockResolvedValue(true),
   untagSubscriber: vi.fn().mockResolvedValue(true),
   setLifecycle: vi.fn().mockResolvedValue(true),
+  enrollInAutomation: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@/lib/notifications/admin', () => ({
@@ -78,14 +80,21 @@ vi.mock('@supabase/supabase-js', () => ({
       });
       return builder;
     }),
-    auth: { admin: { createUser: vi.fn(), generateLink: vi.fn() } },
+    auth: {
+      admin: {
+        createUser: vi
+          .fn()
+          .mockResolvedValue({ data: { user: { id: 'new-user-id', email: 'test@example.com' } }, error: null }),
+        generateLink: vi.fn().mockResolvedValue({ data: { properties: { action_link: 'https://example.com/setup' } } }),
+      },
+    },
   })),
 }));
 
 import { POST } from '../route';
 import { headers } from 'next/headers';
 import { stripe, updateUserProfile } from '@/lib/stripe/server';
-import { setLifecycle } from '@/lib/beehiiv';
+import { setLifecycle, enrollInAutomation } from '@/lib/beehiiv';
 
 function makeRequest(body = ''): Request {
   return new Request('http://localhost/api/stripe/webhook', {
@@ -432,5 +441,81 @@ describe('Beehiiv lifecycle routing', () => {
     });
 
     expect(vi.mocked(setLifecycle)).toHaveBeenCalledWith('test@example.com', 'paid');
+  });
+});
+
+describe('Beehiiv automation enrollment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    // Clear all lifecycle automation env vars between tests
+    for (const key of [
+      'BEEHIIV_TRIAL_AUTOMATION_ID',
+      'BEEHIIV_PAID_AUTOMATION_ID',
+      'BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID',
+      'BEEHIIV_PAID_CANCEL_AUTOMATION_ID',
+      'BEEHIIV_DUNNING_AUTOMATION_ID',
+    ]) {
+      delete process.env[key];
+    }
+    setPriorState(null);
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<ReturnType<typeof headers>>
+    );
+  });
+
+  function fireEvent(type: string, object: Record<string, unknown>): Promise<Response> {
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue({
+      id: `evt_${type}`,
+      type,
+      data: { object },
+    } as unknown as Stripe.Event);
+    return POST(makeRequest('valid body'));
+  }
+
+  it('enrolls in trial automation when checkout completes with trialing status', async () => {
+    process.env.BEEHIIV_TRIAL_AUTOMATION_ID = 'aut_test_trial';
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      status: 'trialing',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
+
+    await fireEvent('checkout.session.completed', {
+      customer: 'cus_123',
+      subscription: 'sub_123',
+    });
+
+    expect(vi.mocked(enrollInAutomation)).toHaveBeenCalledWith('test@example.com', 'aut_test_trial');
+  });
+
+  it('skips enrollment when the automation env var is not set', async () => {
+    setPriorState({ subscription_status: 'trialing', cancel_at_period_end: false });
+
+    await fireEvent('customer.subscription.deleted', {
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'canceled',
+    });
+
+    // lifecycle should still be written, but no enrollment without BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID
+    expect(vi.mocked(setLifecycle)).toHaveBeenCalledWith('test@example.com', 'trial_canceled');
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+  });
+
+  it('enrolls in trial-cancel automation when set and trial canceled', async () => {
+    process.env.BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID = 'aut_test_trial_cancel';
+    setPriorState({ subscription_status: 'trialing', cancel_at_period_end: false });
+
+    await fireEvent('customer.subscription.deleted', {
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'canceled',
+    });
+
+    expect(vi.mocked(enrollInAutomation)).toHaveBeenCalledWith('test@example.com', 'aut_test_trial_cancel');
   });
 });

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -4,7 +4,7 @@ import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { notifyAdmin } from '@/lib/notifications/admin';
-import { tagSubscriber, untagSubscriber, setLifecycle, type Lifecycle } from '@/lib/beehiiv';
+import { tagSubscriber, untagSubscriber, setLifecycle, enrollInAutomation, type Lifecycle } from '@/lib/beehiiv';
 import { sendPasswordSetupEmail } from '@/lib/email/password-setup';
 
 /**
@@ -52,14 +52,49 @@ async function getCustomerEmail(customerId: string): Promise<string | null> {
 }
 
 /**
- * Set the Beehiiv lifecycle field for a customer by email. Non-fatal —
+ * Map each lifecycle state to the Vercel env var holding the Beehiiv
+ * automation ID that should auto-enroll the subscriber on transition.
+ * Missing env var = no enrollment (the automation hasn't been built yet);
+ * setLifecycle still runs so segments and per-step gates work in the UI.
+ */
+const LIFECYCLE_AUTOMATION_ENV: Record<Lifecycle, string> = {
+  lead: 'BEEHIIV_REPORT_CARD_AUTOMATION_ID',
+  free_drip: 'BEEHIIV_FREE_DRIP_AUTOMATION_ID',
+  trialing: 'BEEHIIV_TRIAL_AUTOMATION_ID',
+  past_due: 'BEEHIIV_DUNNING_AUTOMATION_ID',
+  canceling: 'BEEHIIV_CANCELING_AUTOMATION_ID',
+  paid: 'BEEHIIV_PAID_AUTOMATION_ID',
+  trial_canceled: 'BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID',
+  paid_canceled: 'BEEHIIV_PAID_CANCEL_AUTOMATION_ID',
+};
+
+/**
+ * Enroll the subscriber in the Beehiiv automation matching this lifecycle
+ * state, if one is configured. Non-fatal; safe to call before all the
+ * downstream automations have been built (no env var = no-op).
+ */
+async function enrollInLifecycleAutomation(email: string, lifecycle: Lifecycle): Promise<void> {
+  const automationId = process.env[LIFECYCLE_AUTOMATION_ENV[lifecycle]];
+  if (!automationId) return;
+  try {
+    await enrollInAutomation(email, automationId);
+  } catch (err) {
+    console.error(`[webhook] enrollInAutomation(${lifecycle}) failed (non-fatal):`, err);
+  }
+}
+
+/**
+ * Set the Beehiiv lifecycle field for a customer by email AND enroll them
+ * into the matching automation (if its env var is configured). Non-fatal —
  * Beehiiv errors are logged but don't fail the webhook (Stripe shouldn't
  * retry a successful state update just because an email tag failed).
  */
 async function syncLifecycle(customerId: string, lifecycle: Lifecycle): Promise<void> {
   try {
     const email = await getCustomerEmail(customerId);
-    if (email) await setLifecycle(email, lifecycle);
+    if (!email) return;
+    await setLifecycle(email, lifecycle);
+    await enrollInLifecycleAutomation(email, lifecycle);
   } catch (err) {
     console.error(`[webhook] syncLifecycle(${lifecycle}) failed (non-fatal):`, err);
   }
@@ -297,13 +332,16 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       `<b>Status:</b> ${subscription.status}`
   );
 
-  // Sync Beehiiv: set tier to premium (gates paywall content) and route into
-  // Trial Onboarding (status=trialing) or Paid Drip (direct-to-paid checkout).
+  // Sync Beehiiv: set tier to premium (gates paywall content), set lifecycle,
+  // and enroll in the matching automation (Trial Onboarding for trialing,
+  // Paid Drip for direct-to-paid). Each step is non-fatal.
   const rawEmail = (customer as Stripe.Customer).email;
   if (rawEmail) {
     try {
       await tagSubscriber(rawEmail);
-      await setLifecycle(rawEmail, subscription.status === 'trialing' ? 'trialing' : 'paid');
+      const lifecycle: Lifecycle = subscription.status === 'trialing' ? 'trialing' : 'paid';
+      await setLifecycle(rawEmail, lifecycle);
+      await enrollInLifecycleAutomation(rawEmail, lifecycle);
     } catch (tagError) {
       console.error('[webhook] Beehiiv sync failed (non-fatal):', tagError);
     }
@@ -367,7 +405,9 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
     const email = await getCustomerEmail(customerId);
     if (email) {
       await untagSubscriber(email);
-      await setLifecycle(email, prior.status === 'trialing' ? 'trial_canceled' : 'paid_canceled');
+      const lifecycle: Lifecycle = prior.status === 'trialing' ? 'trial_canceled' : 'paid_canceled';
+      await setLifecycle(email, lifecycle);
+      await enrollInLifecycleAutomation(email, lifecycle);
     }
   } catch (err) {
     console.warn(`[webhook] Failed to sync Beehiiv on cancel: ${err}`);


### PR DESCRIPTION
## Summary

Follows up #794. Replaces the planned dynamic-segment-trigger architecture with direct API enrollment because Beehiiv on Scale plan only recalculates segments **once daily** — Trial Onboarding Email 1 would be delayed up to 24h, defeating the whole point of a "welcome" email.

Each lifecycle state now maps to a Vercel env var holding a Beehiiv automation ID. The webhook calls Beehiiv's automation-enrollment endpoint directly on state transition. **Future automations come online by setting an env var — no code change.**

## Architecture

\`\`\`
LIFECYCLE_AUTOMATION_ENV map (in webhook route.ts):
  lead           -> BEEHIIV_REPORT_CARD_AUTOMATION_ID  ✓ already set
  trialing       -> BEEHIIV_TRIAL_AUTOMATION_ID         ✓ just set by Dallas
  free_drip      -> BEEHIIV_FREE_DRIP_AUTOMATION_ID
  past_due       -> BEEHIIV_DUNNING_AUTOMATION_ID
  canceling      -> BEEHIIV_CANCELING_AUTOMATION_ID
  paid           -> BEEHIIV_PAID_AUTOMATION_ID
  trial_canceled -> BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID
  paid_canceled  -> BEEHIIV_PAID_CANCEL_AUTOMATION_ID
\`\`\`

Webhook flow on \`checkout.session.completed\` (trialing):
1. \`tagSubscriber(email)\` — sets Beehiiv tier=premium
2. \`setLifecycle(email, 'trialing')\` — writes lifecycle custom field
3. \`enrollInLifecycleAutomation(email, 'trialing')\` — reads \`BEEHIIV_TRIAL_AUTOMATION_ID\` and calls \`enrollInAutomation()\`

Same pattern on all other lifecycle transitions (refunds, cancels, dunning, etc.). The \`syncLifecycle()\` helper that powers most handlers does steps 2 + 3 in one call.

## Why this matters

- **Sub-second routing latency** vs up to 24h with segment triggers
- **Existing subscribers get enrolled** (segment triggers don't enroll backfilled subscribers)
- **No code change to bring new automations online** — just set the env var in Vercel
- **Safe to deploy with partial config** — missing env var = no-op (the automation isn't built yet, no harm)

## Test plan

- [x] All 22 webhook tests pass (3 new for enrollment: trial enrollment fires, no-op when env var unset, trial-cancel enrollment fires)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Manual: Stripe CLI trigger \`checkout.session.completed\` against preview deploy; verify Vercel logs show \`[beehiiv] Enrolled email in automation aut_920c6d5c-...\`
- [ ] Manual: confirm Beehiiv subscriber's Automations tab shows them in Trial Onboarding within seconds of the webhook firing

## What's NOT in this PR

- The Paid Drip, Trial Cancel, etc. env vars aren't set yet — only \`BEEHIIV_TRIAL_AUTOMATION_ID\` is live. Those handlers no-op silently until the corresponding automations are built and env vars set.

## Spec updates

Added §4 subsection "How triggers actually fire (implementation note)" documenting the env-var pattern and rationale (why not segment triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)