### PR TITLE
ci(scrape-games): add use_zenrows toggle to route through residential proxy

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: ''
+      use_zenrows:
+        description: 'Route gotsport API calls through ZenRows residential proxy (bypasses per-IP WAF budget; costs per request)'
+        required: false
+        type: boolean
+        default: false
       include_recent:
         description: 'Include teams scraped within last 7 days (override default filter)'
         required: false
@@ -306,6 +311,11 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL:  ${{ secrets.SUPABASE_URL }}
           PYTHONPATH:                ${{ github.workspace }}
+          # GotSportScraper reads ZENROWS_API_KEY at __init__ and routes API
+          # calls through the residential proxy when set. Gated on the
+          # use_zenrows workflow input so we can A/B without flipping the
+          # default. Schedule + chain links default to direct (use_zenrows=false).
+          ZENROWS_API_KEY: ${{ inputs.use_zenrows && secrets.ZENROWS_API_KEY || '' }}
         run: ${{ steps.build-command.outputs.command }}
 
       - name: Upload scraped data


### PR DESCRIPTION
## Summary
- Adds a `use_zenrows` `workflow_dispatch` boolean input (default `false`) to `scrape-games.yml`.
- When `true`, the existing `ZENROWS_API_KEY` repo secret is exported to the scrape step; when `false`, the env var is empty.
- `GotSportScraper` (`src/scrapers/gotsport.py:317-320`) already reads `ZENROWS_API_KEY` at init and routes every API call through `https://api.zenrows.com/v1/` when set. No code change needed in the scraper.

## Why
The 2026-05-19 probe runs showed concurrency/delay tuning is hitting a per-IP cumulative WAF budget (210 teams at conc=5/delay 4-6s vs ~290 at conc=10/delay 1.5-2.5s — slower scraping tripped *sooner*, not later). Direct gotsport hits from GHA runners are not viable for full-pool weekly sweeps. ZenRows rotates residential IPs per request, bypassing per-IP budgets.

Default stays `false` so:
- Scheduled cron chain keeps hitting direct (no surprise cost shift).
- Manual dispatches can opt in for A/B testing.
- Once verified, a follow-up commit can flip the default to `true`.

## Test plan
- [ ] Merge, then dispatch `limit_teams=2000, concurrency=10, use_zenrows=true` (no delay overrides — defaults are fine through ZenRows).
- [ ] Confirm logs show `Initialized GotSportScraper (ZenRows: enabled)`.
- [ ] Confirm 0 WAF trips and 2,000 teams completed.
- [ ] Verify ZenRows usage in dashboard (~2-3 requests per team × 2000 ≈ ~5K requests for this probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)