### PR TITLE
fix(age-groups): collapse U18 into U19 in calculate_age_group_from_birth_year

### DIFF
--- a/src/utils/team_utils.py
+++ b/src/utils/team_utils.py
@@ -61,6 +61,7 @@ def calculate_age_group_from_birth_year(birth_year: int, current_year: int = CUR
 
     Formula: age = current_year - birth_year + 1 → f"U{age}"
     Season year rolls over on Aug 1 (see _soccer_season_year).
+    Age 18 collapses into U19 to match AGE_GROUPS (config/settings.py).
 
     Args:
         birth_year: The birth year (e.g., 2014)
@@ -74,8 +75,12 @@ def calculate_age_group_from_birth_year(birth_year: int, current_year: int = CUR
         'U12'
         >>> calculate_age_group_from_birth_year(2013, 2025)
         'U13'
+        >>> calculate_age_group_from_birth_year(2008, 2025)
+        'U19'
     """
     age = current_year - birth_year + 1
     if 7 <= age <= 19:  # Valid youth soccer age range
+        if age == 18:
+            age = 19
         return f"U{age}"
     return None


### PR DESCRIPTION
## Summary

- `AGE_GROUPS` config merges 2008/2007 birth years into U19 (`config/settings.py:90-101`), but the canonical helper `calculate_age_group_from_birth_year` was emitting raw `U18` for 2008 birth years.
- The validator (`src/utils/enhanced_validators.py`) rejects `U18` since it's not in `AGE_GROUPS`, so TGS B2008/2007 divisions were being silently quarantined as `Invalid age group`.
- The remap pattern (`if age == 18: age = 19`) was already idiomatic at `team_name_utils.py:533`. This change centralizes it at the canonical helper so every caller is fixed in one place — TGS scraper, PlayMetrics scraper, Affinity-WA scraper, `enhanced_pipeline`.

## Concrete impact

- TGS Event 3886 import: 144 B2008/2007 games were quarantined as `Invalid age group: 'u18'`. Re-running the import will now classify them as U19 and accept them.
- No effect on already-imported teams (Seattle United 2011 ECNL Male and similar) — they remain in their existing cohorts.

## Test plan

- [x] Existing tests pass: `tests/unit/test_scrape_playmetrics.py` — 59/59 green (already exercises the u18→u19 expectation through `derive_team_age_group`).
- [x] Smoke verification: `calculate_age_group_from_birth_year(2008, 2025)` → `'U19'`; 2007 → `'U19'`; 2014 → `'U12'`; out-of-range → `None`.
- [ ] Re-run TGS Event 3886 scrape+import after merge — expect the previously quarantined 144 games to import as U19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)