### PR TITLE
feat(queue): enqueue new GotSport teams on creation (Phase 8)

### DIFF
--- a/docs/superpowers/specs/phase1-audit-results.md
+++ b/docs/superpowers/specs/phase1-audit-results.md
@@ -70,3 +70,51 @@ Sample from production (5 rows + NULL-score query):
 --- NULL home_score rows ---
 (empty — no scheduled games in DB yet)
 ```
+
+---
+
+## Phase 8: New-team scrape hook audit (2026-05-20)
+
+### Team-insert sites found
+
+| File:Line | Category | Has scrape hook? | Notes |
+|---|---|---|---|
+| `src/models/affinity_wa_matcher.py:396` | Hot — runs inside enhanced_pipeline on every Affinity WA game import | No | Returns `team_id_master`; no enqueue/scrape after insert |
+| `src/models/modular11_matcher.py:1374` | Hot — runs inside enhanced_pipeline on every Modular11 (MLS NEXT) game import | No | Returns `team_id_master`; no enqueue/scrape after insert |
+| `src/models/playmetrics_matcher.py:505` | Hot — runs inside enhanced_pipeline and `scripts/scrape_playmetrics_tournament.py` | No | Returns `team_id_master`; no enqueue/scrape after insert |
+| `src/models/sincsports_matcher.py:741` | Hot — runs inside enhanced_pipeline, `discover_sincsports_teams.py`, and `discover_sincsports_via_tournament.py` | No | Returns `(team_id_master, True)`; no enqueue/scrape after insert |
+| `src/models/tgs_matcher.py:674` | Hot — runs inside enhanced_pipeline on every TGS game import | No | Returns `team_id_master`; no enqueue/scrape after insert |
+| `scripts/discover_teams_from_opponents.py:272` | Hot — weekly ops script creating new teams from unmatched opponents | No | Backfills game FKs after insert, but no enqueue |
+| `frontend/app/api/create-team/route.ts:75` | Hot — user-facing admin API for linking unknown opponents | No | Backfills games + writes audit log, but no `enqueue_scrape_request` call |
+| `scripts/extract_and_import_tgs_teams.py:413,422` | Maintenance — one-off bulk CSV import run before a new TGS game import batch | No | Batch inserts; designed to run before game import (which scrapes inline). Lower priority. |
+| `scripts/import_sincsports_teams.py:438` | Maintenance — one-off bulk import of SincSports teams | No | No enqueue; scraping done separately by import_games_enhanced pipeline |
+| `scripts/import_teams_enhanced.py:162` | Maintenance — one-off enhanced importer for new providers | No | No enqueue; pipeline caller handles scraping |
+| `scripts/migrate_modular11_aliases.py:483` | Maintenance — one-off migration to fix MLS NEXT division alias splits | No | Targeted correction script; runs rarely |
+
+**Un-deprecation paths:** No code path was found that updates `is_deprecated` to `False` on an existing team. `merge_teams.py` only sets deprecated→canonical (marks deprecated teams), never un-deprecates. No gap here.
+
+**Supabase stored procedures / triggers:** No migration function performs `INSERT INTO teams`. The only teams-related trigger is `update_teams_updated_at` (timestamp on UPDATE). No database-level gap.
+
+### Gaps identified
+
+All five hot-path matcher insert sites and both ops/UI scripts lack a scrape hook:
+
+1. `src/models/affinity_wa_matcher.py:396` — no enqueue after team creation
+2. `src/models/modular11_matcher.py:1374` — no enqueue after team creation
+3. `src/models/playmetrics_matcher.py:505` — no enqueue after team creation
+4. `src/models/sincsports_matcher.py:741` — no enqueue after team creation
+5. `src/models/tgs_matcher.py:674` — no enqueue after team creation
+6. `scripts/discover_teams_from_opponents.py:272` — no enqueue after team creation
+7. `frontend/app/api/create-team/route.ts:75` — no enqueue after team creation
+
+The three maintenance scripts (`extract_and_import_tgs_teams.py`, `import_sincsports_teams.py`, `import_teams_enhanced.py`) and the migration script are lower priority — they bulk-import known teams ahead of a game import run, which itself triggers scraping through the pipeline. Worth noting but not blocking.
+
+### Recommended action
+
+**For the 5 matcher sites (gaps 1–5):** After the `self.db.table("teams").insert(team_data).execute()` call in each matcher's `_create_team` (or equivalent) method, call `enqueue_scrape_request` at priority 3 (discovery). The `self.db` handle is already available; the `team_id_master`, `team_name`, `provider_id`, and `provider_team_id` values are all in scope at the insert site. Pass `today()` as the `game_date` placeholder.
+
+**For `discover_teams_from_opponents.py:272` (gap 6):** After the insert and alias write in `_create_or_get_team`, call `enqueue_scrape_request` at priority 3. The `supabase` client, `provider_id`, `provider_team_id`, `team_id_master`, and team metadata are all in scope.
+
+**For `frontend/app/api/create-team/route.ts:75` (gap 7):** After step 3 (team insert) succeeds, call the `enqueue_scrape_request` RPC via the Supabase client before returning the success response. Priority 1 (user-clicked) is appropriate since an admin just manually created the team. The `teamIdMaster`, `teamName`, `game.provider_id`, and `providerTeamIdStr` are all in scope.
+
+**For the 3 maintenance scripts:** Consider adding a post-import enqueue pass (a loop over newly created `team_id_master` values calling `enqueue_scrape_request` at priority 3), but this is a stretch goal — the pipeline-driven game import that follows these scripts effectively triggers schedule scraping through normal operation.

--- a/frontend/app/api/create-team/route.ts
+++ b/frontend/app/api/create-team/route.ts
@@ -189,6 +189,31 @@ export async function POST(request: NextRequest) {
       // Don't fail - the main operation succeeded
     }
 
+    // 7. Schedule-driven-scraping hook: enqueue at priority 1 if this is a
+    //    GotSport team. Admin-initiated team creation deserves a near-immediate
+    //    scrape — process_missing_games drains the queue at 200/15min so the
+    //    new team's schedule should land within a single drain cycle.
+    //    Other providers are out of scope; the queue is GotSport-only for now.
+    if (game.provider_id) {
+      const { data: providerRow } = await supabase.from('providers').select('code').eq('id', game.provider_id).single();
+
+      if (providerRow?.code === 'gotsport') {
+        const { error: enqueueError } = await supabase.rpc('enqueue_scrape_request', {
+          p_team_id_master: teamIdMaster,
+          p_team_name: teamName.trim(),
+          p_provider_id: game.provider_id,
+          p_provider_team_id: providerTeamIdStr,
+          p_game_date: new Date().toISOString().slice(0, 10),
+          p_request_type: 'new_team',
+          p_priority: 1,
+        });
+        if (enqueueError) {
+          console.error('[create-team] Enqueue failed (non-fatal):', enqueueError);
+          // Non-fatal: safety-net sweep will pick this team up within a week.
+        }
+      }
+    }
+
     return NextResponse.json({
       success: true,
       teamIdMaster,

--- a/frontend/app/api/create-team/route.ts
+++ b/frontend/app/api/create-team/route.ts
@@ -194,23 +194,35 @@ export async function POST(request: NextRequest) {
     //    scrape — process_missing_games drains the queue at 200/15min so the
     //    new team's schedule should land within a single drain cycle.
     //    Other providers are out of scope; the queue is GotSport-only for now.
+    //
+    //    The whole block is wrapped so a transient Supabase failure here can't
+    //    return a 500 to an admin whose team was already successfully created,
+    //    aliased, backfilled, and audited. If the enqueue misses, the safety-net
+    //    sweep (priority 4, weekly) picks the team up.
     if (game.provider_id) {
-      const { data: providerRow } = await supabase.from('providers').select('code').eq('id', game.provider_id).single();
+      try {
+        const { data: providerRow } = await supabase
+          .from('providers')
+          .select('code')
+          .eq('id', game.provider_id)
+          .single();
 
-      if (providerRow?.code === 'gotsport') {
-        const { error: enqueueError } = await supabase.rpc('enqueue_scrape_request', {
-          p_team_id_master: teamIdMaster,
-          p_team_name: teamName.trim(),
-          p_provider_id: game.provider_id,
-          p_provider_team_id: providerTeamIdStr,
-          p_game_date: new Date().toISOString().slice(0, 10),
-          p_request_type: 'new_team',
-          p_priority: 1,
-        });
-        if (enqueueError) {
-          console.error('[create-team] Enqueue failed (non-fatal):', enqueueError);
-          // Non-fatal: safety-net sweep will pick this team up within a week.
+        if (providerRow?.code === 'gotsport') {
+          const { error: enqueueError } = await supabase.rpc('enqueue_scrape_request', {
+            p_team_id_master: teamIdMaster,
+            p_team_name: teamName.trim(),
+            p_provider_id: game.provider_id,
+            p_provider_team_id: providerTeamIdStr,
+            p_game_date: new Date().toISOString().slice(0, 10),
+            p_request_type: 'new_team',
+            p_priority: 1,
+          });
+          if (enqueueError) {
+            console.error('[create-team] Enqueue failed (non-fatal):', enqueueError);
+          }
         }
+      } catch (enqueueException) {
+        console.error('[create-team] Enqueue threw (non-fatal):', enqueueException);
       }
     }
 

--- a/scripts/discover_teams_from_opponents.py
+++ b/scripts/discover_teams_from_opponents.py
@@ -37,7 +37,7 @@ import csv
 import os
 import time
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -236,9 +236,15 @@ def create_team_and_alias(
     provider_id: str,
     provider_team_id: str,
     meta: Dict[str, Optional[str]],
+    provider_code: Optional[str] = None,
 ) -> Tuple[str, str]:
     """
     Create a new team and alias mapping.
+
+    When provider_code == 'gotsport', also enqueue a scrape_requests row at
+    priority 3 (discovery) so the new team enters the queue and gets its
+    schedule scraped within ~15 minutes via process_missing_games. Other
+    providers are skipped — schedule-driven-scraping is GotSport-only.
 
     Returns (team_id_master, status) where status is one of:
     'created', 'exists_alias', 'exists_team', 'error'
@@ -310,6 +316,31 @@ def create_team_and_alias(
         error_str = str(e).lower()
         if "unique" not in error_str and "duplicate" not in error_str:
             print(f"  WARNING: Team created but alias failed: {e}")
+
+    # Schedule-driven-scraping hook: GotSport only.
+    # Enqueue at priority 3 (discovery) so the new team enters the priority
+    # queue and process_missing_games scrapes its schedule within ~15 min.
+    # Other providers are out of scope; the queue is GotSport-only for now.
+    if provider_code == "gotsport":
+        try:
+            _execute_with_retry(
+                lambda: supabase.rpc(
+                    "enqueue_scrape_request",
+                    {
+                        "p_team_id_master": team_id_master,
+                        "p_team_name": meta.get("team_name") or "",
+                        "p_provider_id": provider_id,
+                        "p_provider_team_id": provider_team_id,
+                        "p_game_date": date.today().isoformat(),
+                        "p_request_type": "new_team",
+                        "p_priority": 3,
+                    },
+                ).execute()
+            )
+        except Exception as e:
+            # Enqueue failure is non-fatal: the safety-net sweep (priority 4)
+            # will pick this team up within a week.
+            print(f"  WARNING: Team {team_id_master} created but enqueue failed: {e}")
 
     return team_id_master, "created"
 
@@ -536,7 +567,9 @@ def main() -> None:
             continue
 
         if args.execute:
-            team_id_master, status = create_team_and_alias(supabase, provider_id, unknown_pid, meta)
+            team_id_master, status = create_team_and_alias(
+                supabase, provider_id, unknown_pid, meta, provider_code=provider_code
+            )
             stats[status] = stats.get(status, 0) + 1
 
             home_bf, away_bf = 0, 0


### PR DESCRIPTION
## Summary

Closes the new-team scrape hook on the two provider-agnostic team-insert sites identified in the Phase 8 audit. Both patched sites are gated to GotSport — schedule-driven-scraping is GotSport-only per the spec.

## Audit results

Found 7 hot-path team-insert sites across the codebase. Patched the 2 that can produce GotSport teams; left the 5 provider-specific matcher sites as future work when the queue extends beyond GotSport.

| # | File | Patched | Reason |
|---|---|---|---|
| 1 | \`src/models/affinity_wa_matcher.py:396\` | ❌ | Affinity WA — out of scope |
| 2 | \`src/models/modular11_matcher.py:1374\` | ❌ | Modular11 — out of scope |
| 3 | \`src/models/playmetrics_matcher.py:505\` | ❌ | PlayMetrics — out of scope |
| 4 | \`src/models/sincsports_matcher.py:741\` | ❌ | SincSports — out of scope |
| 5 | \`src/models/tgs_matcher.py:674\` | ❌ | TGS — out of scope |
| 6 | \`scripts/discover_teams_from_opponents.py:272\` | ✅ | Multi-provider — gated to GotSport |
| 7 | \`frontend/app/api/create-team/route.ts:75\` | ✅ | Multi-provider — gated to GotSport |

## Changes

**\`scripts/discover_teams_from_opponents.py\`** — opt-in via new \`provider_code\` arg:
- Adds optional \`provider_code\` param to \`create_team_and_alias\`
- After team + alias write succeed, if \`provider_code == 'gotsport'\`, enqueues at **priority 3** (discovery)
- Call site passes \`provider_code\` (already in scope from argparse)

**\`frontend/app/api/create-team/route.ts\`** — provider lookup + GotSport gate:
- After successful insert + alias + backfill + audit, looks up \`providers.code\` from \`game.provider_id\`
- If GotSport, enqueues at **priority 1** (admin-initiated, user is waiting in the UI)
- Drains within one 15-min \`process_missing_games\` cycle

## Failure modes

Enqueue failures are **non-fatal** — the safety-net sweep (priority 4, weekly) picks up stale teams if the immediate enqueue misses. Logged as warnings.

## Final phase summary

This is the last phase in the schedule-driven-scraping spec. Architecture is now:

\`\`\`
Insert sources (priority 1-4):
- User-click "process missing games"    (priority 1)  ← Phase 3
- Admin creates team via UI             (priority 1)  ← THIS PR
- New team discovered from opponent     (priority 3)  ← THIS PR
- Daily yesterday-game enqueue          (priority 2)  ← Phase 4
- Weekly discovery enqueue              (priority 3)  ← Phase 5
- Weekly safety-net enqueue             (priority 4)  ← Phase 6
                  ↓
        scrape_requests table
                  ↓
        process-missing-games (15 min cron, 200/run, priority order)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)