### PR TITLE
fix(webhook): make Beehiiv automation enrollment idempotent on Stripe re-delivery

### DIFF
--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -519,3 +519,81 @@ describe('Beehiiv automation enrollment', () => {
     expect(vi.mocked(enrollInAutomation)).toHaveBeenCalledWith('test@example.com', 'aut_test_trial_cancel');
   });
 });
+
+describe('Idempotency on Stripe webhook re-delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    for (const key of [
+      'BEEHIIV_TRIAL_AUTOMATION_ID',
+      'BEEHIIV_PAID_AUTOMATION_ID',
+      'BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID',
+      'BEEHIIV_PAID_CANCEL_AUTOMATION_ID',
+      'BEEHIIV_DUNNING_AUTOMATION_ID',
+    ]) {
+      delete process.env[key];
+    }
+    setPriorState(null);
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<ReturnType<typeof headers>>
+    );
+  });
+
+  function fireEvent(type: string, object: Record<string, unknown>): Promise<Response> {
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue({
+      id: `evt_${type}`,
+      type,
+      data: { object },
+    } as unknown as Stripe.Event);
+    return POST(makeRequest('valid body'));
+  }
+
+  it('skips trial enrollment when checkout re-delivers and status is unchanged', async () => {
+    process.env.BEEHIIV_TRIAL_AUTOMATION_ID = 'aut_test_trial';
+    // Existing profile already in 'trialing' state → this is a re-delivery
+    setPriorState({ id: '1', subscription_status: 'trialing', cancel_at_period_end: false });
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      status: 'trialing',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
+
+    await fireEvent('checkout.session.completed', {
+      customer: 'cus_123',
+      subscription: 'sub_123',
+    });
+
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+    // Lifecycle write still fires (idempotent upsert)
+    expect(vi.mocked(setLifecycle)).toHaveBeenCalledWith('test@example.com', 'trialing');
+  });
+
+  it('skips Beehiiv sync when subscription.deleted re-delivers (already canceled)', async () => {
+    process.env.BEEHIIV_TRIAL_CANCEL_AUTOMATION_ID = 'aut_test_trial_cancel';
+    process.env.BEEHIIV_PAID_CANCEL_AUTOMATION_ID = 'aut_test_paid_cancel';
+    // Prior state already canceled — first delivery already ran
+    setPriorState({ subscription_status: 'canceled', cancel_at_period_end: false });
+
+    await fireEvent('customer.subscription.deleted', {
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'canceled',
+    });
+
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+  });
+
+  it('skips Dunning enrollment when payment_failed re-delivers (already past_due)', async () => {
+    process.env.BEEHIIV_DUNNING_AUTOMATION_ID = 'aut_test_dunning';
+    setPriorState({ subscription_status: 'past_due', cancel_at_period_end: false });
+
+    await fireEvent('invoice.payment_failed', { customer: 'cus_123' });
+
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -219,12 +219,15 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     cancel_at_period_end: false,
   };
 
-  // Check if a user profile already exists for this Stripe customer (authenticated checkout)
+  // Check if a user profile already exists for this Stripe customer (authenticated
+  // checkout). We also read subscription_status to detect webhook re-deliveries
+  // (Stripe is at-least-once) and skip duplicate Beehiiv automation enrollments.
   const { data: existingProfile } = await getSupabaseAdmin()
     .from('user_profiles')
-    .select('id')
+    .select('id, subscription_status')
     .eq('stripe_customer_id', customerId)
     .maybeSingle();
+  const priorStatus: string | null = existingProfile?.subscription_status ?? null;
 
   let customer: Stripe.Customer | Stripe.DeletedCustomer;
 
@@ -335,13 +338,23 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   // Sync Beehiiv: set tier to premium (gates paywall content), set lifecycle,
   // and enroll in the matching automation (Trial Onboarding for trialing,
   // Paid Drip for direct-to-paid). Each step is non-fatal.
+  //
+  // Idempotency: tagSubscriber + setLifecycle are upserts (same value = no
+  // observable change), but enrollInAutomation creates a fresh journey on
+  // every call. Skip enrollment when prior subscription_status already
+  // matches the new one — that means this is a Stripe webhook re-delivery,
+  // not a genuine state change.
   const rawEmail = (customer as Stripe.Customer).email;
   if (rawEmail) {
     try {
       await tagSubscriber(rawEmail);
       const lifecycle: Lifecycle = subscription.status === 'trialing' ? 'trialing' : 'paid';
       await setLifecycle(rawEmail, lifecycle);
-      await enrollInLifecycleAutomation(rawEmail, lifecycle);
+      if (priorStatus !== subscription.status) {
+        await enrollInLifecycleAutomation(rawEmail, lifecycle);
+      } else {
+        console.log(`[webhook] Skipping enrollment — already in status=${priorStatus} (webhook re-delivery)`);
+      }
     } catch (tagError) {
       console.error('[webhook] Beehiiv sync failed (non-fatal):', tagError);
     }
@@ -398,6 +411,15 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   });
 
   console.log(`[webhook] Subscription canceled for customer ${customerId} (prior status: ${prior.status})`);
