### PR TITLE
feat(queue): daily yesterday-game enqueue (Phase 4)

### DIFF
--- a/.github/workflows/enqueue-yesterday-games.yml
+++ b/.github/workflows/enqueue-yesterday-games.yml
@@ -1,0 +1,48 @@
+name: Enqueue Yesterday-Game Teams
+run-name: >-
+  Enqueue yesterday teams · ${{
+    inputs.dry_run == true && 'DRY RUN' || 'live'
+  }}
+
+on:
+  schedule:
+    # 12:00 UTC = 5am Phoenix, 7am Central, 8am Eastern.
+    # East-Coast Sunday-night games have had ~12 hours to post scores by then.
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: log targets without enqueueing'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: enqueue-yesterday-games
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DRY_RUN_FLAG: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install supabase python-dotenv truststore certifi
+
+      - name: Enqueue yesterday-game teams
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          python scripts/enqueue_yesterday_games.py $DRY_RUN_FLAG

--- a/scripts/enqueue_yesterday_games.py
+++ b/scripts/enqueue_yesterday_games.py
@@ -27,6 +27,7 @@ except ImportError:
     pass
 
 from dotenv import load_dotenv  # noqa: E402
+
 from supabase import create_client  # noqa: E402
 
 load_dotenv(".env.local")

