### PR TITLE
fix(scrape-queue): drop drain limit to 40 to stay under GotSport WAF threshold

### DIFF
--- a/.github/workflows/process-missing-games.yml
+++ b/.github/workflows/process-missing-games.yml
@@ -39,7 +39,7 @@ jobs:
           # Set Python path to include project root
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           # Run with explicit error output
-          python scripts/process_missing_games.py --limit 150 || exit 1
+          python scripts/process_missing_games.py --limit 40 || exit 1
       
       - name: Report results
         if: always()

--- a/scripts/process_missing_games.py
+++ b/scripts/process_missing_games.py
@@ -60,7 +60,7 @@ class MissingGamesProcessor:
         # Stats tracking
         self.stats = {"processed": 0, "successful": 0, "failed": 0, "games_found": 0, "games_imported": 0}
 
-    def get_pending_requests(self, limit: int = 150) -> List[Dict]:
+    def get_pending_requests(self, limit: int = 40) -> List[Dict]:
         """Fetch pending scrape requests from database, ordered by priority then age."""
         try:
             result = (
@@ -562,7 +562,7 @@ class MissingGamesProcessor:
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Process missing game scrape requests")
-    parser.add_argument("--limit", type=int, default=150, help="Maximum number of requests to process")
+    parser.add_argument("--limit", type=int, default=40, help="Maximum number of requests to process")
     parser.add_argument("--dry-run", action="store_true", help="Run without making any changes")
     parser.add_argument("--continuous", action="store_true", help="Run continuously, checking every 30 seconds")
     parser.add_argument("--interval", type=int, default=30, help="Interval in seconds for continuous mode")


### PR DESCRIPTION
## Summary

Drop `process-missing-games` per-run limit from 150 → 40 based on empirical WAF threshold data.

## Why

Manual workflow dispatch on 2026-05-26 17:00 UTC with limit=150 produced:
- **40 requests successful**
- **110 failed** (all with `gotsport: retry exhausted ... reason=cloudfront-waf-second-trip`)
- WAF tripped between the 40th and 41st successful request, then cascade-failed the remainder

This is the cleanest threshold signal we've seen. At ~10–12s per scrape (API + parse + import), 40 teams = ~7–8 min sustained, matching what GotSport's CloudFront WAF appears to count in its rolling window.

## What changes

- `.github/workflows/process-missing-games.yml`: `--limit 150` → `--limit 40`
- `scripts/process_missing_games.py`: default arg + docstring → 40

Drain cadence is ~1–2h (GH Actions scheduler drift), well past the 300s WAF cooldown — so each run starts with a fully reset WAF counter.

## Throughput impact

- Before (theoretical): 150/run × ~12 runs/day × 21% success = ~378 scrapes/day
- After: 40/run × ~12 runs/day × **~100% success** (if threshold theory is right) = **~480 scrapes/day**

So **higher net throughput** despite the smaller batch, because we stop wasting requests on the failed-tail cascade.

## Test plan

- [ ] Manual workflow dispatch after merge — confirm all 40 succeed
- [ ] Wait for ~2-3 scheduled runs and verify failure rate stays near 0
- [ ] If 40 still trips at the tail, drop to 35 with margin

## Follow-up worth noting

The WAFBreaker circuit breaker in `src/scrapers/gotsport.py:114` is supposed to halt the run on second trip — but in this manual run, all 110 post-trip requests still appeared to make API calls (each logged `retry exhausted`). The breaker may not be aborting the outer loop in `process_missing_games.py`. Worth investigating separately if 40 still trips, since the cascade keeps the WAF counter pegged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)