### PR TITLE
ci(scrape-games): expose GOTSPORT_DELAY_MIN/MAX as tunable inputs

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -49,6 +49,16 @@ on:
         required: false
         type: string
         default: '1000'
+      delay_min:
+        description: 'Per-team min delay seconds (sleeps AFTER each team; empty = scraper default 1.5)'
+        required: false
+        type: string
+        default: ''
+      delay_max:
+        description: 'Per-team max delay seconds (sleeps AFTER each team; empty = scraper default 2.5)'
+        required: false
+        type: string
+        default: ''
       include_recent:
         description: 'Include teams scraped within last 7 days (override default filter)'
         required: false
@@ -206,8 +216,20 @@ jobs:
           INCLUDE_RECENT:    ${{ inputs.include_recent }}
           CHAIN_REMAINING:   ${{ inputs.chain_remaining }}
           CONCURRENCY_INPUT: ${{ inputs.concurrency }}
+          DELAY_MIN_INPUT:   ${{ inputs.delay_min }}
+          DELAY_MAX_INPUT:   ${{ inputs.delay_max }}
         run: |
           CMD="python scripts/scrape_games.py --provider gotsport --auto-import"
+
+          # Propagate validated delay overrides to the scraper via env. Regex
+          # gates non-numeric input from reaching float() inside the scraper.
+          # Empty / invalid → fall through to GotSportScraper defaults (1.5/2.5).
+          if [[ "$DELAY_MIN_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "GOTSPORT_DELAY_MIN=$DELAY_MIN_INPUT" >> "$GITHUB_ENV"
+          fi
+          if [[ "$DELAY_MAX_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "GOTSPORT_DELAY_MAX=$DELAY_MAX_INPUT" >> "$GITHUB_ENV"
+          fi
 
           # A chain link is either the cron seed OR a workflow_dispatch with
           # chain_remaining > 0. Both seed and links scrape 25000 teams

--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -223,12 +223,24 @@ jobs:
 
           # Propagate validated delay overrides to the scraper via env. Regex
           # gates non-numeric input from reaching float() inside the scraper.
-          # Empty / invalid → fall through to GotSportScraper defaults (1.5/2.5).
-          if [[ "$DELAY_MIN_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "GOTSPORT_DELAY_MIN=$DELAY_MIN_INPUT" >> "$GITHUB_ENV"
-          fi
-          if [[ "$DELAY_MAX_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "GOTSPORT_DELAY_MAX=$DELAY_MAX_INPUT" >> "$GITHUB_ENV"
+          # Both must be set together — a partial override (e.g. min only) would
+          # leave the other at the scraper default and produce an unintended
+          # range from random.uniform(min, max). Empty / invalid / mismatched
+          # → fall through to GotSportScraper defaults (1.5 / 2.5).
+          DELAY_MIN_OK="false"
+          DELAY_MAX_OK="false"
+          [[ "$DELAY_MIN_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]] && DELAY_MIN_OK="true"
+          [[ "$DELAY_MAX_INPUT" =~ ^[0-9]+(\.[0-9]+)?$ ]] && DELAY_MAX_OK="true"
+          if [ "$DELAY_MIN_OK" = "true" ] && [ "$DELAY_MAX_OK" = "true" ]; then
+            # awk handles float comparison ( [ ] / [[ ]] -lt is integer-only ).
+            if awk -v a="$DELAY_MIN_INPUT" -v b="$DELAY_MAX_INPUT" 'BEGIN { exit !(a <= b) }'; then
+              echo "GOTSPORT_DELAY_MIN=$DELAY_MIN_INPUT" >> "$GITHUB_ENV"
+              echo "GOTSPORT_DELAY_MAX=$DELAY_MAX_INPUT" >> "$GITHUB_ENV"
+            else
+              echo "::warning::delay_min ($DELAY_MIN_INPUT) > delay_max ($DELAY_MAX_INPUT); ignoring overrides"
+            fi
+          elif [ "$DELAY_MIN_OK" = "true" ] || [ "$DELAY_MAX_OK" = "true" ]; then
+            echo "::warning::delay_min and delay_max must be set together; ignoring partial override"
           fi
 
           # A chain link is either the cron seed OR a workflow_dispatch with


### PR DESCRIPTION
## Summary
- Adds `delay_min` and `delay_max` to `scrape-games.yml` `workflow_dispatch` inputs so we can probe the CloudFront WAF threshold without code changes.
- Numeric values (regex-validated) flow through `$GITHUB_ENV` to `GotSportScraper`'s `GOTSPORT_DELAY_MIN/MAX` reads.
- Empty / non-numeric → scraper falls back to its existing defaults (1.5 / 2.5 seconds).

## Why
At concurrency=10 + 1.5–2.5s delay, the 2026-05-19 2,000-team probe still tripped the WAF after ~290 teams (run [26111418994](https://github.com/dallasheidt14/PitchRank/actions/runs/26111418994)). Each team has fanned out into multiple paginated calls since PR #703, so peak req/s is closer to the WAF threshold than the delay math implies. Exposing the delay knobs lets us tune by dispatch (e.g. concurrency=5, delay=4–6s) before committing to a permanent default — or before reaching for ZenRows.

## Test plan
- [ ] Merge, then dispatch `scrape-games.yml` with `limit_teams=2000`, `concurrency=5`, `delay_min=4`, `delay_max=6` from main.
- [ ] Confirm 0 WAF trips and 2,000 teams completed.
- [ ] If clean, lock the chain defaults in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)