### PR TITLE
fix(marketing): remove phantom Schedule view feature + fix Beehiiv merge tags in trial emails

### DIFF
--- a/docs/marketing/trial-onboarding-emails.md
+++ b/docs/marketing/trial-onboarding-emails.md
@@ -1,20 +1,33 @@
 # Trial Onboarding — Email Copy
 
 **Automation:** Trial Onboarding (Beehiiv)
-**Trigger:** `lifecycle becomes trialing` (fired by Stripe `checkout.session.completed` webhook when subscription status is `trialing`)
-**Per-step gate (on every Send Email node):** `Attribute` → `lifecycle` → `is` → `trialing`
+**Trigger:** `Added by API` — webhook fires `enrollInAutomation` when Stripe `checkout.session.completed` arrives with `subscription.status = trialing`
+**Per-step gate (on every Send Email node):** `Attribute` → `Custom Field` → `lifecycle` → `is` → `trialing`
 **Length:** 7 emails over 7 days
 **Goal:** Convert trial → paid subscriber before Stripe auto-charges on Day 8
 
-**Voice notes when editing:**
+## Voice + content rules
+
 - Tone: expert peer, "the parent two years ahead." Direct, warm, data-backed.
 - Never say "Glicko-2" → use **rating engine** or **13-layer algorithm**.
 - Never say "cohort" → use **group**.
 - No invented testimonials, no PowerScore tier thresholds, no college-outcome promises.
+- Only reference real Premium features: **full rankings depth**, **Compare** (two teams + win probability), **Watchlist + rank-change alerts**, **AI Insights** (Season Truth, consistency, persona), **Edit access** (merge dupes, fill games).
 - Mobile-first: short paragraphs, bullets, bold for the one phrase that matters per section.
-- Merge tags use Beehiiv syntax: `{{ first_name | default: "" }}`, `{{ custom.team_name }}`, `{{ custom.state }}`, `{{ custom.age_group }}`. Always include a `default` fallback.
 
-**Beehiiv setup tip:** Paste the body into Beehiiv's rich-text editor. The `**bold**` becomes bold automatically. Headers (`##`) render as H2; bullets render as bullets. Links use the editor's link button.
+## Beehiiv merge tags
+
+Beehiiv syntax: `{{ field_name | fallback_value }}`. Case-sensitive. Single fallback only (no Liquid filter chains).
+
+| Placeholder in this doc | Beehiiv tag to paste | Notes |
+|---|---|---|
+| `{{team_name | your team}}` | `{{team_name | your team}}` | Custom field written by our `/report-card` API. Empty for trial users who didn't come through report-card. |
+| `{{state | }}` | `{{state | }}` | Same — report-card lead only. |
+| `{{age_group | their age group}}` | `{{age_group | their age group}}` | Same. |
+
+**Why no `first_name`:** we don't capture first names anywhere in the funnel today. Skip personal salutations — use plain `Hey —` or no greeting.
+
+**Beehiiv setup tip:** Paste the body into Beehiiv's rich-text editor. `**bold**` renders as bold; `##` as H2; bullets render automatically. For merge tags, either paste the tag literally OR click Beehiiv's **Personalize** button (looks like `{}`) and pick the field — both work.
 
 ---
 
@@ -28,9 +41,9 @@
 
 **Body:**
 
-Hey{{ first_name | default: "" | prepend: " " }} —
+Hey —
 
-You just unlocked the full version of PitchRank for **7 days**. No payment until **{{ trial_end_date | default: "day 8" }}**, and you can cancel anytime before then.
+You just unlocked the full version of PitchRank for **7 days**. No payment for the next 7 days, and you can cancel anytime before then.
 
 Here's the one thing worth doing in the next 5 minutes: **find your team and add it to your Watchlist.**
 
@@ -38,7 +51,7 @@ That single step turns on everything Premium actually does for you:
 
 - Weekly rank-change alerts when your team moves
 - Head-to-head comparisons against any opponent in the country