--- a/scripts/enqueue_yesterday_games.py
+++ b/scripts/enqueue_yesterday_games.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Daily enqueue: scan games table for yesterday's NULL-score rows, enqueue each
+affected GotSport team into scrape_requests at priority 2 via the
+enqueue_scrape_request RPC (idempotent UPSERT-with-LEAST).
+
+Does NOT scrape. process_missing_games (every 15min, 200/run) drains.
+
+Usage:
+    python scripts/enqueue_yesterday_games.py
+    python scripts/enqueue_yesterday_games.py --dry-run
+"""
+import argparse
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta
+
+# Windows SSL workaround (see project memory gotcha_python_supabase_ssl_truststore)
+import truststore
+truststore.inject_into_ssl()
+
+from dotenv import load_dotenv
+load_dotenv(".env.local")
+load_dotenv(".env")
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from supabase import create_client
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GOTSPORT_PROVIDER_CODE = "gotsport"
+PRIORITY_YESTERDAY_GAME = 2
+REQUEST_TYPE = "yesterday_game"
+
+
+def get_gotsport_provider_id(supabase):
+    r = supabase.table("providers").select("id").eq("code", GOTSPORT_PROVIDER_CODE).single().execute()
+    if not r.data:
+        raise RuntimeError(f"Provider '{GOTSPORT_PROVIDER_CODE}' not found")
+    return r.data["id"]
+
+
+def find_teams_to_enqueue(supabase, gotsport_provider_id):
+    """
+    Return distinct dicts {team_id_master, team_name, provider_team_id} for
+    GotSport teams that had a game yesterday with NULL home_score.
+
+    Uses RPC find_yesterday_null_score_teams (created in this PR's migration).
+    """
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    r = supabase.rpc("find_yesterday_null_score_teams", {
+        "p_yesterday": yesterday,
+        "p_provider_id": gotsport_provider_id,
+    }).execute()
+    rows = r.data or []
+    # Distinct on team_id_master (RPC should already DISTINCT, but defensive)
+    seen = {}
+    for row in rows:
+        seen[row["team_id_master"]] = row
+    return list(seen.values())
+
+
+def enqueue_team(supabase, team_id_master, team_name, provider_id, provider_team_id, game_date):
+    """Call enqueue_scrape_request RPC at priority 2."""
+    return supabase.rpc("enqueue_scrape_request", {
+        "p_team_id_master": team_id_master,
+        "p_team_name": team_name,
+        "p_provider_id": provider_id,
+        "p_provider_team_id": provider_team_id,
+        "p_game_date": game_date,
+        "p_request_type": REQUEST_TYPE,
+        "p_priority": PRIORITY_YESTERDAY_GAME,
+    }).execute()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Log targets without enqueueing")
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        logger.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+        sys.exit(1)
+
+    supabase = create_client(url, key)
+    provider_id = get_gotsport_provider_id(supabase)
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    teams = find_teams_to_enqueue(supabase, provider_id)
+    logger.info(f"Found {len(teams)} GotSport teams with yesterday ({yesterday}) NULL-score games")
+
+    if args.dry_run:
+        for t in teams[:20]:
+            logger.info(f"  WOULD ENQUEUE: {t['team_id_master']} ({t.get('team_name', 'unknown')})")
+        logger.info(f"...({len(teams)} total)")
+        return
+
+    success, fail = 0, 0
+    for t in teams:
+        try:
+            enqueue_team(
+                supabase,
+                team_id_master=t["team_id_master"],
+                team_name=t.get("team_name"),
+                provider_id=provider_id,
+                provider_team_id=t.get("provider_team_id"),
+                game_date=yesterday,
+            )
+            success += 1
+        except Exception as e:
+            logger.warning(f"Failed to enqueue {t['team_id_master']}: {e}")
+            fail += 1
+
+    logger.info(f"Enqueued {success} teams at priority {PRIORITY_YESTERDAY_GAME}, {fail} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enqueue_yesterday_games.py
+++ b/scripts/enqueue_yesterday_games.py
@@ -14,19 +14,22 @@ import argparse
 import logging
 import os
 import sys
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
-# Windows SSL workaround (see project memory gotcha_python_supabase_ssl_truststore)
+# Windows SSL workaround (see project memory gotcha_python_supabase_ssl_truststore).
+# truststore must be injected BEFORE supabase is imported.
 import truststore
+
 truststore.inject_into_ssl()
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv  # noqa: E402
+
+from supabase import create_client  # noqa: E402
+
 load_dotenv(".env.local")
 load_dotenv(".env")
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from supabase import create_client
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/scripts/enqueue_yesterday_games.py
+++ b/scripts/enqueue_yesterday_games.py
@@ -17,13 +17,16 @@ import sys
 from datetime import date, timedelta
 
 # Windows SSL workaround (see project memory gotcha_python_supabase_ssl_truststore).
-# truststore must be injected BEFORE supabase is imported.
-import truststore
+# truststore must be injected BEFORE supabase is imported. Optional — CI runners
+# that use the system trust store don't need it; only Windows local runs do.
+try:
+    import truststore
 
-truststore.inject_into_ssl()
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
 
 from dotenv import load_dotenv  # noqa: E402
-
 from supabase import create_client  # noqa: E402
 
 load_dotenv(".env.local")

--- a/supabase/migrations/20260520050216_find_yesterday_null_score_teams.sql
+++ b/supabase/migrations/20260520050216_find_yesterday_null_score_teams.sql
@@ -1,0 +1,31 @@
+-- RPC: find_yesterday_null_score_teams
+--
+-- Returns distinct GotSport teams that had a game yesterday with NULL home_score.
+-- Either side of the matchup counts (home or away). Excludes deprecated teams
+-- and teams already scraped today (last_scraped_at >= today gate).
+--
+-- Used by scripts/enqueue_yesterday_games.py (Phase 4).
+
+CREATE OR REPLACE FUNCTION find_yesterday_null_score_teams(
+    p_yesterday date,
+    p_provider_id uuid
+)
+RETURNS TABLE(team_id_master uuid, team_name text, provider_team_id text)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT DISTINCT t.team_id_master, t.team_name, t.provider_team_id
+    FROM teams t
+    WHERE t.is_deprecated = false
+      AND t.provider_id = find_yesterday_null_score_teams.p_provider_id
+      AND (t.last_scraped_at IS NULL OR t.last_scraped_at::date < CURRENT_DATE)
+      AND EXISTS (
+          SELECT 1 FROM games g
+          WHERE (g.home_team_master_id = t.team_id_master OR g.away_team_master_id = t.team_id_master)
+            AND g.game_date = find_yesterday_null_score_teams.p_yesterday
+            AND g.home_score IS NULL
+      )
+    ORDER BY t.team_id_master;
+$$;
+
+GRANT EXECUTE ON FUNCTION find_yesterday_null_score_teams(date, uuid) TO authenticated, service_role;

--- a/tests/unit/test_enqueue_yesterday_games.py
+++ b/tests/unit/test_enqueue_yesterday_games.py
@@ -1,0 +1,52 @@
+"""Tests for the daily yesterday-game enqueue script."""
+from datetime import date, timedelta
+from unittest.mock import Mock, MagicMock
+import os, sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from scripts.enqueue_yesterday_games import (
+    find_teams_to_enqueue,
+    enqueue_team,
+    PRIORITY_YESTERDAY_GAME,
+)
+
+
+def test_priority_constant_is_2():
+    assert PRIORITY_YESTERDAY_GAME == 2
+
+
+def test_find_teams_to_enqueue_returns_distinct_team_ids():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = [
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+        {"team_id_master": "t-2", "team_name": "B", "provider_team_id": "p-2"},
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},  # dup
+    ]
+    teams = find_teams_to_enqueue(supabase, gotsport_provider_id="gp")
+    team_ids = [t["team_id_master"] for t in teams]
+    assert len(team_ids) == len(set(team_ids)), "Distinct team_ids only"
+
+
+def test_enqueue_team_calls_rpc_with_priority_2():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = "test-request-id"
+    enqueue_team(
+        supabase,
+        team_id_master="t-1",
+        team_name="Team A",
+        provider_id="gp",
+        provider_team_id="p-1",
+        game_date="2026-05-19",
+    )
+    # Verify RPC was called with priority 2
+    rpc_call = supabase.rpc.call_args
+    assert rpc_call.args[0] == "enqueue_scrape_request"
+    payload = rpc_call.args[1]
+    assert payload["p_priority"] == 2
+    assert payload["p_request_type"] == "yesterday_game"
+    assert payload["p_team_id_master"] == "t-1"
+    assert payload["p_team_name"] == "Team A"
+    assert payload["p_provider_id"] == "gp"
+    assert payload["p_provider_team_id"] == "p-1"
+    assert payload["p_game_date"] == "2026-05-19"


### PR DESCRIPTION
## Summary

Phase 4 of schedule-driven-scraping. Adds the daily enqueue script that triggers off yesterday's NULL-score (scheduled) games and pushes them into the priority-2 lane of the \`scrape_requests\` queue. Does not scrape itself — \`process_missing_games\` (15-min cadence, 200/run) drains.

## What

- \`scripts/enqueue_yesterday_games.py\` — scans \`games\` for \`game_date = yesterday AND home_score IS NULL\`, calls \`enqueue_scrape_request\` RPC at priority 2 for each affected GotSport team
- \`supabase/migrations/20260520050216_find_yesterday_null_score_teams.sql\` — supporting RPC that filters by GotSport provider, excludes deprecated teams and already-scraped-today teams
- \`.github/workflows/enqueue-yesterday-games.yml\` — daily cron at 12:00 UTC + manual dispatch with dry-run input
- 3 unit tests

## Tests

\`\`\`
tests/unit/test_enqueue_yesterday_games.py
  test_priority_constant_is_2 PASSED
  test_find_teams_to_enqueue_returns_distinct_team_ids PASSED
  test_enqueue_team_calls_rpc_with_priority_2 PASSED
\`\`\`

Live dry-run smoke test (Phase 2 bootstrap not yet dispatched, so 0 expected):
\`\`\`
Found 0 GotSport teams with yesterday (2026-05-18) NULL-score games
\`\`\`
Script doesn't crash on empty result. Works as soon as Phase 2 lands data.

## Architecture in context

\`\`\`
ENQUEUE SCRIPTS (this PR adds the first one):
├── enqueue_yesterday_games.py     ← THIS PR (daily, priority 2)
├── enqueue_discovery_teams.py     (Phase 5, weekly, priority 3)
└── enqueue_safety_net.py          (Phase 6, weekly, priority 4)
                  ↓
        scrape_requests table (Phase 3)
                  ↓
DRAIN (already deployed):
└── process-missing-games (every 15 min, 200/run, priority order)
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] Dry-run completes without errors on empty data
- [ ] After merge + Phase 2 bootstrap: shadow run via \`gh workflow run enqueue-yesterday-games.yml -f dry_run=true\` to verify trigger query returns non-zero count
- [ ] First live cron at 12:00 UTC tomorrow — confirm enqueue actually happens and queue depth changes

## Next

Phases 5 (discovery enqueue), 6 (safety-net enqueue), 7 (remove scrape-games.yml cron), 8 (new-team hook audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)