### PR TITLE
Add CloudFront WAF circuit-breaker for gotsport scraper

### DIFF
--- a/.claude/skills/scraper-patterns.skill.md
+++ b/.claude/skills/scraper-patterns.skill.md
@@ -46,6 +46,32 @@ time.sleep(1.0)
 time.sleep(random.uniform(0.1, 2.5))
 ```
 
+## CloudFront WAF (gotsport)
+
+GotSport fronted `system.gotsport.com/api/v1/*` with a CloudFront WAF (per-IP
+burst rate limiter) circa 2026-05-01. A tripped IP returns **HTTP 403 with
+`Server: CloudFront`** and a CloudFront-branded HTML error body — distinct from
+a real "team not found" which is `HTTP 404` with `Server: nginx` and JSON body
+`{"error":"Team Not Found"}`. Lockout persists for multiple minutes; fresh
+sessions and cookies don't help.
+
+Coordination: the module-level `WAFBreaker` singleton in
+`src/scrapers/gotsport.py` detects the 403+CloudFront combination via
+`_is_cloudfront_waf_block`, then opens the breaker. All concurrent workers
+sharing the scraper pause on the `WAFBreaker._async_event` (orchestrator) and
+`WAFBreaker.wait_if_open_sync` (per-thread retry loop) until a `threading.Timer`
+fires `_resume()`. A second trip in the same run raises `WAFBlockedError`,
+which the orchestrator catches and exits with code 2.
+
+Cooldown defaults to 300 s (`_WAF_COOLDOWN_DEFAULT`), overridable via
+`GOTSPORT_WAF_COOLDOWN_SEC`.
+
+CLI default `--concurrency` is **5** for residential IPs in
+`scripts/scrape_games.py`. CI uses **20 per shard** (×5 shards = 100 aggregate)
+via the explicit `--concurrency` flag in `.github/workflows/scrape-games.yml`.
+Do not raise the local default without testing against a fresh IP — empirically
+~15 req/s sustained from one IP trips the WAF (measured 2026-05-18).
+
 ## GotSport Endpoint Quirks
 
 GotSport event pages expose three different schedule URLs with very different

--- a/scripts/scrape_games.py
+++ b/scripts/scrape_games.py
@@ -25,7 +25,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
 from src.etl.bulk_ops import bulk_update_last_scraped_at, call_rpc_with_fallback
-from src.scrapers.gotsport import GotSportScraper, TeamNotFoundError
+from src.scrapers.gotsport import GotSportScraper, TeamNotFoundError, WAFBlockedError, get_waf_breaker
 from supabase import create_client
 
 console = Console()
@@ -165,6 +165,11 @@ async def _scrape_team_concurrent(
 ) -> Tuple[int, Optional[str], bool]:
     """Scrape a single team (runs in thread pool for concurrency)"""
     async with semaphore:
+        # Pause if the WAF breaker is open. Stops new work from grabbing the
+        # semaphore while a cooldown is in flight; in-flight requests inside
+        # scrape_team_games block on the sync waiter.
+        await get_waf_breaker().wait_if_open_async()
+
         team_id = team.get("provider_team_id")
         team_name = team.get("team_name", "Unknown")
         team_master_id = team.get("team_id_master")
@@ -243,6 +248,31 @@ async def _scrape_team_concurrent(
             progress.update(task_id, advance=1)
             return 0, None, True
 
+        except WAFBlockedError:
+            # Second WAF trip in this run — fatal. Re-raise so gather() captures
+            # it as a result; the post-gather scan in scrape_games() then
+            # sys.exit(2). Use status="error" — team_scrape_log.status CHECK
+            # only allows ('success','error','partial') and a fresh status would
+            # fail the bulk insert for the whole batch (500 rows at a time).
+            logger.error(
+                "gotsport waf-blocked, aborting run: trip_count=%d team=%s (%s)",
+                get_waf_breaker().trip_count,
+                team_id,
+                team_name,
+            )
+            with file_lock:
+                if team_master_id:
+                    log_buffer.append(
+                        {
+                            "team_id_master": team_master_id,
+                            "games_found": 0,
+                            "status": "error",
+                            "update_last_scraped_at": False,
+                        }
+                    )
+            progress.update(task_id, advance=1)
+            raise
+
         except Exception as e:
             error_msg = f"Team {team_id} ({team_name}): {str(e)}"
             logger.error(error_msg, exc_info=True)
@@ -259,7 +289,7 @@ async def scrape_games(
     include_recent: bool = False,
     since_date: date = None,
     auto_import: bool = False,
-    concurrency: int = 30,
+    concurrency: int = 5,
 ):
     """
     Scrape games from GotSport for all teams or specified teams
@@ -278,8 +308,13 @@ async def scrape_games(
         include_recent: Include teams scraped within last 7 days (override default filter)
         since_date: Override since_date for scraping (for NULL teams)
         auto_import: Automatically import scraped games after scraping completes
-        concurrency: Number of concurrent scrapes (default: 30)
+        concurrency: Number of concurrent scrapes (default: 5; CI workflow passes 20 per shard)
     """
+    # Bind the WAF breaker to this run's event loop. ``bind_loop`` resets
+    # singleton state first so trip counters from a prior ``asyncio.run`` in
+    # the same process don't leak into this run.
+    get_waf_breaker().bind_loop(asyncio.get_running_loop())
+
     supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_ROLE_KEY"))
 
     # Initialize scraper
@@ -451,6 +486,9 @@ async def scrape_games(
             # Execute all tasks concurrently
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
+            # If any worker propagated a WAFBlockedError, abort the run cleanly.
+            waf_aborts = [r for r in results if isinstance(r, WAFBlockedError)]
+
             # Process results
             for result in results:
                 if isinstance(result, Exception):
@@ -476,13 +514,26 @@ async def scrape_games(
         # Always close the file
         output_file_handle.close()
 
+    waf_trip_count = get_waf_breaker().trip_count
     console.print("\n[bold green]✅ Scraping complete![/bold green]")
     console.print(f"  Games scraped: {games_saved_count:,}")
     console.print(f"  Teams processed: {len(teams)}")
     if not_found_count > 0:
         console.print(f"  Missing provider teams skipped: {not_found_count}")
     console.print(f"  Errors: {len(errors)}")
+    if waf_trip_count > 0:
+        console.print(f"  [yellow]CloudFront WAF trips: {waf_trip_count}[/yellow]")
     console.print(f"  Output file: {output_path}")
+
+    if waf_aborts:
+        completed_results = sum(1 for r in results if isinstance(r, tuple))
+        logger.error(
+            "aborting: gotsport CloudFront WAF tripped %d times this run; teams_completed=%d, teams_remaining=%d",
+            waf_trip_count,
+            completed_results,
+            len(teams) - completed_results,
+        )
+        sys.exit(2)
 
     if errors:
         console.print("\n[yellow]Errors encountered:[/yellow]")
@@ -541,7 +592,12 @@ def main():
     parser.add_argument(
         "--auto-import", action="store_true", help="Automatically import scraped games after scraping completes"
     )
-    parser.add_argument("--concurrency", type=int, default=30, help="Number of concurrent scrapes (default: 30)")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=5,
+        help="Number of concurrent scrapes (default: 5; CI workflow overrides via explicit flag)",
+    )
 
     args = parser.parse_args()
 

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -6,11 +6,13 @@ module into this file. The old file remains as a back-compat shim re-exporting
 continue to work with zero changes.
 """
 
+import asyncio
 import json
 import logging
 import os
 import random
 import re
+import threading
 import time
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -33,6 +35,7 @@ except ImportError:
 
 from src.base import GameData
 from src.scrapers._age_normalization import normalize_age
+from src.scrapers._http import RateLimitedError
 from src.scrapers.base import BaseScraper
 from src.scrapers.event_team import EventTeam
 from src.scrapers.gotsport_tier_parser import (
@@ -59,9 +62,18 @@ __all__ = [
     "GotSportScraper",
     "GotsportScraper",
     "TeamNotFoundError",
+    "WAFBlockedError",
+    "get_waf_breaker",
 ]
 
 logger = logging.getLogger(__name__)
+
+# CloudFront WAF cooldown (seconds). GotSport fronted system.gotsport.com/api/v1/*
+# with a per-IP burst rate limiter ~2026-05-01; tripped IPs return 403 with
+# Server: CloudFront and stay locked out for multiple minutes. 300s matches the
+# empirically observed lockout duration (2026-05-18). Override via
+# GOTSPORT_WAF_COOLDOWN_SEC.
+_WAF_COOLDOWN_DEFAULT = 300
 
 
 class TeamNotFoundError(Exception):
@@ -71,6 +83,207 @@ class TeamNotFoundError(Exception):
         self.team_id = team_id
         self.provider = provider
         super().__init__(f"Team {team_id} not found on {provider} (404)")
+
+
+class WAFBlockedError(RateLimitedError):
+    """Raised when GotSport's CloudFront WAF trips a second time in one session.
+
+    Subclass of ``RateLimitedError`` so existing orchestrator rate-limit shapes
+    apply. Construction is keyword-only via the parent ctor — see
+    ``WAFBreaker.trip``.
+    """
+
+
+def _is_cloudfront_waf_block(response: requests.Response) -> bool:
+    """True iff response is a CloudFront WAF block (403 + Server: CloudFront).
+
+    Header-only check; body parse not required and would slow the hot path.
+    """
+    # NOTE: Detector is keyed on 403 only. CloudFront WAFs can also escalate
+    # to 503 for some throttle classes; today the urllib3 adapter at
+    # _init_http_session has status_forcelist=[429,500,502,503,504] which
+    # silently retries 503 three times and raises RetryError with
+    # e.response is None — invisible to this detector. If a future incident
+    # shows WAF 503s, both the urllib3 mount (drop 503 from forcelist, or
+    # move handling app-layer) and this detector must be widened in lockstep.
+    # Do NOT add 403 to the urllib3 status_forcelist without also updating
+    # this detector — that would mask trips.
+    return response.status_code == 403 and response.headers.get("Server") == "CloudFront"
+
+
+class WAFBreaker:
+    """IP-scoped circuit breaker shared across all GotSport workers.
+
+    Cross-worker pause/resume coordination via a ``threading.Lock`` (sync
+    waiters) and an ``asyncio.Event`` (async waiters in the orchestrator).
+    Module-level singleton because the WAF is per-IP, not per-scraper-instance.
+
+    Lifecycle for a single team's worst-case retry:
+        attempt 0 → 403 CloudFront → trip() (count=1) → continue
+        attempt 1 → wait_if_open_sync() blocks ~cooldown_sec
+        attempt 1 → either succeeds (done) OR 403 CloudFront → trip() raises
+        WAFBlockedError (count=2) → run aborts. Wall time = ~1 cooldown,
+        not max_retries × cooldown.
+    """
+
+    def __init__(self) -> None:
+        self._state: str = "closed"
+        self._trip_count: int = 0
+        self._cooldown_sec: int = 0
+        self._open_until: float = 0.0
+        self._lock = threading.Lock()
+        self._async_event = asyncio.Event()
+        self._async_event.set()  # closed state = workers proceed
+        self._resume_timer: Optional[threading.Timer] = None
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Thread the running event loop into the breaker.
+
+        Called once by the orchestrator at startup so ``call_soon_threadsafe``
+        can flip the async event from worker / Timer threads. Resets state
+        first so a new ``asyncio.run`` entry can't inherit trips from a prior
+        run (the singleton lives at module scope).
+        """
+        self.reset()
+        self._loop = loop
+
+    def _aborted_error(self, *, url: str = "", cooldown_sec: float = 0.0) -> "WAFBlockedError":
+        """Single-source the ``WAFBlockedError`` construction used by all abort sites."""
+        return WAFBlockedError(
+            provider="gotsport",
+            url=url,
+            last_retry_after=float(cooldown_sec),
+            reason="cloudfront-waf-second-trip",
+        )
+
+    def trip(self, cooldown_sec: int, *, url: str = "", team_id: str = "") -> None:
+        """Mark the breaker tripped on a CLOSED→OPEN transition.
+
+        States: closed → open → closed (cooldown) → aborted (terminal). Once
+        aborted, every subsequent ``trip``/``wait_if_open_*`` call raises
+        ``WAFBlockedError`` so the abort propagates through every concurrent
+        worker — ``asyncio.gather(return_exceptions=True)`` waits for the
+        whole queue to finish, so without sticky abort the remaining workers
+        would keep scraping past the fatal second trip.
+
+        No-op when already open — concurrent in-flight 403s from one WAF burst
+        must not each count as a separate trip.
+        """
+        with self._lock:
+            if self._state == "aborted":
+                raise self._aborted_error(url=url, cooldown_sec=cooldown_sec)
+            if self._state == "open":
+                return
+            self._trip_count += 1
+            current_count = self._trip_count
+            if current_count >= 2:
+                self._state = "aborted"
+                # Unblock async waiters so they re-check state and raise.
+                if self._loop is not None and not self._loop.is_closed():
+                    self._loop.call_soon_threadsafe(self._async_event.set)
+                else:
+                    self._async_event.set()
+                raise self._aborted_error(url=url, cooldown_sec=cooldown_sec)
+            self._state = "open"
+            self._cooldown_sec = cooldown_sec
+            self._open_until = time.monotonic() + cooldown_sec
+            if self._loop is not None and not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._async_event.clear)
+            else:
+                self._async_event.clear()
+            self._resume_timer = threading.Timer(cooldown_sec, self._resume)
+            self._resume_timer.daemon = True
+            self._resume_timer.start()
+        logger.warning(
+            "gotsport waf-tripped: team=%s cooldown=%ds url=%s trip_count=%d",
+            team_id,
+            cooldown_sec,
+            url,
+            current_count,
+        )
+
+    def wait_if_open_sync(self) -> None:
+        """Block the calling (sync) thread until the breaker is closed.
+
+        Raises ``WAFBlockedError`` when the breaker is in the terminal
+        ``aborted`` state — propagates the fatal trip through every in-flight
+        worker so the orchestrator's gather drains quickly.
+        """
+        while True:
+            with self._lock:
+                if self._state == "aborted":
+                    raise self._aborted_error()
+                if self._state == "closed":
+                    return
+                remaining = self._open_until - time.monotonic()
+            time.sleep(min(max(remaining, 0.1), 1.0))
+            if time.monotonic() >= self._open_until:
+                self._resume()  # idempotent — belt-and-suspenders for Timer
+
+    async def wait_if_open_async(self) -> None:
+        """Async waiter for orchestrator workers before grabbing semaphore.
+
+        Raises ``WAFBlockedError`` if the breaker has transitioned to the
+        terminal ``aborted`` state — without this re-check, queued workers
+        would happily proceed once the event is re-set by the aborting trip.
+        """
+        await self._async_event.wait()
+        with self._lock:
+            if self._state == "aborted":
+                raise self._aborted_error()
+
+    def _resume(self) -> None:
+        """Flip state back to closed. Idempotent; never overrides ``aborted``."""
+        with self._lock:
+            if self._state != "open":
+                return
+            self._state = "closed"
+            elapsed = int(time.monotonic() - (self._open_until - self._cooldown_sec))
+            if self._loop is not None and not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._async_event.set)
+            else:
+                self._async_event.set()
+            trip_count = self._trip_count
+        logger.info(
+            "gotsport waf-resumed: cooldown_elapsed=%ds trip_count=%d",
+            elapsed,
+            trip_count,
+        )
+
+    @property
+    def trip_count(self) -> int:
+        return self._trip_count
+
+    def reset(self) -> None:
+        """Wipe all state. Used by tests (conftest autouse) and ``bind_loop``.
+
+        Recreates ``_async_event`` so a fresh event loop (next ``asyncio.run``
+        or next pytest-asyncio function-scoped loop) can await it without
+        inheriting stale waiter futures bound to the previous loop.
+        """
+        with self._lock:
+            if self._resume_timer is not None:
+                self._resume_timer.cancel()
+                self._resume_timer = None
+            self._loop = None
+            self._state = "closed"
+            self._trip_count = 0
+            self._cooldown_sec = 0
+            self._open_until = 0.0
+            self._async_event = asyncio.Event()
+            self._async_event.set()
+
+
+_waf_breaker = WAFBreaker()
+
+
+def get_waf_breaker() -> WAFBreaker:
+    """Return the module-level WAF breaker singleton."""
+    return _waf_breaker
 
 
 class GotSportScraper(BaseScraper):
@@ -88,6 +301,7 @@ class GotSportScraper(BaseScraper):
         self.max_retries = int(os.getenv("GOTSPORT_MAX_RETRIES", "3"))
         self.timeout = int(os.getenv("GOTSPORT_TIMEOUT", "30"))
         self.retry_delay = float(os.getenv("GOTSPORT_RETRY_DELAY", "2.0"))
+        self.waf_cooldown_sec = int(os.getenv("GOTSPORT_WAF_COOLDOWN_SEC", str(_WAF_COOLDOWN_DEFAULT)))
 
         # ZenRows configuration (optional)
         self.zenrows_api_key = os.getenv("ZENROWS_API_KEY")
@@ -212,6 +426,8 @@ class GotSportScraper(BaseScraper):
 
         # Retry logic
         for attempt in range(self.max_retries):
+            # Pause if the cross-worker breaker is open (cooldown after a WAF trip).
+            _waf_breaker.wait_if_open_sync()
             try:
                 # Use ZenRows if configured
                 if self.use_zenrows:
@@ -284,6 +500,13 @@ class GotSportScraper(BaseScraper):
                     break
 
             except requests.exceptions.HTTPError as e:
+                # CloudFront WAF block: trip the cross-worker breaker so every
+                # in-flight worker pauses for one cooldown. Second trip in this
+                # run propagates WAFBlockedError to the orchestrator for abort.
+                if e.response is not None and _is_cloudfront_waf_block(e.response):
+                    _waf_breaker.trip(self.waf_cooldown_sec, url=api_url, team_id=str(normalized_team_id))
+                    continue
+
                 # Raise TeamNotFoundError on 404 so callers can handle it
                 if e.response is not None and e.response.status_code == 404:
                     logger.warning(f"Team {normalized_team_id} not found (404)")
@@ -1540,6 +1763,12 @@ class GotsportScraper(ProviderScraper):
                     if attempt < self.max_retries - 1:
                         time.sleep(self.retry_delay)
 
+            except WAFBlockedError:
+                # Defensive: not hooked into this method today, but the bare
+                # ``except Exception`` below would silently absorb a WAF abort
+                # if a future caller routes through here.
+                raise
+
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:
                     logger.error(f"Event {event_id} not found (404)")
@@ -1629,6 +1858,12 @@ class GotsportScraper(ProviderScraper):
                     logger.warning(f"No teams found in event {event_id} (attempt {attempt + 1})")
                     if attempt < self.max_retries - 1:
                         time.sleep(self.retry_delay)
+
+            except WAFBlockedError:
+                # Defensive: not hooked into this method today, but the bare
+                # ``except Exception`` below would silently absorb a WAF abort
+                # if a future caller routes through here.
+                raise
 
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 404:

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -227,14 +227,25 @@ class WAFBreaker:
     async def wait_if_open_async(self) -> None:
         """Async waiter for orchestrator workers before grabbing semaphore.
 
-        Raises ``WAFBlockedError`` if the breaker has transitioned to the
-        terminal ``aborted`` state — without this re-check, queued workers
-        would happily proceed once the event is re-set by the aborting trip.
+        Checks state under lock and waits on the event for resume/abort.
+        Handles the race where ``trip()`` flips state to ``open`` on a worker
+        thread and schedules ``event.clear`` via ``call_soon_threadsafe``: a
+        coroutine that enters this method before the scheduled clear runs
+        sees a stale-set event. The ``asyncio.sleep(0)`` yields the loop so
+        any pending threadsafe callbacks (the scheduled clear) run before
+        we await the event for the actual next signal.
         """
-        await self._async_event.wait()
-        with self._lock:
-            if self._state == "aborted":
+        while True:
+            with self._lock:
+                state = self._state
+            if state == "aborted":
                 raise self._aborted_error()
+            if state == "closed":
+                return
+            # state == "open". Yield to drain pending call_soon_threadsafe
+            # callbacks (the scheduled clear), then wait for the next signal.
+            await asyncio.sleep(0)
+            await self._async_event.wait()
 
     def _resume(self) -> None:
         """Flip state back to closed. Idempotent; never overrides ``aborted``."""
@@ -2208,10 +2219,7 @@ class GotsportScraper(ProviderScraper):
                 home_team = match.get("homeTeam") or {}
                 away_team = match.get("awayTeam") or {}
                 if str(home_team.get("team_id")) == queried_str or str(away_team.get("team_id")) == queried_str:
-                    logger.debug(
-                        f"Resolved API team ID {queried_str} from self-match "
-                        f"for {log_label}"
-                    )
+                    logger.debug(f"Resolved API team ID {queried_str} from self-match for {log_label}")
                     return queried_str
 
             # 200 + non-empty + no self-match — treat as unresolved. The API
@@ -2237,8 +2245,7 @@ class GotsportScraper(ProviderScraper):
             AttributeError,
         ) as e:
             logger.warning(
-                f"Error resolving API team ID for {log_label} "
-                f"(reg_id={registration_id}): {type(e).__name__}: {e}"
+                f"Error resolving API team ID for {log_label} (reg_id={registration_id}): {type(e).__name__}: {e}"
             )
             return None
 
@@ -2420,9 +2427,7 @@ class GotsportScraper(ProviderScraper):
                     team_reg_ids = set(re.findall(r"[?&]team=(\d+)", response.text))
                 max_team_pages = int(os.getenv("GOTSPORT_MAX_TEAM_PAGES", "200"))
                 if len(team_reg_ids) > max_team_pages:
-                    logger.warning(
-                        f"Event has {len(team_reg_ids)} team pages, limiting to {max_team_pages}"
-                    )
+                    logger.warning(f"Event has {len(team_reg_ids)} team pages, limiting to {max_team_pages}")
                     team_reg_ids = set(list(team_reg_ids)[:max_team_pages])
                 logger.info(f"Walking {len(team_reg_ids)} per-team schedule pages")
                 pre_team_walk_count = len(games)
@@ -2454,9 +2459,7 @@ class GotsportScraper(ProviderScraper):
             resolved_count = sum(1 for v in api_team_id_cache.values() if v is not None)
             unresolved_count = sum(1 for v in api_team_id_cache.values() if v is None)
             logger.info(f"Total games scraped from schedule pages: {len(games)}")
-            logger.info(
-                f"Team ID resolution: {resolved_count} resolved, {unresolved_count} unresolved"
-            )
+            logger.info(f"Team ID resolution: {resolved_count} resolved, {unresolved_count} unresolved")
             logger.info(f"Games dropped (unresolved teams): {drop_counter[0]}")
             if unresolved_count > 0:
                 logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,23 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_gotsport_waf_breaker():
+    """Reset the module-level GotSport WAF breaker between every test.
+
+    The breaker is a module-level singleton in ``src.scrapers.gotsport`` and
+    its trip counter is monotonic across a run. Without this reset, any test
+    that imports gotsport and trips the breaker would leak state into
+    unrelated tests later in the suite.
+    """
+    from src.scrapers.gotsport import get_waf_breaker
+
+    get_waf_breaker().reset()
+    yield
+    get_waf_breaker().reset()
 
 
 class FakeResponse:

--- a/tests/unit/test_gotsport_waf_breaker.py
+++ b/tests/unit/test_gotsport_waf_breaker.py
@@ -1,0 +1,328 @@
+"""Unit tests for the GotSport CloudFront WAF circuit-breaker primitive.
+
+Covers:
+- ``_is_cloudfront_waf_block`` header detector
+- ``WAFBreaker`` state machine (closed/open/second-trip-raises/resume)
+- ``wait_if_open_async`` blocks until ``_resume`` fires
+- ``scrape_team_games`` trips the breaker on CloudFront 403, ignores nginx 403,
+  and still raises ``TeamNotFoundError`` on 404.
+
+Mock pattern mirrors tests/unit/test_scrapers_http.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import requests
+
+from src.scrapers.gotsport import (
+    GotSportScraper,
+    TeamNotFoundError,
+    WAFBlockedError,
+    _is_cloudfront_waf_block,
+    get_waf_breaker,
+)
+
+
+def _response(status_code: int, headers: dict[str, str] | None = None) -> Mock:
+    mock = Mock()
+    mock.status_code = status_code
+    mock.headers = headers or {}
+    mock.raw = Mock(retries=None)
+    return mock
+
+
+def _http_error(status_code: int, headers: dict[str, str] | None = None) -> requests.exceptions.HTTPError:
+    """Return an HTTPError whose .response carries the given status + headers."""
+    response = _response(status_code, headers)
+    err = requests.exceptions.HTTPError(f"{status_code}", response=response)
+    return err
+
+
+def _make_scraper() -> GotSportScraper:
+    """Build a GotSportScraper without touching the network or DB."""
+    supabase = MagicMock()
+    scraper = GotSportScraper(supabase, provider_code="gotsport")
+    # Short cooldown so trip + resume don't slow the suite.
+    scraper.waf_cooldown_sec = 0.05
+    # Tight retry budget keeps "trip → continue → retry" loops short.
+    scraper.max_retries = 2
+    scraper.retry_delay = 0.01
+    scraper.delay_min = 0
+    scraper.delay_max = 0
+    return scraper
+
+
+# ---------------------------------------------------------------------------
+# _is_cloudfront_waf_block
+# ---------------------------------------------------------------------------
+
+
+def test_is_cloudfront_waf_block_403_with_cloudfront_header_is_true():
+    assert _is_cloudfront_waf_block(_response(403, {"Server": "CloudFront"})) is True
+
+
+def test_is_cloudfront_waf_block_403_with_nginx_header_is_false():
+    assert _is_cloudfront_waf_block(_response(403, {"Server": "nginx"})) is False
+
+
+def test_is_cloudfront_waf_block_404_with_cloudfront_header_is_false():
+    assert _is_cloudfront_waf_block(_response(404, {"Server": "CloudFront"})) is False
+
+
+def test_is_cloudfront_waf_block_200_with_cloudfront_header_is_false():
+    assert _is_cloudfront_waf_block(_response(200, {"Server": "CloudFront"})) is False
+
+
+# ---------------------------------------------------------------------------
+# WAFBreaker state machine
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_first_trip_opens_state():
+    breaker = get_waf_breaker()
+    breaker.trip(0.05, url="https://example/api")
+
+    assert breaker._state == "open"
+    assert breaker.trip_count == 1
+    assert breaker._async_event.is_set() is False
+
+
+def test_breaker_second_trip_raises_wafblockederror():
+    breaker = get_waf_breaker()
+    breaker.trip(0.05, url="https://example/api")
+
+    # Simulate a fresh CLOSED→OPEN transition by resuming first, then tripping.
+    breaker._resume()
+    with pytest.raises(WAFBlockedError) as excinfo:
+        breaker.trip(0.05, url="https://example/api")
+
+    assert excinfo.value.provider == "gotsport"
+    assert excinfo.value.reason == "cloudfront-waf-second-trip"
+    assert breaker.trip_count == 2
+
+
+def test_breaker_concurrent_trips_only_count_closed_to_open():
+    """Concurrent in-flight 403s during one WAF burst must count as one trip.
+
+    Regression test: previously every call to ``trip()`` incremented
+    ``_trip_count`` regardless of state, so two workers hitting 403 from the
+    same burst would immediately raise WAFBlockedError (count=2) and abort
+    the run before any cooldown elapsed.
+    """
+    breaker = get_waf_breaker()
+    # Two concurrent trips from the same WAF burst.
+    breaker.trip(60, url="https://example/api", team_id="A")
+    breaker.trip(60, url="https://example/api", team_id="B")
+
+    assert breaker.trip_count == 1
+    assert breaker._state == "open"
+
+
+def test_breaker_aborted_state_propagates_to_subsequent_waiters():
+    """Once aborted, every subsequent trip/wait raises WAFBlockedError.
+
+    Regression: ``asyncio.gather(return_exceptions=True)`` waits for the whole
+    queue to finish, so without sticky aborted state the workers running
+    after the second trip would happily continue scraping past the fatal abort.
+    """
+    breaker = get_waf_breaker()
+    breaker.trip(60, url="https://example/api", team_id="A")
+    breaker._resume()  # simulate cooldown completion
+
+    # Second CLOSED→OPEN transition flips to terminal aborted state.
+    with pytest.raises(WAFBlockedError):
+        breaker.trip(60, url="https://example/api", team_id="B")
+    assert breaker._state == "aborted"
+
+    # Subsequent worker waiters fast-fail rather than proceed.
+    with pytest.raises(WAFBlockedError):
+        breaker.wait_if_open_sync()
+
+    with pytest.raises(WAFBlockedError):
+        breaker.trip(60, url="https://example/api", team_id="C")
+
+
+@pytest.mark.asyncio
+async def test_wait_if_open_async_raises_when_aborted():
+    """Async waiters must raise WAFBlockedError once breaker is aborted."""
+    breaker = get_waf_breaker()
+    breaker.bind_loop(asyncio.get_running_loop())
+    breaker.trip(60, url="https://example/api", team_id="A")
+    breaker._resume()
+
+    with pytest.raises(WAFBlockedError):
+        breaker.trip(60, url="https://example/api", team_id="B")
+
+    # async waiter should see the aborted state and raise.
+    with pytest.raises(WAFBlockedError):
+        await breaker.wait_if_open_async()
+
+
+@pytest.mark.asyncio
+async def test_suspended_async_waiter_wakes_and_raises_on_abort():
+    """A coroutine already awaiting wait_if_open_async must wake + raise on abort.
+
+    Regression: validates the cross-thread ``call_soon_threadsafe(event.set)``
+    in ``trip()``'s aborted branch. Without it, queued workers parked on the
+    cleared event would never wake to see the aborted state.
+    """
+    breaker = get_waf_breaker()
+    breaker.bind_loop(asyncio.get_running_loop())
+
+    # First trip → state=open, event cleared. Now park a waiter on the event.
+    breaker.trip(60, url="https://example/api", team_id="A")
+    waiter = asyncio.create_task(breaker.wait_if_open_async())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    # Simulate cooldown completion then a second WAF hit → flips to aborted,
+    # which call_soon_threadsafe(event.set)s and wakes the parked waiter.
+    breaker._resume()
+    with pytest.raises(WAFBlockedError):
+        breaker.trip(60, url="https://example/api", team_id="B")
+
+    with pytest.raises(WAFBlockedError):
+        await asyncio.wait_for(waiter, timeout=1.0)
+
+
+def test_bind_loop_resets_trip_count_across_runs():
+    """``bind_loop`` must wipe singleton trip state so consecutive ``asyncio.run``
+    invocations in the same process don't inherit a phantom first trip."""
+    breaker = get_waf_breaker()
+    breaker.trip(60, url="https://example/api", team_id="A")
+    assert breaker.trip_count == 1
+
+    loop = asyncio.new_event_loop()
+    try:
+        breaker.bind_loop(loop)
+        assert breaker.trip_count == 0
+        assert breaker._state == "closed"
+    finally:
+        loop.close()
+
+
+def test_breaker_resume_does_not_override_aborted():
+    """``_resume()`` must not flip ``aborted`` back to ``closed``."""
+    breaker = get_waf_breaker()
+    breaker.trip(60, url="https://example/api", team_id="A")
+    breaker._resume()
+    with pytest.raises(WAFBlockedError):
+        breaker.trip(60, url="https://example/api", team_id="B")
+
+    breaker._resume()  # should be a no-op now
+    assert breaker._state == "aborted"
+
+
+def test_breaker_resumes_after_cooldown():
+    breaker = get_waf_breaker()
+    breaker.trip(0.05, url="https://example/api")
+    assert breaker._state == "open"
+
+    # Sync waiter blocks until cooldown elapses, then flips state.
+    breaker.wait_if_open_sync()
+
+    assert breaker._state == "closed"
+    assert breaker._async_event.is_set() is True
+
+
+def test_breaker_wait_if_open_sync_returns_immediately_when_closed():
+    breaker = get_waf_breaker()
+    start = time.monotonic()
+    breaker.wait_if_open_sync()
+    assert time.monotonic() - start < 0.05
+
+
+# ---------------------------------------------------------------------------
+# async wait_if_open_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_if_open_async_blocks_until_resume():
+    breaker = get_waf_breaker()
+    breaker.bind_loop(asyncio.get_running_loop())
+    breaker.trip(60, url="https://example/api")  # long cooldown — we resume manually
+
+    waiter = asyncio.create_task(breaker.wait_if_open_async())
+
+    # Give the task a chance to start; it should still be pending.
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    breaker._resume()
+    await asyncio.wait_for(waiter, timeout=1.0)
+    assert waiter.done()
+
+
+# ---------------------------------------------------------------------------
+# scrape_team_games integration
+# ---------------------------------------------------------------------------
+
+
+def _patch_club_name(scraper: GotSportScraper) -> None:
+    """Bypass _extract_club_name so test session.get only sees the matches URL."""
+    scraper._extract_club_name = lambda team_id: ""  # type: ignore[method-assign]
+
+
+def test_scrape_team_games_trips_breaker_on_cloudfront_403():
+    scraper = _make_scraper()
+    _patch_club_name(scraper)
+
+    cf_response = _response(403, {"Server": "CloudFront"})
+    cf_response.raise_for_status = MagicMock(side_effect=_http_error(403, {"Server": "CloudFront"}))
+
+    ok_response = _response(200)
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json = MagicMock(return_value=[])
+    ok_response.raw = MagicMock(retries=None)
+
+    # First call → CloudFront 403 trips breaker; second call → 200 empty list.
+    scraper.session = MagicMock()
+    scraper.session.get = MagicMock(side_effect=[cf_response, ok_response])
+
+    result = scraper.scrape_team_games("12345", since_date=None)
+
+    assert result == []
+    assert get_waf_breaker().trip_count == 1
+
+
+def test_scrape_team_games_does_not_trip_breaker_on_nginx_403():
+    scraper = _make_scraper()
+    _patch_club_name(scraper)
+
+    nginx_response = _response(403, {"Server": "nginx"})
+    nginx_response.raise_for_status = MagicMock(side_effect=_http_error(403, {"Server": "nginx"}))
+
+    ok_response = _response(200)
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json = MagicMock(return_value=[])
+    ok_response.raw = MagicMock(retries=None)
+
+    scraper.session = MagicMock()
+    scraper.session.get = MagicMock(side_effect=[nginx_response, ok_response])
+
+    result = scraper.scrape_team_games("12345", since_date=None)
+
+    assert result == []
+    assert get_waf_breaker().trip_count == 0
+
+
+def test_scrape_team_games_404_still_raises_team_not_found():
+    scraper = _make_scraper()
+    _patch_club_name(scraper)
+
+    not_found = _response(404, {"Server": "nginx"})
+    not_found.raise_for_status = MagicMock(side_effect=_http_error(404, {"Server": "nginx"}))
+
+    scraper.session = MagicMock()
+    scraper.session.get = MagicMock(return_value=not_found)
+
+    with pytest.raises(TeamNotFoundError):
+        scraper.scrape_team_games("12345", since_date=None)
+
+    assert get_waf_breaker().trip_count == 0

--- a/tests/unit/test_gotsport_waf_breaker.py
+++ b/tests/unit/test_gotsport_waf_breaker.py
@@ -164,6 +164,40 @@ async def test_wait_if_open_async_raises_when_aborted():
 
 
 @pytest.mark.asyncio
+async def test_wait_if_open_async_handles_stale_set_event_race():
+    """Coroutines entering during the call_soon_threadsafe(clear) race must not proceed.
+
+    Regression: ``trip()`` flips ``_state = "open"`` synchronously on a worker
+    thread but schedules ``_async_event.clear`` via ``call_soon_threadsafe``.
+    A coroutine that enters ``wait_if_open_async`` in the window before the
+    scheduled clear runs would see the still-set event, return, and proceed
+    to scrape during the cooldown. The waiter must loop on state and yield
+    via ``asyncio.sleep(0)`` so the pending clear callback runs before it
+    awaits the next signal.
+    """
+    breaker = get_waf_breaker()
+    breaker.bind_loop(asyncio.get_running_loop())
+
+    # Simulate trip()'s race: flip state=open under lock, schedule the clear
+    # via call_soon_threadsafe (just like production), but don't run the
+    # timer. The clear callback is queued behind any currently-running task.
+    with breaker._lock:
+        breaker._state = "open"
+        breaker._cooldown_sec = 60
+        breaker._open_until = time.monotonic() + 60
+    asyncio.get_running_loop().call_soon_threadsafe(breaker._async_event.clear)
+
+    waiter = asyncio.create_task(breaker.wait_if_open_async())
+    await asyncio.sleep(0.05)
+    assert not waiter.done(), "wait_if_open_async returned during open state"
+
+    # Resume releases the waiter (state=closed, event set).
+    breaker._resume()
+    await asyncio.wait_for(waiter, timeout=1.0)
+    assert waiter.done()
+
+
+@pytest.mark.asyncio
 async def test_suspended_async_waiter_wakes_and_raises_on_abort():
     """A coroutine already awaiting wait_if_open_async must wake + raise on abort.
 

--- a/tests/unit/test_scrape_games.py
+++ b/tests/unit/test_scrape_games.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.scrape_games import _bulk_log_team_scrapes, _is_placeholder_unknown_team, _scrape_team_concurrent
-from src.scrapers.gotsport import TeamNotFoundError
+from src.scrapers.gotsport import TeamNotFoundError, WAFBlockedError
 
 
 class FakeQuery:
@@ -76,6 +76,16 @@ class FakeProgress:
 class MissingTeamScraper:
     def scrape_team_games(self, team_id, since_date=None):
         raise TeamNotFoundError(team_id)
+
+
+class WAFAbortScraper:
+    def scrape_team_games(self, team_id, since_date=None):
+        raise WAFBlockedError(
+            provider="gotsport",
+            url=f"https://example/api/teams/{team_id}/matches",
+            last_retry_after=300.0,
+            reason="cloudfront-waf-second-trip",
+        )
 
 
 def test_is_placeholder_unknown_team_matches_exact_unknown_pattern():
@@ -159,3 +169,44 @@ async def test_scrape_team_concurrent_downgrades_team_not_found_to_skip():
         }
     ]
     assert progress.calls == [("task-1", 1)]
+
+
+@pytest.mark.asyncio
+async def test_scrape_team_concurrent_waf_blocked_reraises_and_logs_error_status():
+    """WAF-blocked workers must log a CHECK-constraint-compatible status and re-raise.
+
+    Regression: status was "aborted_waf" which violated
+    team_scrape_log.status CHECK ('success','error','partial') and would have
+    failed the entire 500-row bulk insert.
+    """
+    progress = FakeProgress()
+    log_buffer = []
+
+    with pytest.raises(WAFBlockedError):
+        await _scrape_team_concurrent(
+            semaphore=asyncio.Semaphore(1),
+            scraper=WAFAbortScraper(),
+            team={
+                "provider_team_id": "12345",
+                "team_name": "Test Team",
+                "team_id_master": "team-master-waf",
+            },
+            since_date=None,
+            scrape_dates_cache={},
+            file_lock=threading.Lock(),
+            output_file_handle=io.StringIO(),
+            log_buffer=log_buffer,
+            flush_counter=[0],
+            progress=progress,
+            task_id="task-waf",
+        )
+
+    assert log_buffer == [
+        {
+            "team_id_master": "team-master-waf",
+            "games_found": 0,
+            "status": "error",
+            "update_last_scraped_at": False,
+        }
+    ]
+    assert progress.calls == [("task-waf", 1)]


### PR DESCRIPTION
GotSport added a CloudFront WAF in front of `system.gotsport.com/api/v1/*` around 2026-05-01. From a residential IP, sustained ~15 req/s trips it and returns 403 with `Server: CloudFront` and a multi-minute lockout. The existing retry budget (3 attempts at ~8s exponential) burns through in 10s and the team errors out, with no shared signal across the 30 concurrent workers.

This adds a module-level `WAFBreaker` singleton in `src/scrapers/gotsport.py` that detects the 403+CloudFront combo and pauses every in-flight worker via a `threading.Lock` (sync) and `asyncio.Event` (async). One cooldown per trip, sticky terminal `aborted` state on the second trip so the orchestrator's `asyncio.gather` drains in milliseconds instead of running the full queue. CLI default concurrency drops from 30 to 5 for residential IPs; CI is unaffected because `scrape-games.yml` passes `--concurrency` explicitly.

## State Machine

```mermaid
stateDiagram-v2
  [*] --> closed
  closed --> open: trip() (1st)
  open --> open: trip() (concurrent burst, no-op)
  open --> closed: _resume() after cooldown
  closed --> aborted: trip() (2nd CLOSED to OPEN)
  aborted --> [*]: WAFBlockedError propagates, sys.exit(2)
```

## Test plan

- [x] Unit tests: 18 in `test_gotsport_waf_breaker.py` covering detector, state machine, sync + async waiters, sticky aborted propagation, cross-loop reset
- [x] Orchestrator regression: `test_scrape_team_concurrent_waf_blocked_reraises_and_logs_error_status` (no aborted_waf CHECK violation, status=error + update_last_scraped_at=False)
- [x] Full gotsport suite (115 tests) green
- [x] CLI `--help` confirms default 5
- [ ] Live-network happy path: `python scripts/scrape_games.py --limit-teams 50 --concurrency 5` from residential IP, expect zero waf-tripped log lines
- [ ] Live-network trip path: `python scripts/scrape_games.py --limit-teams 100 --concurrency 30`, expect 1 trip, 5min pause, then resume or clean abort with exit 2
- [ ] CI sanity: trigger `scrape-games.yml` workflow, expect no waf-tripped lines (workflow uses 20 per shard x 5 shards on separate IPs)