### PR TITLE
ci(enqueue-yesterday-games): shift cron to 1am Mountain (07:00 UTC)

### DIFF
--- a/.github/workflows/enqueue-yesterday-games.yml
+++ b/.github/workflows/enqueue-yesterday-games.yml
@@ -6,9 +6,10 @@ run-name: >-
 
 on:
   schedule:
-    # 12:00 UTC = 5am Phoenix, 7am Central, 8am Eastern.
-    # East-Coast Sunday-night games have had ~12 hours to post scores by then.
-    - cron: '0 12 * * *'
+    # 07:00 UTC = 1am MDT / midnight MST (Mountain). Runs overnight so the
+    # process-missing-games drain (every 15min) has hours to clear the queue
+    # before morning. GH Actions cron is UTC-only, so this drifts ±1h with DST.
+    - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary
- Move `enqueue-yesterday-games.yml` cron from `0 12 * * *` (5am MDT) to `0 7 * * *` (1am MDT / midnight MST).
- Gives the every-15min `process-missing-games` drain overnight runway to clear the queue before US morning traffic.
- GH Actions cron is UTC-only, so local time drifts ±1h between DST/standard.

## Context
~28.6k future GotSport games are scheduled in the `games` table. Each day, the enqueue job finds yesterday's NULL-score games and pushes their teams into `scrape_requests` at priority 2; the drain picks them up at :07/:22/:37/:52. Running enqueue overnight means scores are usually settled in `games` by morning.

## Test plan
- [ ] Verify next scheduled run lands at 07:00 UTC in Actions.
- [ ] Spot-check queue depth around 08:00 UTC and again at 13:00 UTC — should be near zero by morning.