### PR TITLE
ci(scrape-games): expose ZENROWS_PREMIUM_PROXY as dispatch toggle

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -64,6 +64,11 @@ on:
         required: false
         type: boolean
         default: false
+      zenrows_premium_proxy:
+        description: 'When use_zenrows=true: use residential IPs (counted as "protected" / 25x cost). Disable to test datacenter IPs (counted as "standard"). Ignored when use_zenrows=false.'
+        required: false
+        type: boolean
+        default: true
       include_recent:
         description: 'Include teams scraped within last 7 days (override default filter)'
         required: false
@@ -316,6 +321,10 @@ jobs:
           # use_zenrows workflow input so we can A/B without flipping the
           # default. Schedule + chain links default to direct (use_zenrows=false).
           ZENROWS_API_KEY: ${{ inputs.use_zenrows && secrets.ZENROWS_API_KEY || '' }}
+          # premium_proxy=true → ZenRows residential IPs ("protected" billing,
+          # ~25x more expensive). false → datacenter IPs ("standard" billing).
+          # Only read by the scraper when ZENROWS_API_KEY is set.
+          ZENROWS_PREMIUM_PROXY: ${{ inputs.zenrows_premium_proxy && 'true' || 'false' }}
         run: ${{ steps.build-command.outputs.command }}
 
       - name: Upload scraped data

--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -317,6 +317,11 @@ class GotSportScraper(BaseScraper):
         # ZenRows configuration (optional)
         self.zenrows_api_key = os.getenv("ZENROWS_API_KEY")
         self.use_zenrows = bool(self.zenrows_api_key)
+        # premium_proxy=true uses residential IPs → counted as "protected"
+        # by ZenRows billing (~25x more expensive than datacenter "standard").
+        # Defaults to true to preserve prior behavior; set ZENROWS_PREMIUM_PROXY=false
+        # to test whether gotsport's CloudFront WAF tolerates datacenter IPs.
+        self.zenrows_premium_proxy = os.getenv("ZENROWS_PREMIUM_PROXY", "true").lower() == "true"
 
         # Session setup
         self.session = self._init_http_session()
@@ -324,7 +329,12 @@ class GotSportScraper(BaseScraper):
         # Club name cache
         self.club_cache: Dict[str, str] = {}
 
-        logger.info(f"Initialized GotSportScraper (ZenRows: {'enabled' if self.use_zenrows else 'disabled'})")
+        if self.use_zenrows:
+            logger.info(
+                f"Initialized GotSportScraper (ZenRows: enabled, premium_proxy={self.zenrows_premium_proxy})"
+            )
+        else:
+            logger.info("Initialized GotSportScraper (ZenRows: disabled)")
 
     def _init_http_session(self) -> requests.Session:
         """
@@ -607,7 +617,7 @@ class GotSportScraper(BaseScraper):
             "apikey": self.zenrows_api_key,
             "url": url,
             "js_render": "false",
-            "premium_proxy": "true",
+            "premium_proxy": "true" if self.zenrows_premium_proxy else "false",
             "proxy_country": "us",
         }
         # Merge original params into URL


### PR DESCRIPTION
## Summary
- Adds a `zenrows_premium_proxy` boolean `workflow_dispatch` input (default `true` = current behavior).
- Threads it through to a new `ZENROWS_PREMIUM_PROXY` env var read at scraper init.
- The scraper now uses `\"premium_proxy\": \"true\"|\"false\"` in the ZenRows API call based on the env var (previously hard-coded `\"true\"`).
- No behavior change when defaults are kept; existing runs continue to use residential IPs.

## Why
The 2026-05-19 ZenRows validation run (2K teams, 0 WAF trips, run [26115336427](https://github.com/dallasheidt14/PitchRank/actions/runs/26115336427)) proved the integration works end-to-end — but every request was billed as a \"protected\" result because `premium_proxy: true` forces residential IPs. Per ZenRows pricing, standard (datacenter) requests are **~25x cheaper** than protected. If gotsport's CloudFront WAF tolerates ZenRows' datacenter IP pool, the weekly chain shifts from \"need Business 1K (\$999/mo)\" to \"comfortable on Startup (\$129/mo) with massive headroom.\"

This is by far the biggest cost lever in the ZenRows tier structure, so we need a definitive answer at realistic volume. A 2K-team probe with `premium_proxy=false` is the cleanest way to find out.

## Test plan
- [ ] Merge.
- [ ] Dispatch `limit_teams=2000, concurrency=10, use_zenrows=true, zenrows_premium_proxy=false`.
- [ ] Confirm init log shows `ZenRows: enabled, premium_proxy=False`.
- [ ] Outcomes:
  - **Clean (0 WAF trips, 2000 teams)** → standard credits work; pricing shifts to Startup tier.
  - **WAF trips** → datacenter IPs aren't tolerated; stay on protected with tiering for cost control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)