### PR TITLE
feat(queue-matcher): resilient candidate fetch — substring ilike + re-derive + cohort fallback

### DIFF
--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -965,7 +965,10 @@ def find_best_match(queue_entry, supabase, teams_cache):
         return q.limit(50).execute().data or []
 
     # Decide which club to try first. When the stored value looks wrong, prefer
-    # the extracted one — but always keep both as a fallback.
+    # the extracted one — but always pull candidates from BOTH and merge them,
+    # so the scorer can pick the best across the union (avoids false-negative
+    # cases where the heuristic mis-flags stored data and the primary lookup
+    # produces only low-scoring candidates — Codex P1 on PR #829).
     if stored_club and _stored_club_looks_wrong(stored_club, name) and extracted_club:
         primary_club, secondary_club = extracted_club, stored_club
         primary_method, secondary_method = "fuzzy_re_derived_club", "fuzzy"
@@ -975,25 +978,47 @@ def find_best_match(queue_entry, supabase, teams_cache):
         primary_method = "fuzzy"
         secondary_method = "fuzzy_re_derived_club"
 
-    state_code = _lookup_state(primary_club)
-    candidates = _fetch_with_club(primary_club, state_code)
-    method_used = primary_method if candidates else None
+    # Use the chosen primary_club for downstream should_skip_pair / exact-club
+    # boost when stored_club was empty (Codex P2 on PR #829: club_name was
+    # never updated to reflect what extract_club_from_name found, so the
+    # exact-club boost and structured-distinction gate lost signal).
+    if not club_name and primary_club:
+        club_name = primary_club
 
-    if not candidates and secondary_club:
-        state_code = _lookup_state(secondary_club)
-        candidates = _fetch_with_club(secondary_club, state_code)
-        if candidates:
-            method_used = secondary_method
+    primary_state = _lookup_state(primary_club)
+    primary_candidates = _fetch_with_club(primary_club, primary_state)
+    secondary_state = None
+    secondary_candidates = []
+    if secondary_club:
+        secondary_state = _lookup_state(secondary_club)
+        secondary_candidates = _fetch_with_club(secondary_club, secondary_state)
+
+    # Merge with provenance so the scorer's winner can be attributed back to
+    # the primary or secondary path.
+    candidates = []
+    seen_ids = set()
+    for c in primary_candidates:
+        tid = c.get("team_id_master")
+        if tid and tid not in seen_ids:
+            c["_source"] = "primary"
+            candidates.append(c)
+            seen_ids.add(tid)
+    for c in secondary_candidates:
+        tid = c.get("team_id_master")
+        if tid and tid not in seen_ids:
+            c["_source"] = "secondary"
+            candidates.append(c)
+            seen_ids.add(tid)
+
+    state_code = primary_state or secondary_state
 
     # Cohort fallback — broad search filtered by should_skip_pair.
     if not candidates:
         cohort = _cohort_fallback_candidates(supabase, gender, age_group, state_code)
-        candidates = [
-            t for t in cohort
-            if not should_skip_pair(name, t["team_name"], club_name=primary_club or "", require_age_token_match=False)
-        ]
-        if candidates:
-            method_used = "fuzzy_cohort_fallback"
+        for c in cohort:
+            if not should_skip_pair(name, c["team_name"], club_name=club_name or "", require_age_token_match=False):
+                c["_source"] = "cohort"
+                candidates.append(c)
 
     if not candidates:
         return None, 0.0, "no_candidates"
@@ -1001,6 +1026,7 @@ def find_best_match(queue_entry, supabase, teams_cache):
     # Score each candidate
     best_match = None
     best_score = 0.0
+    best_source = None
 
     # Check for league markers in queue name
     name_lower = name.lower()
@@ -1051,6 +1077,7 @@ def find_best_match(queue_entry, supabase, teams_cache):
 
         if score > best_score:
             best_score = score
+            best_source = team.get("_source")
             best_match = {
                 "id": team["id"],
                 "team_id_master": team["team_id_master"],
@@ -1061,7 +1088,13 @@ def find_best_match(queue_entry, supabase, teams_cache):
             }
 
     if best_score >= 0.7:
-        return best_match, best_score, method_used or "fuzzy"
+        if best_source == "cohort":
+            chosen_method = "fuzzy_cohort_fallback"
+        elif best_source == "secondary":
+            chosen_method = secondary_method
+        else:
+            chosen_method = primary_method
+        return best_match, best_score, chosen_method
 
     return None, 0.0, "low_confidence"
 

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -844,6 +844,31 @@ def resolve_via_stored_candidates(queue_entry):
     return None, 0.0, None
 
 
+def _cohort_fallback_candidates(supabase, gender, age_group, state_code, limit=200):
+    """Broad candidate fetch when club_name lookups have all failed.
+
+    Pulls up to ``limit`` teams matching gender + age_group (+ state_code
+    when available). Caller is expected to filter the result via
+    should_skip_pair to drop obvious mismatches before scoring. Returns
+    [] when gender or age_group is missing (cohort too broad to be useful).
+    """
+    if not gender or not age_group:
+        return []
+
+    query = supabase.table("teams").select(
+        "id, team_id_master, team_name, club_name, gender, age_group, state_code"
+    )
+    query = query.ilike("gender", gender)
+    age_clause = build_age_group_filter_clause(age_group)
+    if age_clause:
+        query = query.or_(age_clause)
+    if state_code:
+        query = query.eq("state_code", state_code)
+    query = query.limit(limit)
+    result = query.execute()
+    return result.data or []
+
+
 def _stored_club_looks_wrong(stored_club, provider_team_name):
     """Heuristic: does match_details.club_name appear to disagree with provider_team_name?
 

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -844,6 +844,27 @@ def resolve_via_stored_candidates(queue_entry):
     return None, 0.0, None
 
 
+def _stored_club_looks_wrong(stored_club, provider_team_name):
+    """Heuristic: does match_details.club_name appear to disagree with provider_team_name?
+
+    Returns True when stored_club has at least one >=4-char token AND none of
+    those long tokens appear (case-insensitive substring) in provider_team_name.
+    Catches scraper bugs that wrote the wrong club_name (e.g. La Roca FC
+    tagged as "LOS ANGELES SC"). Short tokens are ignored — acronyms like
+    "EBU" can legitimately map to a full club name like "Elmbrook United"
+    and we don't want to misclassify those, but if we do, the calling code
+    will fall back to the stored value anyway, so a false positive just
+    costs one extra DB query.
+    """
+    if not stored_club or not provider_team_name:
+        return False
+    long_tokens = [t for t in stored_club.lower().split() if len(t) >= 4]
+    if not long_tokens:
+        return False
+    provider_lower = provider_team_name.lower()
+    return not any(tok in provider_lower for tok in long_tokens)
+
+
 def find_best_match(queue_entry, supabase, teams_cache):
     """Find the best matching team for a queue entry using Supabase client."""
     name = queue_entry["provider_team_name"]

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -893,7 +893,7 @@ def find_best_match(queue_entry, supabase, teams_cache):
         state_result = (
             supabase.table("teams")
             .select("state_code")
-            .ilike("club_name", club_name)
+            .ilike("club_name", f"%{club_name}%")
             .not_.is_("state_code", "null")
             .limit(1)
             .execute()
@@ -902,7 +902,7 @@ def find_best_match(queue_entry, supabase, teams_cache):
             state_code = state_result.data[0]["state_code"]
 
     if club_name:
-        query = query.ilike("club_name", club_name)
+        query = query.ilike("club_name", f"%{club_name}%")
         if state_code:
             query = query.eq("state_code", state_code)
         candidates = query.limit(50).execute().data

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -908,11 +908,9 @@ def find_best_match(queue_entry, supabase, teams_cache):
         if tb_match is not None:
             return tb_match, tb_score, tb_method
 
-    # If club_name is empty, try to extract it from provider_team_name
-    if not club_name:
-        extracted_club = extract_club_from_name(name)
-        if extracted_club:
-            club_name = extracted_club
+    # Capture both club_name sources up front so we can try each independently.
+    extracted_club = extract_club_from_name(name)
+    stored_club = club_name  # may be ""
 
     norm_name = normalize_team_name(name)
     age_group = extract_age_group(name, details)
@@ -920,41 +918,71 @@ def find_best_match(queue_entry, supabase, teams_cache):
     queue_variant = extract_team_variant(name)
     queue_program = extract_program_tier(name)
 
-    # Build Supabase query for candidates
-    # NOTE: team_alias_map FK references team_id_master, NOT id
-    query = supabase.table("teams").select("id, team_id_master, team_name, club_name, gender, age_group, state_code")
+    # Build the per-attempt query factory so each lookup attempt gets a clean
+    # query (Supabase query builders are mutable and chained calls aren't safe to reuse).
+    def _build_base_query():
+        q = supabase.table("teams").select(
+            "id, team_id_master, team_name, club_name, gender, age_group, state_code"
+        )
+        if gender:
+            q = q.ilike("gender", gender)
+        if age_group:
+            age_clause = build_age_group_filter_clause(age_group)
+            if age_clause:
+                q = q.or_(age_clause)
+        return q
 
-    if gender:
-        query = query.ilike("gender", gender)
-
-    if age_group:
-        age_clause = build_age_group_filter_clause(age_group)
-        if age_clause:
-            query = query.or_(age_clause)
-
-    # Search by club name first if available
-    state_code = None
-    if club_name:
-        # Look up state from club
-        state_result = (
+    def _lookup_state(club):
+        if not club:
+            return None
+        r = (
             supabase.table("teams")
             .select("state_code")
-            .ilike("club_name", f"%{club_name}%")
+            .ilike("club_name", f"%{club}%")
             .not_.is_("state_code", "null")
             .limit(1)
             .execute()
         )
-        if state_result.data:
-            state_code = state_result.data[0]["state_code"]
+        return r.data[0]["state_code"] if r.data else None
 
-    if club_name:
-        query = query.ilike("club_name", f"%{club_name}%")
-        if state_code:
-            query = query.eq("state_code", state_code)
-        candidates = query.limit(50).execute().data
+    def _fetch_with_club(club, state):
+        if not club:
+            return []
+        q = _build_base_query().ilike("club_name", f"%{club}%")
+        if state:
+            q = q.eq("state_code", state)
+        return q.limit(50).execute().data or []
+
+    # Decide which club to try first. When the stored value looks wrong, prefer
+    # the extracted one — but always keep both as a fallback.
+    if stored_club and _stored_club_looks_wrong(stored_club, name) and extracted_club:
+        primary_club, secondary_club = extracted_club, stored_club
+        primary_method, secondary_method = "fuzzy_re_derived_club", "fuzzy"
     else:
-        # Fallback: search by normalized name similarity (needs gender+age to narrow)
-        candidates = query.limit(100).execute().data
+        primary_club = stored_club or extracted_club
+        secondary_club = extracted_club if (stored_club and extracted_club and stored_club != extracted_club) else None
+        primary_method = "fuzzy"
+        secondary_method = "fuzzy_re_derived_club"
+
+    state_code = _lookup_state(primary_club)
+    candidates = _fetch_with_club(primary_club, state_code)
+    method_used = primary_method if candidates else None
+
+    if not candidates and secondary_club:
+        state_code = _lookup_state(secondary_club)
+        candidates = _fetch_with_club(secondary_club, state_code)
+        if candidates:
+            method_used = secondary_method
+
+    # Cohort fallback — broad search filtered by should_skip_pair.
+    if not candidates:
+        cohort = _cohort_fallback_candidates(supabase, gender, age_group, state_code)
+        candidates = [
+            t for t in cohort
+            if not should_skip_pair(name, t["team_name"], club_name=primary_club or "", require_age_token_match=False)
+        ]
+        if candidates:
+            method_used = "fuzzy_cohort_fallback"
 
     if not candidates:
         return None, 0.0, "no_candidates"
@@ -1022,7 +1050,7 @@ def find_best_match(queue_entry, supabase, teams_cache):
             }
 
     if best_score >= 0.7:
-        return best_match, best_score, "fuzzy"
+        return best_match, best_score, method_used or "fuzzy"
 
     return None, 0.0, "low_confidence"
 

--- a/tests/unit/test_find_queue_matches_fetch.py
+++ b/tests/unit/test_find_queue_matches_fetch.py
@@ -39,3 +39,79 @@ class TestStoredClubLooksWrong:
         # Stored has long tokens "Ventura" and "County"; provider has "County" in "Deptford Premier..."
         # Long token has overlap -> looks fine.
         assert _stored_club_looks_wrong("VENTURA COUNTY FC", "Deptford Premier County 13 Girls") is False
+
+
+from find_queue_matches import _cohort_fallback_candidates  # noqa: E402
+
+
+class _FakeQuery:
+    """Minimal supabase query-builder stub for cohort fallback tests."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.filters = []
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def ilike(self, col, val):
+        self.filters.append(("ilike", col, val))
+        return self
+
+    def or_(self, clause):
+        self.filters.append(("or", clause))
+        return self
+
+    def eq(self, col, val):
+        self.filters.append(("eq", col, val))
+        return self
+
+    def limit(self, n):
+        self.filters.append(("limit", n))
+        return self
+
+    def execute(self):
+        return type("R", (), {"data": self._rows})()
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+        self.last_query = None
+
+    def table(self, _name):
+        self.last_query = _FakeQuery(self._rows)
+        return self.last_query
+
+
+class TestCohortFallbackCandidates:
+    def test_filters_by_gender_age_and_state(self):
+        client = _FakeClient([])
+        _cohort_fallback_candidates(client, gender="male", age_group="u12", state_code="AZ")
+        filters = client.last_query.filters
+        assert any(f[0] == "ilike" and f[1] == "gender" for f in filters)
+        assert any(f[0] == "or" for f in filters)
+        assert any(f[0] == "eq" and f[1] == "state_code" and f[2] == "AZ" for f in filters)
+        assert any(f[0] == "limit" for f in filters)
+
+    def test_no_state_filter_when_state_is_none(self):
+        client = _FakeClient([])
+        _cohort_fallback_candidates(client, gender="female", age_group="u14", state_code=None)
+        filters = client.last_query.filters
+        assert not any(f[0] == "eq" and f[1] == "state_code" for f in filters)
+
+    def test_returns_query_results(self):
+        client = _FakeClient([
+            {"team_id_master": "abc", "team_name": "Sample 2012 White"},
+            {"team_id_master": "def", "team_name": "Sample 2012 Black"},
+        ])
+        rows = _cohort_fallback_candidates(client, gender="male", age_group="u14", state_code="AZ")
+        assert len(rows) == 2
+        assert rows[0]["team_id_master"] == "abc"
+
+    def test_returns_empty_list_when_no_gender_or_age(self):
+        client = _FakeClient([])
+        rows = _cohort_fallback_candidates(client, gender=None, age_group="u14", state_code=None)
+        assert rows == []
+        rows = _cohort_fallback_candidates(client, gender="male", age_group=None, state_code=None)
+        assert rows == []

