### PR TITLE
fix(pipeline): make Phase 1 carveouts work in default validation mode

### DIFF
--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -324,14 +324,22 @@ class EnhancedETLPipeline:
 
         Accepts:
           - Games with valid scores
-          - Future-dated games with NULL scores (scheduled — score arrives later)
+          - Future-dated games where BOTH scores are explicitly missing
+            (scheduled — score arrives later)
 
         Rejects:
           - Past or today-dated games with NULL/invalid scores
+          - Future-dated games with partial or malformed scores (one missing,
+            one present, or unparseable). Scheduled = both missing, period.
         """
         if self._has_valid_scores(game):
             return True
-        return self._is_future_game(game)
+        if not self._is_future_game(game):
+            return False
+        # Strict scheduled-game shape: both scores must be explicitly empty.
+        home_empty = self._is_empty_score(game.get("home_score"))
+        away_empty = self._is_empty_score(game.get("away_score"))
+        return home_empty and away_empty
 
     def _make_composite_key(self, game: Dict) -> str:
         """

--- a/src/utils/enhanced_validators.py
+++ b/src/utils/enhanced_validators.py
@@ -14,6 +14,23 @@ if _project_root not in sys.path:
 from config.settings import AGE_GROUPS  # noqa: E402
 
 
+def _is_future_game_date(date_str: Any) -> bool:
+    """
+    Return True if date_str parses to a date strictly after today.
+
+    Used by validate_game to skip the goals_for/goals_against required-field
+    checks for scheduled games (future-dated rows with both scores NULL).
+    Returns False on missing or unparseable input — scheduled-game carveout
+    only applies when we can prove the date is in the future.
+    """
+    if not date_str:
+        return False
+    try:
+        return parse_game_date(str(date_str)) > date.today()
+    except ValueError:
+        return False
+
+
 def parse_game_date(date_str: str) -> date:
     """
     Parse game date from multiple formats (handles GotSport CSVs and standard formats).
@@ -149,11 +166,20 @@ class EnhancedDataValidator:
             elif home_away.upper() not in ["H", "A"]:
                 errors.append(f"Invalid home_away value: '{home_away}' (must be 'H' or 'A')")
 
-            if goals_for is None:
-                errors.append("Missing required field: goals_for")
-
-            if goals_against is None:
-                errors.append("Missing required field: goals_against")
+            # Scheduled games (game_date > today AND both scores missing) are
+            # exempt from the score required-field check. Played games still need
+            # both scores; partial-score games on any date are still rejected by
+            # the integer validation below.
+            is_scheduled = (
+                goals_for is None
+                and goals_against is None
+                and _is_future_game_date(game.get("game_date"))
+            )
+            if not is_scheduled:
+                if goals_for is None:
+                    errors.append("Missing required field: goals_for")
+                if goals_against is None:
+                    errors.append("Missing required field: goals_against")
 
             if not game.get("game_date"):
                 errors.append("Missing required field: game_date")
@@ -210,10 +236,20 @@ class EnhancedDataValidator:
             elif not str(away_team_id).strip():
                 errors.append("Empty team ID: away_team_id")
 
-            if "home_score" not in game or game["home_score"] is None:
-                errors.append("Missing required field: home_score")
-            if "away_score" not in game or game["away_score"] is None:
-                errors.append("Missing required field: away_score")
+            home_score_missing = "home_score" not in game or game["home_score"] is None
+            away_score_missing = "away_score" not in game or game["away_score"] is None
+            # Scheduled games (game_date > today AND both scores missing) are
+            # exempt from the score required-field check.
+            is_scheduled = (
+                home_score_missing
+                and away_score_missing
+                and _is_future_game_date(game.get("game_date"))
+            )
+            if not is_scheduled:
+                if home_score_missing:
+                    errors.append("Missing required field: home_score")
+                if away_score_missing:
+                    errors.append("Missing required field: away_score")
 
             if not game.get("game_date"):
                 errors.append("Missing required field: game_date")
@@ -225,24 +261,25 @@ class EnhancedDataValidator:
             if str(home_team_id) == str(away_team_id):
                 errors.append(f"Home and away teams cannot be the same: '{home_team_id}'")
 
-            # Validate scores
-            try:
-                home_score = int(game["home_score"])
-                away_score = int(game["away_score"])
+            # Validate scores (skip for scheduled games — scores are NULL by design)
+            if not is_scheduled:
+                try:
+                    home_score = int(game["home_score"])
+                    away_score = int(game["away_score"])
 
-                if home_score < 0:
-                    errors.append(f"Home score cannot be negative: {home_score}")
-                if away_score < 0:
-                    errors.append(f"Away score cannot be negative: {away_score}")
+                    if home_score < 0:
+                        errors.append(f"Home score cannot be negative: {home_score}")
+                    if away_score < 0:
+                        errors.append(f"Away score cannot be negative: {away_score}")
 
-                if home_score > 50:
-                    errors.append(f"Unusually high home score detected: {home_score} (verify data accuracy)")
-                if away_score > 50:
-                    errors.append(f"Unusually high away score detected: {away_score} (verify data accuracy)")
-            except (ValueError, TypeError):
-                errors.append(
-                    f"Scores must be integers: home_score={game.get('home_score')}, away_score={game.get('away_score')}"
-                )
+                    if home_score > 50:
+                        errors.append(f"Unusually high home score detected: {home_score} (verify data accuracy)")
+                    if away_score > 50:
+                        errors.append(f"Unusually high away score detected: {away_score} (verify data accuracy)")
+                except (ValueError, TypeError):
+                    errors.append(
+                        f"Scores must be integers: home_score={game.get('home_score')}, away_score={game.get('away_score')}"
+                    )
         else:
             # Neither format found
             errors.append("Game must have either (team_id, opponent_id) or (home_team_id, away_team_id)")
@@ -269,9 +306,11 @@ class EnhancedDataValidator:
             if game_date.year < 2000:
                 errors.append(f"Game date too far in past: {game_date_str} (year must be >= 2000)")
             elif game_date > datetime.now().date():
-                # Allow up to 1 day in the future for scheduled games
-                if (game_date - datetime.now().date()).days > 1:
-                    errors.append(f"Game date too far in future: {game_date_str} (must be within 1 day of today)")
+                # Allow up to 365 days in the future for scheduled games (most club
+                # schedules publish 3-6 months ahead; tournament brackets can be longer).
+                # Beyond 1 year, likely a typo (e.g., 2099-12-31).
+                if (game_date - datetime.now().date()).days > 365:
+                    errors.append(f"Game date too far in future: {game_date_str} (must be within 365 days of today)")
 
         except ValueError as e:
             errors.append(f"Invalid date format: '{game_date_str}' - {str(e)}")

--- a/tests/test_enhanced_pipeline.py
+++ b/tests/test_enhanced_pipeline.py
@@ -182,8 +182,8 @@ class TestEnhancedValidator:
         assert not is_valid
         assert any('cannot be the same' in err.lower() for err in errors)
         
-        # Test future date (beyond 1 day)
-        future_date = (datetime.now() + timedelta(days=10)).strftime('%Y-%m-%d')
+        # Test future date beyond the 365-day scheduling window (typo guard).
+        future_date = (datetime.now() + timedelta(days=400)).strftime('%Y-%m-%d')
         is_valid, errors = validator.validate_game({
             'game_uid': 'edge-002',
             'home_team_id': 'team-a',
@@ -627,6 +627,125 @@ class TestValidateAndDedupFutureCarveout:
         valid, invalid, stats = await pipeline._validate_and_dedup(games, run_validation=False)
         assert stats["skipped_empty_scores"] == 1
         assert len(valid) == 0
+
+
+class TestScheduledGameValidatorCarveout:
+    """validate_game must accept future-dated NULL-score games (scheduled)
+    and still reject past-dated NULL-score games and partial-score games."""
+
+    def _validator(self):
+        return EnhancedDataValidator()
+
+    def _scheduled_source(self, future_days=7):
+        return {
+            "team_id": "team-a",
+            "opponent_id": "team-b",
+            "home_away": "H",
+            "goals_for": None,
+            "goals_against": None,
+            "game_date": (date.today() + timedelta(days=future_days)).isoformat(),
+            "game_uid": "sched-source-0001",
+        }
+
+    def _scheduled_transformed(self, future_days=7):
+        return {
+            "home_team_id": "team-a",
+            "away_team_id": "team-b",
+            "home_score": None,
+            "away_score": None,
+            "game_date": (date.today() + timedelta(days=future_days)).isoformat(),
+            "game_uid": "sched-trans-0001",
+        }
+
+    def test_source_format_scheduled_game_validates(self):
+        is_valid, errors = self._validator().validate_game(self._scheduled_source())
+        assert is_valid, f"Scheduled source-format game rejected: {errors}"
+
+    def test_transformed_format_scheduled_game_validates(self):
+        is_valid, errors = self._validator().validate_game(self._scheduled_transformed())
+        assert is_valid, f"Scheduled transformed-format game rejected: {errors}"
+
+    def test_past_dated_null_scores_still_rejected_source(self):
+        game = self._scheduled_source()
+        game["game_date"] = (date.today() - timedelta(days=7)).isoformat()
+        is_valid, errors = self._validator().validate_game(game)
+        assert not is_valid
+        assert any("goals_for" in e or "goals_against" in e for e in errors)
+
+    def test_past_dated_null_scores_still_rejected_transformed(self):
+        game = self._scheduled_transformed()
+        game["game_date"] = (date.today() - timedelta(days=7)).isoformat()
+        is_valid, errors = self._validator().validate_game(game)
+        assert not is_valid
+        assert any("home_score" in e or "away_score" in e for e in errors)
+
+    def test_partial_score_future_still_rejected_source(self):
+        """One score present, the other None — not a scheduled-game shape."""
+        game = self._scheduled_source()
+        game["goals_for"] = 2  # partial
+        is_valid, errors = self._validator().validate_game(game)
+        assert not is_valid
+        assert any("goals_against" in e for e in errors)
+
+    def test_partial_score_future_still_rejected_transformed(self):
+        game = self._scheduled_transformed()
+        game["home_score"] = 2  # partial
+        is_valid, errors = self._validator().validate_game(game)
+        assert not is_valid
+        assert any("away_score" in e for e in errors)
+
+
+class TestShouldAcceptForInsertStrictness:
+    """_should_accept_for_insert must reject partial-score or malformed
+    future-dated rows even though _has_valid_scores returns False on them."""
+
+    @pytest.fixture
+    def mock_supabase(self):
+        supabase = Mock()
+        provider_result = Mock()
+        provider_result.data = {'id': 'test-provider-uuid'}
+        supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = provider_result
+        return supabase
+
+    def _make_pipeline(self, mock_supabase):
+        return EnhancedETLPipeline(mock_supabase, 'gotsport', dry_run=True)
+
+    def test_future_partial_score_rejected(self, mock_supabase):
+        pipeline = self._make_pipeline(mock_supabase)
+        game = {
+            "game_date": (date.today() + timedelta(days=7)).isoformat(),
+            "home_score": 2,
+            "away_score": None,
+        }
+        assert pipeline._should_accept_for_insert(game) is False
+
+    def test_future_malformed_score_rejected(self, mock_supabase):
+        pipeline = self._make_pipeline(mock_supabase)
+        game = {
+            "game_date": (date.today() + timedelta(days=7)).isoformat(),
+            "home_score": "abc",
+            "away_score": "xyz",
+        }
+        assert pipeline._should_accept_for_insert(game) is False
+
+    def test_future_both_null_accepted(self, mock_supabase):
+        pipeline = self._make_pipeline(mock_supabase)
+        game = {
+            "game_date": (date.today() + timedelta(days=7)).isoformat(),
+            "home_score": None,
+            "away_score": None,
+        }
+        assert pipeline._should_accept_for_insert(game) is True
+
+    def test_future_empty_string_scores_accepted(self, mock_supabase):
+        """Empty strings count as empty per _is_empty_score — treat as scheduled."""
+        pipeline = self._make_pipeline(mock_supabase)
+        game = {
+            "game_date": (date.today() + timedelta(days=7)).isoformat(),
+            "home_score": "",
+            "away_score": "",
+        }
+        assert pipeline._should_accept_for_insert(game) is True
 
 
 # Run with: pytest tests/test_enhanced_pipeline.py -v


### PR DESCRIPTION
## Summary

Addresses Codex feedback on Phase 1 (#808). Two bugs:

**P1 (Bypass Bug):** `validate_game` rejects scheduled games as \"Missing required field: goals_for/goals_against\" before the Phase 1 carveouts in `_validate_and_dedup` can take effect. The carveout was effectively dead code in default \`skip_validation=False\` runs and only worked with \`--skip-validation\`.

**P2 (Over-Permissive Carveout):** \`_should_accept_for_insert\` accepted any future-dated record where \`_has_valid_scores\` returned False, including partial-score (one missing, one present) or malformed-score records.

## Fixes

- \`validate_game\` source-format and transformed-format paths now recognize future-dated rows with BOTH scores missing as scheduled-game shape and skip the score required-field check. Partial scores still fail validation as before.
- 1-day-ahead \"date too far in future\" gate widened to 365 days so club schedules (which publish months ahead) validate cleanly. Beyond 365 days = still flagged as a typo.
- \`_should_accept_for_insert\` is now strict: scheduled = future-dated AND both scores explicitly empty (via \`_is_empty_score\`). Partial or malformed scores on future dates are rejected.

## Tests

10 new tests, all pass:
- \`TestScheduledGameValidatorCarveout\` (6) — validator accepts scheduled, rejects past-null, rejects partial-future, both formats
- \`TestShouldAcceptForInsertStrictness\` (4) — partial/malformed scores rejected on future dates, both-null still accepted, empty-string treated as empty per existing \`_is_empty_score\` semantics

The 4 pre-existing test failures (\`test_game_validation\`, \`test_duplicate_detection\`, \`test_validate_game_edge_cases\`, \`test_validate_batch\`) are unchanged by this PR.

## Impact

Before this PR, Phase 1 doesn't actually persist scheduled games when run with default validation (which is the default for the existing scrape pipeline). After this PR, scheduled games persist as designed. Phase 4+ enqueue scripts depend on this working — should merge before any Phase 4 work runs in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)