### PR TITLE
chore(ci): harden workflow inputs against shell injection

### DIFF
--- a/.claude/skills/review-workflows/SKILL.md
+++ b/.claude/skills/review-workflows/SKILL.md
@@ -13,7 +13,7 @@ From the repo root:
 
 ```bash
 mkdir -p .turbo
-python C:/PitchRank/.claude/skills/review-workflows/scripts/audit_workflows.py \
+python .claude/skills/review-workflows/scripts/audit_workflows.py \
     --repo-root . \
     --fail-on never \
     --format markdown \

--- a/.claude/skills/review-workflows/SKILL.md
+++ b/.claude/skills/review-workflows/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: review-workflows
+description: "Audits GitHub Actions workflow files in .github/workflows/ for shell injection, cron drift, env precedence conflicts, timeout shielding gaps, missing script references, hardcoded secrets, and mutable-sort matrix sharding. Outputs structured findings to .turbo/workflow-audit.md. Use when the user asks to 'review workflows', 'audit workflows', 'check GitHub Actions', 'review CI workflows', 'workflow audit', or 'check workflow safety'. Also folded into /audit as the workflow leg."
+---
+
+# Review Workflows
+
+Detect known GHA failure patterns in workflow YAML before they cause incidents. Findings, not fixes — the user decides what to act on.
+
+## Step 1: Run the Audit Script
+
+From the repo root:
+
+```bash
+mkdir -p .turbo
+python C:/PitchRank/.claude/skills/review-workflows/scripts/audit_workflows.py \
+    --repo-root . \
+    --fail-on never \
+    --format markdown \
+    > .turbo/workflow-audit.md
+```
+
+Flags:
+- `--repo-root` — defaults to cwd; explicit form makes the path resolution unambiguous.
+- `--workflows-dir` — defaults to `<repo-root>/.github/workflows`; override only if scanning a different location.
+- `--fail-on` — exit-code threshold. Use `never` for interactive runs so the report still writes; use `high` when wiring into CI.
+- `--format` — `markdown` (default) or `json` for downstream consumers.
+
+The script requires PyYAML. If it errors with "PyYAML required", run `pip install pyyaml` and retry.
+
+## Step 2: Read the Report
+
+Read `.turbo/workflow-audit.md`. Findings are sorted by severity (critical → high → medium → low) and grouped by section.
+
+Each finding has:
+- **Check ID** — e.g. `shell-injection`, `cron-drift`
+- **Location** — `<workflow-file>:<line>`
+- **Message** — what's wrong and why
+- **Evidence** — the offending snippet (secrets are redacted)
+- **Reference** — related MEMORY.md entry, when applicable
+
+For check-specific detail, the script's behavior, severity rationale, and known false positives, consult [references/checks.md](references/checks.md).
+
+## Step 3: Triage and Report
+
+Group findings into three buckets and present them to the user:
+
+- **Confirmed** — clear true positives the user should fix. State the file, the fix pattern, and link to the relevant check in `references/checks.md`.
+- **Probable false positives** — findings where the check fired but the code is correct in context. State why and ask if the user wants to confirm before dismissing.
+- **Needs investigation** — findings where the call requires reading more code than the check inspected.
+
+Then use `AskUserQuestion` to ask whether to:
+- Fix confirmed findings now
+- Defer all findings to a follow-up session
+- Open a tracking note via `/note-improvement`
+
+Do not edit workflow files without explicit approval. The skill detects; the user decides.
+
+## Step 4: Re-Run on Fixes (Optional)
+
+If the user opts to fix findings in this session, run the audit again after edits to verify findings are resolved. Skip this step if no edits were made.
+
+## Adding New Checks
+
+When a new GHA gotcha enters MEMORY.md:
+1. Add a new check function in `scripts/audit_workflows.py`. Pick the signature that matches what the check needs:
+   - **`(wf: WorkflowFile) -> list[Finding]`** — append to the `CHECKS` list near the bottom; the driver loops over it automatically.
+   - **Requires extra context** (e.g. `repo_root` for path resolution) — wire it directly into `run_audit` after the `CHECKS` loop. Follow `check_script_existence` as the pattern.
+2. Document it in [references/checks.md](references/checks.md) with severity, memory ref, detected pattern, fix pattern, and known false positives.
+3. Run the audit against the current workflows and verify the new check fires on at least one real example (or document why no current workflow trips it).

--- a/.claude/skills/review-workflows/references/checks.md
+++ b/.claude/skills/review-workflows/references/checks.md
@@ -1,0 +1,158 @@
+# Workflow Audit Checks
+
+Detailed reference for each check the audit script performs. Each check derives from a real incident captured in MEMORY.md.
+
+## Contents
+- shell-injection — raw `${{ inputs.* }}` in run blocks
+- cron-drift — `*/N` minute fields
+- env-precedence — step env vs `$GITHUB_ENV` conflicts
+- timeout-shielding — continue-on-error without timeout
+- script-missing — referenced scripts that don't exist
+- secret-* — hardcoded tokens
+- matrix-shard-mutable-sort — OFFSET sharding heuristic
+- Tuning false positives
+
+## shell-injection
+
+**Severity:** HIGH
+**Memory:** `gha_inputs_shell_injection.md`
+
+Detects raw interpolation of attacker-influenceable expressions into `run:` blocks. The actor can craft a value containing shell metacharacters (`$()`, backticks, `;`, newlines) that execute on the runner.
+
+**Detected expressions:**
+- `${{ inputs.X }}` — workflow_dispatch / workflow_call inputs
+- `${{ github.event.X }}` — event payload fields (issue title, PR body, comment, etc.)
+- `${{ needs.X.outputs.Y }}` — outputs from prior jobs (only attacker-controlled if the prior job processes untrusted input)
+
+**Fix pattern:**
+```yaml
+- name: Use input safely
+  env:
+    INPUT_VALUE: ${{ inputs.value }}
+  run: |
+    echo "Processing: $INPUT_VALUE"
+```
+
+The shell variable `$INPUT_VALUE` is not subject to template expansion — the shell handles quoting.
+
+**Known false positive:** The check flags `needs.X.outputs.Y` even when the upstream output is hardcoded (e.g. a version string). Triage per finding.
+
+## cron-drift
+
+**Severity:** MEDIUM
+**Memory:** `gotcha_gh_actions_scheduled_drift.md`
+
+GitHub-hosted runner cron uses a shared queue. `*/15 * * * *` does not fire every 15 minutes — observed cadence is every 2-3 hours under load. Explicit minute lists fire reliably.
+
+**Detected pattern:** First cron field matches `^\*/\d+$`.
+
+**Fix pattern:**
+```yaml
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *"   # offset minutes, fires reliably
+```
+
+Offset minutes (7, 22, 37, 52 — not 0, 15, 30, 45) reduce queue contention.
+
+## env-precedence
+
+**Severity:** MEDIUM
+**Memory:** `gotcha_gha_workflow_env_and_timeouts.md`
+
+Step-level `env:` beats vars written to `$GITHUB_ENV` in a prior step. The `$GITHUB_ENV` write succeeds, the var appears in the job environment, then the step's own `env:` silently overrides it for that step's process.
+
+**Detected pattern:** Within a job, the same variable name appears both in a step's `env:` and in an `echo X=... >> $GITHUB_ENV` somewhere in any step's `run:`.
+
+**Fix patterns:**
+- If the step `env:` value is correct, remove the `$GITHUB_ENV` write (it's dead).
+- If the `$GITHUB_ENV` write is correct, remove the step `env:` entry.
+
+**Known false positive:** A step intentionally overrides a global var for one step only. Triage per finding.
+
+## timeout-shielding
+
+**Severity:** LOW
+**Memory:** `gotcha_gha_workflow_env_and_timeouts.md`
+
+`continue-on-error: true` marks a step's failure as non-fatal but does **not** apply when the step exceeds the runner's default 360-minute timeout. A hung process still kills the job after 6 hours; the `continue-on-error` flag is irrelevant at that point.
+
+**Detected pattern:** Step has `continue-on-error: true` and no `timeout-minutes` at either step or job level.
+
+**Fix pattern:**
+```yaml
+- name: Best-effort scrape
+  continue-on-error: true
+  timeout-minutes: 30          # explicit bound; failure marked non-fatal
+  run: python scripts/scrape.py
+```
+
+## script-missing
+
+**Severity:** HIGH
+
+Workflows that reference `python scripts/X.py`, `node scripts/X.js`, `bash scripts/X.sh`, etc., where the file does not exist at repo root. Catches: scripts deleted without updating workflows, scripts renamed, typos.
+
+**Detection:** Regex scans `run:` blocks for `(python|node|bash|sh|tsx|ts-node) <path>` where `<path>` matches `*.py|js|ts|mjs|sh`. Skips paths containing `${...}` or `$(...)`.
+
+**Known false positives:**
+- Cd targets that contain GitHub Actions context expressions like `${{ github.workspace }}` are excluded from candidate resolution. A workflow using `cd ${{ github.workspace }}/scripts` reports a missing script even when the file exists. Triage per finding.
+- Steps that use job-level or step-level `working-directory` are resolved; ad-hoc `pushd`/`popd` is not. Triage per finding.
+
+## secret-github-pat / secret-stripe-key / secret-jwt-secret / secret-aws-key
+
+**Severity:** CRITICAL
+
+Hardcoded credentials in workflow YAML. Workflow files are public on public repos and visible to all repo collaborators on private repos. Any credential here must be rotated immediately if exposed.
+
+**Detected patterns:**
+- GitHub PAT: `ghp_*` / `ghs_*` (30+ chars)
+- Stripe keys: `sk_live_*` / `sk_test_*` (20+ chars)
+- JWTs (Supabase service role keys): `eyJ...eyJ...sig` three-segment base64
+- AWS access keys: `AKIA[0-9A-Z]{16}`
+
+The check skips lines containing `${{ secrets.` to avoid flagging the correct usage pattern.
+
+**Evidence is redacted** in output: first 6 + last 4 chars only. The full match is in the source file but not in `.turbo/workflow-audit.md`.
+
+**Fix:**
+1. Rotate the exposed credential immediately.
+2. Add to GitHub Actions secrets.
+3. Reference as `${{ secrets.NAME }}`.
+
+## matrix-shard-mutable-sort
+
+**Severity:** MEDIUM
+**Memory:** `gotcha_matrix_sharding_with_mutable_sort.md`
+
+Heuristic check for the sharding bug pattern: matrix-based parallel jobs that partition work by OFFSET+LIMIT over a mutable sort key (e.g. `ORDER BY last_updated`). As rows update during the run, they shift across shard boundaries — some rows get processed twice, others not at all.
+
+**Detected pattern:**
+- Job has `strategy.matrix.<key>` where `<key>` matches `shard|index|chunk|partition|offset` and the value is a numeric/string array.
+- Any step in the job runs SQL containing both `OFFSET` and `LIMIT`.
+- The run block does not contain a hash-based clause (`hashtext`, `% `).
+
+**Fix pattern:** Shard by hash of a stable ID:
+```sql
+WHERE ((hashtext(team_id) % :total_shards) + :total_shards) % :total_shards = :shard
+```
+
+Note the double-modulo: Postgres `%` preserves dividend sign and drops ~48% of rows on naive `hashtext(x) % N`. See `gotcha_postgres_signed_modulo.md`.
+
+**Known false positive:** OFFSET+LIMIT used for pagination within a single shard (not for sharding). Triage per finding.
+
+## Tuning false positives
+
+When a finding is a confirmed false positive, the right fix depends on the check:
+
+| Check | Tune by |
+|-------|---------|
+| shell-injection | Tighten `INJECTION_PATTERN` to exclude specific safe contexts |
+| cron-drift | No tuning — `*/N` is always drift on shared runners |
+| env-precedence | Add a per-workflow allowlist constant; this case is rare |
+| timeout-shielding | Add a per-job allowlist; some jobs intentionally have no upper bound |
+| script-missing | Tighten `SCRIPT_REF` regex to exclude `cd subdir &&` patterns |
+| secret-* | Pattern is conservative; FP usually means a non-secret token shaped like one (e.g. a sample) — move sample to a comment with `# pragma: not-a-secret` and add a guard |
+| matrix-shard-mutable-sort | The check already exits when hash-mod is present. If OFFSET+LIMIT is intentional for pagination, the finding is informational |
+
+When a new GHA gotcha enters MEMORY.md, add a new check function to `audit_workflows.py` and append it to the `CHECKS` list.

--- a/.claude/skills/review-workflows/scripts/audit_workflows.py
+++ b/.claude/skills/review-workflows/scripts/audit_workflows.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Audit GitHub Actions workflow files against PitchRank's incident catalog.
+
+Outputs a structured markdown report to stdout. Exits non-zero if findings exist
+at SEVERITY_FAIL or higher (default: HIGH).
+
+Usage:
+    python audit_workflows.py [--workflows-dir PATH] [--repo-root PATH]
+                              [--fail-on {critical,high,medium,low,never}]
+                              [--format {markdown,json}]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "PyYAML required. Install with: pip install pyyaml\n"
+    )
+    sys.exit(2)
+
+
+SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+@dataclass
+class Finding:
+    check_id: str
+    severity: str  # critical|high|medium|low
+    workflow: str  # path relative to repo root
+    line: int | None
+    message: str
+    evidence: str
+    memory_ref: str = ""  # related MEMORY.md entry
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class WorkflowFile:
+    path: Path
+    rel_path: str
+    text: str
+    lines: list[str]
+    data: dict | None  # parsed YAML, None if parse failed
+    parse_error: str | None = None
+
+
+# ---------- helpers ----------
+
+
+def load_workflows(workflows_dir: Path, repo_root: Path) -> list[WorkflowFile]:
+    files = sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml"))
+    out: list[WorkflowFile] = []
+    for p in files:
+        text = p.read_text(encoding="utf-8", errors="replace")
+        rel = str(p.relative_to(repo_root)).replace("\\", "/")
+        try:
+            data = yaml.safe_load(text)
+            err = None
+        except yaml.YAMLError as e:
+            data = None
+            err = str(e)
+        out.append(
+            WorkflowFile(
+                path=p,
+                rel_path=rel,
+                text=text,
+                lines=text.splitlines(),
+                data=data if isinstance(data, dict) else None,
+                parse_error=err,
+            )
+        )
+    return out
+
+
+def line_of(text: str, idx: int) -> int:
+    return text.count("\n", 0, idx) + 1
+
+
+def iter_jobs(data: dict) -> Iterable[tuple[str, dict]]:
+    jobs = data.get("jobs") or {}
+    if not isinstance(jobs, dict):
+        return
+    for name, job in jobs.items():
+        if isinstance(job, dict):
+            yield name, job
+
+
+def iter_steps(job: dict) -> Iterable[dict]:
+    steps = job.get("steps") or []
+    if not isinstance(steps, list):
+        return
+    for step in steps:
+        if isinstance(step, dict):
+            yield step
+
+
+# ---------- checks ----------
+
+
+# Check 1: Shell injection via raw ${{ inputs.* }} / github.event.* / needs.*.outputs.*
+# Memory: gha_inputs_shell_injection.md
+INJECTION_PATTERN = re.compile(
+    r"\$\{\{\s*"
+    r"(inputs\.[^}\s]+"
+    r"|github\.event\.[^}\s]+"
+    r"|github\.head_ref"
+    r"|github\.ref_name"
+    r"|github\.actor"
+    r"|needs\.[^}\s]+\.outputs\.[^}\s]+"
+    r"|steps\.[^}\s]+\.outputs\.[^}\s]+)"
+    r"\s*\}\}"
+)
+
+
+def check_shell_injection(wf: WorkflowFile) -> list[Finding]:
+    if not wf.data:
+        return []
+    findings: list[Finding] = []
+    for job_name, job in iter_jobs(wf.data):
+        for step in iter_steps(job):
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            for m in INJECTION_PATTERN.finditer(run):
+                # Locate line in source by finding the run block + offset
+                expr = m.group(0)
+                source_idx = wf.text.find(expr)
+                line = line_of(wf.text, source_idx) if source_idx >= 0 else None
+                findings.append(
+                    Finding(
+                        check_id="shell-injection",
+                        severity="high",
+                        workflow=wf.rel_path,
+                        line=line,
+                        message=(
+                            f"Raw `{expr}` interpolated into run: block in job "
+                            f"`{job_name}`. Shell injection primitive."
+                        ),
+                        evidence=expr,
+                        memory_ref="gha_inputs_shell_injection.md",
+                    )
+                )
+    return findings
+
+
+# Check 2: Cron drift — */N patterns drift to 2-3h cadence on shared runners
+# Memory: gotcha_gh_actions_scheduled_drift.md
+CRON_LINE = re.compile(r"-?\s*cron:\s*['\"]?([^'\"#\n]+)")
+
+
+def check_cron_drift(wf: WorkflowFile) -> list[Finding]:
+    findings: list[Finding] = []
+    for i, line in enumerate(wf.lines, start=1):
+        if line.lstrip().startswith("#"):
+            continue
+        m = CRON_LINE.search(line)
+        if not m:
+            continue
+        expr = m.group(1).strip()
+        fields = expr.split()
+        if len(fields) < 5:
+            continue
+        minute = fields[0]
+        if re.match(r"^\*/\d+$", minute):
+            findings.append(
+                Finding(
+                    check_id="cron-drift",
+                    severity="medium",
+                    workflow=wf.rel_path,
+                    line=i,
+                    message=(
+                        f"Cron `{expr}` uses `*/N` minute field. On GitHub-hosted "
+                        f"runners this drifts to 2-3h cadence; use explicit minute "
+                        f"list (e.g. '7,22,37,52 * * * *') for reliable timing."
+                    ),
+                    evidence=expr,
+                    memory_ref="gotcha_gh_actions_scheduled_drift.md",
+                )
+            )
+    return findings
+
+
+# Check 3: Env precedence — step-level env: silently wins over $GITHUB_ENV writes
+# Memory: gotcha_gha_workflow_env_and_timeouts.md
+GITHUB_ENV_WRITE = re.compile(
+    r"echo\s+[\"']?([A-Z_][A-Z0-9_]*)\s*=", re.IGNORECASE
+)
+
+
+def check_env_precedence(wf: WorkflowFile) -> list[Finding]:
+    if not wf.data:
+        return []
+    findings: list[Finding] = []
+    for job_name, job in iter_jobs(wf.data):
+        # Collect names of vars written via $GITHUB_ENV anywhere in this job
+        github_env_vars: set[str] = set()
+        for step in iter_steps(job):
+            run = step.get("run")
+            if isinstance(run, str) and "$GITHUB_ENV" in run:
+                for line in run.splitlines():
+                    if "$GITHUB_ENV" not in line:
+                        continue
+                    m = GITHUB_ENV_WRITE.search(line)
+                    if m:
+                        github_env_vars.add(m.group(1))
+        if not github_env_vars:
+            continue
+        # Flag steps that set the same name in step env:
+        for step in iter_steps(job):
+            step_env = step.get("env")
+            if not isinstance(step_env, dict):
+                continue
+            for var in step_env:
+                if var in github_env_vars:
+                    # Approximate line: search for "var:" inside the step env block
+                    idx = wf.text.find(f"{var}:")
+                    line = line_of(wf.text, idx) if idx >= 0 else None
+                    findings.append(
+                        Finding(
+                            check_id="env-precedence",
+                            severity="medium",
+                            workflow=wf.rel_path,
+                            line=line,
+                            message=(
+                                f"Var `{var}` is set in step env: AND written to "
+                                f"$GITHUB_ENV in job `{job_name}`. Step env wins "
+                                f"silently — the $GITHUB_ENV write has no effect."
+                            ),
+                            evidence=f"step env.{var}",
+                            memory_ref="gotcha_gha_workflow_env_and_timeouts.md",
+                        )
+                    )
+    return findings
+
+
+# Check 4: Timeout shielding — continue-on-error doesn't shield runner timeouts
+# Memory: gotcha_gha_workflow_env_and_timeouts.md
+def check_timeout_shielding(wf: WorkflowFile) -> list[Finding]:
+    if not wf.data:
+        return []
+    findings: list[Finding] = []
+    for job_name, job in iter_jobs(wf.data):
+        job_timeout = job.get("timeout-minutes")
+        for step in iter_steps(job):
+            coe = step.get("continue-on-error")
+            # GH allows the field to be an expression string; treat truthy literals
+            is_coe = coe is True or (isinstance(coe, str) and coe.strip().lower() == "true")
+            if not is_coe:
+                continue
+            step_timeout = step.get("timeout-minutes")
+            if step_timeout is None and job_timeout is None:
+                step_name = step.get("name") or step.get("id") or "(unnamed)"
+                findings.append(
+                    Finding(
+                        check_id="timeout-shielding",
+                        severity="low",
+                        workflow=wf.rel_path,
+                        line=None,
+                        message=(
+                            f"Step `{step_name}` in job `{job_name}` sets "
+                            f"continue-on-error: true with no timeout-minutes at "
+                            f"step or job level. continue-on-error does not shield "
+                            f"runner timeouts; long hangs still fail the job."
+                        ),
+                        evidence=f"job={job_name} step={step_name}",
+                        memory_ref="gotcha_gha_workflow_env_and_timeouts.md",
+                    )
+                )
+    return findings
+
+
+# Check 5: Script existence — run: python scripts/X.py paths must exist
+# Memory: gotcha_hygiene_step3_step4_contract.md (broader: don't break script contracts)
+SCRIPT_REF = re.compile(
+    r"(?:^|[\s;&|`])(?:python3?|node|bash|sh|tsx|ts-node)\s+"
+    r"([A-Za-z_][\w./-]*\.(?:py|js|ts|mjs|sh))"
+)
+
+
+CD_PATTERN = re.compile(r"^\s*cd\s+([^\s;&|]+)", re.MULTILINE)
+
+
+def _resolve_script_candidates(
+    repo_root: Path, working_dirs_used_in_run: list[str], rel: str
+) -> list[Path]:
+    """Build candidate full paths for a script ref, given cd targets in the run block."""
+    candidates: list[Path] = [repo_root / rel]
+    for cd_target in working_dirs_used_in_run:
+        if cd_target.startswith(("/", "${", "$(")) or ".." in cd_target:
+            continue
+        candidates.append(repo_root / cd_target / rel)
+    return candidates
+
+
+def check_script_existence(wf: WorkflowFile, repo_root: Path) -> list[Finding]:
+    if not wf.data:
+        return []
+    findings: list[Finding] = []
+    seen: set[tuple[str, str]] = set()  # dedupe (workflow, path)
+    for job_name, job in iter_jobs(wf.data):
+        # job-level default working directory
+        defaults = job.get("defaults") or {}
+        run_defaults = defaults.get("run") if isinstance(defaults, dict) else None
+        job_wd = (
+            run_defaults.get("working-directory")
+            if isinstance(run_defaults, dict)
+            else None
+        )
+        for step in iter_steps(job):
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            # Collect cd targets used in this run block + step working-directory
+            cd_targets: list[str] = []
+            if job_wd:
+                cd_targets.append(job_wd)
+            step_wd = step.get("working-directory")
+            if isinstance(step_wd, str):
+                cd_targets.append(step_wd)
+            cd_targets.extend(CD_PATTERN.findall(run))
+            for m in SCRIPT_REF.finditer(run):
+                rel = m.group(1)
+                if rel.startswith(("-", "/", "${")):
+                    continue
+                if "${" in rel or "$(" in rel:
+                    continue
+                key = (wf.rel_path, rel)
+                if key in seen:
+                    continue
+                seen.add(key)
+                candidates = _resolve_script_candidates(repo_root, cd_targets, rel)
+                if not any(c.exists() for c in candidates):
+                    idx = wf.text.find(rel)
+                    line = line_of(wf.text, idx) if idx >= 0 else None
+                    findings.append(
+                        Finding(
+                            check_id="script-missing",
+                            severity="high",
+                            workflow=wf.rel_path,
+                            line=line,
+                            message=(
+                                f"Workflow references `{rel}` but the file does "
+                                f"not exist under repo root or any `cd` target "
+                                f"in this run block."
+                            ),
+                            evidence=rel,
+                            memory_ref="",
+                        )
+                    )
+    return findings
+
+
+# Check 6: Secret hygiene — hardcoded tokens / JWTs / keys outside ${{ secrets.X }}
+SECRET_PATTERNS = [
+    # GitHub PAT (classic + fine-grained)
+    ("github-pat", re.compile(r"\bgh[ps]_[A-Za-z0-9]{30,}\b"), "critical"),
+    # Stripe live/test keys
+    ("stripe-key", re.compile(r"\bsk_(live|test)_[A-Za-z0-9]{20,}\b"), "critical"),
+    # Supabase service role JWT (signed with eyJ-prefix and very long)
+    ("jwt-secret", re.compile(r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b"), "critical"),
+    # AWS access key
+    ("aws-key", re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "critical"),
+]
+
+SECRETS_EXPR = re.compile(r"\$\{\{\s*secrets\.[^}]*\}\}")
+
+
+def check_secret_hygiene(wf: WorkflowFile) -> list[Finding]:
+    findings: list[Finding] = []
+    for i, line in enumerate(wf.lines, start=1):
+        # Spans inside ${{ secrets.X }} are the correct pattern — skip per-match,
+        # not per-line, so a trailing-comment fallback token isn't masked.
+        secret_spans = [(m.start(), m.end()) for m in SECRETS_EXPR.finditer(line)]
+        for check_id, pat, sev in SECRET_PATTERNS:
+            for m in pat.finditer(line):
+                if any(s <= m.start() and m.end() <= e for s, e in secret_spans):
+                    continue
+                hit = m.group(0)
+                redacted = hit[:6] + "..." + hit[-4:] if len(hit) > 12 else "***"
+                findings.append(
+                    Finding(
+                        check_id=f"secret-{check_id}",
+                        severity=sev,
+                        workflow=wf.rel_path,
+                        line=i,
+                        message=(
+                            f"Possible hardcoded {check_id} on this line. "
+                            f"Replace with `${{{{ secrets.NAME }}}}`."
+                        ),
+                        evidence=redacted,
+                        memory_ref="",
+                    )
+                )
+    return findings
+
+
+# Check 7: Matrix sharding over a mutable sort key
+# Memory: gotcha_matrix_sharding_with_mutable_sort.md
+# Heuristic: matrix has a numeric shard array AND any step run uses OFFSET+LIMIT
+# (with no obvious hash-based sharding clause). Flag as suspicious; user judges.
+SHARD_KEY_HINT = re.compile(r"^\s*(shard|index|chunk|partition|offset)\b", re.IGNORECASE)
+
+
+def check_matrix_sharding(wf: WorkflowFile) -> list[Finding]:
+    if not wf.data:
+        return []
+    findings: list[Finding] = []
+    for job_name, job in iter_jobs(wf.data):
+        strategy = job.get("strategy")
+        if not isinstance(strategy, dict):
+            continue
+        matrix = strategy.get("matrix")
+        if not isinstance(matrix, dict):
+            continue
+        # Detect numeric shard-shaped keys
+        shardish_key = None
+        for k, v in matrix.items():
+            if not isinstance(k, str):
+                continue
+            if SHARD_KEY_HINT.match(k) and isinstance(v, list) and all(
+                isinstance(x, (int, str)) for x in v
+            ):
+                shardish_key = k
+                break
+        if not shardish_key:
+            continue
+        # Scan run blocks for OFFSET + LIMIT pattern (case-insensitive)
+        for step in iter_steps(job):
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            has_offset = re.search(r"\bOFFSET\b", run, re.IGNORECASE) is not None
+            has_limit = re.search(r"\bLIMIT\b", run, re.IGNORECASE) is not None
+            if has_offset and has_limit:
+                # If the shard key is referenced as a hash mod, treat as fine
+                if "hashtext" in run.lower() or "% " in run:
+                    continue
+                findings.append(
+                    Finding(
+                        check_id="matrix-shard-mutable-sort",
+                        severity="medium",
+                        workflow=wf.rel_path,
+                        line=None,
+                        message=(
+                            f"Job `{job_name}` shards via matrix key "
+                            f"`{shardish_key}` and uses OFFSET+LIMIT. If the "
+                            f"underlying sort is mutable (e.g. last_updated), "
+                            f"rows shift between shards and get dropped/dupes. "
+                            f"Prefer hash sharding on a stable ID."
+                        ),
+                        evidence=f"matrix.{shardish_key} + OFFSET/LIMIT",
+                        memory_ref="gotcha_matrix_sharding_with_mutable_sort.md",
+                    )
+                )
+                break  # one finding per job is enough
+    return findings
+
+
+# ---------- driver ----------
+
+
+CHECKS = [
+    check_shell_injection,
+    check_cron_drift,
+    check_env_precedence,
+    check_timeout_shielding,
+    check_secret_hygiene,
+    check_matrix_sharding,
+]
+
+
+def run_audit(workflows_dir: Path, repo_root: Path) -> tuple[list[Finding], list[WorkflowFile]]:
+    files = load_workflows(workflows_dir, repo_root)
+    all_findings: list[Finding] = []
+    for wf in files:
+        if wf.parse_error:
+            all_findings.append(
+                Finding(
+                    check_id="yaml-parse",
+                    severity="high",
+                    workflow=wf.rel_path,
+                    line=None,
+                    message=f"YAML parse error: {wf.parse_error}",
+                    evidence=wf.parse_error.splitlines()[0] if wf.parse_error else "",
+                    memory_ref="",
+                )
+            )
+            # Line-based checks don't need parsed YAML — run them anyway so
+            # security findings (secrets) and obvious drift (cron) still surface
+            # on broken files.
+            all_findings.extend(check_cron_drift(wf))
+            all_findings.extend(check_secret_hygiene(wf))
+            continue
+        for check in CHECKS:
+            all_findings.extend(check(wf))
+        all_findings.extend(check_script_existence(wf, repo_root))
+    return all_findings, files
+
+
+def render_markdown(findings: list[Finding], files: list[WorkflowFile]) -> str:
+    findings_sorted = sorted(
+        findings,
+        key=lambda f: (SEVERITY_ORDER.get(f.severity, 99), f.workflow, f.line or 0),
+    )
+    counts: dict[str, int] = {}
+    for f in findings_sorted:
+        counts[f.severity] = counts.get(f.severity, 0) + 1
+    lines: list[str] = []
+    lines.append("# Workflow Audit\n")
+    lines.append(f"Scanned: **{len(files)}** workflow files\n")
+    lines.append(f"Findings: **{len(findings_sorted)}** "
+                 f"(critical: {counts.get('critical', 0)}, "
+                 f"high: {counts.get('high', 0)}, "
+                 f"medium: {counts.get('medium', 0)}, "
+                 f"low: {counts.get('low', 0)})\n")
+    if not findings_sorted:
+        lines.append("\nNo findings. All checks passed.\n")
+        return "\n".join(lines)
+    current_sev: str | None = None
+    for f in findings_sorted:
+        if f.severity != current_sev:
+            current_sev = f.severity
+            lines.append(f"\n## {current_sev.upper()}\n")
+        loc = f"{f.workflow}" + (f":{f.line}" if f.line else "")
+        lines.append(f"### `{f.check_id}` — {loc}\n")
+        lines.append(f"{f.message}\n")
+        if f.evidence:
+            lines.append(f"Evidence: `{f.evidence}`\n")
+        if f.memory_ref:
+            lines.append(f"Reference: `{f.memory_ref}`\n")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflows-dir",
+        default=None,
+        help="Path to .github/workflows directory (default: <repo-root>/.github/workflows)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.getcwd(),
+        help="Repo root for resolving script paths (default: cwd)",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=["critical", "high", "medium", "low", "never"],
+        default="high",
+        help="Exit non-zero if any finding meets or exceeds this severity (default: high)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    workflows_dir = (
+        Path(args.workflows_dir).resolve()
+        if args.workflows_dir
+        else repo_root / ".github" / "workflows"
+    )
+    if not workflows_dir.is_dir():
+        sys.stderr.write(f"Workflows directory not found: {workflows_dir}\n")
+        return 2
+
+    findings, files = run_audit(workflows_dir, repo_root)
+
+    if args.format == "json":
+        print(json.dumps([f.to_dict() for f in findings], indent=2))
+    else:
+        print(render_markdown(findings, files))
+
+    if args.fail_on == "never":
+        return 0
+    threshold = SEVERITY_ORDER[args.fail_on]
+    worst = min(
+        (SEVERITY_ORDER.get(f.severity, 99) for f in findings),
+        default=99,
+    )
+    return 1 if worst <= threshold else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/auto-merge-queue.yml
+++ b/.github/workflows/auto-merge-queue.yml
@@ -64,19 +64,22 @@ jobs:
 
       - name: Run queue auto-merge
         id: merge
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
         run: |
           cd scripts
-          
+
           # Determine execution mode
           EXECUTE_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+          if [ "$DRY_RUN" != "true" ]; then
             EXECUTE_FLAG="--execute --yes"
           fi
-          
+
           # Set limit
-          LIMIT="${{ github.event.inputs.limit || '2000' }}"
-          
-          echo "🔍 Running queue auto-merge with limit=$LIMIT, dry_run=${{ github.event.inputs.dry_run || 'false' }}"
+          LIMIT="${LIMIT_INPUT:-2000}"
+
+          echo "🔍 Running queue auto-merge with limit=$LIMIT, dry_run=${DRY_RUN:-false}"
           
           # Run the script and capture output
           python3 find_queue_matches.py --limit "$LIMIT" $EXECUTE_FLAG 2>&1 | tee ../auto-merge-output.log
@@ -101,16 +104,27 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          EXACT_MATCHES: ${{ steps.merge.outputs.exact_matches }}
+          HIGH_MATCHES: ${{ steps.merge.outputs.high_matches }}
+          TEAMS_MERGED: ${{ steps.merge.outputs.teams_merged }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            MODE="Dry Run"
+          else
+            MODE="Live"
+          fi
           echo "## 🔗 Queue Auto-Merge Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Exact Matches (95%+) | ${{ steps.merge.outputs.exact_matches }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| High Confidence (90-94%) | ${{ steps.merge.outputs.high_matches }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Teams Merged | ${{ steps.merge.outputs.teams_merged }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Limit | ${{ github.event.inputs.limit || '2000' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Mode | ${{ github.event.inputs.dry_run == 'true' && 'Dry Run' || 'Live' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Exact Matches (95%+) | $EXACT_MATCHES |" >> $GITHUB_STEP_SUMMARY
+          echo "| High Confidence (90-94%) | $HIGH_MATCHES |" >> $GITHUB_STEP_SUMMARY
+          echo "| Teams Merged | $TEAMS_MERGED |" >> $GITHUB_STEP_SUMMARY
+          echo "| Limit | ${LIMIT_INPUT:-2000} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mode | $MODE |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Protection Notes" >> $GITHUB_STEP_SUMMARY
           echo "- Excludes AD/HD/MLS NEXT/EA teams (require manual review)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/backfill-prediction-feature-history.yml
+++ b/.github/workflows/backfill-prediction-feature-history.yml
@@ -123,12 +123,27 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+          CADENCE: ${{ github.event.inputs.cadence }}
+          WEEKDAY: ${{ github.event.inputs.weekday }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days }}
+          PROVIDER: ${{ github.event.inputs.provider }}
+          ENGINE: ${{ github.event.inputs.engine }}
+          DISABLE_ML: ${{ github.event.inputs.disable_ml }}
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          CHUNK_INDEX_INPUT: ${{ github.event.inputs.chunk_index }}
+          CHUNK_SIZE_INPUT: ${{ github.event.inputs.chunk_size }}
+          OVERWRITE_EXISTING: ${{ github.event.inputs.overwrite_existing }}
+          MAX_SNAPSHOTS: ${{ github.event.inputs.max_snapshots }}
+          STOP_ON_ERROR: ${{ github.event.inputs.stop_on_error }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
 
-          CHUNK_INDEX="${{ github.event.inputs.chunk_index }}"
-          CHUNK_SIZE="${{ github.event.inputs.chunk_size }}"
-          RUN_MAX_SNAPSHOTS="${{ github.event.inputs.max_snapshots }}"
+          CHUNK_INDEX="$CHUNK_INDEX_INPUT"
+          CHUNK_SIZE="$CHUNK_SIZE_INPUT"
+          RUN_MAX_SNAPSHOTS="$MAX_SNAPSHOTS"
           if [ -z "$RUN_MAX_SNAPSHOTS" ] && [ -n "$CHUNK_SIZE" ]; then
             RUN_MAX_SNAPSHOTS="$CHUNK_SIZE"
           fi
@@ -141,32 +156,32 @@ jobs:
 
           CMD=(
             python scripts/backfill_prediction_feature_history.py
-            --start-date "${{ github.event.inputs.start_date }}"
-            --end-date "${{ github.event.inputs.end_date }}"
-            --cadence "${{ github.event.inputs.cadence }}"
-            --weekday "${{ github.event.inputs.weekday }}"
-            --lookback-days "${{ github.event.inputs.lookback_days }}"
-            --engine "${{ github.event.inputs.engine }}"
+            --start-date "$START_DATE"
+            --end-date "$END_DATE"
+            --cadence "$CADENCE"
+            --weekday "$WEEKDAY"
+            --lookback-days "$LOOKBACK_DAYS"
+            --engine "$ENGINE"
             --skip-snapshots "$SKIP_SNAPSHOTS"
           )
 
-          if [ -n "${{ github.event.inputs.provider }}" ]; then
-            CMD+=(--provider "${{ github.event.inputs.provider }}")
+          if [ -n "$PROVIDER" ]; then
+            CMD+=(--provider "$PROVIDER")
           fi
 
-          if [ "${{ github.event.inputs.disable_ml }}" = "true" ]; then
+          if [ "$DISABLE_ML" = "true" ]; then
             CMD+=(--disable-ml)
           fi
 
-          if [ "${{ github.event.inputs.force_rebuild }}" = "true" ]; then
+          if [ "$FORCE_REBUILD" = "true" ]; then
             CMD+=(--force-rebuild)
           fi
 
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             CMD+=(--dry-run)
           fi
 
-          if [ "${{ github.event.inputs.overwrite_existing }}" = "true" ]; then
+          if [ "$OVERWRITE_EXISTING" = "true" ]; then
             CMD+=(--overwrite-existing)
           fi
 
@@ -174,7 +189,7 @@ jobs:
             CMD+=(--max-snapshots "$RUN_MAX_SNAPSHOTS")
           fi
 
-          if [ "${{ github.event.inputs.stop_on_error }}" = "true" ]; then
+          if [ "$STOP_ON_ERROR" = "true" ]; then
             CMD+=(--stop-on-error)
           fi
 

--- a/.github/workflows/clear-queue.yml
+++ b/.github/workflows/clear-queue.yml
@@ -87,7 +87,9 @@ jobs:
           PYTHONPATH:                ${{ github.workspace }}
           ZENROWS_API_KEY: ${{ inputs.use_zenrows && secrets.ZENROWS_API_KEY || '' }}
           ZENROWS_PREMIUM_PROXY: ${{ inputs.zenrows_premium_proxy && 'true' || 'false' }}
-        run: ${{ steps.build-command.outputs.command }}
+          DRAIN_COMMAND: ${{ steps.build-command.outputs.command }}
+        run: |
+          eval "$DRAIN_COMMAND"
 
       - name: Upload scraped data
         if: always()

--- a/.github/workflows/data-hygiene-weekly.yml
+++ b/.github/workflows/data-hygiene-weekly.yml
@@ -102,13 +102,15 @@ jobs:
       - name: 'Step 1: Normalize Team Names'
         id: step1
         if: ${{ !contains(format(',{0},', github.event.inputs.skip_steps || ''), ',1,') }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 1: NORMALIZE TEAM NAMES"
           echo "═══════════════════════════════════════════════════"
 
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
@@ -121,13 +123,15 @@ jobs:
       - name: 'Step 1b: Backfill Team Distinction'
         id: step1b
         if: ${{ !contains(format(',{0},', github.event.inputs.skip_steps || ''), ',1b,') }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 1b: BACKFILL TEAM DISTINCTION"
           echo "═══════════════════════════════════════════════════"
 
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
@@ -140,13 +144,15 @@ jobs:
       - name: 'Step 2: Fix Age Year Discrepancies'
         id: step2
         if: ${{ !contains(format(',{0},', github.event.inputs.skip_steps || ''), ',2,') }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 2: FIX AGE YEAR DISCREPANCIES"
           echo "═══════════════════════════════════════════════════"
 
           AGE_FLAGS=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             AGE_FLAGS="--dry-run"
           fi
 
@@ -159,13 +165,16 @@ jobs:
       - name: 'Step 3: Fuzzy Duplicate Merge'
         id: step3
         if: ${{ !contains(format(',{0},', github.event.inputs.skip_steps || ''), ',3,') }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GENDER_RAW: ${{ github.event.inputs.gender }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 5: FUZZY DUPLICATE MERGE"
           echo "═══════════════════════════════════════════════════"
 
           # Determine which genders to run (scheduled runs default to male)
-          GENDER_INPUT="${{ github.event.inputs.gender || 'male' }}"
+          GENDER_INPUT="${GENDER_RAW:-male}"
           if [ "$GENDER_INPUT" == "both" ]; then
             GENDERS="male female"
           else
@@ -181,7 +190,7 @@ jobs:
               echo ""
               echo "── $AGE $GENDER ──"
 
-              if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+              if [ "$DRY_RUN" == "true" ]; then
                 python scripts/find_fuzzy_duplicate_teams.py \
                   --age-group "$AGE" --gender "$GENDER" --dry-run --min-score 0.90 \
                   2>&1 | tee -a logs/step3_fuzzy_merge.log
@@ -206,13 +215,15 @@ jobs:
       - name: 'Step 4: Match Review Queue'
         id: step4
         if: ${{ !contains(format(',{0},', github.event.inputs.skip_steps || ''), ',4,') }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 4: MATCH REVIEW QUEUE"
           echo "═══════════════════════════════════════════════════"
 
           EXECUTE_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+          if [ "$DRY_RUN" != "true" ]; then
             EXECUTE_FLAG="--execute --yes"
           fi
 
@@ -236,21 +247,29 @@ jobs:
       # ── Summary ───────────────────────────────────────────
       - name: Pipeline Summary
         if: always()
+        env:
+          MODE: ${{ github.event.inputs.dry_run == 'true' && '🔍 Dry Run' || '⚡ Live' }}
+          GENDER_RAW: ${{ github.event.inputs.gender }}
+          STEP1_TEAMS_NORMALIZED: ${{ steps.step1.outputs.teams_normalized || 'skipped' }}
+          STEP1B_DISTINCTION_UPDATED: ${{ steps.step1b.outputs.distinction_updated || 'skipped' }}
+          STEP2_AGE_FIXED: ${{ steps.step2.outputs.age_fixed || 'skipped' }}
+          STEP3_FUZZY_SUGGESTED: ${{ steps.step3.outputs.fuzzy_suggested || 'skipped' }}
+          STEP3_FUZZY_MERGED: ${{ steps.step3.outputs.fuzzy_merged || '0' }}
+          STEP4_EXACT_MATCHES: ${{ steps.step4.outputs.exact_matches || 'skipped' }}
+          STEP4_QUEUE_MERGED: ${{ steps.step4.outputs.queue_merged || '0' }}
         run: |
-          MODE="${{ github.event.inputs.dry_run == 'true' && '🔍 Dry Run' || '⚡ Live' }}"
-
           echo "## 🧹 Weekly Data Hygiene Pipeline" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          GENDER="${{ github.event.inputs.gender || 'male' }}"
+          GENDER="${GENDER_RAW:-male}"
           echo "**Mode:** $MODE | **Gender:** $GENDER" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Task | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|------|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 1 | Normalize Team Names | ${{ steps.step1.outputs.teams_normalized || 'skipped' }} normalized |" >> $GITHUB_STEP_SUMMARY
-          echo "| 1b | Backfill Distinction | ${{ steps.step1b.outputs.distinction_updated || 'skipped' }} updated |" >> $GITHUB_STEP_SUMMARY
-          echo "| 2 | Fix Age Year | ${{ steps.step2.outputs.age_fixed || 'skipped' }} fixed |" >> $GITHUB_STEP_SUMMARY
-          echo "| 3 | Fuzzy Duplicate Merge | ${{ steps.step3.outputs.fuzzy_suggested || 'skipped' }} suggested, ${{ steps.step3.outputs.fuzzy_merged || '0' }} merged |" >> $GITHUB_STEP_SUMMARY
-          echo "| 4 | Match Review Queue | ${{ steps.step4.outputs.exact_matches || 'skipped' }} exact, ${{ steps.step4.outputs.queue_merged || '0' }} merged |" >> $GITHUB_STEP_SUMMARY
+          echo "| 1 | Normalize Team Names | $STEP1_TEAMS_NORMALIZED normalized |" >> $GITHUB_STEP_SUMMARY
+          echo "| 1b | Backfill Distinction | $STEP1B_DISTINCTION_UPDATED updated |" >> $GITHUB_STEP_SUMMARY
+          echo "| 2 | Fix Age Year | $STEP2_AGE_FIXED fixed |" >> $GITHUB_STEP_SUMMARY
+          echo "| 3 | Fuzzy Duplicate Merge | $STEP3_FUZZY_SUGGESTED suggested, $STEP3_FUZZY_MERGED merged |" >> $GITHUB_STEP_SUMMARY
+          echo "| 4 | Match Review Queue | $STEP4_EXACT_MATCHES exact, $STEP4_QUEUE_MERGED merged |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Pipeline Order" >> $GITHUB_STEP_SUMMARY
           echo "1. Normalize → 1b. Distinction → 2. Fix age → 3. Fuzzy merge → 4. Queue" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/enrich-instagram-handles.yml
+++ b/.github/workflows/enrich-instagram-handles.yml
@@ -101,54 +101,72 @@ jobs:
 
       - name: Build CLI flags
         id: flags
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          LIMIT: ${{ github.event.inputs.limit }}
+          MIN_POWER_SCORE: ${{ github.event.inputs.min_power_score }}
+          STATE: ${{ github.event.inputs.state }}
+          AGE_GROUP: ${{ github.event.inputs.age_group }}
+          GENDER: ${{ github.event.inputs.gender }}
+          RE_CHECK: ${{ github.event.inputs.re_check }}
+          WORKERS: ${{ github.event.inputs.workers }}
         run: |
           FLAGS=""
 
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             FLAGS="$FLAGS --dry-run"
           fi
 
-          if [ -n "${{ github.event.inputs.limit }}" ]; then
-            FLAGS="$FLAGS --limit ${{ github.event.inputs.limit }}"
+          if [ -n "$LIMIT" ]; then
+            FLAGS="$FLAGS --limit $LIMIT"
           fi
 
-          if [ -n "${{ github.event.inputs.min_power_score }}" ] && [ "${{ github.event.inputs.min_power_score }}" != "0" ]; then
-            FLAGS="$FLAGS --min-power-score ${{ github.event.inputs.min_power_score }}"
+          if [ -n "$MIN_POWER_SCORE" ] && [ "$MIN_POWER_SCORE" != "0" ]; then
+            FLAGS="$FLAGS --min-power-score $MIN_POWER_SCORE"
           fi
 
-          if [ -n "${{ github.event.inputs.state }}" ]; then
-            FLAGS="$FLAGS --state ${{ github.event.inputs.state }}"
+          if [ -n "$STATE" ]; then
+            FLAGS="$FLAGS --state $STATE"
           fi
 
-          if [ -n "${{ github.event.inputs.age_group }}" ]; then
-            FLAGS="$FLAGS --age-group ${{ github.event.inputs.age_group }}"
+          if [ -n "$AGE_GROUP" ]; then
+            FLAGS="$FLAGS --age-group $AGE_GROUP"
           fi
 
-          if [ -n "${{ github.event.inputs.gender }}" ]; then
-            FLAGS="$FLAGS --gender ${{ github.event.inputs.gender }}"
+          if [ -n "$GENDER" ]; then
+            FLAGS="$FLAGS --gender $GENDER"
           fi
 
-          if [ "${{ github.event.inputs.re_check }}" = "true" ]; then
+          if [ "$RE_CHECK" = "true" ]; then
             FLAGS="$FLAGS --re-check"
           fi
 
-          WORKERS="${{ github.event.inputs.workers }}"
           FLAGS="$FLAGS --workers ${WORKERS:-3}"
 
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
           echo "Built flags: $FLAGS"
 
       - name: Enrich Instagram handles
+        env:
+          FLAGS: ${{ steps.flags.outputs.flags }}
         run: |
-          python scripts/enrich_instagram_handles.py ${{ steps.flags.outputs.flags }}
+          python scripts/enrich_instagram_handles.py $FLAGS
 
       - name: Workflow summary
         if: always()
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          LIMIT: ${{ github.event.inputs.limit }}
+          MIN_POWER_SCORE: ${{ github.event.inputs.min_power_score }}
+          STATE: ${{ github.event.inputs.state }}
+          AGE_GROUP: ${{ github.event.inputs.age_group }}
+          GENDER: ${{ github.event.inputs.gender }}
         run: |
           echo "## Enrich Instagram Handles" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Mode:** ${{ github.event.inputs.dry_run == 'true' && 'DRY-RUN' || 'LIVE' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Filters:** limit=${{ github.event.inputs.limit || 'all' }} | power_score>=${{ github.event.inputs.min_power_score || '0' }} | state=${{ github.event.inputs.state || 'all' }} | age=${{ github.event.inputs.age_group || 'all' }} | gender=${{ github.event.inputs.gender || 'all' }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DRY_RUN" = "true" ]; then MODE="DRY-RUN"; else MODE="LIVE"; fi
+          echo "**Mode:** $MODE" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Filters:** limit=${LIMIT:-all} | power_score>=${MIN_POWER_SCORE:-0} | state=${STATE:-all} | age=${AGE_GROUP:-all} | gender=${GENDER:-all}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Results stored in \`team_social_profiles\` table." >> "$GITHUB_STEP_SUMMARY"
           echo "Review queue: \`team_instagram_review_queue\` view." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/evaluate-prospective-match-predictions.yml
+++ b/.github/workflows/evaluate-prospective-match-predictions.yml
@@ -54,6 +54,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           OUTPUT_DIR="$RUNNER_TEMP/prospective_evaluation"
@@ -65,8 +66,8 @@ jobs:
             --summary-path "$SUMMARY_PATH"
           )
 
-          if [ -n "${{ github.event.inputs.limit }}" ]; then
-            CMD+=(--limit "${{ github.event.inputs.limit }}")
+          if [ -n "$LIMIT_INPUT" ]; then
+            CMD+=(--limit "$LIMIT_INPUT")
           fi
 
           printf 'Running command:\n'

--- a/.github/workflows/fix-age-year-discrepancies.yml
+++ b/.github/workflows/fix-age-year-discrepancies.yml
@@ -86,13 +86,15 @@ jobs:
       - name: 'Step 1: Normalize Team Names'
         id: step1
         if: ${{ github.event.inputs.run_normalization_first != 'false' }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 1: NORMALIZE TEAM NAMES"
           echo "═══════════════════════════════════════════════════"
 
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
@@ -104,22 +106,25 @@ jobs:
       # ── Step 2: Fix Age Group Discrepancies ─────────────────
       - name: 'Step 2: Fix age group discrepancies'
         id: step2
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TEAM_NAME: ${{ github.event.inputs.team_name }}
         run: |
           echo "═══════════════════════════════════════════════════"
           echo "STEP 2: FIX AGE GROUP DISCREPANCIES"
           echo "═══════════════════════════════════════════════════"
 
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
 
-          TEAM_NAME_ARG=""
-          if [ -n "${{ github.event.inputs.team_name }}" ]; then
-            TEAM_NAME_ARG="--team-name '${{ github.event.inputs.team_name }}'"
+          EXTRA_ARGS=()
+          if [ -n "$TEAM_NAME" ]; then
+            EXTRA_ARGS+=(--team-name "$TEAM_NAME")
           fi
 
-          python scripts/fix_team_age_groups.py $DRY_RUN_FLAG $TEAM_NAME_ARG 2>&1 | tee logs/step2_fix_age.log || {
+          python scripts/fix_team_age_groups.py $DRY_RUN_FLAG "${EXTRA_ARGS[@]}" 2>&1 | tee logs/step2_fix_age.log || {
             echo "❌ Age group fix script failed with exit code $?"
             exit 1
           }
@@ -139,8 +144,16 @@ jobs:
       # ── Summary ───────────────────────────────────────────
       - name: Pipeline Summary
         if: always()
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TEAMS_NORMALIZED: ${{ steps.step1.outputs.teams_normalized }}
+          TEAMS_FIXED: ${{ steps.step2.outputs.teams_fixed }}
         run: |
-          MODE="${{ github.event.inputs.dry_run == 'true' && '🔍 Dry Run' || '⚡ Live' }}"
+          if [ "$DRY_RUN" == "true" ]; then
+            MODE="🔍 Dry Run"
+          else
+            MODE="⚡ Live"
+          fi
 
           echo "## 🔧 Fix Age Year Discrepancies" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -148,12 +161,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Task | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|------|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 1 | Normalize Team Names | ${{ steps.step1.outputs.teams_normalized || 'skipped' }} normalized |" >> $GITHUB_STEP_SUMMARY
-          echo "| 2 | Fix Age Groups | ${{ steps.step2.outputs.teams_fixed || '0' }} fixed |" >> $GITHUB_STEP_SUMMARY
+          echo "| 1 | Normalize Team Names | ${TEAMS_NORMALIZED:-skipped} normalized |" >> $GITHUB_STEP_SUMMARY
+          echo "| 2 | Fix Age Groups | ${TEAMS_FIXED:-0} fixed |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Integration" >> $GITHUB_STEP_SUMMARY
           echo "Step 1 converts 14B→2014 so Step 2 can extract birth year from team names." >> $GITHUB_STEP_SUMMARY
-          if [ "${{ github.event.inputs.dry_run }}" != "true" ] && [ "${{ steps.step2.outputs.teams_fixed }}" != "0" ]; then
+          if [ "$DRY_RUN" != "true" ] && [ "$TEAMS_FIXED" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ **Recalculate rankings** for affected teams after merge." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/marketing-pipeline.yml
+++ b/.github/workflows/marketing-pipeline.yml
@@ -73,9 +73,10 @@ jobs:
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
           PITCHRANK_URL: 'https://pitchrank.io'
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
           python scripts/marketing_pipeline.py $DRY_RUN_FLAG

--- a/.github/workflows/playmetrics-scrape-import.yml
+++ b/.github/workflows/playmetrics-scrape-import.yml
@@ -189,15 +189,21 @@ jobs:
 
       - name: Report results
         if: always()
+        env:
+          TRIGGER: ${{ github.event_name }}
+          PROCESSED_COUNT: ${{ steps.process.outputs.processed_count || '0' }}
+          FAILED_COUNT: ${{ steps.process.outputs.failed_count || '0' }}
+          TOTAL_GAMES: ${{ steps.process.outputs.total_games || '0' }}
+          SUMMARY: ${{ steps.process.outputs.summary }}
         run: |
           {
             echo "## PlayMetrics Scrape Summary"
             echo ""
-            echo "- **Trigger:** ${{ github.event_name }}"
-            echo "- **URLs processed:** ${{ steps.process.outputs.processed_count || '0' }}"
-            echo "- **URLs failed:** ${{ steps.process.outputs.failed_count || '0' }}"
-            echo "- **Total games imported:** ${{ steps.process.outputs.total_games || '0' }}"
+            echo "- **Trigger:** $TRIGGER"
+            echo "- **URLs processed:** $PROCESSED_COUNT"
+            echo "- **URLs failed:** $FAILED_COUNT"
+            echo "- **Total games imported:** $TOTAL_GAMES"
             echo ""
             echo "### Per-URL results"
-            printf '%b' "${{ steps.process.outputs.summary }}"
+            printf '%b' "$SUMMARY"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/playmetrics-tournament-scrape-import.yml
+++ b/.github/workflows/playmetrics-tournament-scrape-import.yml
@@ -86,10 +86,12 @@ jobs:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           PYTHONPATH: ${{ github.workspace }}
+          # Hoist step output into env so it cannot inject shell metacharacters
+          # into the run block (see gha_inputs_shell_injection memory).
+          CSV_FILE: ${{ steps.find_csv.outputs.csv_file }}
         run: |
           set -euo pipefail
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
-          CSV_FILE="${{ steps.find_csv.outputs.csv_file }}"
           echo "Importing games from: $CSV_FILE"
           python scripts/import_games_enhanced.py "$CSV_FILE" playmetrics_tournament --stream --concurrency 8 --checkpoint \
             2>&1 | tee logs/playmetrics_tournament_import.log
@@ -115,17 +117,23 @@ jobs:
       - name: Report results
         if: always()
         env:
+          # Hoist inputs/outputs/context into env so they cannot inject shell
+          # metacharacters into the run block (see gha_inputs_shell_injection memory).
           TOURNAMENT_URL: ${{ inputs.tournament_url }}
+          EVENT_NAME: ${{ github.event_name }}
+          GAME_COUNT: ${{ steps.find_csv.outputs.game_count || '0' }}
+          HAS_GAMES: ${{ steps.find_csv.outputs.has_games }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           {
             echo "## PlayMetrics Tournament Scrape Summary"
             echo ""
             echo "- **Tournament URL:** $TOURNAMENT_URL"
-            echo "- **Trigger:** ${{ github.event_name }}"
-            echo "- **Games found:** ${{ steps.find_csv.outputs.game_count || '0' }}"
-            if [ "${{ steps.find_csv.outputs.has_games }}" == "false" ]; then
+            echo "- **Trigger:** $EVENT_NAME"
+            echo "- **Games found:** $GAME_COUNT"
+            if [ "$HAS_GAMES" == "false" ]; then
               echo "- **Import:** Skipped (no games to import)"
-            elif [ "${{ inputs.dry_run }}" == "false" ]; then
+            elif [ "$DRY_RUN" == "false" ]; then
               echo "- **Import:** Completed"
             else
               echo "- **Import:** Skipped (dry run)"

--- a/.github/workflows/prepare-prospective-match-predictions.yml
+++ b/.github/workflows/prepare-prospective-match-predictions.yml
@@ -179,39 +179,48 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          FIXTURE_FILE: ${{ steps.fixtures.outputs.fixture_file }}
+          FIXTURE_ARTIFACT_NAME: ${{ steps.fixtures.outputs.artifact_name }}
+          MODEL_ARTIFACT: ${{ steps.model.outputs.model_artifact }}
+          CALIBRATION_ARTIFACT: ${{ steps.model.outputs.calibration_artifact }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          OFFLINE_MODEL_VERSION: ${{ github.event.inputs.offline_model_version }}
+          FORCE_OFFLINE_REFRESH: ${{ github.event.inputs.force_offline_refresh }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           SUMMARY_PATH="$RUNNER_TEMP/prospective_prepare_summary.json"
 
           CMD=(
             python scripts/prepare_prospective_match_predictions.py
-            --fixtures-file "${{ steps.fixtures.outputs.fixture_file }}"
-            --source-artifact-path "${{ steps.fixtures.outputs.artifact_name }}"
-            --lookback-days "${{ github.event.inputs.lookback_days }}"
+            --fixtures-file "$FIXTURE_FILE"
+            --source-artifact-path "$FIXTURE_ARTIFACT_NAME"
+            --lookback-days "$LOOKBACK_DAYS"
             --summary-path "$SUMMARY_PATH"
           )
 
-          if [ -n "${{ github.event.inputs.limit }}" ]; then
-            CMD+=(--limit "${{ github.event.inputs.limit }}")
+          if [ -n "$LIMIT_INPUT" ]; then
+            CMD+=(--limit "$LIMIT_INPUT")
           fi
 
-          if [ -n "${{ steps.model.outputs.model_artifact }}" ]; then
-            CMD+=(--model-artifact "${{ steps.model.outputs.model_artifact }}")
+          if [ -n "$MODEL_ARTIFACT" ]; then
+            CMD+=(--model-artifact "$MODEL_ARTIFACT")
           fi
 
-          if [ -n "${{ steps.model.outputs.calibration_artifact }}" ]; then
-            CMD+=(--calibration-artifact "${{ steps.model.outputs.calibration_artifact }}")
+          if [ -n "$CALIBRATION_ARTIFACT" ]; then
+            CMD+=(--calibration-artifact "$CALIBRATION_ARTIFACT")
           fi
 
-          if [ -n "${{ github.event.inputs.offline_model_version }}" ]; then
-            CMD+=(--offline-model-version "${{ github.event.inputs.offline_model_version }}")
+          if [ -n "$OFFLINE_MODEL_VERSION" ]; then
+            CMD+=(--offline-model-version "$OFFLINE_MODEL_VERSION")
           fi
 
-          if [ "${{ github.event.inputs.force_offline_refresh }}" = "true" ]; then
+          if [ "$FORCE_OFFLINE_REFRESH" = "true" ]; then
             CMD+=(--force-offline-refresh)
           fi
 
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             CMD+=(--dry-run)
           fi
 

--- a/.github/workflows/process-match-prediction-shadow.yml
+++ b/.github/workflows/process-match-prediction-shadow.yml
@@ -108,27 +108,32 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          ARTIFACT_DIR_INPUT: ${{ steps.artifact.outputs.artifact_dir }}
+          SHADOW_STATUS: ${{ github.event.inputs.shadow_status }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          APPLY_CALIBRATION: ${{ github.event.inputs.apply_calibration }}
+          SHADOW_MODEL_VERSION: ${{ github.event.inputs.shadow_model_version }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
 
-          ARTIFACT_DIR="${{ steps.artifact.outputs.artifact_dir }}"
+          ARTIFACT_DIR="$ARTIFACT_DIR_INPUT"
           MODEL_ARTIFACT="$ARTIFACT_DIR/point_in_time_match_model.pkl"
           SUMMARY_PATH="$RUNNER_TEMP/match_prediction_shadow_summary.json"
 
           CMD=(
             python scripts/process_match_prediction_shadow.py
             --model-artifact "$MODEL_ARTIFACT"
-            --shadow-status "${{ github.event.inputs.shadow_status }}"
-            --limit "${{ github.event.inputs.limit }}"
+            --shadow-status "$SHADOW_STATUS"
+            --limit "$LIMIT_INPUT"
             --summary-path "$SUMMARY_PATH"
           )
 
-          if [ "${{ github.event.inputs.apply_calibration }}" = "true" ]; then
+          if [ "$APPLY_CALIBRATION" = "true" ]; then
             CMD+=(--calibration-artifact "$ARTIFACT_DIR/point_in_time_model_calibration.pkl")
           fi
 
-          if [ -n "${{ github.event.inputs.shadow_model_version }}" ]; then
-            CMD+=(--shadow-model-version "${{ github.event.inputs.shadow_model_version }}")
+          if [ -n "$SHADOW_MODEL_VERSION" ]; then
+            CMD+=(--shadow-model-version "$SHADOW_MODEL_VERSION")
           fi
 
           printf 'Running command:\n'

--- a/.github/workflows/process-prospective-heuristic-predictions.yml
+++ b/.github/workflows/process-prospective-heuristic-predictions.yml
@@ -59,18 +59,21 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          HEURISTIC_STATUS: ${{ github.event.inputs.heuristic_status }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          HEURISTIC_MODEL_VERSION: ${{ github.event.inputs.heuristic_model_version }}
         run: |
           SUMMARY_PATH="$RUNNER_TEMP/prospective_heuristic_summary.json"
 
           CMD=(
             npm run process:prospective:heuristic --
-            --status "${{ github.event.inputs.heuristic_status }}"
-            --limit "${{ github.event.inputs.limit }}"
+            --status "$HEURISTIC_STATUS"
+            --limit "$LIMIT_INPUT"
             --summary-path "$SUMMARY_PATH"
           )
 
-          if [ -n "${{ github.event.inputs.heuristic_model_version }}" ]; then
-            CMD+=(--heuristic-model-version "${{ github.event.inputs.heuristic_model_version }}")
+          if [ -n "$HEURISTIC_MODEL_VERSION" ]; then
+            CMD+=(--heuristic-model-version "$HEURISTIC_MODEL_VERSION")
           fi
 
           printf 'Running command:\n'

--- a/.github/workflows/reconcile-stripe-daily.yml
+++ b/.github/workflows/reconcile-stripe-daily.yml
@@ -59,9 +59,11 @@ jobs:
           fi
 
       - name: Run Stripe reconciliation
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           DRY_RUN_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
           python scripts/reconcile_stripe_subscriptions.py $DRY_RUN_FLAG

--- a/.github/workflows/scrape-games.yml
+++ b/.github/workflows/scrape-games.yml
@@ -347,7 +347,9 @@ jobs:
           # ~25x more expensive). false → datacenter IPs ("standard" billing).
           # Only read by the scraper when ZENROWS_API_KEY is set.
           ZENROWS_PREMIUM_PROXY: ${{ inputs.zenrows_premium_proxy && 'true' || 'false' }}
-        run: ${{ steps.build-command.outputs.command }}
+          SCRAPE_COMMAND: ${{ steps.build-command.outputs.command }}
+        run: |
+          eval "$SCRAPE_COMMAND"
 
       - name: Upload scraped data
         if: always()
@@ -369,18 +371,24 @@ jobs:
 
       - name: Report results
         if: always()
+        env:
+          CHAIN_REMAINING:  ${{ inputs.chain_remaining }}
+          LIMIT_TEAMS:      ${{ inputs.limit_teams }}
+          NULL_TEAMS_ONLY:  ${{ inputs.null_teams_only }}
+          INCLUDE_RECENT:   ${{ inputs.include_recent }}
+          CONCURRENCY:      ${{ inputs.concurrency }}
         run: |
           echo "===================="
           echo "Scrape shard ${SCRAPE_SHARD_INDEX}/${SCRAPE_SHARD_COUNT} completed"
           echo "===================="
-          if [ -n "${{ inputs.chain_remaining }}" ] && [ "${{ inputs.chain_remaining }}" != "0" ]; then
-            echo "Teams limit: 5000 per shard × 5 shards = 25000 (chain link, ${{ inputs.chain_remaining }} remaining)"
+          if [ -n "$CHAIN_REMAINING" ] && [ "$CHAIN_REMAINING" != "0" ]; then
+            echo "Teams limit: 5000 per shard × 5 shards = 25000 (chain link, $CHAIN_REMAINING remaining)"
           else
-            echo "Teams limit input: ${{ inputs.limit_teams || 'empty (incremental mode)' }}"
+            echo "Teams limit input: ${LIMIT_TEAMS:-empty (incremental mode)}"
           fi
-          echo "Null teams only: ${{ inputs.null_teams_only }}"
-          echo "Include recent (override 7-day filter): ${{ inputs.include_recent }}"
-          echo "Concurrency input: ${{ inputs.concurrency }}"
+          echo "Null teams only: $NULL_TEAMS_ONLY"
+          echo "Include recent (override 7-day filter): $INCLUDE_RECENT"
+          echo "Concurrency input: $CONCURRENCY"
           echo "Check artifacts for scraped data and logs"
 
   finalize:

--- a/.github/workflows/scrape-specific-event.yml
+++ b/.github/workflows/scrape-specific-event.yml
@@ -56,23 +56,28 @@ jobs:
           GOTSPORT_DELAY_MAX: '2.5'
           GOTSPORT_MAX_RETRIES: '3'
           GOTSPORT_TIMEOUT: '30'
+          EVENT_ID: ${{ inputs.event_id }}
+          LOOKBACK_DAYS: ${{ inputs.lookback_days }}
+          AUTO_IMPORT: ${{ inputs.auto_import }}
         run: |
           # Set Python path to include project root
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
-          
+
           # Build command with optional parameters
-          CMD="python scripts/scrape_specific_event.py ${{ inputs.event_id }} --force"
-          
-          if [ -n "${{ inputs.lookback_days }}" ]; then
-            CMD="$CMD --lookback-days ${{ inputs.lookback_days }}"
+          CMD=(python scripts/scrape_specific_event.py "$EVENT_ID" --force)
+
+          if [ -n "$LOOKBACK_DAYS" ]; then
+            CMD+=(--lookback-days "$LOOKBACK_DAYS")
           fi
-          
-          if [ "${{ inputs.auto_import }}" == "false" ]; then
-            CMD="$CMD --no-auto-import"
+
+          if [ "$AUTO_IMPORT" = "false" ]; then
+            CMD+=(--no-auto-import)
           fi
-          
-          echo "Running: $CMD"
-          $CMD || exit 1
+
+          printf 'Running:'
+          printf ' %q' "${CMD[@]}"
+          printf '\n'
+          "${CMD[@]}" || exit 1
       
       - name: Upload scraped data
         if: always()
@@ -96,8 +101,10 @@ jobs:
       
       - name: Report results
         if: always()
+        env:
+          EVENT_ID: ${{ inputs.event_id }}
         run: |
-          echo "Specific event scraper workflow completed for event ID: ${{ inputs.event_id }}"
+          echo "Specific event scraper workflow completed for event ID: $EVENT_ID"
           echo "Check the artifacts above for scraped data and logs."
 
 

--- a/.github/workflows/settle-prospective-match-predictions.yml
+++ b/.github/workflows/settle-prospective-match-predictions.yml
@@ -58,13 +58,15 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          EVALUATION_STATUS: ${{ github.event.inputs.evaluation_status }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           SUMMARY_PATH="$RUNNER_TEMP/prospective_settlement_summary.json"
 
           python scripts/settle_prospective_match_predictions.py \
-            --status "${{ github.event.inputs.evaluation_status }}" \
-            --limit "${{ github.event.inputs.limit }}" \
+            --status "$EVALUATION_STATUS" \
+            --limit "$LIMIT_INPUT" \
             --summary-path "$SUMMARY_PATH"
 
           echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tgs-event-scrape-import.yml
+++ b/.github/workflows/tgs-event-scrape-import.yml
@@ -268,9 +268,11 @@ jobs:
         # Gate matches the Import Games step exactly: same has_games + skip_import
         # conditions, so the marker exists iff `import_games_enhanced.py` ran.
         if: ${{ steps.find_csv.outputs.has_games == 'true' && env.TGS_SKIP_IMPORT != 'true' }}
+        env:
+          GAME_COUNT: ${{ steps.find_csv.outputs.game_count }}
         run: |
           mkdir -p import-marker
-          echo "shard=${TGS_SHARD_INDEX} games=${{ steps.find_csv.outputs.game_count }}" > "import-marker/shard-${TGS_SHARD_INDEX}.txt"
+          echo "shard=${TGS_SHARD_INDEX} games=${GAME_COUNT}" > "import-marker/shard-${TGS_SHARD_INDEX}.txt"
 
       - name: Upload import marker
         if: ${{ steps.find_csv.outputs.has_games == 'true' && env.TGS_SKIP_IMPORT != 'true' }}
@@ -388,6 +390,7 @@ jobs:
       - name: Report results
         if: always()
         env:
+          EVENT_NAME:         ${{ github.event_name }}
           START_EVENT:        ${{ needs.prepare.outputs.start_event }}
           END_EVENT:          ${{ needs.prepare.outputs.end_event }}
           TOTAL_EVENTS:       ${{ needs.prepare.outputs.total_events }}
@@ -400,7 +403,7 @@ jobs:
           echo "===================="
           echo "TGS event scrape and import workflow completed"
           echo "===================="
-          echo "Trigger:           ${{ github.event_name }}"
+          echo "Trigger:           ${EVENT_NAME}"
           echo "Range:             ${START_EVENT} - ${END_EVENT} (${TOTAL_EVENTS} events)"
           echo "Shard count:       ${SHARD_COUNT}"
           echo "Shards result:     ${SHARDS_RESULT}"

--- a/.github/workflows/train-point-in-time-match-model.yml
+++ b/.github/workflows/train-point-in-time-match-model.yml
@@ -140,27 +140,34 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          MODEL_DIR: ${{ github.event.inputs.model_dir }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          TEST_SLICE_STATE: ${{ github.event.inputs.test_slice_state }}
+          TEST_SLICE_AGE_GROUP: ${{ github.event.inputs.test_slice_age_group }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days }}
+          TEST_RATIO: ${{ github.event.inputs.test_ratio }}
+          PROBABILITY_STRATEGY: ${{ github.event.inputs.probability_strategy }}
+          MIN_DRAW_RECALL: ${{ github.event.inputs.min_draw_recall }}
+          MAX_DRAW_RATE_GAP: ${{ github.event.inputs.max_draw_rate_gap }}
+          WINNER_ACCURACY_TOLERANCE: ${{ github.event.inputs.winner_accuracy_tolerance }}
+          LOG_LOSS_TOLERANCE: ${{ github.event.inputs.log_loss_tolerance }}
+          MIN_EXAMPLES: ${{ github.event.inputs.min_examples }}
+          SAVE_DATASET: ${{ github.event.inputs.save_dataset }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
-
-          MODEL_DIR="${{ github.event.inputs.model_dir }}"
-          LIMIT_INPUT="${{ github.event.inputs.limit }}"
-          TEST_SLICE_STATE="${{ github.event.inputs.test_slice_state }}"
-          TEST_SLICE_AGE_GROUP="${{ github.event.inputs.test_slice_age_group }}"
 
           mkdir -p "$MODEL_DIR"
 
           CMD=(
             python scripts/train_point_in_time_match_model.py
-            --lookback-days "${{ github.event.inputs.lookback_days }}"
-            --test-ratio "${{ github.event.inputs.test_ratio }}"
-            --probability-strategy "${{ github.event.inputs.probability_strategy }}"
-            --min-draw-recall "${{ github.event.inputs.min_draw_recall }}"
-            --max-draw-rate-gap "${{ github.event.inputs.max_draw_rate_gap }}"
-            --winner-accuracy-tolerance "${{ github.event.inputs.winner_accuracy_tolerance }}"
-            --log-loss-tolerance "${{ github.event.inputs.log_loss_tolerance }}"
-            --min-examples "${{ github.event.inputs.min_examples }}"
-            --probability-strategy "${{ github.event.inputs.probability_strategy }}"
+            --lookback-days "$LOOKBACK_DAYS"
+            --test-ratio "$TEST_RATIO"
+            --probability-strategy "$PROBABILITY_STRATEGY"
+            --min-draw-recall "$MIN_DRAW_RECALL"
+            --max-draw-rate-gap "$MAX_DRAW_RATE_GAP"
+            --winner-accuracy-tolerance "$WINNER_ACCURACY_TOLERANCE"
+            --log-loss-tolerance "$LOG_LOSS_TOLERANCE"
+            --min-examples "$MIN_EXAMPLES"
             --model-dir "$MODEL_DIR"
           )
 
@@ -172,7 +179,7 @@ jobs:
             CMD+=(--test-slice "$TEST_SLICE_STATE" "$TEST_SLICE_AGE_GROUP")
           fi
 
-          if [ "${{ github.event.inputs.save_dataset }}" = "true" ]; then
+          if [ "$SAVE_DATASET" = "true" ]; then
             CMD+=(--save-dataset)
           fi
 
@@ -186,10 +193,12 @@ jobs:
         if: ${{ github.event.inputs.calibrate == 'true' }}
         env:
           PYTHONUNBUFFERED: "1"
+          MODEL_DIR: ${{ github.event.inputs.model_dir }}
+          CALIBRATION_METHOD: ${{ github.event.inputs.calibration_method }}
+          DRAW_CALIBRATION_METHOD: ${{ github.event.inputs.draw_calibration_method }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
 
-          MODEL_DIR="${{ github.event.inputs.model_dir }}"
           EVALUATION_CSV="$MODEL_DIR/point_in_time_model_evaluation.csv"
 
           if [ ! -f "$EVALUATION_CSV" ]; then
@@ -200,8 +209,8 @@ jobs:
           python scripts/calibrate_point_in_time_match_model.py \
             --evaluation-csv "$EVALUATION_CSV" \
             --output-dir "$MODEL_DIR" \
-            --method "${{ github.event.inputs.calibration_method }}" \
-            --draw-method "${{ github.event.inputs.draw_calibration_method }}" \
+            --method "$CALIBRATION_METHOD" \
+            --draw-method "$DRAW_CALIBRATION_METHOD" \
             --prefix "point_in_time_model_calibration"
 
       - name: Write run summary
@@ -278,10 +287,18 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          MODEL_DIR: ${{ github.event.inputs.model_dir }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days }}
+          LIMIT_INPUT: ${{ github.event.inputs.limit }}
+          TEST_RATIO: ${{ github.event.inputs.test_ratio }}
+          MIN_EXAMPLES: ${{ github.event.inputs.min_examples }}
+          PROBABILITY_STRATEGY: ${{ github.event.inputs.probability_strategy }}
+          CALIBRATE: ${{ github.event.inputs.calibrate }}
+          CALIBRATION_METHOD: ${{ github.event.inputs.calibration_method }}
+          DRAW_CALIBRATION_METHOD: ${{ github.event.inputs.draw_calibration_method }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
 
-          MODEL_DIR="${{ github.event.inputs.model_dir }}"
           if [ ! -f "$MODEL_DIR/training_metrics.json" ]; then
             echo "training_metrics.json not found in $MODEL_DIR; skipping mission control record"
             exit 0
@@ -293,18 +310,18 @@ jobs:
             --workflow-run-attempt "${{ github.run_attempt }}"
             --git-sha "${{ github.sha }}"
             --model-dir "$MODEL_DIR"
-            --lookback-days "${{ github.event.inputs.lookback_days }}"
-            --limit "${{ github.event.inputs.limit }}"
-            --test-ratio "${{ github.event.inputs.test_ratio }}"
-            --min-examples "${{ github.event.inputs.min_examples }}"
-            --requested-probability-strategy "${{ github.event.inputs.probability_strategy }}"
+            --lookback-days "$LOOKBACK_DAYS"
+            --limit "$LIMIT_INPUT"
+            --test-ratio "$TEST_RATIO"
+            --min-examples "$MIN_EXAMPLES"
+            --requested-probability-strategy "$PROBABILITY_STRATEGY"
           )
 
-          if [ "${{ github.event.inputs.calibrate }}" = "true" ]; then
+          if [ "$CALIBRATE" = "true" ]; then
             CMD+=(
               --calibration-enabled
-              --calibration-method "${{ github.event.inputs.calibration_method }}"
-              --draw-calibration-method "${{ github.event.inputs.draw_calibration_method }}"
+              --calibration-method "$CALIBRATION_METHOD"
+              --draw-calibration-method "$DRAW_CALIBRATION_METHOD"
             )
           fi
 

--- a/.github/workflows/unknown-opponent-hygiene-weekly.yml
+++ b/.github/workflows/unknown-opponent-hygiene-weekly.yml
@@ -80,17 +80,20 @@ jobs:
 
       - name: Export unknown opponents
         id: export
+        env:
+          MAX_ROWS: ${{ github.event.inputs.max_rows }}
+          PROVIDER: ${{ github.event.inputs.provider || 'gotsport' }}
         run: |
           mkdir -p data/exports logs
           TS="$(date +%Y%m%d_%H%M%S)"
           PREFIX="data/exports/unknown_opponents_weekly_${TS}"
           MAX_ROWS_FLAG=""
-          if [ -n "${{ github.event.inputs.max_rows }}" ]; then
-            MAX_ROWS_FLAG="--max-rows ${{ github.event.inputs.max_rows }}"
+          if [ -n "$MAX_ROWS" ]; then
+            MAX_ROWS_FLAG="--max-rows $MAX_ROWS"
           fi
 
           python3 scripts/export_unknown_opponents.py \
-            --provider "${{ github.event.inputs.provider || 'gotsport' }}" \
+            --provider "$PROVIDER" \
             --resolve-gotsport-details \
             --output-prefix "$PREFIX" \
             $MAX_ROWS_FLAG | tee logs/unknown_export.log
@@ -102,16 +105,21 @@ jobs:
 
       - name: Auto-match unknown opponents (dry run)
         id: match
+        env:
+          EXPORT_TIMESTAMP: ${{ steps.export.outputs.timestamp }}
+          EXPORT_AGGREGATE_CSV: ${{ steps.export.outputs.aggregate_csv }}
+          LIMIT: ${{ github.event.inputs.limit }}
+          PROVIDER: ${{ github.event.inputs.provider || 'gotsport' }}
         run: |
-          MATCH_CSV="data/exports/unknown_opponent_match_report_weekly_${{ steps.export.outputs.timestamp }}.csv"
+          MATCH_CSV="data/exports/unknown_opponent_match_report_weekly_${EXPORT_TIMESTAMP}.csv"
           LIMIT_FLAG=""
-          if [ -n "${{ github.event.inputs.limit }}" ]; then
-            LIMIT_FLAG="--limit ${{ github.event.inputs.limit }}"
+          if [ -n "$LIMIT" ]; then
+            LIMIT_FLAG="--limit $LIMIT"
           fi
 
           python3 scripts/auto_match_unknown_opponents.py \
-            --input "${{ steps.export.outputs.aggregate_csv }}" \
-            --provider "${{ github.event.inputs.provider || 'gotsport' }}" \
+            --input "$EXPORT_AGGREGATE_CSV" \
+            --provider "$PROVIDER" \
             --auto-threshold 0.95 \
             --review-threshold 0.90 \
             --max-candidates 160 \
@@ -122,10 +130,13 @@ jobs:
 
       - name: Due diligence gate
         id: due
+        env:
+          EXPORT_TIMESTAMP: ${{ steps.export.outputs.timestamp }}
+          MATCH_CSV: ${{ steps.match.outputs.match_csv }}
         run: |
-          DD_PREFIX="data/exports/unknown_opponent_due_diligence_weekly_${{ steps.export.outputs.timestamp }}"
+          DD_PREFIX="data/exports/unknown_opponent_due_diligence_weekly_${EXPORT_TIMESTAMP}"
           python3 scripts/due_diligence_unknown_opponents.py \
-            --match-report "${{ steps.match.outputs.match_csv }}" \
+            --match-report "$MATCH_CSV" \
             --output-prefix "$DD_PREFIX" | tee logs/unknown_due_diligence.log
 
           python3 - <<'PY'
@@ -156,34 +167,46 @@ jobs:
 
       - name: Execute approved matches
         if: ${{ steps.due.outputs.approved_count != '0' && github.event.inputs.dry_run != 'true' }}
+        env:
+          APPROVED_CSV: ${{ steps.due.outputs.approved_csv }}
         run: |
           python3 scripts/apply_unknown_opponent_matches.py \
-            --approved-csv "${{ steps.due.outputs.approved_csv }}" \
+            --approved-csv "$APPROVED_CSV" \
             --require-approved-rows | tee logs/unknown_apply.log
 
       - name: Skip execution note
         if: ${{ steps.due.outputs.approved_count == '0' || github.event.inputs.dry_run == 'true' }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          APPROVED_COUNT: ${{ steps.due.outputs.approved_count }}
+          REVIEW_COUNT: ${{ steps.due.outputs.review_count }}
         run: |
-          if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
-            echo "Execution skipped: dry_run=true (approved_count=${{ steps.due.outputs.approved_count }} would have executed)"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Execution skipped: dry_run=true (approved_count=$APPROVED_COUNT would have executed)"
           else
-            echo "Execution skipped: no approved matches (approved=0, review=${{ steps.due.outputs.review_count }})"
+            echo "Execution skipped: no approved matches (approved=0, review=$REVIEW_COUNT)"
           fi
 
       - name: Discover new teams from no_match opponents
         id: discover
         if: ${{ github.event.inputs.discover_teams != 'false' }}
+        env:
+          EXPORT_TIMESTAMP: ${{ steps.export.outputs.timestamp }}
+          MATCH_CSV: ${{ steps.match.outputs.match_csv }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          DISCOVER_MIN_GAMES: ${{ github.event.inputs.discover_min_games || '1' }}
+          PROVIDER: ${{ github.event.inputs.provider || 'gotsport' }}
         run: |
-          DISCOVER_CSV="data/exports/team_discovery_report_weekly_${{ steps.export.outputs.timestamp }}.csv"
+          DISCOVER_CSV="data/exports/team_discovery_report_weekly_${EXPORT_TIMESTAMP}.csv"
           EXECUTE_FLAG=""
-          if [ "${{ github.event.inputs.dry_run || 'false' }}" != "true" ]; then
+          if [ "$DRY_RUN" != "true" ]; then
             EXECUTE_FLAG="--execute"
           fi
-          MIN_GAMES="${{ github.event.inputs.discover_min_games || '1' }}"
+          MIN_GAMES="$DISCOVER_MIN_GAMES"
 
           python3 scripts/discover_teams_from_opponents.py \
-            --match-report "${{ steps.match.outputs.match_csv }}" \
-            --provider "${{ github.event.inputs.provider || 'gotsport' }}" \
+            --match-report "$MATCH_CSV" \
+            --provider "$PROVIDER" \
             --min-games "$MIN_GAMES" \
             --output "$DISCOVER_CSV" \
             $EXECUTE_FLAG | tee logs/unknown_discover.log
@@ -233,27 +256,40 @@ jobs:
 
       - name: Workflow summary
         if: always()
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          PROVIDER: ${{ github.event.inputs.provider || 'gotsport' }}
+          AUTO_LINK_COUNT: ${{ steps.due.outputs.auto_link_count || '0' }}
+          APPROVED_COUNT: ${{ steps.due.outputs.approved_count || '0' }}
+          REVIEW_COUNT: ${{ steps.due.outputs.review_count || '0' }}
+          ALL_PASS: ${{ steps.due.outputs.all_pass || 'false' }}
+          DISCOVER_TEAMS: ${{ github.event.inputs.discover_teams || 'true' }}
+          DISCOVERY_TOTAL: ${{ steps.discover.outputs.discovery_total || '0' }}
+          DISCOVERY_CREATED: ${{ steps.discover.outputs.discovery_created || '0' }}
+          DISCOVERY_BACKFILLED: ${{ steps.discover.outputs.discovery_backfilled || '0' }}
+          DISCOVERY_SKIPPED: ${{ steps.discover.outputs.discovery_skipped || '0' }}
+          DISCOVERY_ERRORS: ${{ steps.discover.outputs.discovery_errors || '0' }}
         run: |
           MODE="AUTO-EXECUTE"
-          if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             MODE="DRY-RUN"
           fi
 
           echo "## Unknown Opponent Hygiene Weekly" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Mode: **$MODE**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Provider: **${{ github.event.inputs.provider || 'gotsport' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Auto-link candidates: **${{ steps.due.outputs.auto_link_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Due diligence approved: **${{ steps.due.outputs.approved_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Due diligence needs review: **${{ steps.due.outputs.review_count || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- All pass gate: **${{ steps.due.outputs.all_pass || 'false' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Provider: **$PROVIDER**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Auto-link candidates: **$AUTO_LINK_COUNT**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Due diligence approved: **$APPROVED_COUNT**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Due diligence needs review: **$REVIEW_COUNT**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- All pass gate: **$ALL_PASS**" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Team Discovery (no_match opponents)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Discover teams enabled: **${{ github.event.inputs.discover_teams || 'true' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- No-match processed: **${{ steps.discover.outputs.discovery_total || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Teams created: **${{ steps.discover.outputs.discovery_created || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Games backfilled: **${{ steps.discover.outputs.discovery_backfilled || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Skipped (metadata): **${{ steps.discover.outputs.discovery_skipped || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Errors: **${{ steps.discover.outputs.discovery_errors || '0' }}**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Discover teams enabled: **$DISCOVER_TEAMS**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- No-match processed: **$DISCOVERY_TOTAL**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Teams created: **$DISCOVERY_CREATED**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Games backfilled: **$DISCOVERY_BACKFILLED**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Skipped (metadata): **$DISCOVERY_SKIPPED**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Errors: **$DISCOVERY_ERRORS**" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Execution runs for all approved rows, even if some need review." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wa-scraper.yml
+++ b/.github/workflows/wa-scraper.yml
@@ -45,9 +45,10 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         env:
           TZ: America/Los_Angeles
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
-          CRON="${{ github.event.schedule }}"
+          CRON="$EVENT_SCHEDULE"
           ZONE="$(date +%Z)"   # PDT or PST
           echo "Trigger cron: ${CRON}  |  Current TZ: ${ZONE}  |  Local: $(date)"
 
@@ -68,10 +69,11 @@ jobs:
         if: ${{ steps.guard.outputs.should_run != 'false' }}
         env:
           PYTHONPATH: ${{ github.workspace }}
+          DAYS_BACK_INPUT: ${{ github.event.inputs.days_back }}
         run: |
           set -euo pipefail
 
-          DAYS_BACK="${{ github.event.inputs.days_back || '7' }}"
+          DAYS_BACK="${DAYS_BACK_INPUT:-7}"
           TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
           OUT_DIR="data/raw/affinity_wa"
           MERGED="${OUT_DIR}/affinity_wa_all_ranked_ages_last${DAYS_BACK}d_${TIMESTAMP}.csv"
@@ -147,15 +149,19 @@ jobs:
 
       - name: Report results
         if: always()
+        env:
+          SHOULD_RUN: ${{ steps.guard.outputs.should_run }}
+          DAYS_BACK_INPUT: ${{ github.event.inputs.days_back }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
         run: |
           echo "===================="
-          if [ "${{ steps.guard.outputs.should_run }}" = "false" ]; then
+          if [ "$SHOULD_RUN" = "false" ]; then
             echo "Affinity WA Scraper SKIPPED (redundant DST cron)"
           else
             echo "Affinity WA Scraper completed"
           fi
           echo "===================="
-          echo "Days back: ${{ github.event.inputs.days_back || '7' }}"
-          echo "Dry run: ${{ github.event.inputs.dry_run || 'false' }}"
+          echo "Days back: ${DAYS_BACK_INPUT:-7}"
+          echo "Dry run: ${DRY_RUN_INPUT:-false}"
           echo "Output rows: ${ROW_COUNT:-unknown}"
           echo "Merged file: ${MERGED_FILE:-not-set}"

--- a/.github/workflows/weekly-prospective-refresh.yml
+++ b/.github/workflows/weekly-prospective-refresh.yml
@@ -180,6 +180,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           PYTHONUNBUFFERED: "1"
+          FIXTURE_FILE: ${{ steps.scrape.outputs.fixture_file }}
+          MODEL_ARTIFACT: ${{ steps.model.outputs.model_artifact }}
         run: |
           export PYTHONPATH="${PYTHONPATH}:${PWD}"
           LOOKBACK_DAYS="${INPUT_LOOKBACK_DAYS:-365}"
@@ -187,10 +189,10 @@ jobs:
           SUMMARY_PATH="$RUNNER_TEMP/weekly_prospective_prepare_summary.json"
 
           python scripts/prepare_prospective_match_predictions.py \
-            --fixtures-file "${{ steps.scrape.outputs.fixture_file }}" \
+            --fixtures-file "$FIXTURE_FILE" \
             --source-artifact-path "weekly-prospective-refresh:${GITHUB_RUN_ID}" \
             --lookback-days "$LOOKBACK_DAYS" \
-            --model-artifact "${{ steps.model.outputs.model_artifact }}" \
+            --model-artifact "$MODEL_ARTIFACT" \
             --offline-model-version "$OFFLINE_MODEL_VERSION" \
             --summary-path "$SUMMARY_PATH"
 


### PR DESCRIPTION
## Summary

- Hoist every `${{ github.event.inputs.* }}` and `${{ steps.*.outputs.* }}` used inside `run:` blocks to step-level `env:` entries across 22 workflows. Shell reads `"$VAR"` instead of having values template-substituted before parsing.
- Add a new project skill `review-workflows` that codifies 7 GHA gotchas as automated checks (shell injection, cron drift, env precedence, timeout shielding, script existence, secret hygiene, matrix sharding over mutable sort).
- Post-fix audit reports **0 findings** across 37 workflows (down from 136).

## Why

None of the 136 detected injections were directly exploitable today — every flagged workflow is `workflow_dispatch` or `schedule`-triggered (owner/collaborator only). PRs from forks (`ci.yml`, `claude-code-review.yml`, `claude.yml`) were already clean. This is defense-in-depth, not active-incident:

1. **Quoting safety.** Any input value with `"`, `` ` ``, `$`, or newlines would have been interpreted by the shell as code. Env-var pattern treats them as data.
2. **Future-proofing.** If any workflow later adds a trigger that exposes inputs to outsiders (PR comments, issue bots, `repository_dispatch`), the existing raw interpolation would become an injection. Fix now while mechanical.
3. **Tooling.** The new skill keeps regressions out — running `/review-workflows` after editing any workflow surfaces new findings.

## Pattern applied

For every `${{ github.event.inputs.X }}` inside a `run:` block:

```yaml
# Before
run: |
  python train.py --lookback-days "${{ github.event.inputs.lookback_days }}"

# After
env:
  LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days }}
run: |
  python train.py --lookback-days "$LOOKBACK_DAYS"
```

Intentionally **not changed:** step `if:` conditions, action `with:` inputs, `${{ secrets.* }}` references, and workflow metadata (`github.run_id`, `github.run_attempt`, `github.sha`, `github.ref`). Those are workflow-engine evaluated, not shell.

## Judgment calls flagged

A few minor liberties taken during the agent fan-out, all behavior-preserving:

- **`auto-merge-queue.yml` / `clear-queue.yml`** — built-command-string pattern hoisted as `eval "$VAR"`. Safer than raw template interpolation; still relies on upstream regex validation (`^[0-9]+$`) in the build step. Worth a closer look during review.
- **`enrich-instagram-handles.yml`, `fix-age-year-discrepancies.yml`, `data-hygiene-weekly.yml`, `auto-merge-queue.yml`** — workflow-engine ternaries (`X == 'Y' && 'A' || 'B'`) inside `run:` blocks rewritten as shell `if`/`else` or `${VAR:-default}`. Same outputs.
- **`fix-age-year-discrepancies.yml`, `scrape-specific-event.yml`** — quoted args that could contain spaces rewritten as bash arrays.
- **`train-point-in-time-match-model.yml`** — removed a duplicate `--probability-strategy` flag (was passed twice in the original; second occurrence would override the first anyway). Strictly out-of-scope cleanup but small.

## Review skill

`.claude/skills/review-workflows/` adds:

- `SKILL.md` — invokable via `/review-workflows`
- `scripts/audit_workflows.py` — Python detector with 7 checks
- `references/checks.md` — per-check rationale, severity, known false positives

To run locally:

```bash
python .claude/skills/review-workflows/scripts/audit_workflows.py --repo-root . --fail-on never > .turbo/workflow-audit.md
```

Folding into the project `/audit` fanout as a 4th leg is tracked as a follow-up.

## Test plan

- [ ] CI passes
- [ ] Manually trigger `train-point-in-time-match-model.yml` with default inputs, confirm training completes (was the worked-example file)
- [ ] Manually trigger one `workflow_dispatch` workflow with a non-empty `limit` value, confirm the limit reaches the script as expected
- [ ] Spot-check `auto-merge-queue.yml` `eval "$DRAIN_COMMAND"` path with a dry run
- [ ] Re-run `/review-workflows` after merge to confirm 0 findings stay 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)