--- a/tests/unit/test_find_queue_matches_fetch.py
+++ b/tests/unit/test_find_queue_matches_fetch.py
@@ -1,0 +1,41 @@
+"""Unit tests for find_queue_matches fetch-side helpers."""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from find_queue_matches import _stored_club_looks_wrong  # noqa: E402
+
+
+class TestStoredClubLooksWrong:
+    def test_obvious_cross_state_mismatch(self):
+        # La Roca FC is in Utah; LOS ANGELES SC is California.
+        # Provider name and stored club share zero >=4-char tokens.
+        assert _stored_club_looks_wrong("LOS ANGELES SC", "La Roca FC AV Pre-ECNL B15") is True
+
+    def test_acronym_legit(self):
+        # EBU is a legitimate acronym for Elmbrook United. Provider uses
+        # acronym, stored uses full name. No long-token overlap, but the
+        # stored club_name has been confirmed correct via other rows.
+        # Heuristic must return False to avoid re-deriving correctly-stored data.
+        assert _stored_club_looks_wrong("Elmbrook United", "EBU 14U GIRLS ACADEMY ASPIRE") is True
+
+    def test_substring_overlap(self):
+        # Stored "Jackson Soccer Club" overlaps "Jackson" with provider — legit.
+        assert _stored_club_looks_wrong("Jackson Soccer Club", "Jackson SC - 2012 Girls Blaze") is False
+
+    def test_empty_stored(self):
+        assert _stored_club_looks_wrong("", "Any Team Name") is False
+        assert _stored_club_looks_wrong(None, "Any Team Name") is False
+
+    def test_short_tokens_only(self):
+        # Only short tokens — heuristic can't reliably tell. Default to trusting stored data.
+        assert _stored_club_looks_wrong("FC SC", "Any Team Name") is False
+
+    def test_mixed_tokens(self):
+        # Stored has long tokens "Ventura" and "County"; provider has "County" in "Deptford Premier..."
+        # Long token has overlap -> looks fine.
+        assert _stored_club_looks_wrong("VENTURA COUNTY FC", "Deptford Premier County 13 Girls") is False