-- Schedule view with win-probability for every upcoming game
+- AI Insights — including Season Truth (what their record would look like with average luck), consistency profile, and team persona
 
 **[Find your team →](https://pitchrank.io/rankings)**
 
@@ -73,17 +86,23 @@ It's the answer to *"should we move clubs?"* with actual numbers instead of park
 
 **[Try Compare →](https://pitchrank.io/compare)**
 
-### 2. Add up to 5 teams to your Watchlist
+### 2. Watchlist with rank-change alerts
 
-Your kid's team, their two biggest rivals, the team you're scouting for next season's tryouts. Watchlist tracks them all and emails you when rankings shift.
+Your kid's team, their two biggest rivals, the team you're scouting for next season's tryouts. Watchlist tracks them all and emails you when rankings shift week-over-week.
 
-Most parents add 2 teams. The parents who actually use PitchRank week-over-week add 4-5.
+Most parents add 2 teams. The parents who actually use PitchRank week-over-week add more.
 
-### 3. Check the Schedule view before game day
+### 3. AI Insights — Season Truth, consistency, and persona
 
-Every upcoming game on your team's schedule shows the opponent's current ranking and a win probability. Tournament prep goes from "I have no idea who we're playing" to "we should win 2 of 3 group games."
+This is the one nobody finds on their own. Open any team profile and look for the Insights section:
 
-**[Open your team's schedule →](https://pitchrank.io/rankings)**
+- **Season Truth:** what the team's record *would* look like with average luck (i.e., did they earn their wins or get bailed out by a hot keeper?)
+- **Consistency:** are they steady or streaky? Matters for tournament prep.
+- **Persona:** the team's identity in one phrase ("defensive grinder," "high-press chaos," etc.)
+
+It's the closest thing to a scouting report you'll get without paying a coach.
+
+**[Open your team's profile →](https://pitchrank.io/rankings)**
 
 That's it. Reply if you want me to point you at a feature I didn't cover.
 
@@ -112,8 +131,8 @@ PitchRank shows teams both sides have played. If they crushed a team you barely 
 **3. Look at recent form.**
 Last 5 games. A team trending up is a different problem than a team that peaked in September.
 
-**4. (Premium) Check the head-to-head prediction.**
-Win probability based on the full rating engine — not just "they're ranked higher."
+**4. (Premium) Run a Compare.**
+Pull up both teams in Compare. Head-to-head win probability comes from the full rating engine — not just "they're ranked higher."
 
 That's it. Four data points. Way more signal than scrolling Instagram for their tournament photos.
 
@@ -129,7 +148,7 @@ Save the Compare page to your home screen if you do this enough. Faster than the
 
 **Send:** Day 3
 
-**Subject:** Who actually beats {{ custom.team_name | default: "your team" }}?
+**Subject:** Who actually beats {{team_name | your team}}?
 
 **Preview:** A look at the teams in your group worth watching.
 
@@ -137,17 +156,17 @@ Save the Compare page to your home screen if you do this enough. Faster than the
 
 Quick one.
 
-You signed up with **{{ custom.team_name | default: "your team" }}**{{ custom.state | default: "" | prepend: " (" | append: ")" }}. Here's what's interesting about their group:
+You signed up with **{{team_name | your team}}**. Here's what's interesting about their group:
 
-- The full **{{ custom.age_group | default: "age group" }}** rankings update every Monday from real game data — not tournament entries, not parent voting.
+- The full **{{age_group | their age group}}** rankings update every Monday from real game data — not tournament entries, not parent voting.
 - Teams within the same PowerScore range are usually competitive. Big PowerScore gaps usually show up on the scoreboard.
 - **Strength of schedule** matters more than raw record. A 12-3 team that played weak competition is rated lower than a 7-7 team that played up.
 
-**[See where {{ custom.team_name | default: "your team" }} ranks today →](https://pitchrank.io/rankings)**
+**[See where {{team_name | your team}} ranks today →](https://pitchrank.io/rankings)**
 
 Two ideas while you're in there:
 
-1. **Add their next 3 opponents to your Watchlist** so you get alerted when those teams move
+1. **Add their next opponents to your Watchlist** so you get alerted when those teams move
 2. **Compare them to the rival you secretly want to beat** — Compare shows you exactly where the gap is (attack? defense? schedule strength?)
 
 Halfway through your trial. The Compare feature alone is what most parents end up keeping us for.
@@ -166,9 +185,9 @@ Halfway through your trial. The Compare feature alone is what most parents end u
 
 **Body:**
 
-Hey{{ first_name | default: "" | prepend: " " }} —
+Hey —
 
-You're 5 days in. Your trial ends **{{ trial_end_date | default: "in 2 days" }}**, and after that it's **$6.99/mo** (or $69.99/yr — ~17% off if you want to lock it in).
+You're 5 days in. Your trial ends in 2 days, and after that it's **$6.99/mo** (or $69.99/yr — ~17% off if you want to lock it in).
 
 Before that decision lands on you, two things:
 
@@ -206,8 +225,8 @@ Quick side-by-side on what changes if you let it lapse:
 | State rankings (full depth) | Top 10 only | ✓ Full list |
 | Compare two teams | — | ✓ |
 | Watchlist + rank-change alerts | — | ✓ |
-| Schedule view with win probability | — | ✓ |
-| AI Insights (Season Truth, persona) | — | ✓ |
+| AI Insights (Season Truth, consistency, persona) | — | ✓ |
+| Edit access (merge dupes, fill missing games) | — | ✓ |
 
 The free tier stays useful for a quick rank check. The reason people keep paying is the **Compare + Watchlist** combo — there's no other place to do that across ECNL, MLS NEXT, GA, NPL, and state leagues in one view.
 
@@ -235,7 +254,7 @@ Two paths from here:
 
 **1. Do nothing → Premium continues.** Card gets charged $6.99/mo (or $69.99/yr if you swap to yearly). Cancel anytime in one click.
 
-**2. Cancel now → goes back to Free.** Rankings stay; Compare, Watchlist, and Schedule view turn off.
+**2. Cancel now → goes back to Free.** Rankings stay; Compare, Watchlist, AI Insights, and Edit access turn off.
 
 If you've used Compare even twice in the last week, the math is pretty obvious — it's less than the cost of one bad tournament concession-stand lunch per month.
 
@@ -264,4 +283,4 @@ pitchrank.io
 | Unsubscribe rate | <2% per email | Per-email stats |
 | Replies | >5/100 sends | Inbox |
 
-If Email 2 click rate is below 5%, the "3 features" framing isn't landing — A/B test against a personalized version that names the team. If Email 6 click rate is below 8%, the comparison table isn't pulling weight — try a single bold CTA + short bullet list instead.
+If Email 2 click rate is below 5%, the "3 features" framing isn't landing — A/B test against a version that names the team. If Email 6 click rate is below 8%, the comparison table isn't pulling weight — try a single bold CTA + short bullet list instead.


### PR DESCRIPTION
## Summary

Two errors in \`docs/marketing/trial-onboarding-emails.md\` from #794:

1. **Fabricated feature.** Original copy referenced a "Schedule view with win-probability for every upcoming game" in Emails 1, 2, 6, 7 — that feature doesn't exist. Per \`.agents/product-marketing.md\`, real Premium features are: full rankings depth, Compare (with win probability), Watchlist + alerts, AI Insights (Season Truth/consistency/persona), Edit access. Replaced Schedule mentions with AI Insights.

2. **Wrong merge tag syntax.** Used Liquid-style filter chains (\`{{ first_name | default: "" | prepend: " " }}\`) which Beehiiv doesn't support. Beehiiv uses a single fallback: \`{{ field | fallback }}\`. Also removed first_name personalization since we don't capture it anywhere in the funnel.

Doc-only change. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)