### PR TITLE
fix(lint): shorten ScoresMustBeIntegers error to satisfy 120-char limit

### DIFF
--- a/src/utils/enhanced_validators.py
+++ b/src/utils/enhanced_validators.py
@@ -277,8 +277,10 @@ class EnhancedDataValidator:
                     if away_score > 50:
                         errors.append(f"Unusually high away score detected: {away_score} (verify data accuracy)")
                 except (ValueError, TypeError):
+                    home_raw = game.get("home_score")
+                    away_raw = game.get("away_score")
                     errors.append(
-                        f"Scores must be integers: home_score={game.get('home_score')}, away_score={game.get('away_score')}"
+                        f"Scores must be integers: home_score={home_raw}, away_score={away_raw}"
                     )
         else:
             # Neither format found


### PR DESCRIPTION
## Summary

PR #810's added \`is_scheduled\` indent in transformed-format validation pushed an existing f-string error past Ruff's E501 limit (124 > 120), breaking the lint check on main. Pull the score values into local variables to fit.

## Fix

\`\`\`python
except (ValueError, TypeError):
    home_raw = game.get(\"home_score\")
    away_raw = game.get(\"away_score\")
    errors.append(
        f\"Scores must be integers: home_score={home_raw}, away_score={away_raw}\"
    )
\`\`\`

Verified locally:
- \`python -m ruff check src/utils/enhanced_validators.py\` → \`All checks passed!\`
- TestScheduledGameValidatorCarveout (6 tests) → all pass

## Why

\`main\` is currently red on Ruff. Should land ASAP so CI gates clear for #809 and Phase 4+ branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)