### PR TITLE
ci(process-missing-games): offset cron off round-number minutes

### DIFF
--- a/.github/workflows/process-missing-games.yml
+++ b/.github/workflows/process-missing-games.yml
@@ -2,7 +2,10 @@ name: Process Missing Games
 
 on:
   schedule:
-    - cron: '*/15 * * * *'  # every 15 minutes
+    # Offset from :00/:15/:30/:45 to reduce GitHub scheduler contention.
+    # Scheduled workflows are best-effort and silently dropped under load;
+    # round-number minutes collide with every other repo using */15.
+    - cron: '7,22,37,52 * * * *'  # every 15 minutes, off-peak offsets
   workflow_dispatch: # Allow manual trigger from GitHub Actions tab
 
 concurrency:


### PR DESCRIPTION
## Summary
- Shift the schedule from \`*/15 * * * *\` (lands on :00/:15/:30/:45) to \`7,22,37,52 * * * *\`.
- GitHub's scheduled-workflow runner is best-effort and silently drops invocations under load; round-number minute marks collide with every other repo using \`*/15\`. Last 24h showed gaps of 2-6h instead of 15 min.

## Test plan
- [ ] Merge, then watch the workflow runs over the next ~2 hours. Expect runs near :07/:22/:37/:52 with much smaller gaps than before.
- [ ] If gaps are still large after the offset, escalate to a self-looping workflow (one launch runs 4 inner cycles).