### PR TITLE
fix(ci): drop scrape-games concurrency to 8/shard when ZenRows is on

### DIFF
--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -226,6 +226,7 @@ jobs:
           INCLUDE_RECENT:    ${{ inputs.include_recent }}
           CHAIN_REMAINING:   ${{ inputs.chain_remaining }}
           CONCURRENCY_INPUT: ${{ inputs.concurrency }}
+          USE_ZENROWS:       ${{ inputs.use_zenrows }}
           DELAY_MIN_INPUT:   ${{ inputs.delay_min }}
           DELAY_MAX_INPUT:   ${{ inputs.delay_max }}
         run: |
@@ -294,13 +295,26 @@ jobs:
             CMD="$CMD --include-recent"
           fi
 
-          # Concurrency: 10 per shard, single-shard or sharded.
-          # The CloudFront WAF on system.gotsport.com/api/v1/* trips at ~15 req/s
-          # sustained from one IP. The 2026-05-18 chain at 20 per shard had a 97%
-          # error rate from WAF blocks (silent failures pre-circuit-breaker). 10
+          # Concurrency: 8 per shard with ZenRows on, 10 without.
+          #
+          # Direct (use_zenrows=false): The CloudFront WAF on system.gotsport.com
+          # /api/v1/* trips at ~15 req/s sustained from one IP. The 2026-05-18
+          # chain at 20 per shard had a 97% error rate from WAF blocks. 10
           # concurrent + 1.5-2.5s per-team delay stays comfortably under threshold.
-          # Sharded mode runs each shard on a separate IP so 10 × 5 = 50 aggregate.
-          CONCURRENCY=10
+          # Each shard runs on a separate runner IP, so 10 × 5 shards = 50 aggregate
+          # across 5 distinct egress IPs (each below the per-IP WAF limit).
+          #
+          # ZenRows (use_zenrows=true): All shards funnel through one ZenRows API
+          # key, so the shared parallel-request ceiling applies (Startup tier: 50).
+          # 5 shards × 8 concurrency = 40 parallel = 80% of cap, leaving 10 slots
+          # of headroom for retry surges and TLS keepalive churn. The 2026-05-20
+          # chain at 10 × 5 = 50 hit this ceiling and produced 53K RemoteDisconnect
+          # errors against api.zenrows.com mid-run.
+          if [[ "${USE_ZENROWS:-false}" == "true" ]]; then
+            CONCURRENCY=8
+          else
+            CONCURRENCY=10
+          fi
           if [[ "$CONCURRENCY_INPUT" =~ ^[0-9]+$ ]] && [ "$SCRAPE_SHARD_COUNT" = "1" ]; then
             CONCURRENCY="$CONCURRENCY_INPUT"
           fi


### PR DESCRIPTION
## Summary

The 2026-05-20 chain produced **53,504 RemoteDisconnect errors** against \`api.zenrows.com\` mid-run, with **7,554 terminal scrape failures**. Root cause: 5 shards × 10 concurrency = 50 parallel requests, **exactly at the ZenRows Startup-tier ceiling** (50 parallel/key). Any retry jitter or TLS keepalive churn pushed past the cap; ZenRows dropped connections rather than queueing.

## What changed

| Mode | Per-shard concurrency | Aggregate |
|---|---:|---:|
| Direct (no ZenRows) | 10 | 50 across 5 runner IPs (per-IP WAF limit) |
| **ZenRows on (new)** | **8** | **40 (80% of 50-cap)** with 10-slot headroom |

The old comment claimed sharded mode runs on separate IPs so \"10 × 5 = 50 aggregate\" was safe. That's true for direct scrapes (each runner has its own IP), but with ZenRows enabled **all 5 shards funnel through the same API key** — the shared parallel-request ceiling applies, not the per-IP GotSport WAF limit.

## Verification

- [x] Direct (\`use_zenrows=false\`): unchanged, stays at 10
- [x] ZenRows: drops to 8, leaves 10-slot headroom for retry surges
- [ ] Next ZenRows chain run: expect \`RemoteDisconnected\` count to drop sharply (from 53K → near zero)

## Why headroom matters

ZenRows' parallel limit is enforced at request-acceptance time. If you have 50 in flight and a retry fires, request 51 gets `Connection: close` from their LB instead of being queued. The 10-slot headroom absorbs:
- urllib3 retry surges
- TLS keepalive churn during long-running sessions
- The \`_extract_club_name\` and \`validate_team_id\` side-requests that the scraper fires alongside the main matches call

🤖 Generated with [Claude Code](https://claude.com/claude-code)