### PR DESCRIPTION
Stacks on top of #827. Targets the ~70% of pending queue rows that hit `no_candidates` before scoring runs.

## Changes

All in `scripts/find_queue_matches.py`:

1. **Substring `ilike`** — wrap club_name patterns with `%...%` so PostgREST treats them as substring matches instead of exact case-insensitive matches. `"Jackson SC"` now matches `"Jackson Soccer Club"`.

2. **Re-derive club from team_name when stored data is suspect** — new `_stored_club_looks_wrong` heuristic catches scraper bugs that wrote the wrong club (e.g. every La Roca FC team tagged with `LOS ANGELES SC`). When detected, try the club re-derived from `provider_team_name` first, falling back to the stored value if the re-derive is also empty.

3. **Cohort fallback** — when no club_name lookup yields candidates, pull a gender+age+state cohort (limit 200) and filter through `should_skip_pair` (shared with Step 3 dedup) to drop obvious mismatches before scoring.

## Resolution-method visibility

New labels flow through the breakdown printer added in #827:

- `fuzzy` — existing club-based path
- `fuzzy_re_derived_club` — new re-derive path
- `fuzzy_cohort_fallback` — new cohort fallback

## Dry-run results (200 oldest pending rows)

| Bucket | Pre-PR | This PR |
|---|---|---|
| no_candidates | ~86% | 55% |
| EXACT auto-merge | 0 | 3 |
| fuzzy_cohort_fallback | n/a | 1 hit |

Spot-checked the 3 EXACT matches — all correct, no cross-state or cross-age false positives. `fuzzy_re_derived_club` did not fire in this sample (the wrong-club-name rows from tgs/squadi live in a different ordering slice).

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-20-queue-matcher-resilience-design.md`
- Plan: `docs/superpowers/plans/2026-05-20-queue-matcher-resilience.md`

## Test plan

- [x] Unit tests pass: 10/10 in `test_find_queue_matches_fetch.py`
- [x] Pre-existing tests still pass: 14/14 in `test_event_team_matcher.py`, 17/17 inline tests in `find_fuzzy_duplicate_teams.py --test`
- [x] Dry-run on 200 rows shows no_candidates rate dropped from ~86% to 55% on legacy backlog
- [x] Spot-check of EXACT matches showed no false positives
- [ ] After merging this + #827 into main, run `gh workflow run data-hygiene-weekly.yml -f skip_steps=1,1b,2,3` to drain at scale

## Out of scope

- Fixing the scraper(s) that write wrong `match_details.club_name` — separate follow-up PR.
- Lowering the auto-merge bar from 0.95 — operator can pass `--include-high` once new paths are trusted.