### PR TITLE
[codex] fix rankings overtrust for thin quality-result schedules

### DIFF
--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -345,6 +345,15 @@ def _same_age_evidence_policy(age_num: int) -> dict[str, float | int]:
         "quality_result_void_max_top500": 3,
         "quality_result_void_max_avg_opp_power": 0.60,
         "quality_result_void_severe_max_avg_opp_power": 0.52,
+        "thin_quality_results_min_unique_opponents": 18,
+        "thin_quality_results_max_top100": 1,
+        "thin_quality_results_max_top500": 5,
+        "thin_quality_results_max_top500_non_loss": 1,
+        "thin_quality_results_max_top1000_non_loss": 2,
+        "thin_quality_results_max_avg_opp_power": 0.65,
+        "thin_quality_results_min_repeat_share": 0.30,
+        "thin_quality_results_publish_penalty_bonus": 0.018,
+        "thin_quality_results_raw_shrink_bonus": 0.012,
         "local_loop_max_top500": 1,
         "local_loop_max_avg_opp_power": 0.52,
         "local_loop_repeat_share": 0.60,
@@ -1182,6 +1191,34 @@ def _has_weak_field_connectivity_overtrust_profile(
     )
 
 
+def _has_thin_quality_results_profile(row: pd.Series, policy: dict[str, float | int]) -> bool:
+    """Flag thin schedules whose few quality looks are mostly losses.
+
+    These teams can still post strong raw ratings in Glicko, but they have not
+    produced enough same-age quality results to justify that raw strength.
+    """
+    top100 = _safe_int(row.get("same_age_top100_opp_count"))
+    top100_non_loss = _safe_int(row.get("same_age_top100_non_loss_opp_count"))
+    top500 = _safe_int(row.get("same_age_top500_opp_count"))
+    top500_non_loss = _safe_int(row.get("same_age_top500_non_loss_opp_count"))
+    top1000_non_loss = _safe_int(row.get("same_age_top1000_non_loss_opp_count"))
+    unique_opponents = _safe_int(row.get("same_age_unique_opponents"))
+    avg_opp_power = _effective_same_age_avg_opp_power(row, policy)
+    repeat_share = _safe_float(row.get("repeat_opponent_share")) or 0.0
+
+    return bool(
+        unique_opponents >= int(policy["thin_quality_results_min_unique_opponents"])
+        and top100 <= int(policy["thin_quality_results_max_top100"])
+        and top100_non_loss == 0
+        and top500 <= int(policy["thin_quality_results_max_top500"])
+        and top500_non_loss <= int(policy["thin_quality_results_max_top500_non_loss"])
+        and top1000_non_loss <= int(policy["thin_quality_results_max_top1000_non_loss"])
+        and avg_opp_power is not None
+        and avg_opp_power < float(policy["thin_quality_results_max_avg_opp_power"])
+        and repeat_share >= float(policy["thin_quality_results_min_repeat_share"])
+    )
+
+
 def _effective_same_age_avg_opp_power(row: pd.Series, policy: dict[str, float | int]) -> float | None:
     broad_avg_opp_power = _safe_float(row.get("same_age_avg_opp_power_adj"))
     if broad_avg_opp_power is None:
@@ -1389,6 +1426,7 @@ def _same_age_publish_penalty(row: pd.Series) -> float:
     strong_broad_profile = _has_strong_broad_profile(row, policy)
     elite_repetitive_release = _has_elite_repetitive_release_profile(row, policy)
     weak_field_connectivity_profile = _has_weak_field_connectivity_overtrust_profile(row, policy)
+    thin_quality_results_profile = _has_thin_quality_results_profile(row, policy)
     quality_field_strength = _unit_interval(
         quality_avg_opp_power,
         float(policy["quality_bridge_min_avg_opp_power"]),
@@ -1443,6 +1481,10 @@ def _same_age_publish_penalty(row: pd.Series) -> float:
         penalty += float(policy["weak_field_connectivity_publish_penalty_bonus"]) * (
             0.40 + 0.60 * exposure_pressure
         )
+    if thin_quality_results_profile:
+        penalty += float(policy["thin_quality_results_publish_penalty_bonus"]) * (
+            0.45 + 0.55 * max(field_shortfall, 1.0 - quality_support)
+        )
     if thin_recent:
         penalty += 0.008
     if stale_recent:
@@ -1484,13 +1526,14 @@ def _same_age_raw_shrink(row: pd.Series) -> float:
     )
     quality_bridge = _has_quality_bridge_support(row, policy)
     weak_field_connectivity_profile = _has_weak_field_connectivity_overtrust_profile(row, policy)
+    thin_quality_results_profile = _has_thin_quality_results_profile(row, policy)
 
     weak_field_shortfall = _unit_interval(
         float(policy["raw_shrink_max_avg_opp_power"]) - broad_avg_opp_power,
         0.0,
         float(policy["raw_shrink_max_avg_opp_power"]) - float(policy["severe_min_avg_opp_power"]),
     )
