### PR TITLE
feat(queue): weekly discovery enqueue (Phase 5)

### DIFF
--- a/.github/workflows/enqueue-discovery.yml
+++ b/.github/workflows/enqueue-discovery.yml
@@ -1,0 +1,54 @@
+name: Enqueue Discovery Teams
+run-name: >-
+  Enqueue discovery · ${{
+    inputs.dry_run == true && 'DRY RUN' || 'live'
+  }}
+
+on:
+  schedule:
+    # Sunday 14:00 UTC. After the weekend yesterday-game enqueue spike has had
+    # time to drain (daily enqueue runs at 12:00 UTC, drains at 200/15min).
+    - cron: '0 14 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: log targets without enqueueing'
+        required: false
+        type: boolean
+        default: false
+      limit:
+        description: 'Max teams to enqueue (blank = 1000)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: enqueue-discovery
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DRY_RUN_FLAG: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+      LIMIT_FLAG: ${{ inputs.limit != '' && format('--limit {0}', inputs.limit) || '' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install supabase python-dotenv
+
+      - name: Enqueue discovery teams
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          python scripts/enqueue_discovery_teams.py $DRY_RUN_FLAG $LIMIT_FLAG

--- a/scripts/enqueue_discovery_teams.py
+++ b/scripts/enqueue_discovery_teams.py
@@ -19,6 +19,7 @@ import argparse
 import logging
 import os
 import sys
+from datetime import date
 
 # Windows SSL workaround. Optional — CI runners use the system trust store.
 try:
@@ -67,14 +68,19 @@ def find_teams_to_enqueue(supabase, gotsport_provider_id, limit=DEFAULT_LIMIT):
 
 
 def enqueue_team(supabase, team_id_master, team_name, provider_id, provider_team_id):
-    """Call enqueue_scrape_request RPC at priority 3. No game_date — discovery is
-    schedule-wide, not tied to a specific game."""
+    """Call enqueue_scrape_request RPC at priority 3.
+
+    scrape_requests.game_date is NOT NULL, so we pass today's date as a placeholder.
+    The processor scrapes the team's full schedule (±90 days from this anchor) which
+    covers everything discovery cares about. The RPC's UPDATE branch uses COALESCE,
+    so existing pending rows keep their original game_date when upserted.
+    """
     return supabase.rpc("enqueue_scrape_request", {
         "p_team_id_master": team_id_master,
         "p_team_name": team_name,
         "p_provider_id": provider_id,
         "p_provider_team_id": provider_team_id,
-        "p_game_date": None,
+        "p_game_date": date.today().isoformat(),
         "p_request_type": REQUEST_TYPE,
         "p_priority": PRIORITY_DISCOVERY,
     }).execute()

--- a/scripts/enqueue_discovery_teams.py
+++ b/scripts/enqueue_discovery_teams.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Weekly discovery enqueue: find GotSport teams with no future games on record,
+enqueue at priority 3 via the enqueue_scrape_request RPC (idempotent
+UPSERT-with-LEAST). Chips through teams the daily yesterday-game enqueue
+can't see — between-seasons teams, newly-added clubs, etc.
+
+Does NOT scrape. process_missing_games (every 15min, 200/run) drains.
+
+Ordering (in the supporting RPC): teams with a game in the last 90 days come
+first (active, schedule probably arriving soon), then oldest-scraped.
+
+Usage:
+    python scripts/enqueue_discovery_teams.py
+    python scripts/enqueue_discovery_teams.py --dry-run
+    python scripts/enqueue_discovery_teams.py --limit 200
+"""
+import argparse
+import logging
+import os
+import sys
+
+# Windows SSL workaround. Optional — CI runners use the system trust store.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+from dotenv import load_dotenv  # noqa: E402
+
+from supabase import create_client  # noqa: E402
+
+load_dotenv(".env.local")
+load_dotenv(".env")
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GOTSPORT_PROVIDER_CODE = "gotsport"
+PRIORITY_DISCOVERY = 3
+REQUEST_TYPE = "discovery"
+DEFAULT_LIMIT = 1000
+
+
+def get_gotsport_provider_id(supabase):
+    r = supabase.table("providers").select("id").eq("code", GOTSPORT_PROVIDER_CODE).single().execute()
+    if not r.data:
+        raise RuntimeError(f"Provider '{GOTSPORT_PROVIDER_CODE}' not found")
+    return r.data["id"]
+
+
+def find_teams_to_enqueue(supabase, gotsport_provider_id, limit=DEFAULT_LIMIT):
+    """GotSport teams with no future games on record. Uses find_discovery_teams RPC."""
+    r = supabase.rpc("find_discovery_teams", {
+        "p_provider_id": gotsport_provider_id,
+        "p_row_limit": limit,
+    }).execute()
+    rows = r.data or []
+    seen = {}
+    for row in rows:
+        seen[row["team_id_master"]] = row
+    return list(seen.values())
+
+
+def enqueue_team(supabase, team_id_master, team_name, provider_id, provider_team_id):
+    """Call enqueue_scrape_request RPC at priority 3. No game_date — discovery is
+    schedule-wide, not tied to a specific game."""
+    return supabase.rpc("enqueue_scrape_request", {
+        "p_team_id_master": team_id_master,
+        "p_team_name": team_name,
+        "p_provider_id": provider_id,
+        "p_provider_team_id": provider_team_id,
+        "p_game_date": None,
+        "p_request_type": REQUEST_TYPE,
+        "p_priority": PRIORITY_DISCOVERY,
+    }).execute()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Log targets without enqueueing")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        logger.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+        sys.exit(1)
+
+    supabase = create_client(url, key)
+    provider_id = get_gotsport_provider_id(supabase)
+
+    teams = find_teams_to_enqueue(supabase, provider_id, limit=args.limit)
+    logger.info(f"Discovery: {len(teams)} GotSport teams with no future games on record")
+
+    if args.dry_run:
+        for t in teams[:20]:
+            logger.info(f"  WOULD ENQUEUE: {t['team_id_master']} ({t.get('team_name', 'unknown')})")
+        logger.info(f"...({len(teams)} total)")
+        return
+
+    success, fail = 0, 0
+    for t in teams:
+        try:
+            enqueue_team(
+                supabase,
+                team_id_master=t["team_id_master"],
+                team_name=t.get("team_name"),
+                provider_id=provider_id,
+                provider_team_id=t.get("provider_team_id"),
+            )
+            success += 1
+        except Exception as e:
+            logger.warning(f"Failed to enqueue {t['team_id_master']}: {e}")
+            fail += 1
+
+    logger.info(f"Enqueued {success} teams at priority {PRIORITY_DISCOVERY}, {fail} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260520054454_find_discovery_teams.sql
+++ b/supabase/migrations/20260520054454_find_discovery_teams.sql
@@ -1,0 +1,58 @@
+-- RPC: find_discovery_teams
+--
+-- Returns GotSport teams that have NO future games visible in our database.
+-- These are the teams the daily yesterday-game enqueue can't trigger off —
+-- either their season just ended (schedule coming soon), they're new, or they're
+-- genuinely inactive. Discovery enqueue rescrapes them to catch newly-published
+-- schedules.
+--
+-- Ordering: teams with a game in the last 90 days come first (likely between
+-- seasons, schedule update imminent), then everything else by oldest
+-- last_scraped_at (NULLs first — never-scraped teams).
+--
+-- Used by scripts/enqueue_discovery_teams.py (Phase 5).
+
+CREATE OR REPLACE FUNCTION find_discovery_teams(
+    p_provider_id uuid,
+    p_row_limit integer DEFAULT 1000
+)
+RETURNS TABLE(team_id_master uuid, team_name text, provider_team_id text)
+LANGUAGE sql
+STABLE
+AS $$
+    -- Pre-aggregate per-team game flags so we scan games once, not once per team.
+    -- The naive (NOT EXISTS in WHERE + EXISTS in ORDER BY) form timed out at the
+    -- 137K-team scale. This CTE form runs in seconds.
+    WITH team_flags AS (
+        SELECT
+            team_id_master,
+            MAX(CASE WHEN game_date > CURRENT_DATE THEN 1 ELSE 0 END) AS has_future,
+            MAX(CASE WHEN game_date >= CURRENT_DATE - INTERVAL '90 days' THEN 1 ELSE 0 END) AS has_recent
+        FROM (
+            SELECT home_team_master_id AS team_id_master, game_date FROM games WHERE home_team_master_id IS NOT NULL
+            UNION ALL
+            SELECT away_team_master_id AS team_id_master, game_date FROM games WHERE away_team_master_id IS NOT NULL
+        ) g
+        GROUP BY team_id_master
+    )
+    SELECT t.team_id_master, t.team_name, t.provider_team_id
+    FROM teams t
+    LEFT JOIN team_flags tf ON tf.team_id_master = t.team_id_master,
+         (SELECT EXTRACT(YEAR FROM NOW())::int AS yr) c
+    WHERE t.is_deprecated = false
+      AND t.provider_id = find_discovery_teams.p_provider_id
+      AND COALESCE(tf.has_future, 0) = 0  -- no future games on record
+      -- Match scrape-games age filters: PitchRank supports U10-U19 only.
+      AND (t.age_group IS NULL OR UPPER(TRIM(t.age_group)) NOT IN ('U8','U-8','U9','U-9'))
+      AND (t.birth_year IS NULL OR t.birth_year NOT IN (c.yr - 21, c.yr - 20, c.yr - 9, c.yr - 8, c.yr - 7))
+      -- Placeholder unknown team filter.
+      AND NOT (t.team_name = 'unknown_' || t.provider_team_id)
+    ORDER BY
+      -- Teams with a game in the last 90 days first (schedule probably arriving soon),
+      -- then oldest-scraped (NULLs first).
+      COALESCE(tf.has_recent, 0) DESC,
+      t.last_scraped_at ASC NULLS FIRST
+    LIMIT find_discovery_teams.p_row_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION find_discovery_teams(uuid, integer) TO authenticated, service_role;

--- a/tests/unit/test_enqueue_discovery_teams.py
+++ b/tests/unit/test_enqueue_discovery_teams.py
@@ -33,8 +33,10 @@ def test_find_teams_to_enqueue_dedups_team_ids():
     assert len(team_ids) == len(set(team_ids))
 
 
-def test_enqueue_team_uses_priority_3_and_null_game_date():
-    """Discovery isn't tied to a specific game, so game_date is NULL."""
+def test_enqueue_team_uses_priority_3_and_today_game_date():
+    """Discovery uses today's date as a placeholder since game_date is NOT NULL."""
+    from datetime import date
+
     supabase = Mock()
     supabase.rpc.return_value.execute.return_value.data = "test-id"
     enqueue_team(
@@ -49,5 +51,5 @@ def test_enqueue_team_uses_priority_3_and_null_game_date():
     payload = rpc_call.args[1]
     assert payload["p_priority"] == 3
     assert payload["p_request_type"] == "discovery"
-    assert payload["p_game_date"] is None
+    assert payload["p_game_date"] == date.today().isoformat()
     assert payload["p_team_id_master"] == "t-1"

--- a/tests/unit/test_enqueue_discovery_teams.py
+++ b/tests/unit/test_enqueue_discovery_teams.py
@@ -1,0 +1,53 @@
+"""Tests for the weekly discovery enqueue script."""
+import os
+import sys
+from unittest.mock import Mock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from scripts.enqueue_discovery_teams import (
+    DEFAULT_LIMIT,
+    PRIORITY_DISCOVERY,
+    enqueue_team,
+    find_teams_to_enqueue,
+)
+
+
+def test_priority_constant_is_3():
+    assert PRIORITY_DISCOVERY == 3
+
+
+def test_default_limit_is_1000():
+    assert DEFAULT_LIMIT == 1000
+
+
+def test_find_teams_to_enqueue_dedups_team_ids():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = [
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+        {"team_id_master": "t-2", "team_name": "B", "provider_team_id": "p-2"},
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},  # dup
+    ]
+    teams = find_teams_to_enqueue(supabase, gotsport_provider_id="gp")
+    team_ids = [t["team_id_master"] for t in teams]
+    assert len(team_ids) == len(set(team_ids))
+
+
+def test_enqueue_team_uses_priority_3_and_null_game_date():
+    """Discovery isn't tied to a specific game, so game_date is NULL."""
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = "test-id"
+    enqueue_team(
+        supabase,
+        team_id_master="t-1",
+        team_name="Team A",
+        provider_id="gp",
+        provider_team_id="p-1",
+    )
+    rpc_call = supabase.rpc.call_args
+    assert rpc_call.args[0] == "enqueue_scrape_request"
+    payload = rpc_call.args[1]
+    assert payload["p_priority"] == 3
+    assert payload["p_request_type"] == "discovery"
+    assert payload["p_game_date"] is None
+    assert payload["p_team_id_master"] == "t-1"


### PR DESCRIPTION
## Summary

Phase 5 of schedule-driven-scraping. Adds the weekly discovery enqueue that targets teams the daily yesterday-game enqueue can't see — teams with no future games on record (between-seasons, newly-added clubs, schedules not yet published).

## What

- \`scripts/enqueue_discovery_teams.py\` — enqueues 1000 GotSport teams/week at priority 3 via the existing \`enqueue_scrape_request\` RPC
- \`supabase/migrations/20260520054454_find_discovery_teams.sql\` — supporting RPC with a CTE-based pre-aggregation (the naive nested-EXISTS form timed out at 137K teams)
- \`.github/workflows/enqueue-discovery.yml\` — Sunday 14:00 UTC cron + manual dispatch with \`dry_run\` and \`limit\` inputs
- 4 unit tests

## Filters

Discovery RPC mirrors the \`scrape-games.yml\` exclusion logic:
- \`is_deprecated = false\`
- \`provider_id = gotsport\`
- No future games on record (LEFT JOIN to per-team CTE)
- Excludes U8/U9 (PitchRank is U10-U19)
- Excludes \`birth_year\` in (yr-21, yr-20, yr-9, yr-8, yr-7) — dynamic per current year
- Excludes \`unknown_*\` placeholder teams

## Ordering

Teams with a game in the **last 90 days come first** (likely between seasons, schedule arriving soon). Then oldest-scraped (NULLs first).

## Verified live

- RPC returns in ~3.6s on the full 137K-team set
- Dry-run sampled 10 teams: all valid U10+ (e.g. \"FLYTE SC IE- 2013 DPLO\", \"Sporting Beaumont 2014 Steele\"), no placeholders, no U8/U9
- Migration applied to prod

## Architecture

\`\`\`
ENQUEUE SCRIPTS:
├── enqueue_yesterday_games.py    (daily, priority 2)  ← Phase 4
├── enqueue_discovery_teams.py    (weekly, priority 3) ← THIS PR
└── enqueue_safety_net.py         (weekly, priority 4) ← Phase 6
                  ↓
        scrape_requests table
                  ↓
        process-missing-games (every 15min, 200/run, priority order)
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] Live dry-run produces valid output
- [x] RPC performance acceptable (~3.6s)
- [ ] After merge: shadow run via \`gh workflow run enqueue-discovery.yml -f dry_run=true\`
- [ ] First live cron Sunday 14:00 UTC — verify ~1000 teams enqueued and drained over the week

🤖 Generated with [Claude Code](https://claude.com/claude-code)