### PR TITLE
feat(queue): weekly safety-net enqueue (Phase 6)

### DIFF
--- a/.github/workflows/enqueue-safety-net.yml
+++ b/.github/workflows/enqueue-safety-net.yml
@@ -1,0 +1,55 @@
+name: Enqueue Safety-Net Teams
+run-name: >-
+  Enqueue safety-net · ${{
+    inputs.dry_run == true && 'DRY RUN' || 'live'
+  }}
+
+on:
+  schedule:
+    # Sunday 16:00 UTC. After discovery enqueue (14:00 UTC) has had time to
+    # land, so safety-net only picks up teams that neither daily nor discovery
+    # could catch.
+    - cron: '0 16 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: log targets without enqueueing'
+        required: false
+        type: boolean
+        default: false
+      limit:
+        description: 'Max teams to enqueue (blank = 500)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: enqueue-safety-net
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DRY_RUN_FLAG: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+      LIMIT_FLAG: ${{ inputs.limit != '' && format('--limit {0}', inputs.limit) || '' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install supabase python-dotenv
+
+      - name: Enqueue safety-net teams
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          python scripts/enqueue_safety_net.py $DRY_RUN_FLAG $LIMIT_FLAG

--- a/scripts/enqueue_safety_net.py
+++ b/scripts/enqueue_safety_net.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Weekly safety-net enqueue: catch GotSport teams the daily yesterday-game
+enqueue and weekly discovery enqueue both miss. Targets teams that have
+either never been scraped or haven't been scraped in 90+ days.
+
+Enqueues at priority 4 via the enqueue_scrape_request RPC (idempotent
+UPSERT-with-LEAST). Does NOT scrape. process_missing_games (every 15min,
+200/run) drains.
+
+Volume: 500 teams/week by default. Mostly a backstop — should rarely match
+many teams once daily + discovery enqueues stabilize.
+
+Usage:
+    python scripts/enqueue_safety_net.py
+    python scripts/enqueue_safety_net.py --dry-run
+    python scripts/enqueue_safety_net.py --limit 100
+"""
+import argparse
+import logging
+import os
+import sys
+from datetime import date
+
+# Windows SSL workaround. Optional — CI runners use the system trust store.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+from dotenv import load_dotenv  # noqa: E402
+
+from supabase import create_client  # noqa: E402
+
+load_dotenv(".env.local")
+load_dotenv(".env")
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GOTSPORT_PROVIDER_CODE = "gotsport"
+PRIORITY_SAFETY_NET = 4
+REQUEST_TYPE = "safety_net"
+DEFAULT_LIMIT = 500
+
+
+def get_gotsport_provider_id(supabase):
+    r = supabase.table("providers").select("id").eq("code", GOTSPORT_PROVIDER_CODE).single().execute()
+    if not r.data:
+        raise RuntimeError(f"Provider '{GOTSPORT_PROVIDER_CODE}' not found")
+    return r.data["id"]
+
+
+def find_teams_to_enqueue(supabase, gotsport_provider_id, limit=DEFAULT_LIMIT):
+    """Stale GotSport teams (never scraped or last_scraped_at > 90d). Uses find_stale_teams RPC."""
+    r = supabase.rpc("find_stale_teams", {
+        "p_provider_id": gotsport_provider_id,
+        "p_row_limit": limit,
+    }).execute()
+    rows = r.data or []
+    seen = {}
+    for row in rows:
+        seen[row["team_id_master"]] = row
+    return list(seen.values())
+
+
+def enqueue_team(supabase, team_id_master, team_name, provider_id, provider_team_id):
+    """Call enqueue_scrape_request RPC at priority 4.
+
+    scrape_requests.game_date is NOT NULL — pass today's date as placeholder
+    (safety-net scrapes are schedule-wide, not tied to a specific fixture).
+    """
+    return supabase.rpc("enqueue_scrape_request", {
+        "p_team_id_master": team_id_master,
+        "p_team_name": team_name,
+        "p_provider_id": provider_id,
+        "p_provider_team_id": provider_team_id,
+        "p_game_date": date.today().isoformat(),
+        "p_request_type": REQUEST_TYPE,
+        "p_priority": PRIORITY_SAFETY_NET,
+    }).execute()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Log targets without enqueueing")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        logger.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+        sys.exit(1)
+
+    supabase = create_client(url, key)
+    provider_id = get_gotsport_provider_id(supabase)
+
+    teams = find_teams_to_enqueue(supabase, provider_id, limit=args.limit)
+    logger.info(f"Safety net: {len(teams)} GotSport teams stale (never scraped or 90d+ old)")
+
+    if args.dry_run:
+        for t in teams[:20]:
+            logger.info(f"  WOULD ENQUEUE: {t['team_id_master']} ({t.get('team_name', 'unknown')})")
+        logger.info(f"...({len(teams)} total)")
+        return
+
+    success, fail = 0, 0
+    for t in teams:
+        try:
+            enqueue_team(
+                supabase,
+                team_id_master=t["team_id_master"],
+                team_name=t.get("team_name"),
+                provider_id=provider_id,
+                provider_team_id=t.get("provider_team_id"),
+            )
+            success += 1
+        except Exception as e:
+            logger.warning(f"Failed to enqueue {t['team_id_master']}: {e}")
+            fail += 1
+
+    logger.info(f"Enqueued {success} teams at priority {PRIORITY_SAFETY_NET}, {fail} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260520155417_find_stale_teams.sql
+++ b/supabase/migrations/20260520155417_find_stale_teams.sql
@@ -1,0 +1,41 @@
+-- RPC: find_stale_teams
+--
+-- Returns GotSport teams that have never been scraped or that haven't been
+-- scraped in the last 90 days. Safety-net backstop for teams the daily
+-- yesterday-game enqueue and weekly discovery enqueue both miss (deprecated→
+-- undeprecated cycles, provider relinks, etc.).
+--
+-- Filters mirror scrape-games.yml exclusion logic:
+-- - is_deprecated = false
+-- - GotSport provider
+-- - Excludes U8/U9 (age_group + birth_year)
+-- - Excludes U20+ (birth_year)
+-- - Excludes 'unknown_*' placeholder teams
+--
+-- Ordering: oldest scraped first (NULLs first — never-scraped teams).
+--
+-- Used by scripts/enqueue_safety_net.py (Phase 6).
+
+CREATE OR REPLACE FUNCTION find_stale_teams(
+    p_provider_id uuid,
+    p_row_limit integer DEFAULT 500
+)
+RETURNS TABLE(team_id_master uuid, team_name text, provider_team_id text)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT t.team_id_master, t.team_name, t.provider_team_id
+    FROM teams t, (SELECT EXTRACT(YEAR FROM NOW())::int AS yr) c
+    WHERE t.is_deprecated = false
+      AND t.provider_id = find_stale_teams.p_provider_id
+      AND (t.last_scraped_at IS NULL OR t.last_scraped_at < NOW() - INTERVAL '90 days')
+      -- Age filters: PitchRank supports U10-U19 only.
+      AND (t.age_group IS NULL OR UPPER(TRIM(t.age_group)) NOT IN ('U8','U-8','U9','U-9'))
+      AND (t.birth_year IS NULL OR t.birth_year NOT IN (c.yr - 21, c.yr - 20, c.yr - 9, c.yr - 8, c.yr - 7))
+      -- Placeholder unknown filter.
+      AND NOT (t.team_name = 'unknown_' || t.provider_team_id)
+    ORDER BY t.last_scraped_at ASC NULLS FIRST
+    LIMIT find_stale_teams.p_row_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION find_stale_teams(uuid, integer) TO authenticated, service_role;

--- a/tests/unit/test_enqueue_safety_net.py
+++ b/tests/unit/test_enqueue_safety_net.py
@@ -1,0 +1,53 @@
+"""Tests for the weekly safety-net enqueue script."""
+import os
+import sys
+from datetime import date
+from unittest.mock import Mock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from scripts.enqueue_safety_net import (
+    DEFAULT_LIMIT,
+    PRIORITY_SAFETY_NET,
+    enqueue_team,
+    find_teams_to_enqueue,
+)
+
+
+def test_priority_constant_is_4():
+    assert PRIORITY_SAFETY_NET == 4
+
+
+def test_default_limit_is_500():
+    assert DEFAULT_LIMIT == 500
+
+
+def test_find_teams_to_enqueue_dedups_team_ids():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = [
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+        {"team_id_master": "t-2", "team_name": "B", "provider_team_id": "p-2"},
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+    ]
+    teams = find_teams_to_enqueue(supabase, gotsport_provider_id="gp")
+    team_ids = [t["team_id_master"] for t in teams]
+    assert len(team_ids) == len(set(team_ids))
+
+
+def test_enqueue_team_uses_priority_4_and_today_game_date():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = "test-id"
+    enqueue_team(
+        supabase,
+        team_id_master="t-1",
+        team_name="Team A",
+        provider_id="gp",
+        provider_team_id="p-1",
+    )
+    rpc_call = supabase.rpc.call_args
+    assert rpc_call.args[0] == "enqueue_scrape_request"
+    payload = rpc_call.args[1]
+    assert payload["p_priority"] == 4
+    assert payload["p_request_type"] == "safety_net"
+    assert payload["p_game_date"] == date.today().isoformat()
+    assert payload["p_team_id_master"] == "t-1"


### PR DESCRIPTION
## Summary

Phase 6 of schedule-driven-scraping. Backstop layer for GotSport teams that fall through both the daily yesterday-game enqueue (priority 2) and weekly discovery enqueue (priority 3). Targets teams with \`last_scraped_at IS NULL\` or \`last_scraped_at < NOW() - 90 days\`.

Should rarely have work — only activates for teams undergoing edge-case lifecycle events (deprecation cycles, provider relinks, prolonged inactivity).

## What

- \`scripts/enqueue_safety_net.py\` — enqueues up to 500 stale GotSport teams/week at priority 4 via \`enqueue_scrape_request\` RPC
- \`supabase/migrations/20260520155417_find_stale_teams.sql\` — RPC with same age/placeholder filters as discovery + scrape-games
- \`.github/workflows/enqueue-safety-net.yml\` — Sunday 16:00 UTC cron, after discovery (14:00 UTC)
- 4 unit tests

## Verified live

RPC returned **0 in-scope stale teams** today. Breakdown of 9,063 raw stale GotSport teams:
- 7,341 placeholder \`unknown_*\` rows (correctly excluded)
- 2,293 U8/U9 (out of scope)
- 169 out-of-range birth years
- Net in-scope stale: **0**

Healthy state — the existing chain has covered every in-scope team within 90 days. Phase 6 will start matching teams as they age past the threshold organically.

## Architecture

Final enqueue pipeline:

\`\`\`
ENQUEUE SCRIPTS:
├── User clicks "Process Missing Games"  (priority 1) ← Phase 3
├── enqueue_yesterday_games.py           (priority 2) ← Phase 4
├── enqueue_discovery_teams.py           (priority 3) ← Phase 5
└── enqueue_safety_net.py                (priority 4) ← THIS PR
                  ↓
        scrape_requests table
                  ↓
        process-missing-games (every 15min, 200/run, priority order)
\`\`\`

## Test plan

- [x] Unit tests pass (4)
- [x] Live dry-run completes (0 matches today — healthy state)
- [x] RPC sub-second response
- [ ] After merge: shadow run via \`gh workflow run enqueue-safety-net.yml -f dry_run=true\`
- [ ] Will start producing real enqueues as in-scope teams age past 90d organically

## Phases remaining

- Phase 7: Remove \`scrape-games.yml\` scheduled cron (keep as manual ZenRows tool)
- Phase 8: New-team scrape hook audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)