-    if weak_field_shortfall <= 0.0:
+    if weak_field_shortfall <= 0.0 and not thin_quality_results_profile:
         return 0.0
 
     exposure_pressure = (
@@ -1510,6 +1553,11 @@ def _same_age_raw_shrink(row: pd.Series) -> float:
     if weak_field_connectivity_profile:
         shrink += float(policy["weak_field_connectivity_raw_shrink_bonus"]) * weak_field_shortfall * (
             0.50 + 0.50 * exposure_pressure
+        )
+    if thin_quality_results_profile:
+        profile_shortfall = max(weak_field_shortfall, 0.30 + 0.40 * max(0.0, 1.0 - quality_support))
+        shrink += float(policy["thin_quality_results_raw_shrink_bonus"]) * (
+            0.45 + 0.55 * profile_shortfall
         )
     if top100 == 0 and top500 <= 2:
         shrink *= 0.70

--- a/tests/unit/test_same_age_evidence_gates.py
+++ b/tests/unit/test_same_age_evidence_gates.py
@@ -1150,6 +1150,46 @@ def test_same_age_publish_penalty_hits_low_connectivity_weak_field_profile():
     assert _same_age_publish_penalty(row) > 0.035
 
 
+def test_same_age_publish_penalty_hits_thin_quality_results_profile():
+    row = pd.Series(
+        {
+            "age_num": 12,
+            "same_age_unique_opponents": 24,
+            "same_age_top100_opp_count": 1,
+            "same_age_top100_non_loss_opp_count": 0,
+            "same_age_top500_opp_count": 5,
+            "same_age_top500_non_loss_opp_count": 1,
+            "same_age_top1000_non_loss_opp_count": 2,
+            "same_age_avg_opp_power_adj": 0.633812958699286,
+            "repeat_opponent_share": 0.404761904761905,
+            "unique_opp_states": 6,
+            "games_last_180_days": 23,
+            "days_since_last": 5,
+        }
+    )
+    assert _same_age_publish_penalty(row) > 0.02
+
+
+def test_same_age_publish_penalty_hits_thin_weak_results_profile():
+    row = pd.Series(
+        {
+            "age_num": 12,
+            "same_age_unique_opponents": 21,
+            "same_age_top100_opp_count": 0,
+            "same_age_top100_non_loss_opp_count": 0,
+            "same_age_top500_opp_count": 1,
+            "same_age_top500_non_loss_opp_count": 1,
+            "same_age_top1000_non_loss_opp_count": 2,
+            "same_age_avg_opp_power_adj": 0.50963877039193,
+            "repeat_opponent_share": 0.344827586206897,
+            "unique_opp_states": 5,
+            "games_last_180_days": 19,
+            "days_since_last": 5,
+        }
+    )
+    assert _same_age_publish_penalty(row) > 0.05
+
+
 def test_same_age_raw_shrink_hits_weak_field_high_exposure_profile():
     row = pd.Series(
         {
@@ -1165,6 +1205,46 @@ def test_same_age_raw_shrink_hits_weak_field_high_exposure_profile():
             "unique_opp_states": 8,
             "games_last_180_days": 9,
             "days_since_last": 3,
+        }
+    )
+    assert _same_age_raw_shrink(row) > 0.015
+
+
+def test_same_age_raw_shrink_hits_thin_quality_results_profile():
+    row = pd.Series(
+        {
+            "age_num": 12,
+            "same_age_unique_opponents": 24,
+            "same_age_top100_opp_count": 1,
+            "same_age_top100_non_loss_opp_count": 0,
+            "same_age_top500_opp_count": 5,
+            "same_age_top500_non_loss_opp_count": 1,
+            "same_age_top1000_non_loss_opp_count": 2,
+            "same_age_avg_opp_power_adj": 0.633812958699286,
+            "repeat_opponent_share": 0.404761904761905,
+            "unique_opp_states": 6,
+            "games_last_180_days": 23,
+            "days_since_last": 5,
+        }
+    )
+    assert _same_age_raw_shrink(row) > 0.008
+
+
+def test_same_age_raw_shrink_hits_thin_weak_results_profile():
+    row = pd.Series(
+        {
+            "age_num": 12,
+            "same_age_unique_opponents": 21,
+            "same_age_top100_opp_count": 0,
+            "same_age_top100_non_loss_opp_count": 0,
+            "same_age_top500_opp_count": 1,
+            "same_age_top500_non_loss_opp_count": 1,
+            "same_age_top1000_non_loss_opp_count": 2,
+            "same_age_avg_opp_power_adj": 0.50963877039193,
+            "repeat_opponent_share": 0.344827586206897,
+            "unique_opp_states": 5,
+            "games_last_180_days": 19,
+            "days_since_last": 5,
         }
     )
     assert _same_age_raw_shrink(row) > 0.015


### PR DESCRIPTION
## What changed
- added a `thin_quality_results` same-age evidence profile in the rankings calculator
- increased pre-cap skepticism for teams with limited quality same-age results but strong raw ratings
- added regression tests covering the two overranked U12 profile shapes that triggered this investigation

## Why
Two U12 Male teams were ranking too high because the engine still trusted raw strength too much when the schedule had very few meaningful same-age quality results. The existing skepticism and cap logic was not strong enough for thin schedules where the few quality looks were mostly losses.

## Root cause
The same-age evidence layer handled very weak-field and low-connectivity profiles, but it did not specifically penalize schedules that had some nominal top-500 exposure without enough positive quality results to justify the raw rating. That left a gap where thin Arizona-heavy schedules could still publish too high.

## Impact
This should pull inflated teams like PRFC Scottsdale 2014 PRE-ACADEMY and FC Deportivo AZ 2014 Gallegos back toward a more defensible range without changing the release behavior for broad, high-quality schedules.

## Validation
- `python -m pytest tests/unit/test_same_age_evidence_gates.py -q`
- `python -m pytest tests/unit/test_calculate_rankings_publish_contract.py -q`
