### PR TITLE
ci(hygiene): drain entire review queue instead of capping Step 4 at 200

### DIFF
--- a/.github/workflows/data-hygiene-weekly.yml
+++ b/.github/workflows/data-hygiene-weekly.yml
@@ -216,7 +216,7 @@ jobs:
             EXECUTE_FLAG="--execute --yes"
           fi
 
-          python scripts/find_queue_matches.py --force $EXECUTE_FLAG 2>&1 | tee logs/step4_queue_matches.log
+          python scripts/find_queue_matches.py --limit 0 --force $EXECUTE_FLAG 2>&1 | tee logs/step4_queue_matches.log
 
           EXACT=$(grep -oP 'EXACT \(95%\+\):\s+\K\d+' logs/step4_queue_matches.log || echo "0")
           QUEUE_MERGED=$(grep -oP 'Approved: \K\d+' logs/step4_queue_matches.log || echo "0")

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -1103,7 +1103,7 @@ def analyze_queue(limit=100, min_confidence=0.90, force=False):
     """Analyze queue entries and find matches using Supabase client.
 
     Args:
-        limit: Max number of entries to analyze
+        limit: Max number of entries to analyze. 0 means no cap — process every pending entry.
         min_confidence: Minimum confidence score (unused, kept for compatibility)
         force: If True, ignore last_analyzed_at filter and reprocess all pending entries
     """
@@ -1113,9 +1113,10 @@ def analyze_queue(limit=100, min_confidence=0.90, force=False):
     all_entries = []
     page_size = 1000
     offset = 0
+    unlimited = not limit  # limit=0 (or None) → drain entire queue
 
-    while len(all_entries) < limit:
-        fetch_size = min(page_size, limit - len(all_entries))
+    while unlimited or len(all_entries) < limit:
+        fetch_size = page_size if unlimited else min(page_size, limit - len(all_entries))
 
         query = (
             supabase.table("team_match_review_queue")
@@ -1141,7 +1142,7 @@ def analyze_queue(limit=100, min_confidence=0.90, force=False):
         offset += fetch_size
         print(f"  Fetched {len(all_entries)} entries so far...")
 
-    entries = all_entries[:limit]
+    entries = all_entries if unlimited else all_entries[:limit]
 
     results = {
         "exact": [],  # 95%+ match
@@ -1348,7 +1349,7 @@ def execute_merges(results, dry_run=True, min_confidence=0.95):
 
 def main():
     parser = argparse.ArgumentParser(description="Find matches for queue entries")
-    parser.add_argument("--limit", type=int, default=200, help="Max entries to analyze (default: 200)")
+    parser.add_argument("--limit", type=int, default=200, help="Max entries to analyze (default: 200; 0 = no cap, drain all pending)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show more details")
     parser.add_argument("--dry-run", action="store_true", default=True, help="Show what would be merged (default)")
     parser.add_argument("--execute", action="store_true", help="Actually execute merges")

--- a/scripts/find_queue_matches.py
+++ b/scripts/find_queue_matches.py
@@ -1123,6 +1123,7 @@ def analyze_queue(limit=100, min_confidence=0.90, force=False):
             .select("id, provider_id, provider_team_id, provider_team_name, match_details, confidence_score")
             .eq("status", "pending")
             .order("created_at")
+            .order("id")  # stable secondary key for offset pagination
         )
 
         if not force:
@@ -1349,7 +1350,12 @@ def execute_merges(results, dry_run=True, min_confidence=0.95):
 
 def main():
     parser = argparse.ArgumentParser(description="Find matches for queue entries")
-    parser.add_argument("--limit", type=int, default=200, help="Max entries to analyze (default: 200; 0 = no cap, drain all pending)")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Max entries to analyze (default: 200; 0 = no cap, drain all pending)",
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="Show more details")
     parser.add_argument("--dry-run", action="store_true", default=True, help="Show what would be merged (default)")
     parser.add_argument("--execute", action="store_true", help="Actually execute merges")


### PR DESCRIPTION
## Summary
- `scripts/find_queue_matches.py`: `--limit 0` now means "no cap — process every pending entry" (default stays at 200 for manual smoke runs)
- `.github/workflows/data-hygiene-weekly.yml`: Step 4 now passes `--limit 0` so the weekly run actually drains the full backlog instead of nibbling 200/week

## Why
Audit during this session found Step 4 was the only hygiene step with a hardcoded cap — Steps 1, 1b, 2, 3 all process the full table. With ~12,971 pending queue entries and a 200/week cap, the backlog would take ~65 weeks to drain (ignoring inflow).

## Test plan
- [ ] Trigger workflow with `dry_run=true skip_steps=1,1b,2,3` and confirm Step 4 fetches >200 entries
- [ ] Confirm Resolution method breakdown shows real numbers (`fuzzy`, `fuzzy_cohort_fallback`, `stored_tiebreak:*`, etc.) across the full queue
- [ ] After merge, monitor next scheduled Monday run for Step 4 wall-clock (~80 min estimated based on dry-run sampling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)