### PR TITLE
fix(scrapers): remove past=true so GotSport returns future games

### DIFF
--- a/src/scrapers/gotsport.py
+++ b/src/scrapers/gotsport.py
@@ -429,7 +429,13 @@ class GotSportScraper(BaseScraper):
 
         # API endpoint
         api_url = f"{self.BASE_URL}/teams/{normalized_team_id}/matches"
-        params = {"past": "true"}
+        # NOTE: do NOT pass `past=true` here. With that param the GotSport API
+        # returns past games only — which silently drops every scheduled fixture.
+        # Calling without it returns past + future together (verified empirically:
+        # active teams return 1-7 future fixtures alongside their played history).
+        # The /schedule-driven-scraping/ design requires future games to land in
+        # the games table so the daily enqueue can trigger off them.
+        params: Dict[str, str] = {}
 
         # Try to add date filtering at API level (if supported)
         # Common parameter names: since_date, from_date, date_from, since


### PR DESCRIPTION
## Summary

**The actual root cause of why Phase 1 wasn't persisting scheduled games in production.**

\`src/scrapers/gotsport.py:432\` was hardcoding \`params = {\"past\": \"true\"}\` on the \`/teams/{id}/matches\` API call. With that param, the GotSport API returns **past games only** — silently dropping every scheduled fixture before it ever reaches the pipeline. The Phase 1 (#808) and Phase 1.5 (#810) carveouts in \`enhanced_pipeline.py\` were correctly built, but never had future-dated games to act on.

## Empirical verification

Probed 5 active teams with no \`past\` param. All returned past + future together:

| Team | Past | Future | Latest |
|---|---:|---:|---|
| 2009 Academy NPL | 157 | 7 | 2026-06-25 |
| 2012 EDT 2 | 141 | 7 | 2026-06-29 |
| 2014 Swoosh | 131 | 5 | 2026-06-29 |
| USA 2013 Premier Gold | 30 | 1 | 2026-05-31 |
| IFFC 2016 Claret - Richens | 64 | 1 | 2026-05-27 |

Same call with \`past=true\` returns an empty/non-list response on these teams. Same call with \`past=false\` also returns empty. No \`past\` param at all is what works.

## What the 38 \"skipped_empty_scores\" actually were

In the test scrape run, the 38 skipped rows were past data-quality NULLs (games whose scores were never entered), not future games. Future games never made it into the input set.

## Diff

One change: \`params = {\"past\": \"true\"}\` → \`params: Dict[str, str] = {}\` in \`scrape_team_games\`. Added an explanatory comment. The \`validate_team_id\` helper at line 849 also uses \`past=true\` but only checks HTTP 200, so left as-is to minimize diff.

## Test plan

- [x] Empirical API probe across 5 active teams (above)
- [x] Module imports cleanly (\`from src.scrapers.gotsport import GotSportScraper\`)
- [x] Ruff clean
- [ ] After merge: dispatch \`scrape-games.yml -f limit_teams=500\` (small test), verify future-scheduled rows land:
  \`\`\`sql
  SELECT count(*) FROM games WHERE home_score IS NULL AND game_date > CURRENT_DATE;
  -- Expected: > 0 (previously 0)
  \`\`\`
- [ ] If sanity-check is good, dispatch full sweep — this is the Phase 2 bootstrap that's been blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)