### PR TITLE
fix(scrape-games): import partial scrape before WAF abort exit

### DIFF
--- a/scripts/scrape_games.py
+++ b/scripts/scrape_games.py
@@ -525,16 +525,6 @@ async def scrape_games(
         console.print(f"  [yellow]CloudFront WAF trips: {waf_trip_count}[/yellow]")
     console.print(f"  Output file: {output_path}")
 
-    if waf_aborts:
-        completed_results = sum(1 for r in results if isinstance(r, tuple))
-        logger.error(
-            "aborting: gotsport CloudFront WAF tripped %d times this run; teams_completed=%d, teams_remaining=%d",
-            waf_trip_count,
-            completed_results,
-            len(teams) - completed_results,
-        )
-        sys.exit(2)
-
     if errors:
         console.print("\n[yellow]Errors encountered:[/yellow]")
         for error in errors[:10]:
@@ -542,7 +532,10 @@ async def scrape_games(
         if len(errors) > 10:
             console.print(f"  ... and {len(errors) - 10} more")
 
-    # Auto-import if requested
+    # Auto-import (incl. on WAF abort): per-team JSONL writes mean the file
+    # already contains every game scraped before the breaker fired. Importing
+    # here preserves that work; without it `sys.exit(2)` below would discard
+    # ~hours of successful scrapes alongside the failed teams.
     if auto_import and games_saved_count > 0:
         console.print("\n[bold cyan]🔄 Auto-importing games...[/bold cyan]")
         try:
@@ -567,6 +560,20 @@ async def scrape_games(
     elif games_saved_count > 0:
         console.print("\n[green]Next step: Import games[/green]")
         console.print(f"  python scripts/import_games_enhanced.py {output_path} {provider} --stream")
+
+    # Surface WAF abort to the workflow AFTER import, so the partial scrape is
+    # preserved but CI still fails loudly (exit 2) — the chain dispatcher in
+    # scrape-games.yml gates on `needs.scrape-and-import.result == 'success'`,
+    # so a non-zero exit here correctly stops the chain.
+    if waf_aborts:
+        completed_results = sum(1 for r in results if isinstance(r, tuple))
+        logger.error(
+            "aborting: gotsport CloudFront WAF tripped %d times this run; teams_completed=%d, teams_remaining=%d",
+            waf_trip_count,
+            completed_results,
+            len(teams) - completed_results,
+        )
+        sys.exit(2)
 
     return str(output_path)
 


### PR DESCRIPTION
## Summary
- Reorders the tail of `scrape_games()` so `--auto-import` runs **before** the `sys.exit(2)` triggered by a WAF abort.
- Per-team JSONL writes + flushes (already in the worker) mean the output file is complete-up-to-the-trip at abort time; the import step just hadn't been allowed to run.
- CI still surfaces the failure via exit code 2 — the chain dispatcher in `scrape-games.yml` gates on `needs.scrape-and-import.result == 'success'`, so the chain still halts correctly.

## Why
The 2026-05-19 probe runs at conc=10 / 1.5–2.5s delay (run [26111418994](https://github.com/dallasheidt14/PitchRank/actions/runs/26111418994)) and conc=5 / 4–6s delay (run [26113619984](https://github.com/dallasheidt14/PitchRank/actions/runs/26113619984)) each scraped 150–290 teams successfully before the WAF breaker tripped — and then threw away every one of those scrapes. With each shard burning ~10–15 minutes of compute + gotsport traffic before the trip, that's expensive data to discard.

Team-scrape logs (used for `last_scraped_at`) already update before the abort via the bulk-log step at the top of `finally`, so partial team timestamps were already preserved. This change brings the games table into parity.

## Test plan
- [ ] Merge, then dispatch a deliberately-tripping run (e.g. conc=10 / delay=1.5–2.5 / 2,000 teams from a warm IP). Confirm logs show `Auto-importing games…` AFTER the WAF trip log AND BEFORE `Process completed with exit code 2`.
- [ ] Confirm games from completed teams are present in Supabase post-run.
- [ ] Confirm `scrape-and-import` job conclusion is still `failure` and the chain `finalize` step does not dispatch a next link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)