### PR TITLE
fix(enqueue-queue): rewrite find_yesterday_null_score_teams to drive from games + drop drain limit to 150

### DIFF
--- a/.github/workflows/process-missing-games.yml
+++ b/.github/workflows/process-missing-games.yml
@@ -39,7 +39,7 @@ jobs:
           # Set Python path to include project root
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           # Run with explicit error output
-          python scripts/process_missing_games.py --limit 200 || exit 1
+          python scripts/process_missing_games.py --limit 150 || exit 1
       
       - name: Report results
         if: always()

--- a/scripts/process_missing_games.py
+++ b/scripts/process_missing_games.py
@@ -60,7 +60,7 @@ class MissingGamesProcessor:
         # Stats tracking
         self.stats = {"processed": 0, "successful": 0, "failed": 0, "games_found": 0, "games_imported": 0}
 
-    def get_pending_requests(self, limit: int = 200) -> List[Dict]:
+    def get_pending_requests(self, limit: int = 150) -> List[Dict]:
         """Fetch pending scrape requests from database, ordered by priority then age."""
         try:
             result = (
@@ -562,7 +562,7 @@ class MissingGamesProcessor:
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Process missing game scrape requests")
-    parser.add_argument("--limit", type=int, default=200, help="Maximum number of requests to process")
+    parser.add_argument("--limit", type=int, default=150, help="Maximum number of requests to process")
     parser.add_argument("--dry-run", action="store_true", help="Run without making any changes")
     parser.add_argument("--continuous", action="store_true", help="Run continuously, checking every 30 seconds")
     parser.add_argument("--interval", type=int, default=30, help="Interval in seconds for continuous mode")

--- a/supabase/migrations/20260526000000_find_yesterday_null_score_teams_v2.sql
+++ b/supabase/migrations/20260526000000_find_yesterday_null_score_teams_v2.sql
@@ -1,0 +1,42 @@
+-- RPC: find_yesterday_null_score_teams (v2)
+--
+-- Rewrite drives from games (via idx_games_date) on game_date + NULL home_score,
+-- then joins teams. The v1 form drove from teams with an EXISTS subquery, which
+-- timed out under tournament-weekend volume (Memorial Day 2026: 7,214 NULL-score
+-- games on a single day vs ~600 on a normal day).
+--
+-- Returns distinct GotSport teams that had a game on p_yesterday with NULL
+-- home_score. Either side of the matchup counts. Excludes deprecated teams and
+-- teams already scraped today.
+
+CREATE OR REPLACE FUNCTION find_yesterday_null_score_teams(
+    p_yesterday date,
+    p_provider_id uuid
+)
+RETURNS TABLE(team_id_master uuid, team_name text, provider_team_id text)
+LANGUAGE sql
+STABLE
+AS $$
+    WITH affected_masters AS (
+        SELECT home_team_master_id AS master_id
+        FROM games
+        WHERE game_date = find_yesterday_null_score_teams.p_yesterday
+          AND home_score IS NULL
+          AND home_team_master_id IS NOT NULL
+        UNION
+        SELECT away_team_master_id AS master_id
+        FROM games
+        WHERE game_date = find_yesterday_null_score_teams.p_yesterday
+          AND home_score IS NULL
+          AND away_team_master_id IS NOT NULL
+    )
+    SELECT DISTINCT t.team_id_master, t.team_name, t.provider_team_id
+    FROM affected_masters am
+    JOIN teams t ON t.team_id_master = am.master_id
+    WHERE t.is_deprecated = false
+      AND t.provider_id = find_yesterday_null_score_teams.p_provider_id
+      AND (t.last_scraped_at IS NULL OR t.last_scraped_at::date < CURRENT_DATE)
+    ORDER BY t.team_id_master;
+$$;
+
+GRANT EXECUTE ON FUNCTION find_yesterday_null_score_teams(date, uuid) TO authenticated, service_role;


### PR DESCRIPTION
## Summary

- **Rewrite `find_yesterday_null_score_teams` RPC** to drive from `games` via `idx_games_date`, then join `teams` — fixes Postgres statement timeout (error 57014) seen on 2026-05-24 and 2026-05-25 enqueue runs
- **Drop `process-missing-games` drain limit from 200 → 150** to stay under GotSport's CloudFront WAF rate threshold

## Why

The `Enqueue Yesterday-Game Teams` workflow failed on **2026-05-24** ([run 26357247678](https://github.com/dallasheidt14/PitchRank/actions/runs/26357247678)) and **2026-05-25** ([run 26397188457](https://github.com/dallasheidt14/PitchRank/actions/runs/26397188457)). Tournament-weekend volume (Memorial Day):

| Date | NULL-score games in DB | Enqueued | Outcome |
|---|---|---|---|
| 2026-05-22 | 559 | 994 | enqueue ✅ (drain 79% WAF-failed) |
| 2026-05-23 | **7,214** | **0** | RPC statement timeout ❌ |
| 2026-05-24 | **4,480** | **0** | RPC statement timeout ❌ |

The v1 RPC drove from `teams` with an `EXISTS` subquery over `games`. Under the volume spike, the planner couldn't finish in the statement timeout window.

v2 drives the other direction: filter `games` first (on indexed `game_date`), union home + away `team_master_id`s, then join `teams` for the provider / deprecation / `last_scraped_at` filters.

Separately, the drain has been failing ~79% on GotSport's CloudFront WAF (`cloudfront-waf-second-trip`). Dropping per-run batch from 200 → 150 should reduce the burst rate enough to stay under the WAF threshold. This is the lower-risk first lever; if it isn't enough we can revisit retry/backoff or UA tactics.

## Apply

Migration is **manual** (no migration CI in this repo). Paste `supabase/migrations/20260526000000_find_yesterday_null_score_teams_v2.sql` into Supabase Dashboard → SQL Editor and run. It's `CREATE OR REPLACE FUNCTION`, idempotent and safe.

## Test plan

- [ ] Apply migration via Supabase Dashboard SQL Editor
- [ ] Manual dispatch of `Enqueue Yesterday-Game Teams` workflow (will target 2026-05-25 yesterday-game teams) — verify it completes without timeout
- [ ] Backfill May 23 + 24 via one-off script invocation (separate PR / direct run)
- [ ] Monitor next 2-3 drain runs for WAF-failure rate at limit=150 vs prior 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)