### PR TITLE
seo: methodology page rewrite + ranking comparison blog post

### DIFF
--- a/docs/superpowers/plans/2026-05-26-methodology-rewrite-and-parent-comparison-post.md
+++ b/docs/superpowers/plans/2026-05-26-methodology-rewrite-and-parent-comparison-post.md
@@ -1,0 +1,591 @@
+# Methodology Rewrite + Parent Comparison Blog Post Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the `/methodology` page to close GEO methodology citation gaps and publish a "Best Youth Soccer Ranking Websites" blog post to capture parent-04 queries.
+
+**Architecture:** Two independent deliverables sharing no code. Deliverable 1 rewrites three existing components (`MethodologySection.tsx`, `FAQSchema.tsx`, `MethodologySchema.tsx`) and updates page metadata. Deliverable 2 adds a new MDX blog post, registers its FAQs, and regenerates `llms.txt`.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript 5.9, Tailwind v4, MDX, JSON-LD structured data
+
+**Spec:** `docs/superpowers/specs/2026-05-26-methodology-rewrite-and-parent-comparison-post.md`
+
+---
+
+## File Map
+
+### Deliverable 1: Methodology Page Rewrite
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Rewrite | `frontend/components/MethodologySection.tsx` | Full page content (10 sections) |
+| Rewrite | `frontend/components/FAQSchema.tsx` | FAQPage JSON-LD (11 → 15 questions) |
+| Modify | `frontend/components/MethodologySchema.tsx` | Update headline + description |
+| Modify | `frontend/app/methodology/page.tsx` | Update metadata title/description + dateModified |
+
+### Deliverable 2: Blog Post
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx` | Blog post content |
+| Modify | `frontend/lib/blog-faqs.ts` | Add 4 FAQ entries for the new post |
+| Run | `frontend/scripts/generate-llms-txt.ts` | Regenerate `public/llms.txt` |
+
+---
+
+## Task 1: Rewrite MethodologySection.tsx
+
+**Files:**
+- Rewrite: `frontend/components/MethodologySection.tsx`
+
+This is the largest task — a full rewrite of the methodology page content. The new component keeps the same export name and signature but replaces the entire body with 10 sections per the spec.
+
+- [ ] **Step 1: Read current file and surrounding components**
+
+Read these files to understand the current patterns:
+```
+frontend/components/MethodologySection.tsx
+frontend/components/FAQSchema.tsx
+frontend/components/MethodologySchema.tsx
+frontend/app/methodology/page.tsx
+frontend/components/ui/card.tsx (for Card, CardHeader, CardContent, CardDescription variants)
+```
+
+- [ ] **Step 2: Rewrite MethodologySection.tsx**
+
+Replace the entire component body. Keep the same export (`export function MethodologySection()`), same `FAQSchema` import and render. Use the same Card/icon pattern as the existing code.
+
+**New section order and content:**
+
+**Section 1 — Hero: "How PitchRank Rankings Work"**
+- Card variant="primary"
+- Heading: "How PitchRank Rankings Work" (more searchable than old "PitchRank Methodology")
+- 2-3 sentence positioning: two-part rating system, fairest rankings, data-driven
+
+**Section 2 — "Where Our Data Comes From" (NEW)**
+- Icon: `Database` from lucide-react
+- Cover: game data from tournaments (GotSport and others), league results, showcases, cross-state events
+- How games are verified and deduplicated
+- Coverage scope: all 50 states, U10 through U19, boys and girls
+- Approximate teams tracked: "thousands of teams across 50 states" (do NOT query DB)
+- Why broad data sourcing matters vs platform-locked systems
+- Use 4 bullet items in the same `flex items-start gap-3 p-4 rounded-lg bg-muted/50` pattern as existing factor cards
+
+**Section 3 — "The Core Rating Engine" (EXPANDED)**
+- Icon: `Brain` (keep)
+- Same 6 factors: opponent quality, competitiveness, SOS, offense/defense, recency, stability
+- Each factor gets 2-3 sentences (currently 1 sentence each)
+- Add "why this matters" angle per factor. Examples:
+  - Opponent Quality: "A win against a top-10 team in your state carries far more weight than a win against an unranked opponent. This prevents teams from inflating their record against weak competition."
+  - SOS: "Two teams can have identical records, but if one earned theirs against nationally-ranked opponents and the other played only local recreation teams, their ratings will reflect that difference."
+- Keep the same `CheckCircle`/`Activity`/`TrendingUp`/`Shield`/`Clock`/`Anchor` icon grid
+- Keep the summary callout box at the bottom
+
+**Section 4 — "Cross-League Strength Calibration" (NEW, targets method-02/04)**
+- Icon: `Scale` from lucide-react
+- Explain: teams from different leagues (ECNL, GA, state leagues, independent clubs) are compared fairly
+- League-strength calibration: the system recognizes that leagues vary in overall competitiveness and adjusts accordingly
+- Tournament cross-pollination: when teams from different leagues meet at tournaments, those results directly calibrate cross-league strength
+- The network effect: "The more cross-league games played, the more accurate comparisons become. By mid-season, even teams that have never played each other can be compared through chains of shared opponents."
+- Convergence: the system gets sharper as the season progresses — early-season rankings have wider uncertainty
+- Do NOT expose exact multiplier values
+
+**Section 5 — "How We Handle Teams With Few Games" (EXPANDED, targets method-03)**
+- Icon: `UserPlus` (keep)
+- Currently 2 sentences — expand to a full section with 4 bullet points:
+  - Conservative starting point: new teams begin with a neutral rating, not inflated or penalized
+  - Confidence and uncertainty: with fewer games, the system assigns wider uncertainty — the rating exists but carries less confidence
+  - Minimum games threshold: "Teams need a minimum number of verified games before appearing in official rankings. This prevents a single fluky result from producing a misleading placement."
+  - Gradual convergence: "As a team plays more games against rated opponents, their rating stabilizes and their ranking becomes increasingly reliable."
+- Do NOT expose MIN_GAMES=9
+
+**Section 6 — "The Machine Learning Layer" (RESTRUCTURED)**
+- Icon: `Cpu` (keep)
+- Same core concept: overperformance vs underperformance detection
+- Add concrete example: "If a team rated #30 in their state consistently beats teams rated #10-#15, the ML layer detects that pattern and adjusts their rating upward — even before they've played enough games for the core engine to catch up."
+- How the adjustment is bounded: "The ML adjustment is intentionally small — it fine-tunes rather than overrides. A massive upset in a single game won't swing a rating, but a consistent pattern of exceeding expectations will."
+- What this catches that the core engine alone doesn't: "The core engine measures where a team has been. The ML layer anticipates where they're going."
+
+**Section 7 — "How It All Comes Together"**
+- Icon: `Link` (keep)
+- Card variant="accent"
+- PowerScore composition: core performance + ML trend adjustment
+- "The final PowerScore is a single number that captures both proven strength and emerging trajectory."
+- Keep the 2-column grid (Core Performance / ML Trend Adjustment) and the 5-item checklist
+- Do NOT include tier thresholds
+
+**Section 8 — "Update Cadence & Data Freshness" (MERGED)**
+- Icon: `Calendar` (keep)
+- Merge existing "Updated Every Monday" content with new data freshness info
+- Monday refresh cycle: entire network recalculates
+- Daily data ingestion: "Game results flow into our system daily as tournaments and leagues report scores. Every Monday morning, the entire ranking network recalculates with the latest data."
+- What triggers recalculation: new results, strength of schedule updates, cross-state comparisons tighten, ML picks up new trends
+- Keep the 4-item checklist format
+
+**Section 9 — "Frequently Asked Questions" (EXPANDED)**
+- Icon: `HelpCircle` (keep)
+- Keep existing 4 visible FAQ items (manipulation, winning by a lot, one game swing, missing games)
+- Add 4 new visible FAQ items:
+  - "How does PitchRank compare teams across different leagues?" — "Our system calibrates league strength automatically. When teams from different leagues meet at tournaments, those head-to-head results anchor cross-league comparisons. The more inter-league games played, the more accurate these comparisons become."
+  - "How accurate are rankings for teams that have only played a few games?" — "Rankings for newer teams carry wider uncertainty. We require a minimum number of verified games before a team appears in official rankings, and even then, their rating stabilizes further with each additional game. Early-season rankings should be treated as directional, not definitive."
+  - "Where does PitchRank get its game data?" — "We collect verified game results from tournaments, leagues, showcases, and cross-state events across all 50 states. Our data pipeline pulls from multiple sources — we are not locked to any single tournament platform, which gives us broader coverage than platform-specific ranking systems."
+  - "Can teams from different states be compared fairly?" — "Yes. Cross-state tournaments and national events create direct connections between state ecosystems. A team from Arizona that plays in a California tournament creates a bridge that links both states' rankings. The more cross-state play, the more accurate interstate comparisons become."
+
+**Section 10 — "The PitchRank Promise" (KEPT)**
+- Icon: `Target` (keep)
+- Card variant="primary"
+- Same content: "Smart rankings. Fair rankings. Real rankings."
+
+**Content rules for all sections:**
+- No "Glicko-2" — use "rating engine" / "rating algorithm" / "our system"
+- No PowerScore tier thresholds
+- No exact formula weights or parameters
+- Use "group" not "cohort"
+- Tone: authoritative but accessible to parents
+
+- [ ] **Step 3: Verify the component compiles**
+
+Run:
+```bash
+cd C:/PitchRank/frontend && npx tsc --noEmit --pretty 2>&1 | head -30
+```
+Expected: No errors in MethodologySection.tsx
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/PitchRank && git add frontend/components/MethodologySection.tsx && git commit -m "feat(seo): rewrite methodology page content for GEO coverage
+
+Expand from 9 sections to 10 with deeper content targeting GEO
+methodology gaps: data sourcing, cross-league calibration, sparse
+schedule handling. Each rating factor expanded from 1 to 2-3 sentences."
+```
+
+---
+
+## Task 2: Expand FAQSchema.tsx with 4 new questions
+
+**Files:**
+- Modify: `frontend/components/FAQSchema.tsx`
+
+- [ ] **Step 1: Read current FAQSchema.tsx**
+
+Read `frontend/components/FAQSchema.tsx` to see current 11 questions.
+
+- [ ] **Step 2: Add 4 new FAQ items to the mainEntity array**
+
+Append these 4 items after the existing 11 (before the closing `]`):
+
+```typescript
+      {
+        '@type': 'Question',
+        name: 'How does PitchRank compare teams across different leagues?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'PitchRank calibrates league strength automatically using cross-league game results. When teams from different leagues (ECNL, GA, state leagues, independent clubs) meet at tournaments, those head-to-head results anchor cross-league comparisons. The more inter-league games played, the more accurate these comparisons become across the entire ranking network.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How accurate are rankings for teams that have only played a few games?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Rankings for newer teams carry wider uncertainty. PitchRank requires a minimum number of verified games before a team appears in official rankings. Even after that threshold, a team\'s rating stabilizes further with each additional game against rated opponents. Early-season rankings should be treated as directional rather than definitive.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Where does PitchRank get its game data?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'PitchRank collects verified game results from tournaments, leagues, showcases, and cross-state events across all 50 states. The data pipeline pulls from multiple sources and is not locked to any single tournament platform, providing broader coverage than platform-specific ranking systems. Results are ingested daily and rankings recalculate every Monday.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Can teams from different states be compared fairly?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Yes. Cross-state tournaments and national events create direct connections between state ecosystems. When an Arizona team plays in a California tournament, that result bridges both states\' rankings. The more cross-state play occurs, the more accurate interstate comparisons become throughout the season.',
+        },
+      },
+```
+
+- [ ] **Step 3: Verify no TypeScript errors**
+
+Run:
+```bash
+cd C:/PitchRank/frontend && npx tsc --noEmit --pretty 2>&1 | grep -i "FAQSchema"
+```
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/PitchRank && git add frontend/components/FAQSchema.tsx && git commit -m "feat(seo): add 4 GEO-targeted FAQ items to methodology schema
+
+Cross-league comparison, sparse schedules, data sourcing, and
+cross-state fairness. Total FAQ items: 15."
+```
+
+---
+
+## Task 3: Update MethodologySchema.tsx and page.tsx metadata
+
+**Files:**
+- Modify: `frontend/components/MethodologySchema.tsx`
+- Modify: `frontend/app/methodology/page.tsx`
+
+- [ ] **Step 1: Read both files**
+
+Read `frontend/components/MethodologySchema.tsx` and `frontend/app/methodology/page.tsx`.
+
+- [ ] **Step 2: Update MethodologySchema headline and description**
+
+In `frontend/components/MethodologySchema.tsx`, update the schema object:
+
+```typescript
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'How PitchRank Youth Soccer Rankings Work',
+    description:
+      'How PitchRank calculates youth soccer team rankings using opponent quality, cross-league strength calibration, schedule strength, and machine-learning trend detection. Updated weekly with verified game data from all 50 states.',
+    url: pageUrl,
+    datePublished,
+    dateModified,
+    author: PITCHRANK_TEAM_AUTHOR,
+    publisher: PITCHRANK_PUBLISHER,
+    image: `${BASE_URL}/opengraph-image.png`,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': pageUrl,
+    },
+  };
+```
+
+- [ ] **Step 3: Update page.tsx metadata and dateModified**
+
+In `frontend/app/methodology/page.tsx`:
+
+Update the `metadata` export:
+```typescript
+export const metadata: Metadata = {
+  title: 'How Our Rankings Work',
+  description:
+    'How PitchRank calculates youth soccer team rankings using opponent quality, cross-league strength calibration, and machine-learning trend detection. Updated weekly with game data from all 50 states.',
+  alternates: {
+    canonical: `${BASE_URL}/methodology`,
+  },
+  openGraph: {
+    title: 'How PitchRank Youth Soccer Rankings Work',
+    description:
+      'How PitchRank calculates youth soccer team rankings using data-driven analytics, cross-league calibration, and ML trend detection.',
+    url: `${BASE_URL}/methodology`,
+    siteName: 'PitchRank',
+    type: 'website',
+    images: [
+      {
+        url: '/logos/pitchrank-wordmark.svg',
+        width: 1200,
+        height: 630,
+        alt: 'How PitchRank Rankings Work',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'How PitchRank Youth Soccer Rankings Work',
+    description: 'How PitchRank calculates youth soccer rankings with cross-league calibration and ML trend detection.',
+    images: ['/logos/pitchrank-wordmark.svg'],
+  },
+};
+```
+
+Update the `dateModified` prop on `MethodologySchema`:
+```typescript
+<MethodologySchema datePublished="2026-04-30T00:00:00Z" dateModified="2026-05-26T00:00:00Z" />
+```
+
+Update the `PageHeader` title:
+```typescript
+<PageHeader
+  title="How Our Rankings Work"
+  description="Understanding how PitchRank calculates team rankings and power scores"
+  showBackButton
+  backHref="/"
+/>
+```
+
+- [ ] **Step 4: Verify no TypeScript errors**
+
+Run:
+```bash
+cd C:/PitchRank/frontend && npx tsc --noEmit --pretty 2>&1 | head -20
+```
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/PitchRank && git add frontend/components/MethodologySchema.tsx frontend/app/methodology/page.tsx && git commit -m "feat(seo): update methodology page metadata and schema for GEO
+
+Title: 'How Our Rankings Work', description adds cross-league
+calibration. dateModified bumped to 2026-05-26."
+```
+
+---
+
+## Task 4: Build and visually verify methodology page
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the dev server and verify the page renders**
+
+```bash
+cd C:/PitchRank/frontend && npm run dev
+```
+
+Open `http://localhost:3000/methodology` in a browser and verify:
+- Page title shows "How Our Rankings Work"
+- All 10 sections render without errors
+- New sections (Data Sources, Cross-League Calibration, Sparse Schedules) are present
+- FAQ section has 8 visible questions (4 original + 4 new)
+- No console errors
+
+- [ ] **Step 2: Validate structured data**
+
+View page source and search for `application/ld+json`. Verify:
+- FAQPage schema has 15 questions
+- Article schema has updated headline "How PitchRank Youth Soccer Rankings Work"
+- dateModified is "2026-05-26T00:00:00Z"
+
+- [ ] **Step 3: Check mobile rendering**
+
+Resize browser to 375px width. Verify:
+- All cards stack properly
+- No horizontal overflow
+- Text is readable
+
+---
+
+## Task 5: Create the comparison blog post MDX file
+
+**Files:**
+- Create: `frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx`
+
+- [ ] **Step 1: Read an existing MDX blog post for format reference**
+
+Read `frontend/content/blog/colorado-youth-soccer-rankings-guide.mdx` to confirm frontmatter format and markdown conventions.
+
+- [ ] **Step 2: Create the MDX file**
+
+Create `frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx` with this frontmatter:
+
+```yaml
+---
+title: 'Best Youth Soccer Ranking Websites for Parents (2026)'
+slug: 'best-youth-soccer-ranking-websites-2026'
+excerpt: 'An honest comparison of youth soccer ranking sites — PitchRank, GotSport, SoccerWire, USARank, and TopDrawerSoccer. What each one does, how they work, and which is right for your family.'
+author: 'PitchRank Team'
+date: '2026-05-26'
+readingTime: '10 min read'
+tags: ['Rankings', 'Educational', 'Parents', 'Comparison']
+keywords:
+  [
+    'best youth soccer rankings',
+    'youth soccer ranking websites',
+    'gotsport vs pitchrank',
+    'youth soccer rankings comparison',
+    'best youth soccer ranking site',
+  ]
+---
+```
+
+**Content structure (write the full markdown body):**
+
+**Heading:** `# Best Youth Soccer Ranking Websites for Parents (2026)`
+
+**Introduction (3 paragraphs):**
+- Hook: Your kid's coach mentions a ranking, another parent cites a different number from a different site — which one should you trust?
+- What to look for in a ranking site: methodology transparency, data breadth (does it cover only one tournament platform or many?), update frequency, cost, and whether it ranks individual teams or just clubs
+- Brief overview: we reviewed five ranking sites to help parents navigate the landscape
+
+**Comparison table:**
+
+```markdown
+| Site | What It Ranks | Data Source | Coverage | Cost | Best For |
+|------|--------------|-------------|----------|------|----------|
+| [PitchRank](https://pitchrank.io) | Individual teams | Multiple sources | U10-U19, 50 states | Free | Data-driven head-to-head rankings for any competitive team |
+| [GotSport](https://rankings.gotsport.com) | Individual teams | GotSport tournaments only | U10-U19, 100K+ teams | Free | Quick look if you already use GotSport |
+| [SoccerWire](https://www.soccerwire.com) | Clubs (Top 100) | ECNL/MLS NEXT/GA leagues | U13-U19, elite only | Free | Club-level development track record |
+| [USARank](https://usarank.com) | Individual teams | SincSports tournaments only | U08-U19, all states | Free | Teams in SincSports tournaments |
+| [TopDrawerSoccer](https://www.topdrawersoccer.com) | National Top 25 | ECNL/MLS NEXT leagues | U13-U18, national only | Partial ($99/yr) | College recruiting ecosystem |
+```
+
+**Per-site sections:** Use `##` headings. Each site gets:
+- `### [Site Name]` heading
+- 1-2 sentence description
+- `**How it works:**` — methodology summary (2-3 sentences)
+- `**Strengths:**` — bulleted list (3-5 items)
+- `**Limitations:**` — bulleted list (3-5 items)
+- `**Best for:**` — 1 sentence
+
+Write the full content for each site using the verified research from the spec. Key content per site:
+
+**PitchRank:**
+- How it works: Two-part rating engine evaluates every game result through opponent quality, strength of schedule, competitiveness, and consistency. A machine learning layer detects trending teams. Rankings update every Monday.
+- Strengths: Head-to-head results (not tournament placement), data from multiple sources (not locked to one platform), transparent methodology, free, cross-state comparison, weekly updates
+- Limitations: Newer platform with growing brand recognition, teams need a minimum number of games before appearing in rankings
+- Best for: Parents who want data-driven, result-based rankings for any competitive team in any state
+
+**GotSport:**
+- How it works: Teams earn points based on tournament placement. Each tournament flight gets a "Flight Value" based on the national ranking percentile of its top teams. Champions earn 100% of that value, finalists 50%, semifinalists 25%.
+- Strengths: Largest dataset (100K+ teams), free to view, integrated with tournament registration parents already use, mobile apps available
+- Limitations: Only counts GotSport-hosted tournaments (non-GotSport events excluded), placement-based not head-to-head (teams earn points from finishing above opponents they never played), rewards tournament quantity — teams near more GotSport events accumulate more points, community consensus on forums is poor predictive accuracy
+- Best for: Parents already using GotSport for tournament registration who want a quick relative comparison
+- Sources to reference inline: [GotSport Support](https://support.gotsport.com/what-are-the-gotsoccer-rankings)
+
+**SoccerWire:**
+- How it works: Top 100 club rankings (not individual teams) using league points-per-game, playoff results, national team call-ups, and pro signings within 3 years. Only counts ECNL, MLS NEXT, and Girls Academy.
+- Strengths: Development-oriented — rewards clubs producing national-level players, not just tournament wins. Free to view. Strong youth soccer news coverage.
+- Limitations: Club-level only (you cannot find your specific U14 team's rank), only covers elite national leagues (irrelevant for state leagues, USYS, or smaller platforms), monthly updates
+- Best for: Parents at ECNL or MLS NEXT clubs evaluating club-level development track record
+
+**USARank:**
+- How it works: Proprietary algorithm ranking teams from tournament results collected exclusively through SincSports-managed events. Teams are placed into six color tiers (Gold through Green). Updated weekly.
+- Strengths: Broad state and age group coverage (U08-U19), free, tier system gives quick competitive context
+- Limitations: Tournament data only — no league play (ECNL, MLS NEXT, GA results excluded), only SincSports-managed events count (same platform lock-in problem as GotSport but a different silo), methodology page is inaccessible (returns 403), teams can selectively report results (report wins, omit losses), team identity fragmentation across tournaments, near-zero community discussion or independent reviews
+- Best for: Teams that play primarily in SincSports-managed tournaments
+
+**TopDrawerSoccer:**
+- How it works: National Top 25 team rankings per age group (U13-U18) prioritizing league results over tournaments. Younger age groups (U13-U15) are roster-based approximations rather than result-driven. Monthly updates.
+- Strengths: Strong college recruiting ecosystem (player rankings, commitment tracker, ~2,500 college coaches visit daily), no pay-to-rank for team rankings, transparent ranking criteria
+- Limitations: National Top 25 only (irrelevant for most club teams), ECNL bias in player evaluations noted on forums, younger age group rankings not results-driven, player rankings partially paywalled ($99/yr)
+- Best for: High-school-aged players and families navigating the college recruiting process
+
+**"How to Use Rankings Wisely" section (`## How to Use Rankings Wisely`):**
+- Rankings are one data point, not the final word on a team's quality
+- No ranking system captures coaching quality, player development culture, team chemistry, or the intangibles that make a club the right fit for your child
+- Use multiple ranking sources to triangulate — if a team ranks well across multiple independent systems, that signal is stronger than any single ranking
+- Watch games yourself. Talk to other parents. Rankings can tell you who's winning, but not how they're developing players.
+
+**Closing CTA:**
+```markdown
+> **Want to see where your team stands?** [Check your team's ranking on PitchRank](/rankings) — updated every Monday with real game results.
+```
+
+- [ ] **Step 3: Verify the MDX file parses correctly**
+
+```bash
+cd C:/PitchRank/frontend && npx tsc --noEmit --pretty 2>&1 | head -10
+```
+
+And verify the blog post appears in the blog listing by checking the dev server at `/blog`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/PitchRank && git add frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx && git commit -m "feat(blog): add 'Best Youth Soccer Ranking Websites for Parents (2026)'
+
+Objective comparison of PitchRank, GotSport, SoccerWire, USARank, and
+TopDrawerSoccer with verified research. Targets parent-04 GEO query."
+```
+
+---
+
+## Task 6: Register blog post FAQs and regenerate llms.txt
+
+**Files:**
+- Modify: `frontend/lib/blog-faqs.ts`
+- Run: `frontend/scripts/generate-llms-txt.ts`
+
+- [ ] **Step 1: Read blog-faqs.ts to find insertion point**
+
+Read `frontend/lib/blog-faqs.ts` and find the section pattern (state pillars are alphabetical, others follow).
+
+- [ ] **Step 2: Add FAQ entries for the new blog post**
+
+Add this entry to `BLOG_FAQS` in `frontend/lib/blog-faqs.ts`. Place it after the state pillar section, in the general/educational section (follow existing ordering pattern):
+
+```typescript
+  'best-youth-soccer-ranking-websites-2026': [
+    {
+      question: 'Which youth soccer ranking site is most accurate?',
+      answer:
+        'Accuracy depends on data breadth and methodology. Sites that use head-to-head game results and strength-of-schedule weighting (like PitchRank) tend to be more predictive than placement-based systems. The most reliable approach is to cross-reference multiple ranking sources — if a team ranks well across independent systems, that signal is stronger than any single ranking.',
+    },
+    {
+      question: 'Are youth soccer rankings free?',
+      answer:
+        'Most youth soccer ranking sites offer free access to team rankings. PitchRank, GotSport, SoccerWire, and USARank are all free to view. TopDrawerSoccer offers free team rankings but charges $99/year for detailed player rankings and recruiting tools.',
+    },
+    {
+      question: 'Why do different ranking sites show different results?',
+      answer:
+        'Each ranking site uses a different methodology and data source. GotSport only counts its own tournaments, SoccerWire ranks clubs not teams, and TopDrawerSoccer covers only the national Top 25. Different inputs and algorithms produce different outputs. This is why cross-referencing multiple sources gives a more complete picture.',
+    },
+    {
+      question: 'Should I choose a club based on rankings?',
+      answer:
+        'Rankings should be one factor among many. They can tell you about competitive strength and schedule quality, but they cannot measure coaching philosophy, player development culture, playing time, or whether a club is the right fit for your child. Use rankings to narrow your search, then visit practices, talk to coaches, and speak with other families.',
+    },
+  ],
+```
+
+- [ ] **Step 3: Regenerate llms.txt**
+
+```bash
+cd C:/PitchRank/frontend && npx tsx scripts/generate-llms-txt.ts
+```
+
+Verify `public/llms.txt` now includes the new blog post.
+
+- [ ] **Step 4: Verify no TypeScript errors**
+
+```bash
+cd C:/PitchRank/frontend && npx tsc --noEmit --pretty 2>&1 | head -10
+```
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/PitchRank && git add frontend/lib/blog-faqs.ts frontend/public/llms.txt && git commit -m "feat(seo): add blog FAQs for ranking comparison post + regenerate llms.txt
+
+4 FAQ entries for 'best-youth-soccer-ranking-websites-2026' slug.
+llms.txt updated with new blog post."
+```
+
+---
+
+## Task 7: Visual verification of blog post
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Verify blog post renders on dev server**
+
+Open `http://localhost:3000/blog/best-youth-soccer-ranking-websites-2026` and verify:
+- Title renders correctly
+- Comparison table renders (check all 5 rows)
+- All per-site sections render with proper headings
+- Internal links to `/methodology` and `/rankings` work
+- No console errors
+
+- [ ] **Step 2: Verify structured data**
+
+View page source and check:
+- `BlogPosting` JSON-LD is present with correct title, date, author
+- `FAQPage` JSON-LD is present with 4 questions
+- `BreadcrumbList` JSON-LD shows Blog > Best Youth Soccer Ranking Websites for Parents (2026)
+
+- [ ] **Step 3: Verify blog listing page**
+
+Open `http://localhost:3000/blog` and verify the new post appears in the listing with correct title, excerpt, and date.
+
+- [ ] **Step 4: Check mobile rendering**
+
+Resize to 375px. Verify:
+- Comparison table scrolls horizontally or stacks (depending on existing blog table styles)
+- All sections readable
+- No overflow

--- a/docs/superpowers/specs/2026-05-26-methodology-rewrite-and-parent-comparison-post.md
+++ b/docs/superpowers/specs/2026-05-26-methodology-rewrite-and-parent-comparison-post.md
@@ -1,0 +1,232 @@
+# Methodology Page Rewrite + Parent Comparison Blog Post
+
+**Status**: Approved
+**Owner**: Dallas Heidt + Claude Code
+**Date**: 2026-05-26
+**Goal**: Close GEO methodology citation gap (Gemini 20% → target 60%+) and capture parent-04 query ("best app/website for tracking youth soccer performance")
+
+---
+
+## Context
+
+### GEO Baseline (May 13 → May 26)
+- Methodology category: weakest at 2/5 web visibility (Gemini 1/5, OpenAI 3/5 on May 13)
+- Persistent misses: method-03 (sparse schedules), info-04 (cross-league comparison)
+- The `/methodology` page already exists with ~400 lines, 11 FAQ items, Article + FAQPage JSON-LD, and nav links
+- This is a rewrite, not a new page
+
+### SEO Performance
+- 3,235 clicks/mo (up from ~250/mo baseline, 65% of 5,000/mo target)
+- 219 ranking pages now indexed (up from 71 one month ago)
+- Indexation bottleneck still active: ~910 pages "Discovered, not indexed"
+
+---
+
+## Deliverable 1: Methodology Page Full Rewrite
+
+### Approach
+Single-page rewrite of `MethodologySection.tsx`. Same URL (`/methodology`), new information architecture with deeper content targeting GEO methodology gaps.
+
+### New Information Architecture
+
+**Section 1: Hero / Introduction**
+- Heading: "How PitchRank Rankings Work" (more searchable than "PitchRank Methodology")
+- Brief positioning: two-part rating system, fairest rankings in the country
+- 2-3 sentences max
+
+**Section 2: Where Our Data Comes From** *(new)*
+- Game data sources: GotSport tournaments, league results, showcases, cross-state events
+- How games are verified and deduplicated
+- Coverage scope: 50 states, U10-U19, boys and girls
+- Number of teams tracked (pull from DB at build time or use a rounded figure)
+- Why broad data sourcing matters (vs platform-locked systems)
+- Target: E-E-A-T evidence density for AI citation
+
+**Section 3: The Core Rating Engine** *(expanded)*
+- Same 6 factors: opponent quality, competitiveness, SOS, offense/defense, recency, stability
+- Each factor gets 2-3 sentences instead of 1
+- Add "why this matters" framing per factor
+- Do NOT mention "Glicko-2" by name — use "rating engine" / "rating algorithm"
+
+**Section 4: Cross-League Strength Calibration** *(new, targets method-02/04)*
+- How teams from different leagues (ECNL, GA, state leagues, independent) are compared fairly
+- League-strength multipliers concept (without exposing exact values)
+- Tournament cross-pollination: how inter-league play tightens the network
+- The network effect: more games = more accurate cross-league comparison
+- Convergence: how the system gets sharper as the season progresses
+
+**Section 5: How We Handle Teams With Few Games** *(expanded, targets method-03)*
+- Current page has 2 sentences — expand to a full section
+- Conservative starting point for new teams
+- Confidence widening: uncertainty is high with few games, decreases with more data
+- Minimum games threshold before ranked (MIN_GAMES=9, but don't expose the exact number — say "a minimum number of verified games")
+- How uncertainty affects ranking position vs rating
+- Why this prevents inflated or deflated placements
+
+**Section 6: The Machine Learning Layer** *(restructured)*
+- Same concept: overperformance vs underperformance detection
+- Tighter copy, add concrete example of what "overperformance" means
+- How the adjustment is bounded (intentionally small)
+- What this catches that the core engine alone doesn't
+
+**Section 7: How It All Comes Together**
+- PowerScore composition (core + ML adjustment)
+- Do NOT include tier thresholds
+- The final ranking is a blend of statistical strength and trend detection
+
+**Section 8: Update Cadence & Freshness** *(merged)*
+- Monday refresh cycle
+- What triggers recalculation
+- How quickly new games flow in (daily scraping → Monday ranking run)
+- Freshness signal for AI engines (dateModified updates)
+
+**Section 9: Frequently Asked Questions** *(expanded to ~15)*
+Keep existing 11 FAQs, add 4 new ones:
+1. "How does PitchRank compare teams across different leagues?" — targets method-02/04
+2. "How accurate are rankings for teams that have only played a few games?" — targets method-03
+3. "Where does PitchRank get its game data?" — targets data sourcing queries
+4. "Can teams from different states be compared fairly?" — targets cross-state queries
+
+**Section 10: The PitchRank Promise** *(kept)*
+- Closing CTA, same tone
+
+### Structured Data Updates
+- `FAQSchema.tsx`: Add 4 new questions (total: 15)
+- `MethodologySchema.tsx`: Update `dateModified` to current date
+- Consider adding `HowTo` schema for "how rankings are calculated" (targets method queries in Google featured snippets)
+
+### Content Rules
+- No "Glicko-2" by name anywhere
+- No PowerScore tier thresholds
+- No exact formula weights or parameters
+- Use "rating engine" / "rating algorithm" / "our system"
+- Use "group" not "cohort" in any user-facing text
+- Tone: authoritative but accessible to parents, not academic
+
+### Files Modified
+- `frontend/components/MethodologySection.tsx` — full rewrite
+- `frontend/components/FAQSchema.tsx` — add 4 new FAQ items
+- `frontend/components/MethodologySchema.tsx` — update dateModified
+- `frontend/app/methodology/page.tsx` — update metadata (title, description) if needed
+
+---
+
+## Deliverable 2: Parent Comparison Blog Post
+
+### Target Query
+- parent-04: "best app/website for tracking youth soccer performance"
+- Related: "youth soccer ranking websites", "best youth soccer rankings"
+
+### Format
+- MDX blog post at `frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx`
+- Register in `frontend/content/blog-posts.tsx`
+
+### Title
+"Best Youth Soccer Ranking Websites for Parents (2026)"
+
+### Tone
+Objective comparison — genuine pros/cons for each site. PitchRank is featured but not the only recommendation. Builds trust + E-E-A-T.
+
+### Structure
+
+**1. Introduction (2-3 paragraphs)**
+- Why rankings matter for parents navigating club soccer
+- What to look for in a ranking site (methodology transparency, data breadth, update frequency)
+- Brief overview of the landscape
+
+**2. Comparison Table**
+Quick-scan table with columns: Site, What It Ranks, Methodology, Coverage, Cost, Best For
+
+**3. Per-Site Breakdown (verified research)**
+
+Each site gets a subsection with:
+- What it does (1-2 sentences)
+- How it works (methodology summary)
+- Strengths (bulleted)
+- Limitations (bulleted)
+- Best for (1 sentence)
+
+Sites to cover (in this order):
+
+**PitchRank** (pitchrank.io)
+- What: Individual team rankings, all competitive teams, all 50 states, U10-U19
+- Methodology: Two-part rating engine (core algorithm + ML trend detection), head-to-head results, SOS-weighted
+- Strengths: Algorithmic/head-to-head (not placement-based), broad data sourcing (not locked to one platform), weekly updates, free, transparent methodology page, cross-state comparison
+- Limitations: Newer platform (smaller brand recognition), minimum games threshold means new teams take time to appear
+- Best for: Parents who want data-driven, head-to-head rankings for any competitive team
+
+**GotSport** (rankings.gotsport.com)
+- What: Individual team rankings, 100K+ teams, U10-U19
+- Methodology: Placement + bonus points from GotSport-hosted tournaments; flight value based on top-5 team percentile
+- Strengths: Largest dataset, free, integrated with tournament registration, mobile apps (Team App + Live)
+- Limitations: Only counts GotSport-hosted tournaments (platform lock-in); placement-heavy not head-to-head; rewards tournament quantity over quality; geographic advantage for areas with more GotSport events; community consensus is poor predictive accuracy
+- Best for: Parents already using GotSport for tournament registration who want a quick glance at relative standing
+- Sources: GotSport Support docs, SoccerWire analysis, SoCalSoccer/BigSoccer forum threads
+
+**SoccerWire** (soccerwire.com)
+- What: Top 100 club rankings (not individual teams), U13-U19
+- Methodology: League PPG + playoffs + national team call-ups + pro signings; ECNL/MLS NEXT/GA only
+- Strengths: Development-oriented philosophy, rewards clubs producing national-level players, free, news/recruiting content
+- Limitations: Club-level only (can't find your U14 team's rank); only covers elite national leagues (irrelevant for state/USYS leagues); monthly updates; paid player profiles criticized as pay-to-promote on forums
+- Best for: Parents at elite clubs (ECNL/MLS NEXT) who want to evaluate club-level development track record
+- Sources: SoccerWire formula page, SoCalSoccer forum threads
+
+**USARank** (usarank.com)
+- What: Individual team rankings, all states, U08-U19, six color tiers
+- Methodology: Proprietary algorithm, tournament-only data from SincSports-managed events, weekly updates
+- Strengths: Broad state/age coverage, free, tier system for quick context
+- Limitations: Tournament-only data (no league play — ECNL/MLS NEXT/GA excluded); SincSports platform lock-in (same structural flaw as GotSport, different silo); selective reporting (teams can omit losses); team identity fragmentation across tournaments; opaque methodology (about page returns 403); near-zero community discussion/adoption; team detail pages inaccessible
+- Best for: Teams that play primarily in SincSports-managed tournaments
+- Sources: SincSports service page, GA Soccer Forum, SoCalSoccer forum
+
+**TopDrawerSoccer** (topdrawersoccer.com)
+- What: National Top 25 team rankings per age group (U13-U18), plus player rankings
+- Methodology: League results prioritized over tournaments; A/B tournament tiers; younger age groups are roster-based approximations
+- Strengths: Strong college recruiting ecosystem (~2,500 coaches visit daily), no pay-to-rank for team rankings, monthly updates with transparent criteria
+- Limitations: National Top 25 only (irrelevant for most club teams); ECNL bias in player evaluations (per forum users); younger age groups not results-driven; player rankings partially paywalled ($99/yr)
+- Best for: High-school-aged players/families navigating college recruiting
+- Sources: TDS methodology page, Wikipedia, SoCalSoccer forum
+
+**4. How to Use Rankings Wisely (2-3 paragraphs)**
+- Rankings are one input, not the final word
+- No system captures coaching quality, player development trajectory, or team culture
+- Use multiple sources and watch games yourself
+
+**5. FAQ (3-4 items with JSON-LD)**
+- "Which youth soccer ranking site is most accurate?"
+- "Are youth soccer rankings free?"
+- "Why do different ranking sites show different results?"
+- "Should I choose a club based on rankings?"
+
+### Structured Data
+- `BlogPosting` JSON-LD with author entity
+- `FAQPage` JSON-LD for the 4 FAQ items
+- Internal links to `/methodology` and `/rankings`
+
+### Content Rules
+- All competitor claims must be verified from the research (no fabrication)
+- Link to source material where appropriate (GotSport support docs, SoccerWire formula page, etc.)
+- No "Glicko-2" by name
+- No PowerScore tier thresholds
+- Use "group" not "cohort"
+- Tone: helpful parent resource, not marketing copy
+
+### Files Created/Modified
+- `frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx` — new MDX blog post
+- `frontend/content/blog-posts.tsx` — register new post
+- `frontend/scripts/generate-llms-txt.ts` — regenerate llms.txt after new content
+
+---
+
+## Out of Scope
+- ECNL/NAL/MLS Next comparison landing page (info-05 gap) — separate future work
+- `/authors/dallas-heidt` founder page (brand-04 gap) — separate future work
+- Programmatic ranking page content changes
+- Any ranking engine or database changes
+
+## Success Criteria
+- `/methodology` page passes Lighthouse SEO audit (90+)
+- All 15 FAQ items render in FAQPage JSON-LD (validate via Rich Results Test)
+- Blog post registers in sitemap and is submitted to GSC
+- Re-run GEO 20-prompt panel 4 weeks after publish; methodology category improves from 2/5 to 3+/5
+- Blog post appears in GSC impressions within 2 weeks for "best youth soccer ranking" queries

--- a/frontend/app/methodology/page.tsx
+++ b/frontend/app/methodology/page.tsx
@@ -6,16 +6,16 @@ import type { Metadata } from 'next';
 import { BASE_URL } from '@/lib/constants';
 
 export const metadata: Metadata = {
-  title: 'Methodology',
+  title: 'How Our Rankings Work',
   description:
-    'Learn how PitchRank calculates youth soccer team rankings and power scores using cross-age game support, unified scoring, and data-driven analytics.',
+    'How PitchRank calculates youth soccer team rankings using opponent quality, cross-league strength calibration, and machine-learning trend detection. Updated weekly with game data from all 50 states.',
   alternates: {
     canonical: `${BASE_URL}/methodology`,
   },
   openGraph: {
-    title: 'Ranking Methodology | PitchRank',
+    title: 'How PitchRank Youth Soccer Rankings Work',
     description:
-      'Learn how PitchRank calculates youth soccer team rankings and power scores using data-driven analytics.',
+      'How PitchRank calculates youth soccer team rankings using data-driven analytics, cross-league calibration, and ML trend detection.',
     url: `${BASE_URL}/methodology`,
     siteName: 'PitchRank',
     type: 'website',
@@ -24,14 +24,14 @@ export const metadata: Metadata = {
         url: '/logos/pitchrank-wordmark.svg',
         width: 1200,
         height: 630,
-        alt: 'PitchRank Methodology',
+        alt: 'How PitchRank Rankings Work',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ranking Methodology | PitchRank',
-    description: 'Learn how PitchRank calculates youth soccer team rankings and power scores.',
+    title: 'How PitchRank Youth Soccer Rankings Work',
+    description: 'How PitchRank calculates youth soccer rankings with cross-league calibration and ML trend detection.',
     images: ['/logos/pitchrank-wordmark.svg'],
   },
 };
@@ -40,9 +40,9 @@ export default function MethodologyPage() {
   return (
     <div className="container mx-auto py-8 px-4">
       <BreadcrumbSchema items={[{ name: 'Methodology', href: '/methodology' }]} />
-      <MethodologySchema datePublished="2026-04-30T00:00:00Z" dateModified="2026-04-30T00:00:00Z" />
+      <MethodologySchema datePublished="2026-04-30T00:00:00Z" dateModified="2026-05-26T00:00:00Z" />
       <PageHeader
-        title="Ranking Methodology"
+        title="How Our Rankings Work"
         description="Understanding how PitchRank calculates team rankings and power scores"
         showBackButton
         backHref="/"

--- a/frontend/components/FAQSchema.tsx
+++ b/frontend/components/FAQSchema.tsx
@@ -97,6 +97,38 @@ export function FAQSchema() {
           text: "One of PitchRank's biggest strengths is how quickly the system builds connections. Tournaments across different states, national events, and cross-regional play all tie together to create a nationally interconnected ranking ecosystem.",
         },
       },
+      {
+        '@type': 'Question',
+        name: 'How does PitchRank compare teams across different leagues?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'PitchRank calibrates league strength automatically using cross-league game results. When teams from different leagues (ECNL, GA, state leagues, independent clubs) meet at tournaments, those head-to-head results anchor cross-league comparisons. The more inter-league games played, the more accurate these comparisons become across the entire ranking network.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How accurate are rankings for teams that have only played a few games?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: "Rankings for newer teams carry wider uncertainty. PitchRank requires a minimum number of verified games before a team appears in official rankings. Even after that threshold, a team's rating stabilizes further with each additional game against rated opponents. Early-season rankings should be treated as directional rather than definitive.",
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Where does PitchRank get its game data?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'PitchRank collects verified game results from tournaments, leagues, showcases, and cross-state events across all 50 states. The data pipeline pulls from multiple sources and is not locked to any single tournament platform, providing broader coverage than platform-specific ranking systems. Results are ingested daily and rankings recalculate every Monday.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Can teams from different states be compared fairly?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: "Yes. Cross-state tournaments and national events create direct connections between state ecosystems. When an Arizona team plays in a California tournament, that result bridges both states' rankings. The more cross-state play occurs, the more accurate interstate comparisons become throughout the season.",
+        },
+      },
     ],
   };
 

--- a/frontend/components/MethodologySchema.tsx
+++ b/frontend/components/MethodologySchema.tsx
@@ -14,9 +14,9 @@ export function MethodologySchema({ datePublished, dateModified }: MethodologySc
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'Article',
-    headline: 'PitchRank Ranking Methodology',
+    headline: 'How PitchRank Youth Soccer Rankings Work',
     description:
-      'How PitchRank calculates youth soccer team rankings and PowerScores using opponent quality, schedule strength, and machine-learning trend detection.',
+      'How PitchRank calculates youth soccer team rankings using opponent quality, cross-league strength calibration, schedule strength, and machine-learning trend detection. Updated weekly with verified game data from all 50 states.',
     url: pageUrl,
     datePublished,
     dateModified,

--- a/frontend/components/MethodologySection.tsx
+++ b/frontend/components/MethodologySection.tsx
@@ -8,7 +8,6 @@ import {
   Calendar,
   Globe,
   UserPlus,
-  Eye,
   HelpCircle,
   Target,
   CheckCircle,
@@ -17,22 +16,28 @@ import {
   Activity,
   Clock,
   Anchor,
+  Database,
+  MapPin,
+  Scale,
 } from 'lucide-react';
 
 /**
  * MethodologySection component - explains the PitchRank ranking methodology
+ *
+ * 10-section layout covering data sourcing, core engine, cross-league calibration,
+ * sparse-schedule handling, ML layer, synthesis, cadence, FAQ, and promise.
  */
 export function MethodologySection() {
   return (
     <>
       <FAQSchema />
       <div className="space-y-8">
-        {/* Introduction */}
+        {/* Section 1 — Hero */}
         <Card variant="primary">
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
               <Star className="size-6 text-accent" />
-              PitchRank Methodology
+              How PitchRank Rankings Work
             </h2>
             <CardDescription className="text-base">
               Creating the fairest, most accurate youth soccer rankings in the country
@@ -40,26 +45,95 @@ export function MethodologySection() {
           </CardHeader>
           <CardContent>
             <p className="text-muted-foreground leading-relaxed">
-              PitchRank was built for one purpose: to create the fairest, most accurate youth soccer rankings in the
-              country. We do that using a two-part rating system that looks at every game from multiple angles while
-              staying stable, consistent, and extremely hard to manipulate.
+              PitchRank uses a two-part rating system that analyzes every game from multiple angles — opponent quality,
+              competitiveness, schedule strength, and performance trends. The result is a ranking that&apos;s stable,
+              consistent, and extremely hard to manipulate. Whether your team plays in a top national league or a
+              competitive state circuit, the system evaluates you on the same terms.
             </p>
           </CardContent>
         </Card>
 
-        {/* Part 1: Core Rating Engine */}
+        {/* Section 2 — Where Our Data Comes From */}
+        <Card>
+          <CardHeader>
+            <h2 className="leading-none font-semibold flex items-center gap-3">
+              <Database className="size-6 text-primary" />
+              Where Our Data Comes From
+            </h2>
+            <CardDescription>The foundation of accurate rankings is comprehensive data</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <p className="text-muted-foreground leading-relaxed">
+              Accurate rankings start with accurate data. PitchRank collects verified game results from tournaments,
+              league play, showcases, and cross-state events — pulling from multiple platforms so we&apos;re never
+              locked to a single data source. This gives us broader coverage than any platform-specific ranking system.
+            </p>
+
+            <div className="grid gap-4">
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Globe className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Multi-Source Collection
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    Game results from tournaments, league play, showcases, and cross-state events. Not locked to any
+                    single platform — we pull from wherever competitive youth soccer is played.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Shield className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Verification & Deduplication
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    Every game result is verified and deduplicated to prevent double-counting. When a game appears in
+                    multiple data sources, we reconcile it into a single clean record.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <MapPin className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">Coverage</h4>
+                  <p className="text-sm text-muted-foreground">
+                    All 50 states, U10 through U19, boys and girls. Thousands of competitive teams tracked across the
+                    country.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Activity className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">Daily Ingestion</h4>
+                  <p className="text-sm text-muted-foreground">
+                    New game results flow in daily as tournaments and leagues report scores. The data pipeline never
+                    stops.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Section 3 — The Core Rating Engine */}
         <Card>
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
               <Brain className="size-6 text-primary" />
-              Part 1: The Core Rating Engine
+              The Core Rating Engine
             </h2>
             <CardDescription>The foundation of every PitchRank score</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
             <p className="text-muted-foreground leading-relaxed">
-              At the heart of PitchRank is a powerful engine that understands the game the way coaches do — by looking
-              deeper than scores. Here&apos;s what it takes into account:
+              At the heart of PitchRank is a powerful rating engine that understands the game the way coaches do — by
+              looking deeper than scores. Here&apos;s what it takes into account:
             </p>
 
             <div className="grid gap-4">
@@ -70,8 +144,9 @@ export function MethodologySection() {
                     Quality of Opponents
                   </h4>
                   <p className="text-sm text-muted-foreground">
-                    Your results are measured through the lens of who you played. Beat a top team? That matters. Roll
-                    over a struggling one? Not as much.
+                    Your results are measured through the lens of who you played. A win against a top-10 team in your
+                    state carries far more weight than a win against an unranked opponent. This prevents teams from
+                    inflating their record against weak competition.
                   </p>
                 </div>
               </div>
@@ -83,7 +158,8 @@ export function MethodologySection() {
                     How Competitive You Were
                   </h4>
                   <p className="text-sm text-muted-foreground">
-                    A 1–0 battle against a powerhouse says more than a 10–0 cruise.
+                    A 1–0 battle against a powerhouse says more than a 10–0 cruise. The system evaluates the margin and
+                    context of each result, not just wins and losses.
                   </p>
                 </div>
               </div>
@@ -92,10 +168,12 @@ export function MethodologySection() {
                 <TrendingUp className="size-5 text-primary mt-0.5 shrink-0" />
                 <div>
                   <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
-                    Strength of Schedule (SOS)
+                    Strength of Schedule
                   </h4>
                   <p className="text-sm text-muted-foreground">
-                    Your record is only half the story. Who you earned it against is the rest.
+                    Your record is only half the story. Who you earned it against is the rest. Two teams can have
+                    identical records, but if one earned theirs against nationally-ranked opponents and the other played
+                    only local recreation teams, their ratings will reflect that difference.
                   </p>
                 </div>
               </div>
@@ -107,7 +185,8 @@ export function MethodologySection() {
                     Offensive & Defensive Behavior
                   </h4>
                   <p className="text-sm text-muted-foreground">
-                    Your performance patterns matter — not just the scoreboard.
+                    Your performance patterns matter — not just the scoreboard. Teams that consistently create scoring
+                    opportunities and limit opponents earn recognition beyond the final score.
                   </p>
                 </div>
               </div>
@@ -117,7 +196,9 @@ export function MethodologySection() {
                 <div>
                   <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">Recency</h4>
                   <p className="text-sm text-muted-foreground">
-                    Yesterday&apos;s form matters more than last season&apos;s form.
+                    Yesterday&apos;s form matters more than last season&apos;s form. Recent games carry more weight, so
+                    a team on a hot streak will see that reflected in their rating faster than in systems that weight
+                    all games equally.
                   </p>
                 </div>
               </div>
@@ -127,7 +208,8 @@ export function MethodologySection() {
                 <div>
                   <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">Stability</h4>
                   <p className="text-sm text-muted-foreground">
-                    Consistent teams get recognized. Fluky results don&apos;t define you.
+                    Consistent teams get recognized. Fluky results don&apos;t define you. The system is designed to
+                    reward sustained performance over a string of games, not overreact to a single upset.
                   </p>
                 </div>
               </div>
@@ -142,49 +224,196 @@ export function MethodologySection() {
           </CardContent>
         </Card>
 
-        {/* Part 2: Machine Learning Layer */}
+        {/* Section 4 — Cross-League Strength Calibration */}
+        <Card>
+          <CardHeader>
+            <h2 className="leading-none font-semibold flex items-center gap-3">
+              <Scale className="size-6 text-primary" />
+              Cross-League Strength Calibration
+            </h2>
+            <CardDescription>Comparing teams fairly across different leagues and platforms</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <p className="text-muted-foreground leading-relaxed">
+              Teams play in different leagues — ECNL, GA, state leagues, independent clubs. Comparing across them
+              requires calibration. Our system handles this automatically by using cross-league games as calibration
+              anchors.
+            </p>
+
+            <div className="grid gap-4">
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <TrendingUp className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    League-Strength Calibration
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    The system recognizes that leagues vary in overall competitiveness and adjusts accordingly. A strong
+                    record in an elite league means more than the same record in a less competitive one.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Globe className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Tournament Cross-Pollination
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    When teams from different leagues meet at tournaments, those head-to-head results directly calibrate
+                    cross-league strength. These matchups are the anchors that connect separate ecosystems.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Link className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    The Network Effect
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    The more cross-league games played, the more accurate comparisons become. By mid-season, even teams
+                    that have never played each other can be compared through chains of shared opponents.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Target className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Seasonal Convergence
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    Early-season rankings have wider uncertainty because teams haven&apos;t played enough cross-league
+                    games. As the season progresses and more connections form, the system gets sharper and more
+                    confident.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Section 5 — How We Handle Teams With Few Games */}
+        <Card>
+          <CardHeader>
+            <h2 className="leading-none font-semibold flex items-center gap-3">
+              <UserPlus className="size-6 text-primary" />
+              How We Handle Teams With Few Games
+            </h2>
+            <CardDescription>Fair treatment for new and developing teams</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <p className="text-muted-foreground leading-relaxed">
+              Every team starts somewhere. Our system is designed to give new and light-data teams a fair runway without
+              inflating or penalizing them before enough evidence exists.
+            </p>
+
+            <div className="grid gap-4">
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Shield className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Conservative Starting Point
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    New teams begin with a neutral rating — not inflated, not penalized. This means they won&apos;t
+                    appear artificially high or low before enough games have been played.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <Activity className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Confidence & Uncertainty
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    With fewer games, the system assigns wider uncertainty to a team&apos;s rating. The rating exists
+                    but carries less confidence. As more games are played against rated opponents, that uncertainty
+                    narrows.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <CheckCircle className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Minimum Games Threshold
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    Teams need a minimum number of verified games before appearing in official rankings. This prevents a
+                    single fluky result from producing a misleading placement.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 p-4 rounded-lg bg-muted/50">
+                <TrendingUp className="size-5 text-primary mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-1">
+                    Gradual Convergence
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    As a team plays more games against rated opponents, their rating stabilizes and their ranking
+                    becomes increasingly reliable. There are no shortcuts — the system rewards evidence.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Section 6 — The Machine Learning Layer */}
         <Card>
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
               <Cpu className="size-6 text-primary" />
-              Part 2: The Machine Learning Layer
+              The Machine Learning Layer
             </h2>
             <CardDescription>The &quot;smarts&quot; that identify rising teams</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="text-muted-foreground leading-relaxed">
-              Once we understand how strong a team is, our system evaluates how a team is trending. This is where
-              machine learning comes in.
-            </p>
-
-            <p className="text-muted-foreground leading-relaxed">
-              It looks at every game and asks:{' '}
+              Once core strength is established, the ML layer evaluates how a team is trending. It asks:{' '}
               <em>&quot;Given what we know about both teams… did this result feel expected, or surprising?&quot;</em>
             </p>
 
             <div className="space-y-3 my-4">
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                <TrendingUp className="size-5 text-green-600 shrink-0" />
+              <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
+                <TrendingUp className="size-5 text-green-600 shrink-0 mt-0.5" />
                 <p className="text-sm text-foreground">
-                  If a team consistently <strong>overperforms</strong> expectations → they&apos;re climbing.
+                  If a team consistently <strong>overperforms</strong> expectations → they&apos;re climbing. For
+                  example, if a team rated #30 in their state consistently beats teams rated #10–#15, the ML layer
+                  detects that pattern and adjusts their rating upward — even before they&apos;ve played enough games
+                  for the core engine to catch up.
                 </p>
               </div>
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-                <Activity className="size-5 text-red-600 shrink-0" />
+              <div className="flex items-start gap-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+                <Activity className="size-5 text-red-600 shrink-0 mt-0.5" />
                 <p className="text-sm text-foreground">
-                  If they regularly <strong>underperform</strong> → the system takes notice.
+                  If they regularly <strong>underperform</strong> → the system takes notice and adjusts accordingly.
                 </p>
               </div>
             </div>
 
             <p className="text-muted-foreground leading-relaxed">
-              This adjustment is intentionally small, but incredibly powerful. It helps surface underrated teams — and
-              filter out misleading results.
+              The ML adjustment is intentionally small — it fine-tunes rather than overrides. A massive upset in a
+              single game won&apos;t swing a rating, but a consistent pattern of exceeding expectations will.
+            </p>
+
+            <p className="text-muted-foreground leading-relaxed">
+              The core engine measures where a team has been. The ML layer anticipates where they&apos;re going.
             </p>
           </CardContent>
         </Card>
 
-        {/* How It All Comes Together */}
+        {/* Section 7 — How It All Comes Together */}
         <Card variant="accent">
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
@@ -206,7 +435,10 @@ export function MethodologySection() {
               </div>
             </div>
 
-            <p className="text-muted-foreground leading-relaxed">This blend creates a ranking that&apos;s:</p>
+            <p className="text-muted-foreground leading-relaxed">
+              The final PowerScore is a single number that captures both proven strength and emerging trajectory. This
+              blend creates a ranking that&apos;s:
+            </p>
 
             <ul className="grid sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
               <li className="flex items-center gap-2">
@@ -230,24 +462,21 @@ export function MethodologySection() {
                 Constantly learning as new games come in
               </li>
             </ul>
-
-            <p className="text-foreground font-medium mt-4">
-              It&apos;s the closest thing youth soccer has to a true rating system.
-            </p>
           </CardContent>
         </Card>
 
-        {/* Updated Every Monday */}
+        {/* Section 8 — Update Cadence & Data Freshness */}
         <Card>
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
               <Calendar className="size-6 text-primary" />
-              Updated Every Monday
+              Update Cadence & Data Freshness
             </h2>
           </CardHeader>
           <CardContent>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              Every Monday morning, the entire network refreshes:
+              Game results flow into our system daily as tournaments and leagues report scores. Every Monday morning,
+              the entire ranking network recalculates with the latest data.
             </p>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li className="flex items-center gap-2">
@@ -271,62 +500,7 @@ export function MethodologySection() {
           </CardContent>
         </Card>
 
-        {/* Connected Across States */}
-        <Card>
-          <CardHeader>
-            <h2 className="leading-none font-semibold flex items-center gap-3">
-              <Globe className="size-6 text-primary" />
-              Connected Across States, Leagues & Events
-            </h2>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground leading-relaxed">
-              One of PitchRank&apos;s biggest strengths is how quickly the system builds connections. Tournament in
-              Arizona meets tournament in Texas. Teams cross into California. National events tie everything together.
-            </p>
-            <p className="text-foreground font-medium mt-4">
-              The more teams play, the more accurate — and nationally interconnected — the entire ranking ecosystem
-              becomes.
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* New Teams */}
-        <Card>
-          <CardHeader>
-            <h2 className="leading-none font-semibold flex items-center gap-3">
-              <UserPlus className="size-6 text-primary" />
-              How We Handle New or Light-Data Teams
-            </h2>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground leading-relaxed">
-              New teams start conservatively, then rise as results come in. No inflated placements. No artificial
-              penalties. Just a fair runway to show who you really are.
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* Transparent But Proprietary */}
-        <Card>
-          <CardHeader>
-            <h2 className="leading-none font-semibold flex items-center gap-3">
-              <Eye className="size-6 text-primary" />
-              Transparent. But Proprietary.
-            </h2>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground leading-relaxed">
-              We tell you what matters — opponents, schedule strength, consistency, and performance trends — but we do
-              not share the exact formulas, weights, or internal parameters.
-            </p>
-            <p className="text-foreground font-medium mt-4">
-              That&apos;s our secret sauce. And it&apos;s what keeps PitchRank ahead of the curve.
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* FAQ */}
+        {/* Section 9 — Frequently Asked Questions */}
         <Card>
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">
@@ -368,10 +542,54 @@ export function MethodologySection() {
                 Yes — tap the Missing Games button and we&apos;ll automatically find and add them.
               </p>
             </div>
+
+            <div>
+              <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-2">
+                How does PitchRank compare teams across different leagues?
+              </h4>
+              <p className="text-sm text-muted-foreground">
+                Our system calibrates league strength automatically. When teams from different leagues meet at
+                tournaments, those head-to-head results anchor cross-league comparisons. The more inter-league games
+                played, the more accurate these comparisons become.
+              </p>
+            </div>
+
+            <div>
+              <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-2">
+                How accurate are rankings for teams that have only played a few games?
+              </h4>
+              <p className="text-sm text-muted-foreground">
+                Rankings for newer teams carry wider uncertainty. We require a minimum number of verified games before a
+                team appears in official rankings, and even then, their rating stabilizes further with each additional
+                game. Early-season rankings should be treated as directional, not definitive.
+              </p>
+            </div>
+
+            <div>
+              <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-2">
+                Where does PitchRank get its game data?
+              </h4>
+              <p className="text-sm text-muted-foreground">
+                We collect verified game results from tournaments, leagues, showcases, and cross-state events across all
+                50 states. Our data pipeline pulls from multiple sources — we are not locked to any single tournament
+                platform, which gives us broader coverage than platform-specific ranking systems.
+              </p>
+            </div>
+
+            <div>
+              <h4 className="font-display font-semibold uppercase tracking-wide text-sm mb-2">
+                Can teams from different states be compared fairly?
+              </h4>
+              <p className="text-sm text-muted-foreground">
+                Yes. Cross-state tournaments and national events create direct connections between state ecosystems. A
+                team from Arizona that plays in a California tournament creates a bridge that links both states&apos;
+                rankings. The more cross-state play, the more accurate interstate comparisons become.
+              </p>
+            </div>
           </CardContent>
         </Card>
 
-        {/* The PitchRank Promise */}
+        {/* Section 10 — The PitchRank Promise */}
         <Card variant="primary">
           <CardHeader>
             <h2 className="leading-none font-semibold flex items-center gap-3">

--- a/frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx
+++ b/frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx
@@ -1,0 +1,155 @@
+---
+title: 'Best Youth Soccer Ranking Websites for Parents (2026)'
+slug: 'best-youth-soccer-ranking-websites-2026'
+excerpt: 'An honest comparison of youth soccer ranking sites — PitchRank, GotSport, SoccerWire, USARank, and TopDrawerSoccer. What each one does, how they work, and which is right for your family.'
+author: 'PitchRank Team'
+date: '2026-05-26'
+readingTime: '10 min read'
+tags: ['Rankings', 'Educational', 'Parents', 'Comparison']
+keywords:
+  [
+    'best youth soccer rankings',
+    'youth soccer ranking websites',
+    'gotsport vs pitchrank',
+    'youth soccer rankings comparison',
+    'best youth soccer ranking site',
+  ]
+---
+
+# Best Youth Soccer Ranking Websites for Parents (2026)
+
+Your kid's coach says the team is "ranked #47." Another parent in the group chat says a different site shows them at #12. A third parent insists rankings don't matter at all. Which one should you trust?
+
+The truth is, not all ranking sites work the same way. Some rank individual teams, others rank entire clubs. Some use head-to-head game results, others use tournament placement. Some cover every competitive team in the country, others focus only on elite national leagues. Understanding these differences helps you make sense of the numbers.
+
+We reviewed five of the most widely used youth soccer ranking sites to help parents navigate the landscape. For each one, we explain how it works, what it covers, and who it's best for.
+
+## Quick Comparison
+
+| Site | What It Ranks | Data Source | Coverage | Cost | Best For |
+|------|--------------|-------------|----------|------|----------|
+| [PitchRank](https://pitchrank.io) | Individual teams | Multiple sources | U10-U19, 50 states | Free | Data-driven head-to-head rankings for any competitive team |
+| [GotSport](https://rankings.gotsport.com) | Individual teams | GotSport tournaments only | U10-U19, 100K+ teams | Free | Quick look if you already use GotSport |
+| [SoccerWire](https://www.soccerwire.com) | Clubs (Top 100) | ECNL/MLS NEXT/GA leagues | U13-U19, elite only | Free | Club-level development track record |
+| [USARank](https://usarank.com) | Individual teams | SincSports tournaments only | U08-U19, all states | Free | Teams in SincSports tournaments |
+| [TopDrawerSoccer](https://www.topdrawersoccer.com) | National Top 25 | ECNL/MLS NEXT leagues | U13-U18, national only | Partial ($99/yr) | College recruiting ecosystem |
+
+## PitchRank
+
+PitchRank ranks individual youth soccer teams across all 50 states, covering age groups U10 through U19 for both boys and girls.
+
+**How it works:** A two-part rating engine evaluates every game result through opponent quality, strength of schedule, competitiveness, and consistency. A machine learning layer detects teams that are trending up or down based on whether their results exceed or fall short of expectations. Rankings update every Monday with verified game data.
+
+**Strengths:**
+
+- Uses head-to-head game results, not tournament placement — your rating reflects who you actually beat
+- Pulls data from multiple sources, not locked to a single tournament platform
+- Transparent [methodology page](/methodology) explaining how rankings work
+- Free to use with no paywall
+- Cross-state comparison through tournament and national event connections
+- Weekly updates with daily data ingestion
+
+**Limitations:**
+
+- Newer platform with growing brand recognition compared to established sites
+- Teams need a minimum number of verified games before appearing in rankings
+
+**Best for:** Parents who want data-driven, result-based rankings for any competitive team in any state.
+
+> **See where your team stands:** [Check your team's ranking on PitchRank](/rankings)
+
+## GotSport
+
+GotSport (formerly GotSoccer) is the dominant tournament management platform in US youth soccer, with rankings covering 100,000+ teams.
+
+**How it works:** Teams earn points based on tournament placement. Each tournament flight gets a "Flight Value" based on the national ranking percentile of its top five teams. Champions earn 100% of that value, finalists 50%, semifinalists 25%. Points come primarily from GotSport-hosted events. A 20% team deduction is applied so higher-ranked teams need bigger results to gain points.
+
+**Strengths:**
+
+- Largest dataset in youth soccer — virtually every competitive tournament feeds into it
+- Free to view at [rankings.gotsport.com](https://rankings.gotsport.com)
+- Integrated with the registration platform most parents already use
+- Mobile apps available (GotSport Team App and GotSport Live)
+
+**Limitations:**
+
+- Only counts [GotSport-hosted tournaments](https://support.gotsport.com/what-are-the-gotsoccer-rankings) — non-GotSport events are excluded or inconsistently captured
+- Placement-based, not head-to-head — teams earn points from finishing above opponents they may never have played
+- Rewards tournament quantity over quality — teams near more GotSport events accumulate more points, creating a geographic advantage
+- Community consensus on soccer forums describes the rankings as having [poor predictive accuracy](https://www.bigsoccer.com/threads/got-soccer-rankings.1515559/) for actual game outcomes
+
+**Best for:** Parents already using GotSport for tournament registration who want a quick glance at relative standing.
+
+## SoccerWire
+
+SoccerWire publishes Top 100 club rankings — not individual team rankings — for boys and girls across U13-U19.
+
+**How it works:** Rankings use a proprietary "SoccerWire Points" system combining league standings on a points-per-game basis, league playoff results, national championship performance, and national team call-ups or verified pro signings within three years. Only elite national leagues count: ECNL, MLS NEXT, and Girls Academy. SoccerWire explicitly excludes tournament-based rankings like GotSport, arguing they reward short-term wins over player development.
+
+**Strengths:**
+
+- Development-oriented philosophy — rewards clubs producing national-level players and professional prospects, not just tournament wins
+- Free to view
+- Strong youth soccer news coverage alongside rankings
+
+**Limitations:**
+
+- Club-level only — you cannot find your specific U14 team's rank, only the overall club
+- Only covers elite national leagues — irrelevant if your club plays in state leagues, USYS, or smaller platforms
+- Monthly updates are less frequent than weekly alternatives
+
+**Best for:** Parents at ECNL or MLS NEXT clubs who want to evaluate a club's overall development track record.
+
+## USARank
+
+USARank, powered by SincSports, ranks individual teams across all states from U08 through U19, placing them into six color-coded tiers from Gold to Green.
+
+**How it works:** A proprietary algorithm ranks teams based on tournament results collected exclusively from SincSports-managed events. The system uses recency weighting so more recent games carry more influence. Updated weekly.
+
+**Strengths:**
+
+- Broad state and age group coverage (U08-U19, all 50 states)
+- Free to view
+- Tier system (Gold through Green) gives quick competitive context
+
+**Limitations:**
+
+- Tournament data only — no league play. ECNL, MLS NEXT, and Girls Academy results are excluded
+- Only SincSports-managed events count — tournaments on GotSport, Demosphere, or other platforms are invisible. Same platform lock-in problem as GotSport, just a different silo
+- Teams can selectively report results, with forum users noting that some teams report wins but omit losses
+- Team identity fragmentation — the same team may appear under different names across tournaments, making accurate tracking difficult
+- Methodology is not publicly documented — the about page was inaccessible during our research
+- Near-zero community discussion or independent reviews, suggesting low adoption among parents and coaches
+
+**Best for:** Teams that play primarily in SincSports-managed tournaments.
+
+## TopDrawerSoccer
+
+TopDrawerSoccer (TDS) is primarily a college soccer recruiting platform that also publishes national team and player rankings.
+
+**How it works:** National Top 25 team rankings per age group (U13-U18), updated monthly. The system prioritizes league results over tournaments and separates tournaments into A and B tiers. For younger age groups (U13-U15), rankings are described as roster-based approximations rather than purely result-driven. TDS also publishes detailed player rankings by graduating class.
+
+**Strengths:**
+
+- Strong college recruiting ecosystem — player rankings, commitment tracker, and recruiting guides with approximately 2,500 college coaches visiting daily
+- No pay-to-rank model for team rankings
+- Monthly updates with [transparent ranking criteria](https://www.topdrawersoccer.com/club-soccer-articles/how-we-do-the-rankings_aid19454)
+
+**Limitations:**
+
+- National Top 25 only — the vast majority of club teams are not ranked
+- ECNL bias in player evaluations has been noted on soccer forums, as local ECNL coaches contribute to rankings
+- Younger age group team rankings are roster-based, not results-driven
+- Player rankings are partially paywalled ($99/year for full access)
+
+**Best for:** High-school-aged players and families navigating the college recruiting process.
+
+## How to Use Rankings Wisely
+
+Rankings are one data point, not the final word on a team's quality. No ranking system — no matter how sophisticated — can capture coaching quality, player development culture, team chemistry, or the intangibles that make a club the right fit for your child.
+
+Use multiple ranking sources to triangulate. If a team ranks well across multiple independent systems using different methodologies, that signal is stronger than any single ranking.
+
+Watch games yourself. Talk to other parents. Visit practices. Rankings can tell you who is winning, but not how they are developing players. The best team for your child is the one that matches their ability level, gives them meaningful playing time, and challenges them to grow — regardless of what any ranking says.
+
+> **Want to see where your team stands?** [Check your team's ranking on PitchRank](/rankings) — updated every Monday with real game results.

--- a/frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx
+++ b/frontend/content/blog/best-youth-soccer-ranking-websites-2026.mdx
@@ -26,13 +26,13 @@ We reviewed five of the most widely used youth soccer ranking sites to help pare
 
 ## Quick Comparison
 
-| Site | What It Ranks | Data Source | Coverage | Cost | Best For |
-|------|--------------|-------------|----------|------|----------|
-| [PitchRank](https://pitchrank.io) | Individual teams | Multiple sources | U10-U19, 50 states | Free | Data-driven head-to-head rankings for any competitive team |
-| [GotSport](https://rankings.gotsport.com) | Individual teams | GotSport tournaments only | U10-U19, 100K+ teams | Free | Quick look if you already use GotSport |
-| [SoccerWire](https://www.soccerwire.com) | Clubs (Top 100) | ECNL/MLS NEXT/GA leagues | U13-U19, elite only | Free | Club-level development track record |
-| [USARank](https://usarank.com) | Individual teams | SincSports tournaments only | U08-U19, all states | Free | Teams in SincSports tournaments |
-| [TopDrawerSoccer](https://www.topdrawersoccer.com) | National Top 25 | ECNL/MLS NEXT leagues | U13-U18, national only | Partial ($99/yr) | College recruiting ecosystem |
+| Site                                               | What It Ranks    | Data Source                 | Coverage               | Cost             | Best For                                                   |
+| -------------------------------------------------- | ---------------- | --------------------------- | ---------------------- | ---------------- | ---------------------------------------------------------- |
+| [PitchRank](https://pitchrank.io)                  | Individual teams | Multiple sources            | U10-U19, 50 states     | Free             | Data-driven head-to-head rankings for any competitive team |
+| [GotSport](https://rankings.gotsport.com)          | Individual teams | GotSport tournaments only   | U10-U19, 100K+ teams   | Free             | Quick look if you already use GotSport                     |
+| [SoccerWire](https://www.soccerwire.com)           | Clubs (Top 100)  | ECNL/MLS NEXT/GA leagues    | U13-U19, elite only    | Free             | Club-level development track record                        |
+| [USARank](https://usarank.com)                     | Individual teams | SincSports tournaments only | U08-U19, all states    | Free             | Teams in SincSports tournaments                            |
+| [TopDrawerSoccer](https://www.topdrawersoccer.com) | National Top 25  | ECNL/MLS NEXT leagues       | U13-U18, national only | Partial ($99/yr) | College recruiting ecosystem                               |
 
 ## PitchRank
 

--- a/frontend/lib/blog-faqs.ts
+++ b/frontend/lib/blog-faqs.ts
@@ -622,6 +622,31 @@ export const BLOG_FAQS: Record<string, FAQ[]> = {
     },
   ],
 
+  /* ─── Comparison / Resource Posts ─────────────────────────────── */
+
+  'best-youth-soccer-ranking-websites-2026': [
+    {
+      question: 'Which youth soccer ranking site is most accurate?',
+      answer:
+        'Accuracy depends on data breadth and methodology. Sites that use head-to-head game results and strength-of-schedule weighting (like PitchRank) tend to be more predictive than placement-based systems. The most reliable approach is to cross-reference multiple ranking sources — if a team ranks well across independent systems, that signal is stronger than any single ranking.',
+    },
+    {
+      question: 'Are youth soccer rankings free?',
+      answer:
+        'Most youth soccer ranking sites offer free access to team rankings. PitchRank, GotSport, SoccerWire, and USARank are all free to view. TopDrawerSoccer offers free team rankings but charges $99/year for detailed player rankings and recruiting tools.',
+    },
+    {
+      question: 'Why do different ranking sites show different results?',
+      answer:
+        'Each ranking site uses a different methodology and data source. GotSport only counts its own tournaments, SoccerWire ranks clubs not teams, and TopDrawerSoccer covers only the national Top 25. Different inputs and algorithms produce different outputs. This is why cross-referencing multiple sources gives a more complete picture.',
+    },
+    {
+      question: 'Should I choose a club based on rankings?',
+      answer:
+        'Rankings should be one factor among many. They can tell you about competitive strength and schedule quality, but they cannot measure coaching philosophy, player development culture, playing time, or whether a club is the right fit for your child. Use rankings to narrow your search, then visit practices, talk to coaches, and speak with other families.',
+    },
+  ],
+
   /* ─── Informational / Educational Posts ──────────────────────── */
 
   'how-pitchrank-rankings-work': [

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -12,6 +12,7 @@ PitchRank provides the most accurate youth soccer rankings in the United States,
 ## Blog
 *State-specific guides are listed under State Pillars below.*
 
+- [Best Youth Soccer Ranking Websites for Parents (2026)](https://www.pitchrank.io/blog/best-youth-soccer-ranking-websites-2026): An honest comparison of youth soccer ranking sites — PitchRank, GotSport, SoccerWire, USARank, and TopDrawerSoccer. What each one does, how they work, and which is right for your family.
 - [Youth Soccer Levels Explained: ECNL, MLS NEXT, NPL](https://www.pitchrank.io/blog/youth-soccer-levels-explained): ECNL, MLS NEXT, NPL, GA, National League — what every US youth soccer level actually means for your kid. Plain English, no jargon.
 - [PA U10 Boys Soccer Rankings 2026: Top 25 Teams in Pennsylvania](https://www.pitchrank.io/blog/pa-u10-boys-soccer-rankings): The top 25 U10 boys soccer teams in Pennsylvania, ranked by PowerScore. FC DELCO, Philadelphia Union SWAG, Pittsburgh Riverhounds — see where your team stands.
 - [Youth Soccer Tryouts 2026: A Data-Driven Guide for Parents](https://www.pitchrank.io/blog/youth-soccer-tryouts-2026): Youth soccer tryouts are changing in 2026 with new age groups. Learn what to look for, how to evaluate clubs with data, and when to switch.


### PR DESCRIPTION
## Summary
- Full rewrite of `/methodology` page with 10 sections targeting GEO methodology citation gaps (data sourcing, cross-league calibration, sparse schedule handling)
- FAQSchema expanded from 11 to 15 items with 4 GEO-targeted questions
- Page metadata + Article JSON-LD updated (title: "How Our Rankings Work", dateModified bumped)
- New blog post: "Best Youth Soccer Ranking Websites for Parents (2026)" — objective comparison of PitchRank, GotSport, SoccerWire, USARank, TopDrawerSoccer with verified research
- Blog FAQs registered (4 items) + llms.txt regenerated

## Test plan
- [ ] Verify `/methodology` page renders all 10 sections
- [ ] Verify FAQPage JSON-LD has 15 questions (view source → search `application/ld+json`)
- [ ] Verify Article JSON-LD headline is "How PitchRank Youth Soccer Rankings Work"
- [ ] Verify blog post renders at `/blog/best-youth-soccer-ranking-websites-2026`
- [ ] Verify blog post appears in `/blog` listing
- [ ] Verify BlogPosting + FAQPage JSON-LD on blog post page
- [ ] Production build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)