### PR TITLE
fix(webhook): set last_failed_invoice_url before Dunning enrollment

### DIFF
--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -603,4 +603,28 @@ describe('Idempotency on Stripe webhook re-delivery', () => {
     expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
     expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
   });
+
+  it('pins payment_failed ordering: invoice URL → Dunning enroll → DB status', async () => {
+    // Regression guard for codex P1 review on PRs #800/#802:
+    //   - setSubscriberCustomField MUST run before enrollInAutomation so the
+    //     first dunning email renders the per-invoice URL (not portal fallback).
+    //   - updateUserProfile (subscription_status='past_due') MUST run AFTER
+    //     enrollInAutomation so a mid-flight timeout doesn't orphan a
+    //     past_due record that never enrolled (Stripe retry would early-return
+    //     on prior.status === 'past_due').
+    process.env.BEEHIIV_DUNNING_AUTOMATION_ID = 'aut_test_dunning';
+    setPriorState({ subscription_status: 'active', cancel_at_period_end: false });
+
+    await fireEvent('invoice.payment_failed', {
+      customer: 'cus_123',
+      hosted_invoice_url: 'https://invoice.stripe.com/i/test_ordering',
+    });
+
+    const fieldOrder = vi.mocked(setSubscriberCustomField).mock.invocationCallOrder[0];
+    const enrollOrder = vi.mocked(enrollInAutomation).mock.invocationCallOrder[0];
+    const profileOrder = vi.mocked(updateUserProfile).mock.invocationCallOrder.at(-1) ?? 0;
+
+    expect(fieldOrder).toBeLessThan(enrollOrder);
+    expect(enrollOrder).toBeLessThan(profileOrder);
+  });
 });

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -505,12 +505,11 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
     console.log(`[webhook] Skipping Dunning enrollment — already past_due (webhook re-delivery)`);
     return;
   }
-  await syncLifecycle(customerId, 'past_due');
 
-  // Pass Stripe's per-invoice "pay this invoice" URL into Beehiiv so dunning
-  // emails can deep-link straight to it instead of routing through the
-  // customer portal. Falls back to the portal login link in the email template
-  // if the field is empty.
+  // Order matters: write last_failed_invoice_url BEFORE syncLifecycle.
+  // Beehiiv automations triggered by enrollment render their first email at
+  // enrollment time, so the per-invoice URL must already be on the subscriber
+  // record or the dunning email falls back to the generic portal link.
   const hostedUrl = invoice.hosted_invoice_url;
   if (hostedUrl) {
     try {
@@ -520,6 +519,8 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
       console.error(`[webhook] Failed to set last_failed_invoice_url (non-fatal):`, err);
     }
   }
+
+  await syncLifecycle(customerId, 'past_due');
 }
 
 /**

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -493,23 +493,27 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
   const customerId = invoice.customer as string;
   const prior = await getPriorState(customerId);
 
-  await updateUserProfile(getSupabaseAdmin(), customerId, {
-    subscription_status: 'past_due',
-  });
-
   console.log(`[webhook] Payment failed for customer ${customerId} (prior status: ${prior.status})`);
 
-  // Re-delivery: subscription_status is already 'past_due' from a prior run.
-  // Skip syncLifecycle to avoid duplicate Dunning enrollment.
+  // Re-delivery: prior subscription_status was already 'past_due' from an
+  // earlier successful run. Skip the entire side-effect chain to avoid
+  // duplicate Dunning enrollment.
   if (prior.status === 'past_due') {
     console.log(`[webhook] Skipping Dunning enrollment — already past_due (webhook re-delivery)`);
     return;
   }
 
-  // Order matters: write last_failed_invoice_url BEFORE syncLifecycle.
-  // Beehiiv automations triggered by enrollment render their first email at
-  // enrollment time, so the per-invoice URL must already be on the subscriber
-  // record or the dunning email falls back to the generic portal link.
+  // Order matters:
+  //   1. setSubscriberCustomField (last_failed_invoice_url) — must run BEFORE
+  //      enrollment because Beehiiv automations triggered by enrollment
+  //      render their first email at enrollment time. If the field is empty
+  //      the dunning email falls back to the generic portal link.
+  //   2. syncLifecycle — enrolls the subscriber in the Dunning automation.
+  //   3. updateUserProfile (subscription_status='past_due') — commit LAST so
+  //      it doubles as the dedup key for #797. If any earlier step fails or
+  //      the request times out, the DB stays in the prior state and Stripe's
+  //      retry runs the full flow again, instead of orphaning a `past_due`
+  //      record that never got enrolled.
   const hostedUrl = invoice.hosted_invoice_url;
   if (hostedUrl) {
     try {
@@ -521,6 +525,10 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
   }
 
   await syncLifecycle(customerId, 'past_due');
+
+  await updateUserProfile(getSupabaseAdmin(), customerId, {
+    subscription_status: 'past_due',
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Address Codex P1 on #800: `syncLifecycle('past_due')` synchronously enrolls the subscriber in the Beehiiv Dunning automation, which renders its first email at enrollment time.
- Writing `last_failed_invoice_url` *after* the enrollment means the first dunning email is composed with the field still empty — the template silently falls back to the generic portal link, defeating #800.
- Reorder: write the custom field first, then `syncLifecycle`. Ordering-only change; no signature touches.

## Test plan
- [ ] `tsc --noEmit` passes (verified locally).
- [ ] Trigger a test `invoice.payment_failed` for a clean subscriber; confirm Beehiiv subscriber record shows `last_failed_invoice_url` populated before the first Dunning email lands.
- [ ] Verify the Dunning email body links to the Stripe hosted invoice URL, not the portal fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)