+
+  // Webhook re-delivery: prior.status is already 'canceled' from a previous
+  // run of this handler. Skip Beehiiv writes — otherwise we'd mis-route to
+  // paid_canceled (because the 'trialing' signal is gone) and re-enroll in
+  // the win-back automation.
+  if (prior.status === 'canceled' || prior.status === null) {
+    console.log(`[webhook] Skipping Beehiiv sync — already canceled (webhook re-delivery)`);
+    return;
+  }
 
   // Remove premium tag in Beehiiv + route into Trial Cancel or Paid Win-Back
   // based on whether they were trialing or actively paying when canceled.
@@ -462,12 +484,20 @@ async function handleInvoicePaid(invoice: Stripe.Invoice) {
  */
 async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
   const customerId = invoice.customer as string;
+  const prior = await getPriorState(customerId);
 
   await updateUserProfile(getSupabaseAdmin(), customerId, {
     subscription_status: 'past_due',
   });
 
-  console.log(`[webhook] Payment failed for customer ${customerId}`);
+  console.log(`[webhook] Payment failed for customer ${customerId} (prior status: ${prior.status})`);
+
+  // Re-delivery: subscription_status is already 'past_due' from a prior run.
+  // Skip syncLifecycle to avoid duplicate Dunning enrollment.
+  if (prior.status === 'past_due') {
+    console.log(`[webhook] Skipping Dunning enrollment — already past_due (webhook re-delivery)`);
+    return;
+  }
   await syncLifecycle(customerId, 'past_due');
 }
 


### PR DESCRIPTION
## Summary

Addresses the codex P2 finding from #796 (which merged before this fix landed). Stripe webhooks are at-least-once — without guards, a re-delivery of \`checkout.session.completed\`, \`customer.subscription.deleted\`, or \`invoice.payment_failed\` would re-enroll the subscriber into the matching Beehiiv automation, duplicating the entire sequence in their inbox.

## Fixes

| Handler | Guard added |
|---|---|
| \`handleCheckoutCompleted\` | Extends the existing user_profiles lookup to also read \`subscription_status\`, skips \`enrollInLifecycleAutomation\` when prior status already matches new \`subscription.status\`. (\`setLifecycle\` still runs — it's an idempotent upsert.) |
| \`handleSubscriptionDeleted\` | Skips ALL Beehiiv writes when prior is already \`canceled\`. Without this, a re-delivery would lose the original \`trialing\` signal in \`prior.status\` and mis-route to \`paid_canceled\` regardless of the original cancel type. |
| \`handleInvoicePaymentFailed\` | Skips \`syncLifecycle('past_due')\` when prior is already \`past_due\`. |

\`handleSubscriptionUpdated\` and \`handleInvoicePaid\` already had transition guards (\`canceling != prior.canceling\`, \`trialing/past_due → active\`), so those remain idempotent.

## Known weakness left

\`handleChargeRefunded\` has no idempotency guard. Refund webhooks don't update \`subscription_status\`, so the same trick doesn't apply. Rare event, low blast radius (5-email duplicate win-back sequence). Documented in commit but not fixed — bulletproof fix would be a small Supabase table tracking processed Stripe event IDs.

## Test plan

- [x] 25 tests passing (3 new for the re-delivery scenarios)
- [x] tsc + eslint clean
- [ ] Stripe CLI: \`stripe events resend evt_xxx\` to confirm second delivery is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)