### PR TITLE
Distinction cleanup: drop noisy tokens, re-enable composed team names on rankings + search

### DIFF
--- a/docs/superpowers/plans/2026-05-28-distinction-phase0-harness.md
+++ b/docs/superpowers/plans/2026-05-28-distinction-phase0-harness.md
@@ -1,0 +1,499 @@
+# Distinction Cleanup — Phase 0 Characterization Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a committed before-picture of team-name `distinction` quality and a frozen merge-gate baseline, changing no production logic, so Phase 1 scope can be chosen from real numbers.
+
+**Architecture:** Two read-only diagnostic scripts, modernized in place. (A) `dryrun_team_distinction.py` runs the *canonical* `resolve_distinction` over all teams and reports coverage, identity-key collisions, and problem-bucket counts. (B) `validate_normalizer.py` replays every historical merge through the *production* dedup gate (`_team_distinction.should_skip_pair`) and reports how often it would now block a real merge. New logic lives in small pure helpers that are unit-tested; DB/printing glue is verified by running.
+
+**Tech Stack:** Python 3.11, Supabase Python client, pytest. No DB writes. No frontend changes.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-team-name-distinction-cleanup-design.md`
+
+**Branch:** `feat/distinction-cleanup` (already created).
+
+---
+
+## File Structure
+
+- **Modify** `scripts/dryrun_team_distinction.py` — drop the drifted local `resolve_distinction`; import the canonical one; add a pure `classify_distinction_problems()` helper; add a "PROBLEM BUCKETS" report section.
+- **Modify** `scripts/validate_normalizer.py` — fix env loading; move client creation into `main()`; replace the old `team_name_normalizer` logic with a pure `replay_merge_verdict()` helper built on `_team_distinction.should_skip_pair`; report false-skip rate.
+- **Create** `tests/unit/test_distinction_phase0.py` — unit tests for both pure helpers.
+- **Create** `docs/superpowers/reports/2026-05-28-distinction-quality.txt` and `docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt` — captured run output (committed).
+
+---
+
+## Task 1: Pure helper — `classify_distinction_problems`
+
+Classifies a resolved distinction string into zero or more problem buckets. Pure function, no DB. Buckets: `unknown`, `league_token`, `club_acronym`, `multi_token`, `single_char`.
+
+**Files:**
+- Modify: `scripts/dryrun_team_distinction.py` (add helper near the top, after the existing constant blocks ~line 53)
+- Test: `tests/unit/test_distinction_phase0.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_distinction_phase0.py`:
+
+```python
+import sys
+from pathlib import Path
+
+# scripts/ holds dryrun_team_distinction.py and validate_normalizer.py
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from dryrun_team_distinction import classify_distinction_problems  # noqa: E402
+
+
+def test_none_distinction_has_no_problems():
+    assert classify_distinction_problems(None, "Solar SC") == set()
+
+
+def test_clean_color_distinction_has_no_problems():
+    assert classify_distinction_problems("white", "Solar SC") == set()
+
+
+def test_unknown_token_flagged():
+    assert "unknown" in classify_distinction_problems("unknown", None)
+
+
+def test_league_token_flagged():
+    # "nl" is league-redundant; "mls" too. ad/hd are NOT flagged (Modular11 sacred).
+    assert "league_token" in classify_distinction_problems("martinez|north|nl", "DKSC")
+    assert "league_token" not in classify_distinction_problems("hd", "LA Bulls")
+    assert "league_token" not in classify_distinction_problems("ad", "Breakers FC")
+
+
+def test_club_acronym_flagged():
+    # "cosc" == initials of California Odyssey Soccer Club
+    assert "club_acronym" in classify_distinction_problems("cosc", "California Odyssey Soccer Club")
+    # a real color is not an acronym
+    assert "club_acronym" not in classify_distinction_problems("blue", "San Diego Surf Soccer Club")
+
+
+def test_multi_token_flagged():
+    assert "multi_token" in classify_distinction_problems("blue|alcaraz", "San Diego Surf")
+    assert "multi_token" not in classify_distinction_problems("blue", "San Diego Surf")
+
+
+def test_single_char_flagged():
+    assert "single_char" in classify_distinction_problems("a", "Some Club")
+    assert "single_char" not in classify_distinction_problems("white", "Some Club")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q`
+Expected: FAIL with `ImportError: cannot import name 'classify_distinction_problems'`
+
+- [ ] **Step 3: Add the helper**
+
+In `scripts/dryrun_team_distinction.py`, after the `_PROGRAM_DISTINCTIONS` block (~line 52), add:
+
+```python
+# League-equivalent tokens that are redundant with the `league` column.
+# Deliberately EXCLUDES "ad"/"hd" — those are load-bearing for Modular11
+# (MLS NEXT) display and must never be flagged. See the cleanup design spec.
+_LEAGUE_TOKENS = {
+    "ecnl", "ecnl-rl", "ecrl", "rl", "ga", "npl", "dpl", "dplo",
+    "scdsl", "nal", "mlsnext", "mls-next", "next", "ea", "ea2",
+    "pre-ecnl", "mls", "nl",
+}
+
+
+def _club_acronym(club_name):
+    """First-letter acronym of a club name's significant tokens (>=3 words).
+
+    'California Odyssey Soccer Club' -> 'cosc'. Returns '' when the club has
+    fewer than 3 significant tokens (acronyms shorter than that are too
+    collision-prone to flag).
+    """
+    toks = _club_tokens(club_name)  # already lowercased, noise-stripped
+    # Preserve original order from the club string for a stable acronym.
+    if not club_name:
+        return ""
+    import re as _re
+    ordered = [
+        t.strip("()[]'*.,")
+        for t in _re.split(r"[\s\-_./]+", club_name.lower())
+        if t.strip("()[]'*.,") in toks
+    ]
+    if len(ordered) < 3:
+        return ""
+    return "".join(t[0] for t in ordered)
+
+
+def classify_distinction_problems(distinction, club_name):
+    """Return the set of problem buckets a resolved distinction falls into.
+
+    Buckets: 'unknown', 'league_token', 'club_acronym', 'multi_token',
+    'single_char'. Empty set means the distinction looks clean. Pure function.
+    """
+    problems = set()
+    if not distinction:
+        return problems
+    tokens = [t for t in distinction.split("|") if t]
+    if len(tokens) >= 2:
+        problems.add("multi_token")
+    acronym = _club_acronym(club_name)
+    for t in tokens:
+        tl = t.lower()
+        if tl == "unknown":
+            problems.add("unknown")
+        if tl in _LEAGUE_TOKENS:
+            problems.add("league_token")
+        if len(tl) == 1:
+            problems.add("single_char")
+        if acronym and tl == acronym:
+            problems.add("club_acronym")
+    return problems
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /c/PitchRank
+git add scripts/dryrun_team_distinction.py tests/unit/test_distinction_phase0.py
+git commit -m "feat(distinction): add classify_distinction_problems diagnostic helper"
+```
+
+---
+
+## Task 2: Point the dry-run at the canonical resolver + emit problem buckets
+
+Remove the drifted local `resolve_distinction` so the report reflects production logic, and add a PROBLEM BUCKETS section to the report.
+
+**Files:**
+- Modify: `scripts/dryrun_team_distinction.py` (import swap ~line 32; delete local `resolve_distinction` ~lines 74-170; extend `main()` ~line 247 onward)
+
+- [ ] **Step 1: Swap to the canonical resolver**
+
+Change the import block (~line 32) from:
+
+```python
+from src.utils.team_name_utils import extract_distinctions  # noqa: E402
+```
+
+to:
+
+```python
+from src.utils.team_name_utils import extract_distinctions, resolve_distinction  # noqa: E402
+```
+
+Then **delete** the entire local `def resolve_distinction(...)` (the block spanning from `def resolve_distinction(name: str, club_name: Optional[str] = None)` through its `return "|".join(out)` ~lines 74-170). Leave `_CLUB_NOISE`, `_LEAGUE_EQUIVS`, `_PROGRAM_DISTINCTIONS`, and `_club_tokens` in place (still used).
+
+- [ ] **Step 2: Pass state_code to the canonical resolver**
+
+In `main()`, change the per-team resolve call (~line 213) from:
+
+```python
+        dist = resolve_distinction(name, club)
+```
+
+to:
+
+```python
+        dist = resolve_distinction(name, club, t.get("state_code"))
+```
+
+- [ ] **Step 3: Accumulate problem buckets during the team loop**
+
+In `main()`, immediately after `t["_distinction"] = dist` (~line 247), add:
+
+```python
+        for bucket in classify_distinction_problems(dist, club):
+            problem_buckets[bucket] += 1
+            if len(problem_samples[bucket]) < 10 and not t.get("is_deprecated"):
+                problem_samples[bucket].append((club, name, dist))
+```
+
+And initialize the accumulators just before the `for t in teams:` loop (~line 209), alongside the existing counters:
+
+```python
+    problem_buckets = collections.Counter()
+    problem_samples = collections.defaultdict(list)
+```
+
+- [ ] **Step 4: Print the PROBLEM BUCKETS section**
+
+In `main()`, after the existing "RESOLVED SAMPLES" block (~line 297), add:
+
+```python
+    print("\n=== PROBLEM BUCKETS (resolved distinctions only) ===")
+    print(f"  {'bucket':16} {'count':>8}  {'% of resolved':>14}")
+    for bucket, n in problem_buckets.most_common():
+        pct = (100 * n / resolved) if resolved else 0.0
+        print(f"  {bucket:16} {n:>8,}  {pct:>13.1f}%")
+    for bucket, _ in problem_buckets.most_common():
+        print(f"\n--- sample: {bucket} ---")
+        for club, name, dist in problem_samples[bucket][:10]:
+            print(f"  club={club!r:30.30} name={name!r:45.45} dist={dist!r}")
+```
+
+- [ ] **Step 5: Smoke-run the script (read-only)**
+
+Run: `cd /c/PitchRank && SUPABASE_KEY=$(grep -m1 '^SUPABASE_SERVICE_ROLE_KEY=' .env.local | cut -d= -f2-) python scripts/dryrun_team_distinction.py | tail -40`
+Expected: prints COVERAGE, SOURCE WINNER, UNIQUENESS CHECK, and the new PROBLEM BUCKETS section with non-zero counts; no errors; no DB writes.
+
+> Note: the script reads `SUPABASE_SERVICE_ROLE_KEY`/`SUPABASE_SERVICE_KEY`. If `.env.local` only defines the service-role key, the inline `SUPABASE_KEY=...` shim above is harmless; the script already prefers the service keys.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /c/PitchRank
+git add scripts/dryrun_team_distinction.py
+git commit -m "feat(distinction): dry-run uses canonical resolver + problem-bucket report"
+```
+
+---
+
+## Task 3: Pure helper — `replay_merge_verdict`
+
+Maps a historical merge (deprecated + canonical team rows) to the production gate's verdict. Pure function, no DB.
+
+**Files:**
+- Modify: `scripts/validate_normalizer.py` (add helper + imports)
+- Test: `tests/unit/test_distinction_phase0.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_distinction_phase0.py`:
+
+```python
+from validate_normalizer import replay_merge_verdict  # noqa: E402
+
+
+def test_replay_no_data_when_missing_team():
+    assert replay_merge_verdict(None, {"team_name": "x", "club_name": "x"}) == "no_data"
+    assert replay_merge_verdict({"team_name": "x", "club_name": "x"}, None) == "no_data"
+
+
+def test_replay_no_data_when_missing_name():
+    dep = {"team_name": "", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "no_data"
+
+
+def test_replay_allowed_for_identical_names():
+    dep = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "allowed"
+
+
+def test_replay_false_skip_for_different_squads():
+    # The gate (correctly) skips different-color squads; replaying a *merge*
+    # of them is therefore a 'false_skip' from the replay's point of view —
+    # this verifies the True -> 'false_skip' mapping.
+    dep = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Blue", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "false_skip"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q`
+Expected: FAIL with `ImportError: cannot import name 'replay_merge_verdict'`
+
+- [ ] **Step 3: Add the helper (and the gate import) to `validate_normalizer.py`**
+
+Replace the stale import line `from team_name_normalizer import parse_team_name, teams_match` with:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # scripts/ for _team_distinction
+from _team_distinction import should_skip_pair  # production masters-dedup gate
+```
+
+Then add the helper at module level (after the imports):
+
+```python
+def replay_merge_verdict(dep, can):
+    """Replay one historical merge through the production dedup gate.
+
+    dep/can are team rows (dicts) with 'team_name' and 'club_name', or None.
+    Returns:
+      'no_data'    — a row is missing or has a blank team_name
+      'allowed'    — gate would NOT skip the pair (a real merge stays reachable)
+      'false_skip' — gate WOULD skip the pair (it would block this real merge)
+
+    Uses require_age_token_match=True to mirror find_fuzzy_duplicate_teams.py
+    (the path that produces masters merges).
+    """
+    if not dep or not can:
+        return "no_data"
+    dep_name = (dep.get("team_name") or "").strip()
+    can_name = (can.get("team_name") or "").strip()
+    if not dep_name or not can_name:
+        return "no_data"
+    club = (can.get("club_name") or dep.get("club_name") or "")
+    skipped = should_skip_pair(dep_name, can_name, club_name=club, require_age_token_match=True)
+    return "false_skip" if skipped else "allowed"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q`
+Expected: PASS (11 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /c/PitchRank
+git add scripts/validate_normalizer.py tests/unit/test_distinction_phase0.py
+git commit -m "feat(distinction): add replay_merge_verdict gate-baseline helper"
+```
+
+---
+
+## Task 4: Rewire `validate_normalizer.main()` onto the gate
+
+Fix env loading, make the module import-safe, and rewrite the per-merge loop + summary to use `replay_merge_verdict`.
+
+**Files:**
+- Modify: `scripts/validate_normalizer.py` (env block ~lines 16-17; `main()` loop ~lines 95-179)
+
+- [ ] **Step 1: Fix env loading + remove module-level client**
+
+Replace lines 16-17:
+
+```python
+load_dotenv("/Users/pitchrankio-dev/Projects/PitchRank/.env")
+supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_KEY"))
+```
+
+with:
+
+```python
+load_dotenv("C:/PitchRank/.env.local")
+load_dotenv("C:/PitchRank/.env")
+```
+
+Then, at the top of `main()` (before `print("Fetching merge history...")`), add:
+
+```python
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_KEY")
+    if not (url and key):
+        print("Missing Supabase creds (need SUPABASE_URL + a service key)")
+        return
+    supabase = create_client(url, key)
+```
+
+- [ ] **Step 2: Rewrite the per-merge loop**
+
+Replace the loop body and result tracking (~lines 84-135) so it uses the helper. The new `main()` body from `# Track results` to the end of the loop becomes:
+
+```python
+    verdicts = Counter()
+    false_skips = []
+
+    print("\nReplaying merges through the production dedup gate...")
+    for i, merge in enumerate(all_merges):
+        if i % 500 == 0:
+            print(f"  Processing {i}/{len(all_merges)}...")
+        dep = teams_cache.get(merge["deprecated_team_id"])
+        can = teams_cache.get(merge["canonical_team_id"])
+        verdict = replay_merge_verdict(dep, can)
+        verdicts[verdict] += 1
+        if verdict == "false_skip" and len(false_skips) < 40:
+            false_skips.append((dep, can))
+```
+
+- [ ] **Step 3: Rewrite the summary**
+
+Replace the summary section (~lines 137-179) with:
+
+```python
+    total = len(all_merges)
+    allowed = verdicts["allowed"]
+    false_skip = verdicts["false_skip"]
+    no_data = verdicts["no_data"]
+
+    print("\n" + "=" * 60)
+    print("MERGE-VERDICT BASELINE (production gate: should_skip_pair)")
+    print("=" * 60)
+    print(f"\nHistorical merges replayed: {total:,}")
+    evaluable = total - no_data
+    print(f"  ✅ allowed (gate keeps merge reachable): {allowed:,}"
+          f"  ({100*allowed/evaluable:.2f}% of evaluable)" if evaluable else "  (no evaluable rows)")
+    print(f"  ❌ false_skip (gate would BLOCK this merge): {false_skip:,}"
+          f"  ({100*false_skip/evaluable:.2f}% of evaluable)" if evaluable else "")
+    print(f"  ⚠️  no_data (missing team rows): {no_data:,}")
+
+    print("\n" + "-" * 60)
+    print(f"SAMPLE FALSE-SKIPS (first {len(false_skips)})")
+    print("-" * 60)
+    for dep, can in false_skips:
+        print(f"\n  deprecated: {dep.get('team_name')!r}  (club={dep.get('club_name')!r})")
+        print(f"  canonical : {can.get('team_name')!r}  (club={can.get('club_name')!r})")
+```
+
+- [ ] **Step 4: Run the unit tests again (regression guard)**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q`
+Expected: PASS (11 passed) — confirms the rewire didn't break the importable helper.
+
+- [ ] **Step 5: Smoke-run the script (read-only)**
+
+Run: `cd /c/PitchRank && python scripts/validate_normalizer.py | tail -50`
+Expected: prints "MERGE-VERDICT BASELINE", a false_skip count + percent, and sample false-skips; no errors; no DB writes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /c/PitchRank
+git add scripts/validate_normalizer.py
+git commit -m "feat(distinction): rewire validate_normalizer onto production dedup gate"
+```
+
+---
+
+## Task 5: Capture and commit the Phase 0 reports
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-05-28-distinction-quality.txt`
+- Create: `docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt`
+
+- [ ] **Step 1: Capture both reports to files**
+
+```bash
+cd /c/PitchRank
+mkdir -p docs/superpowers/reports
+python scripts/dryrun_team_distinction.py > docs/superpowers/reports/2026-05-28-distinction-quality.txt 2>&1
+python scripts/validate_normalizer.py   > docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt 2>&1
+```
+
+- [ ] **Step 2: Sanity-check the captured files**
+
+Run: `cd /c/PitchRank && tail -25 docs/superpowers/reports/2026-05-28-distinction-quality.txt && echo "=====" && tail -20 docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt`
+Expected: distinction report ends with PROBLEM BUCKETS counts; baseline report ends with false-skip rate + samples.
+
+- [ ] **Step 3: Commit the reports**
+
+```bash
+cd /c/PitchRank
+git add docs/superpowers/reports/2026-05-28-distinction-quality.txt docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt
+git commit -m "docs(distinction): capture Phase 0 characterization reports"
+```
+
+- [ ] **Step 4: Hand back for review**
+
+Stop here. Present the two reports' headline numbers (coverage, collision rate, problem-bucket counts, false-skip rate) and ask the user to decide Phase 1 scope: composer-only (`resolve_distinction`) vs. root parser (`extract_distinctions`).
+
+---
+
+## Self-Review
+
+**Spec coverage:** Phase 0 deliverables in the spec — (A) distinction quality report via modernized `dryrun_team_distinction.py` ✅ Tasks 1-2; (B) merge-verdict baseline via rewired `validate_normalizer.py` ✅ Tasks 3-4; committed report ✅ Task 5; "no logic changes / no DB writes / no display changes" ✅ (both scripts read-only; production `resolve_distinction`/`extract_distinctions`/`should_skip_pair` untouched). Modular11 carve-out honored (`ad`/`hd` excluded from `_LEAGUE_TOKENS`) ✅.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; run commands have expected output. ✅
+
+**Type/name consistency:** `classify_distinction_problems(distinction, club_name)`, `_club_acronym(club_name)`, `_LEAGUE_TOKENS`, `replay_merge_verdict(dep, can)` used identically across tasks and tests. `should_skip_pair(..., require_age_token_match=True)` matches the signature in `scripts/_team_distinction.py`. `resolve_distinction(name, club, state_code)` matches `src/utils/team_name_utils.py`. ✅

--- a/docs/superpowers/plans/2026-05-29-distinction-phase1-display-cleanup.md
+++ b/docs/superpowers/plans/2026-05-29-distinction-phase1-display-cleanup.md
@@ -1,0 +1,327 @@
+# Distinction Cleanup — Phase 1 (Display / Source Cleanup) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clean the stored `teams.distinction` value so displayed team names read well — by dropping a club's own initials, stray single letters, and redundant league tokens from the composite — without touching the merge/dedup gate.
+
+**Architecture:** The only logic change is in `resolve_distinction()` (`src/utils/team_name_utils.py`), the function that assembles the stored distinction string. The merge gate (`should_skip_pair`) recomputes from raw names and does NOT read this value, so these changes cannot affect matching/merging. After the logic change we re-run the Phase 0 quality report as a before/after guard, re-backfill the column, and present a sample for sign-off. Re-enabling `composeTeamDisplay` on rankings/search is a SEPARATE follow-up after the user eyeballs cleaned data.
+
+**Tech Stack:** Python 3.11, pytest, Supabase Python client.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-team-name-distinction-cleanup-design.md`
+**Phase 0 baseline reports:** `docs/superpowers/reports/2026-05-28-distinction-quality.txt`
+
+**Branch:** `feat/distinction-cleanup` (already created; continue on it).
+
+**Scope guardrails:**
+- Modular11 / MLS NEXT stays untouched: `ad`/`hd` are never dropped.
+- This plan changes ONLY `resolve_distinction` + its helper + tests + a re-backfill. No frontend changes, no merge-gate (`should_skip_pair`/`extract_distinctions`) changes, no DB schema changes.
+- Accepted tradeoff: dropping single-character tokens could in rare cases erase a genuine "Team A/B/C" tag. Task 2's collision check is the safety net — if it collapses real teams, collisions spike and we reconsider.
+
+---
+
+## File Structure
+
+- **Modify** `src/utils/team_name_utils.py` — add `_club_acronym()` helper near `_club_tokens()`; extend `_LEAGUE_DISTINCTION_BLOCKLIST` with `mls`/`nl`; add three drop rules inside `resolve_distinction()`.
+- **Create** `tests/unit/test_resolve_distinction_cleanup.py` — unit tests for the three drops + two "must-preserve" cases.
+- **No other code files.** Tasks 2–4 run existing scripts (`scripts/dryrun_team_distinction.py`, `scripts/backfill_team_distinction.py`) and produce report artifacts under `docs/superpowers/reports/`.
+
+---
+
+## Task 1: Clean `resolve_distinction` output (TDD)
+
+**Files:**
+- Modify: `src/utils/team_name_utils.py`
+- Test: `tests/unit/test_resolve_distinction_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_resolve_distinction_cleanup.py`:
+
+```python
+from src.utils.team_name_utils import resolve_distinction
+
+
+def test_drops_club_acronym_short():
+    # "vsa" = initials of Virginia Soccer Assocation -> not a squad tag
+    got = resolve_distinction("VSA 2014 Premier Red", "Virginia Soccer Assocation", "VA")
+    assert got == "red|premier"  # vsa dropped; red (color) before premier (program)
+
+
+def test_drops_club_acronym_long():
+    # "cosc" = initials of California Odyssey Soccer Club; ECNL is league, 2013 is age
+    got = resolve_distinction("COSC ECNL 2013", "California Odyssey Soccer Club", "CA")
+    assert got is None
+
+
+def test_drops_stray_single_char():
+    # "c" left over from "F.C" is not a squad tag
+    got = resolve_distinction("MIDWEST GLADIATORS F.C", "MIDWEST GLADIATORS F.C", "TX")
+    assert got is None
+
+
+def test_drops_leftover_league_token():
+    got = resolve_distinction("Hoover-Vestavia 2009 MLS NEXT", "Hoover-Vestavia Soccer", "AL")
+    assert got is None  # mls + next both dropped as league tokens
+
+
+def test_preserves_real_squad_tag():
+    # color + direction is a legitimate squad distinguisher
+    got = resolve_distinction("CCV Stars 2011 East Navy", "Ccv Stars", "AZ")
+    assert got == "navy|east"  # 2-word club -> no acronym; nothing stripped
+
+
+def test_preserves_modular11_ad_hd():
+    # HD must survive (Modular11 / MLS NEXT format is sacred)
+    got = resolve_distinction("Carolina Core FC U13 HD", "Carolina Core FC Youth", "NC")
+    assert got is not None and "hd" in got.split("|")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_resolve_distinction_cleanup.py -q`
+Expected: FAILs — `test_drops_club_acronym_short` returns `red|premier|vsa`, `test_drops_club_acronym_long` returns `cosc`, `test_drops_stray_single_char` returns `c`, `test_drops_leftover_league_token` returns `mls`. (`test_preserves_*` may already pass.)
+
+> If the import line fails (`ModuleNotFoundError: src`), add at the top of the test file:
+> `import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))` — but try without it first; the repo's pyproject usually puts the root on the path.
+
+- [ ] **Step 3: Add the `_club_acronym` helper**
+
+In `src/utils/team_name_utils.py`, immediately AFTER the existing `def _club_tokens(club_name)` function, add:
+
+```python
+def _club_acronym(club_name: Optional[str]) -> str:
+    """First-letter acronym of a club's words (>=3 words), else ''.
+
+    'California Odyssey Soccer Club' -> 'cosc'. Used to drop a club's own
+    initials from its distinction — those identify the club, not the squad,
+    so they are noise in the composite. Includes noise words (soccer/club) so
+    the acronym matches how clubs actually abbreviate themselves. Returns ''
+    for <3-word clubs (short acronyms collide too easily to drop safely).
+    """
+    if not club_name:
+        return ""
+    words = [
+        w.strip("()[]'*.,")
+        for w in re.split(r"[\s\-_./]+", club_name.lower())
+        if w.strip("()[]'*.,")
+    ]
+    if len(words) < 3:
+        return ""
+    return "".join(w[0] for w in words)
+```
+
+- [ ] **Step 4: Extend the league-token blocklist**
+
+In `src/utils/team_name_utils.py`, find the `_LEAGUE_DISTINCTION_BLOCKLIST = frozenset({ ... })` definition and add `"mls"` and `"nl"` to the set (these leak through the length-2/3 recovery today). The resulting set must still NOT contain `"ad"` or `"hd"`. Example resulting definition:
+
+```python
+_LEAGUE_DISTINCTION_BLOCKLIST = frozenset({
+    "ecnl", "ecnl-rl", "ecrl", "rl", "ga", "npl", "dpl", "dplo",
+    "scdsl", "nal", "mlsnext", "mls-next", "next", "ea", "ea2",
+    "pre-ecnl", "aspire", "mls", "nl",
+})
+```
+
+(Only `"mls"` and `"nl"` are added; keep every pre-existing member. This set is used ONLY inside `resolve_distinction`, so this does not affect the merge gate.)
+
+- [ ] **Step 5: Add the three drop rules inside `resolve_distinction`**
+
+In `resolve_distinction()`, AFTER the block that computes `club_toks` (and adds state-name tokens to it) and BEFORE the `squad_words = sorted(...)` line, add:
+
+```python
+    club_acronym = _club_acronym(club_name)
+```
+
+Then change the squad-words loop from:
+
+```python
+    squad_words = sorted(d.get("squad_words") or [])
+    for sw in squad_words:
+        sw_l = sw.lower()
+        if sw_l in club_toks:
+            continue  # club or state leakage — drop
+        parts.append(sw_l)
+```
+
+to:
+
+```python
+    squad_words = sorted(d.get("squad_words") or [])
+    for sw in squad_words:
+        sw_l = sw.lower()
+        if sw_l in club_toks:
+            continue  # club or state leakage — drop
+        if len(sw_l) == 1:
+            continue  # stray single letter (e.g. "C" from "F.C") — not a squad tag
+        if club_acronym and sw_l == club_acronym:
+            continue  # club's own initials — identifies the club, not the squad
+        parts.append(sw_l)
+```
+
+Then, in the length-2/3 recovery loop, add an acronym guard. Change:
+
+```python
+        if tok in club_toks:
+            continue
+```
+
+(inside that recovery `for tok in raw_toks:` loop) to:
+
+```python
+        if tok in club_toks:
+            continue
+        if club_acronym and tok == club_acronym:
+            continue  # club's own initials — drop
+```
+
+(The `mls`/`nl` league tokens are already handled in this loop because it skips any token in `_LEAGUE_DISTINCTION_BLOCKLIST`, which now includes them.)
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_resolve_distinction_cleanup.py -q`
+Expected: 6 passed.
+
+- [ ] **Step 7: Run the existing distinction tests for regressions**
+
+Run: `cd /c/PitchRank && python -m pytest tests/unit/test_distinction_phase0.py -q && python -m src.utils.team_name_utils`
+Expected: `test_distinction_phase0.py` 11 passed; the `team_name_utils` inline `__main__` self-tests print and exit 0 (no `❌`). If any inline `resolve_distinction` case now fails because its expected value included a dropped token (club-acronym/single-char/`mls`/`nl`), update that expected value in the inline `distinction_cases` list to the new correct output and note it in the commit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /c/PitchRank
+git add src/utils/team_name_utils.py tests/unit/test_resolve_distinction_cleanup.py
+git commit -m "feat(distinction): drop club-acronym/single-char/league tokens from resolve_distinction"
+```
+
+---
+
+## Task 2: Verify against the Phase 0 quality report (before/after guard)
+
+No code change — this confirms the cleanup did what we expect AND did not collapse real teams. The dry-run script is read-only.
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-05-29-distinction-quality-after.txt`
+
+- [ ] **Step 1: Re-run the quality report with the new logic**
+
+Run:
+```bash
+cd /c/PitchRank && python scripts/dryrun_team_distinction.py > docs/superpowers/reports/2026-05-29-distinction-quality-after.txt 2>&1
+```
+Expected: completes with no error (truststore handles SSL); file ends with a PROBLEM BUCKETS section.
+
+- [ ] **Step 2: Compare buckets and collisions to the Phase 0 baseline**
+
+Run:
+```bash
+cd /c/PitchRank && echo "--- BEFORE (Phase 0) ---" && grep -A8 "PROBLEM BUCKETS" docs/superpowers/reports/2026-05-28-distinction-quality.txt | head -8 && grep -E "Collision keys|Collision team count|resolved :" docs/superpowers/reports/2026-05-28-distinction-quality.txt && echo "--- AFTER ---" && grep -A8 "PROBLEM BUCKETS" docs/superpowers/reports/2026-05-29-distinction-quality-after.txt | head -8 && grep -E "Collision keys|Collision team count|resolved :" docs/superpowers/reports/2026-05-29-distinction-quality-after.txt
+```
+Expected:
+- `club_acronym`, `single_char`, and `league_token` buckets drop to ~0 (a few residuals are acceptable).
+- `multi_token` count drops (composites shrank as junk tokens were removed).
+- **Collision keys / collision team count do NOT increase materially** (a small change is fine; a large jump means single-char/acronym drops collapsed distinguishable teams — STOP and report, do not proceed to backfill).
+
+- [ ] **Step 3: Record the comparison**
+
+Append a short summary to the AFTER report file (so the artifact is self-describing):
+```bash
+cd /c/PitchRank && { echo ""; echo "=== BEFORE/AFTER vs 2026-05-28 baseline ==="; echo "(buckets club_acronym/single_char/league_token expected ~0; collisions expected ~stable)"; } >> docs/superpowers/reports/2026-05-29-distinction-quality-after.txt
+```
+
+- [ ] **Step 4: Commit the after-report**
+
+```bash
+cd /c/PitchRank
+git add docs/superpowers/reports/2026-05-29-distinction-quality-after.txt
+git commit -m "docs(distinction): capture post-cleanup quality report (before/after guard)"
+```
+
+> GATE: If Step 2 showed a material collision increase, STOP and report to the controller/user before Task 3. Otherwise proceed.
+
+---
+
+## Task 3: Re-backfill `teams.distinction` with the cleaned logic
+
+`scripts/backfill_team_distinction.py` reads `resolve_distinction` (now updated) and writes only rows whose value changed (idempotent — safe to re-run/resume).
+
+- [ ] **Step 1: Dry-run the backfill and eyeball the change count + samples**
+
+Run:
+```bash
+cd /c/PitchRank && python scripts/backfill_team_distinction.py --dry-run 2>&1 | tail -40
+```
+Expected: prints a "Distinction Backfill Summary" table and a single `Would update: <N>` line. `N` should be in the low tens of thousands (≈ the club_acronym + single_char + league_token + affected multi_token teams), NOT ~150K. Sample resolutions should show junk tokens removed (e.g. `'VSA 2014 Premier Red' -> 'red|premier'`).
+
+- [ ] **Step 2: Run the live backfill in the background**
+
+The Supabase REST API can drop connections past ~10K updates; the script retries and refreshes the client every 2000 rows, and is idempotent, so a partial run can simply be re-run to resume.
+
+Run (background, since it writes thousands of rows):
+```bash
+cd /c/PitchRank && python scripts/backfill_team_distinction.py > docs/superpowers/reports/2026-05-29-backfill.log 2>&1
+```
+(Use the controller's background-run mechanism; do not foreground a multi-minute write.)
+Expected on completion: log ends with `Updated: <N>` matching (approximately) the dry-run count.
+
+- [ ] **Step 3: Confirm the backfill landed**
+
+After it completes, re-run the dry-run; it should now report a near-zero delta (the column already matches the new logic):
+```bash
+cd /c/PitchRank && python scripts/backfill_team_distinction.py --dry-run 2>&1 | grep -E "Would update"
+```
+Expected: `Would update: 0` (or a tiny residual). If it still shows the original large N, the live run did not complete — re-run Step 2 to resume.
+
+> No commit here — this step changes database rows, not files. The `.log` is committed in Task 4.
+
+---
+
+## Task 4: Verify in-product + present before/after sample (user checkpoint)
+
+`composeTeamDisplay` is STILL live on Compare, TeamSelector, RecentMovers, and infographics, so the cleaned data is already visible there. This task confirms a clean DB-level sample and hands a before/after to the user.
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-05-29-distinction-before-after-sample.txt`
+
+- [ ] **Step 1: Pull a before/after sample straight from the DB**
+
+Use the Supabase MCP `execute_sql` (read-only) on project `pfkrhmprwxtghtpinrot` to sample teams that had junk tokens, showing `club_name`, `team_name`, and the new `distinction`:
+```sql
+SELECT club_name, team_name, league, distinction
+FROM teams
+WHERE is_deprecated = FALSE
+  AND distinction IS NOT NULL
+  AND club_name IS NOT NULL
+ORDER BY random()
+LIMIT 30;
+```
+Confirm the new `distinction` values are clean (no club initials, no stray single letters, no `mls`/`nl`), and that any `ad`/`hd` (Modular11) values are intact. Save the 30-row result into the sample report file.
+
+- [ ] **Step 2: Commit the sample + backfill log**
+
+```bash
+cd /c/PitchRank
+git add docs/superpowers/reports/2026-05-29-distinction-before-after-sample.txt docs/superpowers/reports/2026-05-29-backfill.log
+git commit -m "docs(distinction): capture post-backfill sample + backfill log"
+```
+
+- [ ] **Step 3: Hand back to the user (checkpoint)**
+
+STOP. Present to the user: the bucket before/after numbers (Task 2), the collision delta (the safety check), and the 30-row sample (Task 1). Ask whether the cleaned tags look right. Re-enabling `composeTeamDisplay` on the rankings table + global search (un-reverting PR #743) is the next increment and requires its own plan + visual smoke test — do NOT make frontend changes in this plan.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 = display/source cleanup, per the chosen scope):**
+- "Clean stored distinction for display by dropping club-acronym / single-char / league tokens" → Task 1 (the three drop rules + blocklist extension). ✅
+- "Does not touch the merge gate" → only `resolve_distinction` + its private helper + `_LEAGUE_DISTINCTION_BLOCKLIST` (all used solely by `resolve_distinction`) are changed; `should_skip_pair`/`extract_distinctions` untouched. ✅
+- "Re-run the quality report as the before/after guard; collisions must not worsen" → Task 2 (with an explicit STOP gate). ✅
+- "Re-backfill the stored values" → Task 3 (idempotent, background, resumable). ✅
+- "Show a before/after sample before flipping display on; Modular11 untouched" → Task 4 checkpoint; `ad`/`hd` preserved (tested in Task 1 Step 1 and re-checked in Task 4 Step 1). ✅
+- Frontend re-enable explicitly deferred to a follow-up plan. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; run commands have expected output. ✅
+
+**Type/name consistency:** `_club_acronym(club_name)` (returns `str`), `club_acronym` local, `_LEAGUE_DISTINCTION_BLOCKLIST`, `resolve_distinction(name, club_name, state_code)` used consistently across tasks and tests. The three drop rules reference `club_toks`/`club_acronym`/`sw_l`/`tok` exactly as named in the existing function. ✅

--- a/docs/superpowers/plans/2026-05-29-distinction-phase1b-reenable-display.md
+++ b/docs/superpowers/plans/2026-05-29-distinction-phase1b-reenable-display.md
@@ -1,0 +1,214 @@
+# Distinction Cleanup — Phase 1b: Re-enable Composed Display on Rankings + Global Search
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the cleaned, composed team name (`composeTeamDisplay`) on the two surfaces PR #743 reverted to raw `team_name` — the rankings table and global search — now that the underlying distinction data is clean.
+
+**Architecture:** Pure frontend display change. `composeTeamDisplay(team)` already exists and is live on every other surface (Compare, Team Selector, Recent Movers, infographics, Unknown-Opponent). We re-wire it into `RankingsTable` (cell render + team-column sort key + SEO JSON-LD + in-table filter haystack) and `GlobalSearch` (dropdown label). Search *matching* is unchanged — `useTeamSearch.searchable_name` already folds in league/distinction tokens. Navigation uses `team_id_master`, so display text changes cannot affect links. Modular11/MLS NEXT teams stay verbatim because `has_modular11_alias` is populated on both surfaces' rows and `composeTeamDisplay` short-circuits on it.
+
+**Tech Stack:** Next.js 16 / React 19 / TypeScript, `frontend/lib/utils.ts` (`composeTeamDisplay`).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-team-name-distinction-cleanup-design.md`
+**Reverted-by:** PR #743 (`42180ba21`); this un-reverts its two surfaces against current code.
+
+**Branch:** `feat/distinction-cleanup` (continue on it).
+
+**Why no unit-test-first (TDD note):** This is a display re-wire of an already-unit-tested helper (`composeTeamDisplay`). The behavior that broke last time was *visual* (names looked bad due to dirty data, now fixed). The meaningful gate is the **visual smoke test in Task 3**, plus `tsc`/lint. Component snapshot tests would be brittle and are not added.
+
+---
+
+## File Structure
+
+- **Modify** `frontend/components/RankingsTable.tsx` — 4 edits: import, cell render, team-column sort key, SEO schema name, in-table filter haystack.
+- **Modify** `frontend/components/GlobalSearch.tsx` — 2 edits: import, dropdown label (+ aria-label).
+- No backend, no type, no data changes.
+
+---
+
+## Task 1: RankingsTable — composed name in cell, sort, SEO, and filter
+
+**Files:**
+- Modify: `frontend/components/RankingsTable.tsx`
+
+- [ ] **Step 1: Import `composeTeamDisplay`**
+
+Add `composeTeamDisplay` to the imports from `@/lib/utils`. If `RankingsTable.tsx` already imports from `@/lib/utils`, add it to that import list; otherwise add a new line near the other `@/components`/`@/lib` imports (e.g. just after the `RankingsSchema` import on line 16):
+```tsx
+import { composeTeamDisplay } from '@/lib/utils';
+```
+
+- [ ] **Step 2: Render the composed name in the team cell**
+
+Replace the visible team-name span (currently around line 569):
+```tsx
+                              {team.team_name}
+```
+with:
+```tsx
+                              {composeTeamDisplay(team)}
+```
+(Leave the `{club_name} • {STATE}` subline below it unchanged.)
+
+- [ ] **Step 3: Sort the team column by the composed name**
+
+In the `sortedRankings` `sort` callback, the `case 'team':` branch (around lines 139–142) currently reads:
+```tsx
+        case 'team':
+          aValue = a.team_name.toLowerCase();
+          bValue = b.team_name.toLowerCase();
+          break;
+```
+Change it to:
+```tsx
+        case 'team':
+          aValue = composeTeamDisplay(a).toLowerCase();
+          bValue = composeTeamDisplay(b).toLowerCase();
+          break;
+```
+
+- [ ] **Step 4: Use the composed name in the SEO schema**
+
+In `topTeamsForSchema` (around line 324), change:
+```tsx
+      teamName: team.team_name,
+```
+to:
+```tsx
+      teamName: composeTeamDisplay(team),
+```
+
+- [ ] **Step 5: Make the in-table filter match the composed name**
+
+The `visibleRankings` haystack (around line 192) currently reads:
+```tsx
+      const haystack = normalize(`${team.team_name ?? ''} ${team.club_name ?? ''}`);
+```
+Change it to also include the league + distinction tokens that now appear in the visible name:
+```tsx
+      const haystack = normalize(
+        `${team.team_name ?? ''} ${team.club_name ?? ''} ${team.league ?? ''} ${(team.distinction ?? '').replace(/\|/g, ' ')}`
+      );
+```
+
+- [ ] **Step 6: Typecheck + lint the change**
+
+```bash
+cd /c/PitchRank/frontend && npx tsc --noEmit 2>&1 | tail -20
+cd /c/PitchRank/frontend && npx eslint components/RankingsTable.tsx 2>&1 | tail -20
+cd /c/PitchRank/frontend && npx prettier --write components/RankingsTable.tsx
+```
+Expected: `tsc` reports no errors in `RankingsTable.tsx`; eslint clean; prettier reformats if needed. (Do NOT run `prettier --check .` repo-wide — on Windows it false-flags CRLF; only format the changed file.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /c/PitchRank
+git add frontend/components/RankingsTable.tsx
+git commit -m "feat(rankings): render composed team name in rankings table (re-enable #722 display)"
+```
+
+---
+
+## Task 2: GlobalSearch — composed name in the dropdown
+
+**Files:**
+- Modify: `frontend/components/GlobalSearch.tsx`
+
+- [ ] **Step 1: Import `composeTeamDisplay`**
+
+Add near the existing imports (e.g. after the `useTeamSearch` import on line 11):
+```tsx
+import { composeTeamDisplay } from '@/lib/utils';
+```
+
+- [ ] **Step 2: Render the composed name in the result row**
+
+The dropdown label (line 249) currently reads:
+```tsx
+                      <div className="font-medium truncate">{highlightMatch(team.team_name, deferredSearchQuery)}</div>
+```
+Change it to:
+```tsx
+                      <div className="font-medium truncate">{highlightMatch(composeTeamDisplay(team), deferredSearchQuery)}</div>
+```
+
+- [ ] **Step 3: Update the row aria-label to match the visible name**
+
+Line 247 currently reads:
+```tsx
+                      aria-label={`Select ${team.team_name}`}
+```
+Change it to:
+```tsx
+                      aria-label={`Select ${composeTeamDisplay(team)}`}
+```
+(Leave the search-matching logic in `searchResults` untouched — it already uses `searchable_name`, which includes the composed tokens, so typing either the raw or composed form still finds the team.)
+
+- [ ] **Step 4: Typecheck + lint the change**
+
+```bash
+cd /c/PitchRank/frontend && npx tsc --noEmit 2>&1 | tail -20
+cd /c/PitchRank/frontend && npx eslint components/GlobalSearch.tsx 2>&1 | tail -20
+cd /c/PitchRank/frontend && npx prettier --write components/GlobalSearch.tsx
+```
+Expected: no `tsc` errors, eslint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /c/PitchRank
+git add frontend/components/GlobalSearch.tsx
+git commit -m "feat(search): render composed team name in global search dropdown (re-enable #722 display)"
+```
+
+---
+
+## Task 3: Visual smoke test (the gate that #743 failed)
+
+This is the verification that the composed names now read well on the live UI. No code change unless a defect is found.
+
+- [ ] **Step 1: Whole-project typecheck**
+
+```bash
+cd /c/PitchRank/frontend && npx tsc --noEmit 2>&1 | tail -20
+```
+Expected: no errors.
+
+- [ ] **Step 2: Start the dev server**
+
+```bash
+cd /c/PitchRank/frontend && npm run dev
+```
+(Run in background; wait for "Ready"/local URL. `.env.local` is present in `C:/PitchRank/frontend`.)
+
+- [ ] **Step 3: Verify the rankings table**
+
+Open the rankings page (e.g. `http://localhost:3000/rankings?ageGroup=u14&gender=male`, or the app's default rankings route). Confirm:
+- Team names render as composed (e.g. `Phoenix Premier FC Premier` / `SD Surf ECNL RL Blue`-style), **not** raw or junk.
+- A **Modular11 / MLS NEXT** team (filter to one, or find an `... U13 AD/HD` team) still shows its **raw verbatim name** (e.g. `Carolina Core FC U13 HD`), not a composed/duplicated `... MLS Next HD HD`.
+- The `{club} • {STATE}` subline still shows.
+- Clicking a row navigates to `/teams/<id>` (links still work).
+- Typing in the in-table cohort search matches the visible composed name (e.g. search a distinction word like `premier` or a league like `ecnl`).
+- No console errors.
+
+- [ ] **Step 4: Verify global search**
+
+Use the top-nav search box. Confirm:
+- Dropdown rows show the composed name (clean), Modular11 teams show raw.
+- Typing the **raw** form (e.g. part of `team_name`) finds the team.
+- Typing a **composed** token (e.g. a distinction word or league) finds the team.
+- Selecting a result navigates to the team page.
+
+- [ ] **Step 5: Stop the dev server and report**
+
+Stop `npm run dev`. Report the smoke-test outcome (pass, or specific visual issues). If a defect is found (e.g. a class of names still reads poorly), capture the example and STOP for a fix decision — do not paper over it.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Phase 1b goal = "re-enable composed names on the two reverted flagship surfaces." Task 1 covers RankingsTable (render/sort/schema/filter); Task 2 covers GlobalSearch (label/aria); Task 3 is the visual gate. ✅
+
+**Placeholder scan:** Every code step shows the exact before/after snippet; commands have expected output. The only soft spots are line numbers ("around line N") — intentional, since formatting may shift; the code anchors are exact. ✅
+
+**Type/name consistency:** `composeTeamDisplay(team)` is called with `RankingRow` in both files; `RankingRow` includes `team_name`, `club_name`, `league`, `distinction`, `has_modular11_alias` (verified in `frontend/types/RankingRow.ts`), which is structurally compatible with `composeTeamDisplay`'s parameter type. `has_modular11_alias` is populated on rankings rows (RPC migration `20260505000000`) and on search rows (`useTeamSearch.ts:131`). ✅

--- a/docs/superpowers/reports/2026-05-28-distinction-quality.txt
+++ b/docs/superpowers/reports/2026-05-28-distinction-quality.txt
@@ -1,0 +1,331 @@
+Scanned 170,134 teams
+
+=== COVERAGE ===
+  resolved : 148,985  (87.6%)
+  null     : 21,149  (12.4%)
+
+=== SOURCE WINNER ===
+  squad_word    95,753  (56.3%)
+  color         49,702  (29.2%)
+  coach         40,740  (23.9%)
+  NULL          31,383  (18.4%)
+  direction     12,840  (7.5%)
+  number         6,722  (4.0%)
+
+=== UNIQUENESS CHECK ===
+Live teams: 159,834
+Unique keys: 140,717
+Collision keys (>=2 teams sharing identity): 3,341
+Collision team count: 6,907
+
+--- Sample collisions (first 15) ---
+
+KEY: club='lakewood soccer club'  age=u13  league=''  gender=Male  state=MI  distinction=''
+  - id=155ec0fc team_name='Lakewood 2013/14B'  orig=None
+  - id=098ba46e team_name='Lakewood 2013 B'  orig=None
+
+KEY: club='hoosier futbol club'  age=u19  league=''  gender=Male  state=IN  distinction='ii|wolves|elite'
+  - id=74601f63 team_name='Hoosier Futbol Club - Hoosier FC 2007/08B Elite Wolves II'  orig=None
+  - id=9eb384b9 team_name='Hoosier FC 2008 Elite Wolves II'  orig='Hoosier FC 2008B Elite Wolves II'
+
+KEY: club='valley united sc'  age=u12  league=''  gender=Male  state=CA  distinction='armas'
+  - id=c0660c27 team_name='2014 Armas'  orig='B2014 Armas'
+  - id=c7bc4e0c team_name='Armas'  orig=None
+
+KEY: club='la surf soccer club'  age=u8  league=''  gender=Male  state=CA  distinction='socal|lc'
+  - id=132b81aa team_name='LC 2018 - SOCAL'  orig='LC B2018 - SOCAL'
+  - id=107b6e3c team_name='LC U9 - SOCAL'  orig='LC BU9 - SOCAL'
+
+KEY: club='laingsburg soccer club'  age=u11  league=''  gender=Male  state=MI  distinction=''
+  - id=c84e351e team_name='Laingsburg Soccer Club - Laingsburg U11'  orig='Laingsburg Soccer Club - Laingsburg u11 Boys'
+  - id=ad304aab team_name='Laingsburg U10'  orig='Laingsburg u10 boys'
+
+KEY: club='socal elite fc'  age=u11  league=''  gender=Male  state=CA  distinction='gold'
+  - id=0146d961 team_name='2015 Gold'  orig='B15 Gold'
+  - id=448efce3 team_name='U8 Gold'  orig='BU8 Gold'
+
+KEY: club='lonestar'  age=u17  league='ECNL_RL'  gender=Female  state=TX  distinction='south|stxcl'
+  - id=32146304 team_name='ECNL RL STXCL 2009 STH'  orig='ECNL RL STXCL G09 STH'
+  - id=9d372839 team_name='Lonestar SC STH ECNL RL STXCL 2009'  orig='Lonestar SC STH ECNL RL STXCL G09'
+
+KEY: club='oklahoma energy fc'  age=u19  league='ECNL'  gender=Male  state=OK  distinction=''
+  - id=8c8dbe22 team_name='OK Energy FC 2007 ECNL'  orig='OK Energy FC 08/07B ECNL'
+  - id=799be661 team_name='OK Energy FC ECNL B07/06'  orig=None
+
+KEY: club='st. louis scott gallagher'  age=u12  league=''  gender=Female  state=IL  distinction='black|slsg|elite'
+  - id=6952c139 team_name='SLSG IL G 2014 Elite Black'  orig=None
+  - id=3c39fdb4 team_name='SLSG - SLSG IL G 2014 Elite Black'  orig=None
+
+KEY: club='real colorado'  age=u19  league=''  gender=Male  state=CO  distinction='olympico'
+  - id=21c0172c team_name='2008 Olympico'  orig='2008 Boys Olympico'
+  - id=2f7185e2 team_name='Real Colorado - 2006/2007 Olympico'  orig='Real Colorado - 2006/2007 Boys Olympico'
+  - id=6bd0a66f team_name='2007/2008 Olympico'  orig='2007/2008 Boys Olympico'
+
+KEY: club='washington east surf'  age=u9  league=''  gender=Male  state=WA  distinction='royal|elite'
+  - id=888a64e8 team_name='2017 Elite ROYAL'  orig='B17 ELITE ROYAL'
+  - id=403d3f73 team_name='2017 Elite Royal'  orig='B17 Elite Royal'
+
+KEY: club='mechanicville-stillwater'  age=u15  league=''  gender=Female  state=NY  distinction='msusc'
+  - id=60a4638d team_name='MSUSC U14'  orig='MSUSC U14G'
+  - id=5d5e1846 team_name='MSUSC U12'  orig='MSUSC Girls U12'
+
+KEY: club='christiansburg sc'  age=u12  league=''  gender=Male  state=VA  distinction='csc'
+  - id=8991a6c8 team_name='CSC 2014/2015/2016'  orig='CSC 2014/2015/2016 Boys'
+  - id=1c615465 team_name='Christiansburg SC - CSC 2014'  orig='Christiansburg SC - CSC 2014 Boys'
+
+KEY: club='ovid-elsie'  age=u10  league=''  gender=Male  state=MI  distinction='oe'
+  - id=687abfaa team_name='OE U10'  orig='OE u10 Boys'
+  - id=fd4de662 team_name='OE U9'  orig='OE U9 Boys'
+
+KEY: club='chula vista fc'  age=u11  league=''  gender=Male  state=CA  distinction='tuilla'
+  - id=c66755ae team_name='U12 Tuilla'  orig='BU12 Tuilla'
+  - id=ed40d126 team_name='Chula Vista FC 2015 Tuilla'  orig='Chula Vista FC B2015 Tuilla'
+
+=== RESOLVED SAMPLES (random 15 of 25) ===
+  club='West Side Alliance SC'             name='West Side Alliance SC - WSA 2015 Black Xander'         → distinction='black|west|xander|wsa'
+  club='Classics Elite SA'                 name='CE 2008 USC TX RL'                                     → distinction='usc|ce'
+  club='Virginia Soccer Assocation'        name='VSA 2014 Premier Red'                                  → distinction='red|premier|vsa'
+  club='Mount Pleasant Soccer Club'        name='MPSC 2007'                                             → distinction='mpsc'
+  club='Lake Jackson SC'                   name='United'                                                → distinction='united'
+  club='Boilers FC'                        name='Boilers FC 2013 Black'                                 → distinction='black'
+  club='Ccv Stars'                         name='CCV Stars 2011 East Navy'                              → distinction='navy|east'
+  club='PSA'                               name="PSA Monmouth '08/07 RL"                                → distinction='monmouth'
+  club='Ntx United FC'                     name='NTX United FC 2016 Fannin'                             → distinction='fannin'
+  club='MIDWEST GLADIATORS F.C'            name='MIDWEST GLADIATORS F.C'                                → distinction='c'
+  club='Tournament Team'                   name='Tournament Team - Skyline FC 2015'                     → distinction='skyline'
+  club='El Paso Premier League'            name='Texas United 915 2009'                                 → distinction='united'
+  club='Yardley Makefield Soccer'          name='Yardley Makefield Soccer 2014 Milan'                   → distinction='milan'
+  club='Ole FC'                            name='CFC Ole 2011 NAL'                                      → distinction='cfc'
+  club='City SC'                           name='2009 Aspire'                                           → distinction='aspire'
+
+=== PROBLEM BUCKETS (resolved distinctions only) ===
+  bucket              count   % of resolved
+  multi_token        78,107           52.4%
+  club_acronym       10,723            7.2%
+  unknown             8,475            5.7%
+  single_char         7,435            5.0%
+  league_token        2,889            1.9%
+
+--- sample: multi_token ---
+  club='Virginia Soccer Assocation'   name='VSA 2014 Premier Red'                        dist='red|premier|vsa'
+  club='Classics Elite SA'            name='CE 2008 USC TX RL'                           dist='usc|ce'
+  club='Ccv Stars'                    name='CCV Stars 2011 East Navy'                    dist='navy|east'
+  club='Tennessee United SC'          name='TUSC 2010 DPLO'                              dist='dplo|tusc'
+  club='Central Washington Sounders'  name='CWS 2009 ECNL RL Cuevas'                     dist='cuevas|cws'
+  club='Greater Randolph Area YSA'    name='Greater Randolph Area YSA - ROADRUNNERS PETE dist='peterson|roadrunners'
+  club='Beach FC'                     name='Beach FC 2015 Pre-NPL Current'               dist='current|pre'
+  club='United Soccer Club'           name='AFCHSV 2015 SCCL'                            dist='sccl|afchsv'
+  club='West Side Alliance SC'        name='West Side Alliance SC - WSA 2015 Black Xande dist='black|west|xander|wsa'
+  club='AC Delray, Inc.'              name='AC Delray, Inc. - 2014 Elite'                dist='delray,|elite'
+
+--- sample: club_acronym ---
+  club='Virginia Soccer Assocation'   name='VSA 2014 Premier Red'                        dist='red|premier|vsa'
+  club='Mount Pleasant Soccer Club'   name='MPSC 2007'                                   dist='mpsc'
+  club='Central Washington Sounders'  name='CWS 2009 ECNL RL Cuevas'                     dist='cuevas|cws'
+  club='Frisco Soccer Association'    name='Frisco Soccer Association - FSA Tornadoes 20 dist='michelena|2016br|association|tornadoes|fsa'
+  club='Wadsworth Amateur Soccer Asso name='WASA Grizzly United 2016 Div 4S'             dist='div|4s|grizzly|united|wasa'
+  club='Frisco Soccer Association'    name='FSA Frisco Fire 2015BR A Queen'              dist='queen|2015br|a|fire|fsa'
+  club='United Soccer Athletes'       name='USA 2010 Premier Gold'                       dist='gold|premier|usa'
+  club='The St. James Football Club'  name='TSJFC 2014 South Blue'                       dist='blue|south|tsjfc'
+  club='Charlotte Soccer Academy'     name='CSA Charlotte King'                          dist='king|csa'
+  club='Central Arkansas Soccer Club' name='CASC 2013 Royals'                            dist='royals|casc'
+
+--- sample: unknown ---
+  club=''                             name='unknown_3594392'                             dist='unknown'
+  club=''                             name='unknown_3838670'                             dist='unknown'
+  club=''                             name='unknown_3639511'                             dist='unknown'
+  club=''                             name='unknown_3926123'                             dist='unknown'
+  club=''                             name='unknown_3960794'                             dist='unknown'
+  club=''                             name='unknown_3902642'                             dist='unknown'
+  club=''                             name='unknown_3660178'                             dist='unknown'
+  club=''                             name='unknown_3943225'                             dist='unknown'
+  club=''                             name='unknown_3718962'                             dist='unknown'
+  club=''                             name='unknown_3686555'                             dist='unknown'
+
+--- sample: single_char ---
+  club='MIDWEST GLADIATORS F.C'       name='MIDWEST GLADIATORS F.C'                      dist='c'
+  club='Arizona Soccer Club'          name='AZSC 2014 Pre-NL Premier 2'                  dist='2|azsc|premier|pre|nl'
+  club='Alabama FC'                   name='Alabama FC 2010 SCCL 1'                      dist='sccl|1'
+  club='Frisco Soccer Association'    name='FSA Frisco Fire 2015BR A Queen'              dist='queen|2015br|a|fire|fsa'
+  club='Beach Futbol Club'            name='Beach Futbol Club - U11 ES A. Lopez'         dist='lopez|a|es'
+  club='Delaware County Futbol Club'  name='Delaware County FC 2013 2'                   dist='2'
+  club='WW Surf'                      name='Western Washington Surf - 2016 Puyallup A'   dist='puyallup|a|western'
+  club='Worthington United'           name='Worthington United U94 2015 Navy 1'          dist='1|navy|u94'
+  club='Minnesota Rush'               name='2014 EDT 2'                                  dist='edt|2'
+  club='Orlando City Youth Soccer'    name='OPSS-Seminole 2014 PRE ECNL - C'             dist='c|opss|seminole|pre'
+
+--- sample: league_token ---
+  club='Tennessee United SC'          name='TUSC 2010 DPLO'                              dist='dplo|tusc'
+  club='Arizona Soccer Club'          name='AZSC 2014 Pre-NL Premier 2'                  dist='2|azsc|premier|pre|nl'
+  club='Real Futbol Academy'          name='Real FA U19 MLS NEXT AD'                     dist='fa|mls|ad'
+  club='Michigan Stars Elite SC'      name='MI Stars 2007 MLS Next AD'                   dist='mls|ad'
+  club='FC Delco'                     name="PRE MLS NEXT White '15"                      dist='white|pre|mls'
+  club='Hoover-Vestavia Soccer'       name='Hoover-Vestavia 2009 MLS NEXT'               dist='mls'
+  club='FC Delco'                     name="PRE MLS NEXT White '14"                      dist='white|pre|mls'
+  club='RSL Arizona South'            name='2013 Sanchez Royals DPLO'                    dist='sanchez|dplo|royals'
+  club='FC Wisconsin'                 name='FC Wisconsin - *FC Wisconsin U17 NL P2 2009' dist='p2|nl'
+  club='Tormenta FC'                  name='Tormenta FC 2009 MLS'                        dist='mls'
+
+=== NULL SAMPLES (random 15 of 25) ===
+  club='Delaware Football Club'            name='Delaware FC ECNL RL 2012'
+  club='Sporting Wichita'                  name='SPORTING WICHITA 2013 DPL Academy'
+  club='LMVSC'                             name='ECNL RL 2011'
+  club='Oklahoma Energy FC'                name='OK Energy FC 2007 ECNL'
+  club='San Diego Surf Soccer Club'        name='ECNL 2012'
+  club='Medford Strikers SC'               name='Medford Strikers 2011'
+  club='Shore FC'                          name='Shore FC - Shore FC 2007 NAL'
+  club='City SC Southwest'                 name='City SC Southwest 2018'
+  club='HS ELEV8'                          name='HS ELEV8 - ELEV8 2015'
+  club='Auburn Soccer Club'                name='Auburn Soccer Club 2012'
+  club='Laingsburg Soccer Club'            name='Laingsburg Soccer Club - Laingsburg U11'
+  club='Cleveland Football Academy'        name='Cleveland Football Academy 2012'
+  club='South Texas FC'                    name='U10'
+  club='Lakewood Soccer Club'              name='Lakewood 2013/14B'
+  club='Sol SC Florida'                    name='Sol SC Florida 2011'
+
+=== COLLISION ANALYSIS ===
+  Collisions where all teams share team_name (likely already-known dupes): 121
+  Collisions where team_names differ (priority rule may be lossy): 3220
+  Collisions where distinction is NULL for the whole group (Bucket 4): 1076
+  → Bucket 4 CSV written: C:/PitchRank/logs/distinction_bucket4_likely_merges.csv  (2,255 teams across 1,076 groups)
+
+--- Bucket 4 (top 25 groups by size) ---
+
+[12] club='next 11 academy'  age=u15  league=''  gender=Male  state=IN
+    id=8291f04b  team_name='Next 2011 Academy U11'  orig='Next 11 Academy U11 Boys'
+    id=2726c3f6  team_name='Next 2011 Academy - Next 11 Academy 15U'  orig='Next 11 Academy - Next 11 Academy 15U'
+    id=a49ace6c  team_name='Next 2011 Academy - Next 11 Academy 11U'  orig='Next 11 Academy - Next 11 Academy 11U'
+    id=a5c5cb33  team_name='Next 2011 Academy - Next 11 Academy 9U'  orig='Next 11 Academy - Next 11 Academy 9U'
+    id=c53328f7  team_name='Next 2011 Academy - Next 11 Academy 10U'  orig='Next 11 Academy - Next 11 Academy 10U'
+    id=edb5ff0e  team_name='Next 2011 Academy 14U'  orig='Next 11 Academy 14U'
+    … +6 more
+
+[5] club='charlotte soccer academy'  age=u19  league='ECNL'  gender=Male  state=NC
+    id=418bd018  team_name='Charlotte SA Academy ECNL B07/06'  orig=None
+    id=01005d1c  team_name='Charlotte SA ECNL 2008'  orig='Charlotte SA ECNL B08'
+    id=20c5eb32  team_name='Charlotte Soccer Academy - Charlotte SA ECNL B08/07'  orig=None
+    id=5e8fa5a4  team_name='Charlotte SA ECNL B07/06'  orig=None
+    id=50787da5  team_name='Charlotte SA Academy ECNL 2008'  orig='Charlotte SA Academy ECNL B08'
+
+[4] club='pateadores soccer club'  age=u19  league='ECNL_RL'  gender=Male  state=CA
+    id=ec282a32  team_name='Pateadores ECNL RL 2008'  orig='Pateadores ECNL RL B08'
+    id=0620d025  team_name='Pateadores ECNL RL B06/07'  orig=None
+    id=ff832b49  team_name='ECNL RL 2008 NB'  orig='ECNL RL B08 NB'
+    id=b9e97b33  team_name='Pateadores ECNL RL B07/06 NB'  orig=None
+
+[4] club='possible fc'  age=u10  league=''  gender=Male  state=CA
+    id=cf97ebf6  team_name='2016 Academy'  orig=None
+    id=c312ab8b  team_name='U8 Academy'  orig=None
+    id=c1758dbc  team_name='POSSIBLE FC 2016'  orig='POSSIBLE FC B2016'
+    id=9c3a9296  team_name='U9 Academy'  orig=None
+
+[4] club='charlotte independence sc'  age=u19  league='ECNL'  gender=Male  state=NC
+    id=32dd5a4c  team_name='Charlotte Independence Academy ECNL B07/06'  orig=None
+    id=c1dd3db3  team_name='Charlotte Independence ECNL 2008'  orig='Charlotte Independence ECNL B08'
+    id=03cc5a41  team_name='Charlotte Independence ECNL B07/06'  orig=None
+    id=b456662e  team_name='Charlotte Independence Academy ECNL 2008'  orig='Charlotte Independence Academy ECNL B08'
+
+[4] club='dallas texans'  age=u19  league='ECNL_RL'  gender=Male  state=TX
+    id=99a28fa2  team_name='Dallas Texans RL 2007'  orig='Dallas Texans RL B07'
+    id=bef91b1b  team_name='Dallas Texans ECNL RL NTX B07/08'  orig=None
+    id=d810df49  team_name='Dallas Texans ECNL RL NTX B07/06'  orig=None
+    id=101b50cd  team_name='Dallas Texans - Dallas Texans ECRL 2007'  orig='Dallas Texans - Dallas Texans ECRL 07/08B'
+
+[4] club='san diego force fc'  age=u11  league=''  gender=Female  state=CA
+    id=66e101db  team_name='U12 Academy'  orig='GU12 Academy'
+    id=afa5af6c  team_name='2015 Academy'  orig='2015 Girls Academy'
+    id=df1f760c  team_name='U11 Academy'  orig='GU11 Academy'
+    id=b776b0ad  team_name='SD Force FC 2015 Academy'  orig='SD Force FC G2015 Academy'
+
+[4] club='charlotte soccer academy'  age=u16  league='ECNL'  gender=Male  state=NC
+    id=69f2dcfc  team_name='Charlotte SA Academy ECNL 2010'  orig='Charlotte SA Academy ECNL B10'
+    id=416b97fa  team_name='Charlotte SA ECNL 2010'  orig='Charlotte SA ECNL B10'
+    id=7c3a0e5f  team_name='ECNL 2010'  orig='ECNL B10'
+    id=bb42ef44  team_name='Academy ECNL 2010'  orig='Academy ECNL B10'
+
+[4] club='rebels soccer club'  age=u11  league=''  gender=Male  state=CA
+    id=d8f717c6  team_name='U7 Academy'  orig='BU07 Academy'
+    id=378bb614  team_name='2015'  orig=None
+    id=803543de  team_name='U8 Academy B18'  orig='BU08 Academy (B18)'
+    id=f0ff377a  team_name='U8 Academy'  orig='GU08 Academy'
+
+[4] club='charlotte soccer academy'  age=u17  league='ECNL'  gender=Male  state=NC
+    id=f06920b0  team_name='Charlotte SA ECNL 2009'  orig='Charlotte SA ECNL B09'
+    id=042cab2a  team_name='Academy ECNL 2009'  orig='Academy ECNL B09'
+    id=95d88e3d  team_name='ECNL 2009'  orig='ECNL B09'
+    id=7eedddf8  team_name='Charlotte SA Academy ECNL 2009'  orig='Charlotte SA Academy ECNL B09'
+
+[3] club='legends fc (ca)'  age=u19  league=''  gender=Female  state=CA
+    id=0c699365  team_name='Legends FC CA - AV 2008 FC'  orig='Legends FC (CA) - AV G08 FC'
+    id=4326cd6e  team_name='2008 FC'  orig='G08 FC'
+    id=5aa15162  team_name='Legends FC CA - LA 2008 FC'  orig='Legends FC (CA) - LA G08 FC'
+
+[3] club='steel city fc'  age=u19  league='ECNL_RL'  gender=Male  state=PA
+    id=e01a708d  team_name='Steel City FC ECNL RL 2008'  orig='Steel City FC ECNL RL B08'
+    id=2b9a9006  team_name='Steel City FC ECNL RL B07/06'  orig=None
+    id=925fc2c1  team_name='Steel City FC 2007/08B Academy ECNL-RL'  orig=None
+
+[3] club='legends fc (ca)'  age=u19  league='ECNL'  gender=Female  state=CA
+    id=6a0c1fa4  team_name='ECNL G07/08'  orig=None
+    id=b805c8c8  team_name='Legends FC U19 ECNL'  orig='Legends FC GU19 ECNL'
+    id=2cf6e86e  team_name='ECNL G07/06'  orig=None
+
+[3] club='eastside fc'  age=u19  league='ECNL_RL'  gender=Male  state=WA
+    id=6d4ca1df  team_name='Eastside FC RL 2007'  orig='Eastside FC RL B07'
+    id=2d1405d9  team_name='Eastside FC ECNL RL B07/06'  orig=None
+    id=95b01e16  team_name='Eastside FC ECNL RL B07/08'  orig=None
+
+[3] club='lonestar'  age=u19  league='ECNL_RL'  gender=Female  state=TX
+    id=32744f2c  team_name='Lonestar Soccer Club - Lonestar 2006 ECRL'  orig='Lonestar Soccer Club - Lonestar 06/07 ECRL'
+    id=90041633  team_name='Lonestar SC ECNL RL G06/07'  orig=None
+    id=1141c98a  team_name='Lonestar SC ECNL-RL 2008'  orig='Lonestar SC ECNL-RL G08'
+
+[3] club='sporting queen city'  age=u19  league=''  gender=Female  state=OH
+    id=e1846b0b  team_name='Sporting Queen City 2007'  orig='Sporting Queen City G07'
+    id=b73b2741  team_name='Sporting Queen City - Sporting Queen City G07/G08'  orig=None
+    id=1773070d  team_name='Sporting Queen City - Sporting Queen City U18/U19'  orig=None
+
+[3] club='fc united iowa'  age=u14  league=''  gender=Male  state=IA
+    id=7d3d60df  team_name='FC United U13/14B'  orig=None
+    id=29419296  team_name='FC United U14'  orig='FC United U14B'
+    id=358eb6bd  team_name='FC United Iowa - FC United 2012'  orig='FC United (Iowa) - FC United 2012B'
+
+[3] club='pittsburgh riverhounds'  age=u19  league='ECNL_RL'  gender=Male  state=PA
+    id=12ff79de  team_name='Pittsburgh Riverhounds Academy RL 2008'  orig='Pittsburgh Riverhounds Academy RL 2008 Boys'
+    id=5995cdc1  team_name='Pittsburgh Riverhounds - RL 2007'  orig='Pittsburgh Riverhounds - RL B07'
+    id=6eb788e0  team_name='Pittsburgh Riverhounds - Pittsburgh Riverhounds 2008/2007 ECNL RL'  orig='Pittsburgh Riverhounds - Pittsburgh Riverhounds 2008/2007 ECNL RL Boys'
+
+[3] club='nc fusion'  age=u19  league='ECNL'  gender=Female  state=NC
+    id=1925d96c  team_name='NC Fusion ECNL G07/08'  orig=None
+    id=682ad2bb  team_name='NC Fusion ECNL G07/06'  orig=None
+    id=f563d53a  team_name='NC Fusion ECNL 2008'  orig='NC Fusion ECNL (08G)'
+
+[3] club='lenawee united fc'  age=u10  league=''  gender=Male  state=MI
+    id=bbb4d99a  team_name='Lenawee United FC U9/U10 - 2016/2017'  orig='Lenawee United FC Boys U9/U10 - 2016/2017'
+    id=b4cf29d2  team_name='Lenawee United FC U10 - 2016'  orig='Lenawee United FC Boys U10 - 2016'
+    id=741c160e  team_name='Lenawee United FC - Lenawee United FC - U9 2016'  orig='Lenawee United FC - Lenawee United FC - BU9 2016'
+
+[3] club='rebels soccer club'  age=u19  league='ECNL_RL'  gender=Male  state=CA
+    id=53541558  team_name='Rebels SC B07/08 ECRL'  orig=None
+    id=8ee86916  team_name='Rebels SC ECNL RL B07/06'  orig=None
+    id=3a173232  team_name='Rebels SC ECNL RL 2008'  orig='Rebels SC ECNL RL B08'
+
+[3] club='san diego surf soccer club'  age=u19  league='ECNL'  gender=Male  state=CA
+    id=0e55ec97  team_name='San Diego Surf - 2008 ECNL'  orig='San Diego Surf - Boys 2008 ECNL'
+    id=a70b3c49  team_name='ECNL B06/07'  orig=None
+    id=35f03ad3  team_name='ECNL B08/07'  orig=None
+
+[3] club='lenawee united fc'  age=u12  league=''  gender=Female  state=MI
+    id=e99998f6  team_name='Lenawee United FC U11/U12 - 2014/2015'  orig='Lenawee United FC Girls U11/U12 - 2014/2015'
+    id=ce0f8366  team_name='Lenawee United FC - U11 2014'  orig='Lenawee United FC - GU11 2014'
+    id=ca594419  team_name='Lenawee United FC U12 - 2014'  orig='Lenawee United FC Girls U12 - 2014'
+
+[3] club='sporting wichita'  age=u19  league='ECNL_RL'  gender=Male  state=KS
+    id=3b303c69  team_name='Sporting Wichita ECNL RL 2008'  orig='Sporting Wichita ECNL RL B08'
+    id=a54dea1e  team_name='Sporting Wichita ECNL RL B07/06'  orig=None
+    id=7303397c  team_name='Sporting Wichita 2008 ECNL-RL Academy'  orig='Sporting Wichita 2008 ECNL-RL ACADEMY'
+
+[3] club='albion sc santa monica'  age=u12  league=''  gender=Female  state=CA
+    id=16d4dbd6  team_name='ALBION SC Santa Monica U13 DPL'  orig='ALBION SC Santa Monica GU13 DPL'
+    id=a5df06a1  team_name='ALBION SC Santa Monica 2014 Academy'  orig='ALBION SC Santa Monica G14 Academy'
+    id=f204b958  team_name='ALBION SC Santa Monica U13 Academy'  orig='ALBION SC Santa Monica GU13 Academy'

--- a/docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt
+++ b/docs/superpowers/reports/2026-05-28-merge-verdict-baseline.txt
@@ -1,0 +1,182 @@
+Fetching merge history...
+Total merges: 10370
+
+Pre-fetching team data (this avoids rate limits)...
+  Need 19542 unique teams...
+  Fetched 0/19542 teams...
+  Fetched 1000/19542 teams...
+  Fetched 2000/19542 teams...
+  Fetched 3000/19542 teams...
+  Fetched 4000/19542 teams...
+  Fetched 5000/19542 teams...
+  Fetched 6000/19542 teams...
+  Fetched 7000/19542 teams...
+  Fetched 8000/19542 teams...
+  Fetched 9000/19542 teams...
+  Fetched 10000/19542 teams...
+  Fetched 11000/19542 teams...
+  Fetched 12000/19542 teams...
+  Fetched 13000/19542 teams...
+  Fetched 14000/19542 teams...
+  Fetched 15000/19542 teams...
+  Fetched 16000/19542 teams...
+  Fetched 17000/19542 teams...
+  Fetched 18000/19542 teams...
+  Fetched 19000/19542 teams...
+  Cached 19542 teams
+
+Replaying merges through the production dedup gate...
+  Processing 0/10370...
+  Processing 500/10370...
+  Processing 1000/10370...
+  Processing 1500/10370...
+  Processing 2000/10370...
+  Processing 2500/10370...
+  Processing 3000/10370...
+  Processing 3500/10370...
+  Processing 4000/10370...
+  Processing 4500/10370...
+  Processing 5000/10370...
+  Processing 5500/10370...
+  Processing 6000/10370...
+  Processing 6500/10370...
+  Processing 7000/10370...
+  Processing 7500/10370...
+  Processing 8000/10370...
+  Processing 8500/10370...
+  Processing 9000/10370...
+  Processing 9500/10370...
+  Processing 10000/10370...
+
+============================================================
+MERGE-VERDICT BASELINE (production gate: should_skip_pair)
+============================================================
+
+Historical merges replayed: 10,370
+  allowed (gate keeps merge reachable): 8,010  (77.24% of evaluable)
+  false_skip (gate would BLOCK this merge): 2,360  (22.76% of evaluable)
+  no_data (missing team rows): 0
+
+------------------------------------------------------------
+SAMPLE FALSE-SKIPS (first 40)
+------------------------------------------------------------
+
+  deprecated: 'Chattanooga FC - 2011 Navy'  (club='Chattanooga Football Club Academy')
+  canonical : 'Chattanooga FC U15 HD'  (club='Chattanooga Football Club Academy')
+
+  deprecated: 'ALBION SC Denver 2013 MLS next 2'  (club='ALBION SC Denver')
+  canonical : 'ALBION SC Denver U13 AD'  (club='ALBION SC Denver')
+
+  deprecated: 'West Covina F.C.'  (club='West Covina SC')
+  canonical : 'West Covina FC'  (club='West Covina SC')
+
+  deprecated: 'Phoenix Premier FC 2014 Black'  (club='Phoenix Premier FC')
+  canonical : 'Phoenix Premier FC 2014 SW Black'  (club='Phoenix Premier FC')
+
+  deprecated: 'Dothan Shockers FC 2013'  (club='Dothan Shockers FC')
+  canonical : 'Dothan Shockers FC 13/14GC'  (club='Dothan Shockers FC')
+
+  deprecated: 'FLYTE SC IE- 2013 DPL'  (club='Flyte SC Ie')
+  canonical : 'FLYTE SC IE- 2013 DPLO'  (club='Flyte SC Ie')
+
+  deprecated: 'LCPFC 2012 NPL'  (club='Florida Premier FC')
+  canonical : 'LPFC 2012 NPL'  (club='Florida Premier FC')
+
+  deprecated: 'FLYTE SC IE- 2012 DPL'  (club='Flyte SC Ie')
+  canonical : 'FLYTE SC IE- 2012 DPLO'  (club='Flyte SC Ie')
+
+  deprecated: '2012 FPFC WC Elite'  (club='Florida Premier FC')
+  canonical : '2012 G FPFC WC Elite'  (club='Florida Premier FC')
+
+  deprecated: 'Fall Select U12 - Mahe1'  (club='Walnut Creek Surf Soccer Club')
+  canonical : 'Fall Select U12 - Mahe'  (club='Walnut Creek Surf Soccer Club')
+
+  deprecated: 'Utah Royals FC-AZ ECNL 2012'  (club='Utah Royals FC - AZ')
+  canonical : 'Utah Royals FC-AZ RL 2012'  (club='Utah Royals FC - AZ')
+
+  deprecated: 'LWPFC White Payaras 2011'  (club='Lake Washington Premier Football Club')
+  canonical : 'LWPFC White Piranhas 2011'  (club='Lake Washington Premier Football Club')
+
+  deprecated: 'Worldwide Soccer Club B2015B'  (club='Worldwide FC')
+  canonical : 'Worldwide Soccer Club 2015'  (club='Worldwide FC')
+
+  deprecated: 'SD Surf Academy 2015 Jaewoo'  (club='San Diego Surf Soccer Club')
+  canonical : 'SD Surf Academy 2015 Jaewoo K.'  (club='San Diego Surf Soccer Club')
+
+  deprecated: 'PRE-ECNL 2014 I'  (club='San Diego Surf Soccer Club')
+  canonical : 'San Diego Surf PRE-ECNL 2014 I Garton'  (club='San Diego Surf Soccer Club')
+
+  deprecated: 'Connecticut FC United ECNL RL 2011'  (club='Connecticut FC')
+  canonical : 'Connecticut FC United ECNL 2011'  (club='Connecticut FC')
+
+  deprecated: 'Real Atletico FC 2013-B'  (club='Real Atletico Futbol Club')
+  canonical : 'Real Atletico FC 2013'  (club='Real Atletico Futbol Club')
+
+  deprecated: 'INLAND SURF 2014'  (club='Inland Surf')
+  canonical : 'Inland Surf - 2014 EA - 2'  (club='Inland Surf')
+
+  deprecated: 'Greenbush SC 2009/2010 Green'  (club='Greenbush Soccer Club')
+  canonical : 'Greenbush SC 2009/10 Green'  (club='Greenbush Soccer Club')
+
+  deprecated: 'Eclipse 2013 ECNL'  (club='Eclipse Select Soccer Club')
+  canonical : 'Eclipse 2013 PRE-ECNL'  (club='Eclipse Select Soccer Club')
+
+  deprecated: 'LA Surf - MLS 2013'  (club='LA Surf Soccer Club')
+  canonical : 'Los Angeles Surf U13 HD'  (club='LA Surf Soccer Club')
+
+  deprecated: 'FC Central Illinois 2012 Select'  (club='FC Central Illinois')
+  canonical : 'FC Central Illinois 2012 B Select'  (club='FC Central Illinois')
+
+  deprecated: 'ECNL RL 2013'  (club='Playmaker Futbol Academy')
+  canonical : 'Playmaker Futbol Academy ECNL-RL 2013'  (club='Playmaker Futbol Academy')
+
+  deprecated: 'ECNL RL 2010'  (club='Playmaker Futbol Academy')
+  canonical : 'Playmaker Futbol Academy ECNL-RL 2010'  (club='Playmaker Futbol Academy')
+
+  deprecated: 'Greenbush SC 2013-2014 Green'  (club='Greenbush Soccer Club')
+  canonical : 'Greenbush SC 2013/14 Green'  (club='Greenbush Soccer Club')
+
+  deprecated: 'Phoenix Rising FC U13 MLS Next HD'  (club='Phoenix Rising FC')
+  canonical : 'Phoenix Rising FC U13 HD'  (club='Phoenix Rising FC')
+
+  deprecated: 'Phoenix Rising FC U13 MLS Next AD'  (club='Phoenix Rising FC')
+  canonical : 'Phoenix Rising FC U13 AD'  (club='Phoenix Rising FC')
+
+  deprecated: 'RSL AZ 2010 MLS Next AD'  (club='RSL Arizona')
+  canonical : 'RSL Arizona U16 AD'  (club='RSL Arizona')
+
+  deprecated: 'RSL AZ Mesa 2013 MLS Next AD'  (club='RSL Arizona Mesa')
+  canonical : 'RSL Arizona Mesa U13 AD'  (club='RSL Arizona Mesa')
+
+  deprecated: 'Barca Residency Academy U16 MLS NEXT AD'  (club='Barca Residency Academy')
+  canonical : 'Barca Residency Academy U16 AD'  (club='Barca Residency Academy')
+
+  deprecated: 'Phoenix Rising U16 MLS Next AD'  (club='Phoenix Rising FC')
+  canonical : 'Phoenix Rising FC U16 AD'  (club='Phoenix Rising FC')
+
+  deprecated: 'RSL AZ North 2010 MLS Next New Tier'  (club='RSL Arizona North')
+  canonical : 'RSL Arizona U16 AD'  (club='RSL Arizona')
+
+  deprecated: 'SC DEL SOL U16 MLS Next AD'  (club='SC del Sol')
+  canonical : 'SC Del Sol U16 AD'  (club='SC del Sol')
+
+  deprecated: 'Phoenix Premier FC 2009 MLS NEXT AD'  (club='Phoenix Premier FC')
+  canonical : 'Phoenix Premier FC U17 AD'  (club='Phoenix Premier FC')
+
+  deprecated: 'U17 MLS NEXT AD'  (club='Phoenix Rising FC')
+  canonical : 'Phoenix Rising FC U17 AD'  (club='Phoenix Rising FC')
+
+  deprecated: 'RSL AZ Mesa 2009 MLS Next New Tier'  (club='RSL Arizona South')
+  canonical : 'RSL Arizona Mesa U17 AD'  (club='RSL Arizona Mesa')
+
+  deprecated: 'U17 2009 MLS NEXT'  (club='SC del Sol')
+  canonical : 'SC Del Sol U17 HD'  (club='SC del Sol')
+
+  deprecated: 'U17 2009 MLS NEXT Academy'  (club='SC del Sol')
+  canonical : 'SC Del Sol U17 HD'  (club='SC del Sol')
+
+  deprecated: 'FC Tucson U13 MLS NEXT AD'  (club='FC Tucson Youth Soccer')
+  canonical : 'FC Tucson Youth Soccer Club U13 AD'  (club='FC Tucson Youth Soccer')
+
+  deprecated: 'Phoenix Premier FC 2013 MLS NEXT AD'  (club='Phoenix Premier FC')
+  canonical : 'Phoenix Rising FC U13 AD'  (club='Phoenix Rising FC')

--- a/docs/superpowers/reports/2026-05-29-distinction-before-after-sample.txt
+++ b/docs/superpowers/reports/2026-05-29-distinction-before-after-sample.txt
@@ -1,0 +1,36 @@
+Phase 1 distinction cleanup — post-backfill verification (2026-05-29)
+
+Backfill result: Updated 11,705 rows, 0 errors (see 2026-05-29-backfill.log).
+Logic change: resolve_distinction now drops (a) a club's own first-letter
+acronym (>=3-word clubs), and (b) leftover league tokens (mls, nl). Single-char
+tokens are KEPT (real Team A/B). Modular11 ad/hd untouched.
+
+Bucket movement (full reports: 2026-05-28-distinction-quality.txt vs
+2026-05-29-distinction-quality-after.txt):
+  club_acronym  7.2% -> 0.3%
+  league_token  1.9% -> 0.2%
+  single_char   5.0% -> 5.1%  (kept by design)
+  multi_token  52.4% -> 49.2% (composites shrank)
+Identity-key collisions: 6,907 -> 7,488 teams (read-only diagnostic only; the
+distinction column is written but never read to link/merge teams).
+
+--- LIVE post-backfill sample (random active teams) ---
+New Canaan FC                "New Canaan FC 2015 Black"                -> black
+FC ATLETICO                  "FC ATLETICO 2015 Red"                    -> red
+Holmdel FC                   "Holmdel FC 2010 Bayern"                  -> bayern
+Lawrenceburg Greendale SC    "LGSC G16/17 Thunder"                     -> thunder        (lgsc acronym dropped)
+Parsippany SC                "PSC Academy 2009 NL Premier"             -> premier|psc     (nl dropped; psc kept - 2-word club)
+Crystal Lake Soccer Fed.     "FORCE 2006 Elite Pool"                   -> pool|force|elite
+Hunter SC                    "Yellow Jackets"                          -> yellow|jackets
+Cheverly Soccer Club         "LIONS 2014 TRVL"                         -> trvl|lions
+
+--- Modular11 AD/HD (must be preserved) ---
+VA Rush Soccer Club          "Virginia Rush U17 AD"                    -> ad
+Miami Futbol Academy Rush    "...2009 U17 MLS AD"                      -> ad   (mls dropped, ad kept)
+San Francisco Glens          "San Francisco Glens SC U16 HD"           -> hd
+FC Dallas                    "FC Dallas U13 HD"                        -> hd
+San Francisco Seals          "San Francisco Seals U14 AD"              -> ad
+Modesto Ajax United          "Modesto Ajax United U17 HD"             -> hd
+
+Next step (separate follow-up): re-enable composeTeamDisplay on the rankings
+table + global search (un-revert PR #743), with a visual smoke test.

--- a/docs/superpowers/reports/2026-05-29-distinction-quality-after.txt
+++ b/docs/superpowers/reports/2026-05-29-distinction-quality-after.txt
@@ -1,0 +1,337 @@
+Scanned 170,134 teams
+
+=== COVERAGE ===
+  resolved : 146,890  (86.3%)
+  null     : 23,244  (13.7%)
+
+=== SOURCE WINNER ===
+  squad_word    95,753  (56.3%)
+  color         49,702  (29.2%)
+  coach         40,740  (23.9%)
+  NULL          31,383  (18.4%)
+  direction     12,840  (7.5%)
+  number         6,722  (4.0%)
+
+=== UNIQUENESS CHECK ===
+Live teams: 159,833
+Unique keys: 140,417
+Collision keys (>=2 teams sharing identity): 3,623
+Collision team count: 7,488
+
+--- Sample collisions (first 15) ---
+
+KEY: club='ole fc'  age=u15  league='NL'  gender=Female  state=CT  distinction='cfc'
+  - id=ca46f76b team_name='CFC Ole 2011 NAL'  orig='CFC Ole G2011 NAL'
+  - id=112283cc team_name='CFC Ole 2011 Academy NL'  orig='CFC Ole G2011 Academy NL'
+
+KEY: club='lakewood soccer club'  age=u13  league=''  gender=Male  state=MI  distinction=''
+  - id=155ec0fc team_name='Lakewood 2013/14B'  orig=None
+  - id=098ba46e team_name='Lakewood 2013 B'  orig=None
+
+KEY: club='hoosier futbol club'  age=u19  league=''  gender=Male  state=IN  distinction='ii|wolves|elite'
+  - id=74601f63 team_name='Hoosier Futbol Club - Hoosier FC 2007/08B Elite Wolves II'  orig=None
+  - id=9eb384b9 team_name='Hoosier FC 2008 Elite Wolves II'  orig='Hoosier FC 2008B Elite Wolves II'
+
+KEY: club='valley united sc'  age=u12  league=''  gender=Male  state=CA  distinction='armas'
+  - id=c0660c27 team_name='2014 Armas'  orig='B2014 Armas'
+  - id=c7bc4e0c team_name='Armas'  orig=None
+
+KEY: club='la surf soccer club'  age=u8  league=''  gender=Male  state=CA  distinction='socal|lc'
+  - id=132b81aa team_name='LC 2018 - SOCAL'  orig='LC B2018 - SOCAL'
+  - id=107b6e3c team_name='LC U9 - SOCAL'  orig='LC BU9 - SOCAL'
+
+KEY: club='laingsburg soccer club'  age=u11  league=''  gender=Male  state=MI  distinction=''
+  - id=c84e351e team_name='Laingsburg Soccer Club - Laingsburg U11'  orig='Laingsburg Soccer Club - Laingsburg u11 Boys'
+  - id=ad304aab team_name='Laingsburg U10'  orig='Laingsburg u10 boys'
+
+KEY: club='socal elite fc'  age=u11  league=''  gender=Male  state=CA  distinction='gold'
+  - id=0146d961 team_name='2015 Gold'  orig='B15 Gold'
+  - id=448efce3 team_name='U8 Gold'  orig='BU8 Gold'
+
+KEY: club='lonestar'  age=u17  league='ECNL_RL'  gender=Female  state=TX  distinction='south|stxcl'
+  - id=32146304 team_name='ECNL RL STXCL 2009 STH'  orig='ECNL RL STXCL G09 STH'
+  - id=9d372839 team_name='Lonestar SC STH ECNL RL STXCL 2009'  orig='Lonestar SC STH ECNL RL STXCL G09'
+
+KEY: club='oklahoma energy fc'  age=u19  league='ECNL'  gender=Male  state=OK  distinction=''
+  - id=8c8dbe22 team_name='OK Energy FC 2007 ECNL'  orig='OK Energy FC 08/07B ECNL'
+  - id=799be661 team_name='OK Energy FC ECNL B07/06'  orig=None
+
+KEY: club='st. louis scott gallagher'  age=u12  league=''  gender=Female  state=IL  distinction='black|elite'
+  - id=6952c139 team_name='SLSG IL G 2014 Elite Black'  orig=None
+  - id=3c39fdb4 team_name='SLSG - SLSG IL G 2014 Elite Black'  orig=None
+
+KEY: club='real colorado'  age=u19  league=''  gender=Male  state=CO  distinction='olympico'
+  - id=21c0172c team_name='2008 Olympico'  orig='2008 Boys Olympico'
+  - id=2f7185e2 team_name='Real Colorado - 2006/2007 Olympico'  orig='Real Colorado - 2006/2007 Boys Olympico'
+  - id=6bd0a66f team_name='2007/2008 Olympico'  orig='2007/2008 Boys Olympico'
+
+KEY: club='washington east surf'  age=u9  league=''  gender=Male  state=WA  distinction='royal|elite'
+  - id=888a64e8 team_name='2017 Elite ROYAL'  orig='B17 ELITE ROYAL'
+  - id=403d3f73 team_name='2017 Elite Royal'  orig='B17 Elite Royal'
+
+KEY: club='mechanicville-stillwater'  age=u15  league=''  gender=Female  state=NY  distinction='msusc'
+  - id=60a4638d team_name='MSUSC U14'  orig='MSUSC U14G'
+  - id=5d5e1846 team_name='MSUSC U12'  orig='MSUSC Girls U12'
+
+KEY: club='christiansburg sc'  age=u12  league=''  gender=Male  state=VA  distinction='csc'
+  - id=8991a6c8 team_name='CSC 2014/2015/2016'  orig='CSC 2014/2015/2016 Boys'
+  - id=1c615465 team_name='Christiansburg SC - CSC 2014'  orig='Christiansburg SC - CSC 2014 Boys'
+
+KEY: club='ovid-elsie'  age=u10  league=''  gender=Male  state=MI  distinction='oe'
+  - id=687abfaa team_name='OE U10'  orig='OE u10 Boys'
+  - id=fd4de662 team_name='OE U9'  orig='OE U9 Boys'
+
+=== RESOLVED SAMPLES (random 15 of 25) ===
+  club='Tournament Team'                   name='Tournament Team - Skyline FC 2015'                     → distinction='skyline'
+  club='Classics Elite SA'                 name='CE 2008 USC TX RL'                                     → distinction='usc|ce'
+  club='Virginia Soccer Assocation'        name='VSA 2014 Premier Red'                                  → distinction='red|premier'
+  club='Central Washington Sounders'       name='CWS 2009 ECNL RL Cuevas'                               → distinction='cuevas'
+  club='Lake Jackson SC'                   name='United'                                                → distinction='united'
+  club='Salvo SC'                          name='Salvo SC - Salvo SC 2013 Navy'                         → distinction='navy'
+  club='Ccv Stars'                         name='CCV Stars 2011 East Navy'                              → distinction='navy|east'
+  club='Wichita Regional Soccer Associatio name='FC VICTORIA 2013'                                      → distinction='victoria'
+  club='Ntx United FC'                     name='NTX United FC 2016 Fannin'                             → distinction='fannin'
+  club='Beach FC'                          name='Beach FC 2015 Pre-NPL Current'                         → distinction='current|pre'
+  club='Boilers FC'                        name='Boilers FC 2013 Black'                                 → distinction='black'
+  club='Houston Surf Soccer Club'          name='2015 Blue'                                             → distinction='blue'
+  club='Yardley Makefield Soccer'          name='Yardley Makefield Soccer 2014 Milan'                   → distinction='milan'
+  club='Cottage Grove United SC'           name='Cottage Grove United SC - 2014 State'                  → distinction='state'
+  club='Greater Randolph Area YSA'         name='Greater Randolph Area YSA - ROADRUNNERS PETERSON'      → distinction='peterson|roadrunners'
+
+=== PROBLEM BUCKETS (resolved distinctions only) ===
+  bucket              count   % of resolved
+  multi_token        72,280           49.2%
+  unknown             8,475            5.8%
+  single_char         7,435            5.1%
+  club_acronym          459            0.3%
+  league_token          310            0.2%
+
+--- sample: multi_token ---
+  club='Virginia Soccer Assocation'   name='VSA 2014 Premier Red'                        dist='red|premier'
+  club='Classics Elite SA'            name='CE 2008 USC TX RL'                           dist='usc|ce'
+  club='Ccv Stars'                    name='CCV Stars 2011 East Navy'                    dist='navy|east'
+  club='Tennessee United SC'          name='TUSC 2010 DPLO'                              dist='dplo|tusc'
+  club='Greater Randolph Area YSA'    name='Greater Randolph Area YSA - ROADRUNNERS PETE dist='peterson|roadrunners'
+  club='Beach FC'                     name='Beach FC 2015 Pre-NPL Current'               dist='current|pre'
+  club='United Soccer Club'           name='AFCHSV 2015 SCCL'                            dist='sccl|afchsv'
+  club='West Side Alliance SC'        name='West Side Alliance SC - WSA 2015 Black Xande dist='black|west|xander|wsa'
+  club='AC Delray, Inc.'              name='AC Delray, Inc. - 2014 Elite'                dist='delray,|elite'
+  club='Arizona Soccer Club'          name='AZSC 2014 Pre-NL Premier 2'                  dist='2|azsc|premier|pre'
+
+--- sample: unknown ---
+  club=''                             name='unknown_3594392'                             dist='unknown'
+  club=''                             name='unknown_3838670'                             dist='unknown'
+  club=''                             name='unknown_3639511'                             dist='unknown'
+  club=''                             name='unknown_3926123'                             dist='unknown'
+  club=''                             name='unknown_3960794'                             dist='unknown'
+  club=''                             name='unknown_3902642'                             dist='unknown'
+  club=''                             name='unknown_3660178'                             dist='unknown'
+  club=''                             name='unknown_3943225'                             dist='unknown'
+  club=''                             name='unknown_3718962'                             dist='unknown'
+  club=''                             name='unknown_3686555'                             dist='unknown'
+
+--- sample: single_char ---
+  club='MIDWEST GLADIATORS F.C'       name='MIDWEST GLADIATORS F.C'                      dist='c'
+  club='Arizona Soccer Club'          name='AZSC 2014 Pre-NL Premier 2'                  dist='2|azsc|premier|pre'
+  club='Alabama FC'                   name='Alabama FC 2010 SCCL 1'                      dist='sccl|1'
+  club='Frisco Soccer Association'    name='FSA Frisco Fire 2015BR A Queen'              dist='queen|2015br|a|fire'
+  club='Beach Futbol Club'            name='Beach Futbol Club - U11 ES A. Lopez'         dist='lopez|a|es'
+  club='Delaware County Futbol Club'  name='Delaware County FC 2013 2'                   dist='2'
+  club='WW Surf'                      name='Western Washington Surf - 2016 Puyallup A'   dist='puyallup|a|western'
+  club='Worthington United'           name='Worthington United U94 2015 Navy 1'          dist='1|navy|u94'
+  club='Minnesota Rush'               name='2014 EDT 2'                                  dist='edt|2'
+  club='Orlando City Youth Soccer'    name='OPSS-Seminole 2014 PRE ECNL - C'             dist='c|opss|seminole|pre'
+
+--- sample: club_acronym ---
+  club='Wesley Chapel Weddington Athl name='2014 U12 WCWAA Premier G'                    dist='wcwaa|premier'
+  club='Auburn Soccer Club'           name='Auburn Soccer Club - 2016 ASC Wolverines'    dist='asc|wolverines'
+  club='St. Petersburg Football Club' name='St Petersburg FC 2011 SPFC'                  dist='spfc'
+  club='St. Anthony Village Soccer Cl name='2010 SAVSC'                                  dist='savsc'
+  club='Sierra Gold Soccer Club'      name='2025 SGSC Gladiators'                        dist='sgsc|gladiators'
+  club='Southern Soccer Academy'      name='Southern Soccer Academy - 2025 SSA Marietta  dist='ssa|leon|lions|marietta|mudcreek'
+  club='Charlotte Soccer Academy'     name='2013 CSA Huntersville King G'                dist='csa|huntersville|king'
+  club='Charlotte Soccer Academy'     name='2015 CSA HV Roma Elite'                      dist='csa|roma|elite|hv'
+  club='Charlotte Soccer Academy'     name='2013 13U CSA Charlotte King G'               dist='csa|king'
+  club='Sierra Gold Soccer Club'      name='2025 SGSC Strikers'                          dist='sgsc|strikers'
+
+--- sample: league_token ---
+  club='Tennessee United SC'          name='TUSC 2010 DPLO'                              dist='dplo|tusc'
+  club='RSL Arizona South'            name='2013 Sanchez Royals DPLO'                    dist='sanchez|dplo|royals'
+  club='Albion SC Atlanta'            name='ALBION SC Atlanta G06/07 DPLO'               dist='dplo'
+  club='Real Salt Lake-AZ (RSL-AZ)'   name='RSL-AZ North 2012 Tomasevic Royals DPLO'     dist='north|dplo|royals|tomasevic'
+  club='AFC Lightning'                name='AFC Lightning Middle GA 2009 DPLO'           dist='dplo|middle'
+  club=''                             name='FC Premier VALENCIA 2012 EA2'                dist='ea2|valencia|premier'
+  club='Phoenix Rising FC North Valle name='PRFC North Valley 2009 DPLO'                 dist='north|dplo|prfc'
+  club='Central Cal Aztecs'           name='Central Cal Aztecs 2013 EA2'                 dist='central|ea2'
+  club='Pima County Surf Soccer Club' name='Pima 2013 G DPLO'                            dist='dplo'
+  club='Albion SC Central Valley'     name='Albion SC CV 2012 DPLO'                      dist='dplo|cv'
+
+=== NULL SAMPLES (random 15 of 25) ===
+  club='HS ELEV8'                          name='HS ELEV8 - ELEV8 2015'
+  club='Delaware Football Club'            name='Delaware FC ECNL RL 2012'
+  club='Mount Pleasant Soccer Club'        name='MPSC 2007'
+  club='Mount Pleasant Soccer Club'        name='MPSC 2016'
+  club='San Diego Surf Soccer Club'        name='ECNL 2013'
+  club='Cleveland Football Academy'        name='Cleveland Football Academy 2012'
+  club='Oxford United FC(OH)'              name='Oxford United FC(OH - Oxford United 2016'
+  club='San Diego Surf Soccer Club'        name='ECNL 2012'
+  club='Laingsburg Soccer Club'            name='Laingsburg Soccer Club - Laingsburg U11'
+  club='City SC Southwest'                 name='City SC Southwest 2018'
+  club='Spartak Academy'                   name='Spartak Academy 2014'
+  club='ODA'                               name='ODA - 2009'
+  club='Sporting Wichita'                  name='SPORTING WICHITA 2013 DPL Academy'
+  club='FC Copa Academy'                   name='ECNL RL 2011'
+  club='Oklahoma Energy FC'                name='OK Energy FC 2007 ECNL'
+
+=== COLLISION ANALYSIS ===
+  Collisions where all teams share team_name (likely already-known dupes): 119
+  Collisions where team_names differ (priority rule may be lossy): 3504
+  Collisions where distinction is NULL for the whole group (Bucket 4): 1268
+  → Bucket 4 CSV written: C:/PitchRank/logs/distinction_bucket4_likely_merges.csv  (2,661 teams across 1,268 groups)
+
+--- Bucket 4 (top 25 groups by size) ---
+
+[12] club='next 11 academy'  age=u15  league=''  gender=Male  state=IN
+    id=8291f04b  team_name='Next 2011 Academy U11'  orig='Next 11 Academy U11 Boys'
+    id=2726c3f6  team_name='Next 2011 Academy - Next 11 Academy 15U'  orig='Next 11 Academy - Next 11 Academy 15U'
+    id=a49ace6c  team_name='Next 2011 Academy - Next 11 Academy 11U'  orig='Next 11 Academy - Next 11 Academy 11U'
+    id=a5c5cb33  team_name='Next 2011 Academy - Next 11 Academy 9U'  orig='Next 11 Academy - Next 11 Academy 9U'
+    id=c53328f7  team_name='Next 2011 Academy - Next 11 Academy 10U'  orig='Next 11 Academy - Next 11 Academy 10U'
+    id=edb5ff0e  team_name='Next 2011 Academy 14U'  orig='Next 11 Academy 14U'
+    … +6 more
+
+[5] club='charlotte soccer academy'  age=u19  league='ECNL'  gender=Male  state=NC
+    id=418bd018  team_name='Charlotte SA Academy ECNL B07/06'  orig=None
+    id=01005d1c  team_name='Charlotte SA ECNL 2008'  orig='Charlotte SA ECNL B08'
+    id=20c5eb32  team_name='Charlotte Soccer Academy - Charlotte SA ECNL B08/07'  orig=None
+    id=5e8fa5a4  team_name='Charlotte SA ECNL B07/06'  orig=None
+    id=50787da5  team_name='Charlotte SA Academy ECNL 2008'  orig='Charlotte SA Academy ECNL B08'
+
+[5] club='total futbol academy'  age=u10  league=''  gender=Male  state=CA
+    id=49084e61  team_name='Total Futbol Academy - TFA-AV 2016'  orig='Total Futbol Academy - TFA-AV B2016'
+    id=ecdee1aa  team_name='Total Futbol Academy - TFA-IE 2016'  orig='Total Futbol Academy - TFA-IE B2016'
+    id=bd9b1b80  team_name='TFA-OC 2016'  orig='TFA-OC B2016'
+    id=87a9291b  team_name='TFA-IE 2016'  orig='TFA-IE B2016'
+    id=ec209f40  team_name='TFA-AV U9'  orig='TFA-AV BU9'
+
+[4] club='pateadores soccer club'  age=u19  league='ECNL_RL'  gender=Male  state=CA
+    id=ec282a32  team_name='Pateadores ECNL RL 2008'  orig='Pateadores ECNL RL B08'
+    id=0620d025  team_name='Pateadores ECNL RL B06/07'  orig=None
+    id=ff832b49  team_name='ECNL RL 2008 NB'  orig='ECNL RL B08 NB'
+    id=b9e97b33  team_name='Pateadores ECNL RL B07/06 NB'  orig=None
+
+[4] club='total futbol academy'  age=u14  league=''  gender=Male  state=CA
+    id=a9b38af0  team_name='TFA-IE 2012'  orig='TFA-IE B2012'
+    id=9269ed92  team_name='Total Futbol Academy - TFA IE'  orig=None
+    id=9cb6591a  team_name='TFA-AV 2012'  orig='TFA-AV B2012'
+    id=0e3f4983  team_name='TFA-SFV 2012'  orig='TFA-SFV B2012'
+
+[4] club='possible fc'  age=u10  league=''  gender=Male  state=CA
+    id=cf97ebf6  team_name='2016 Academy'  orig=None
+    id=c312ab8b  team_name='U8 Academy'  orig=None
+    id=c1758dbc  team_name='POSSIBLE FC 2016'  orig='POSSIBLE FC B2016'
+    id=9c3a9296  team_name='U9 Academy'  orig=None
+
+[4] club='charlotte independence sc'  age=u19  league='ECNL'  gender=Male  state=NC
+    id=32dd5a4c  team_name='Charlotte Independence Academy ECNL B07/06'  orig=None
+    id=c1dd3db3  team_name='Charlotte Independence ECNL 2008'  orig='Charlotte Independence ECNL B08'
+    id=03cc5a41  team_name='Charlotte Independence ECNL B07/06'  orig=None
+    id=b456662e  team_name='Charlotte Independence Academy ECNL 2008'  orig='Charlotte Independence Academy ECNL B08'
+
+[4] club='dallas texans'  age=u19  league='ECNL_RL'  gender=Male  state=TX
+    id=99a28fa2  team_name='Dallas Texans RL 2007'  orig='Dallas Texans RL B07'
+    id=bef91b1b  team_name='Dallas Texans ECNL RL NTX B07/08'  orig=None
+    id=d810df49  team_name='Dallas Texans ECNL RL NTX B07/06'  orig=None
+    id=101b50cd  team_name='Dallas Texans - Dallas Texans ECRL 2007'  orig='Dallas Texans - Dallas Texans ECRL 07/08B'
+
+[4] club='san diego force fc'  age=u11  league=''  gender=Female  state=CA
+    id=66e101db  team_name='U12 Academy'  orig='GU12 Academy'
+    id=afa5af6c  team_name='2015 Academy'  orig='2015 Girls Academy'
+    id=df1f760c  team_name='U11 Academy'  orig='GU11 Academy'
+    id=b776b0ad  team_name='SD Force FC 2015 Academy'  orig='SD Force FC G2015 Academy'
+
+[4] club='charlotte soccer academy'  age=u16  league='ECNL'  gender=Male  state=NC
+    id=69f2dcfc  team_name='Charlotte SA Academy ECNL 2010'  orig='Charlotte SA Academy ECNL B10'
+    id=416b97fa  team_name='Charlotte SA ECNL 2010'  orig='Charlotte SA ECNL B10'
+    id=7c3a0e5f  team_name='ECNL 2010'  orig='ECNL B10'
+    id=bb42ef44  team_name='Academy ECNL 2010'  orig='Academy ECNL B10'
+
+[4] club='charlotte eagles soccer club'  age=u19  league=''  gender=Male  state=NC
+    id=7da46268  team_name='CESC 2007 Academy'  orig='CESC 07/08 Academy'
+    id=f85289cb  team_name='Charlotte Eagles Soccer Club - CESC Academy 2008'  orig='Charlotte Eagles Soccer Club - CESC Academy 08'
+    id=e8a5d593  team_name='Charlotte Eagles Soccer Club - 2008 Academy'  orig='Charlotte Eagles Soccer Club - B08 Academy'
+    id=afa4066d  team_name='Charlotte Eagles Soccer Club - 2006 Academy'  orig='Charlotte Eagles Soccer Club - B06 Academy'
+
+[4] club='total futbol academy'  age=u13  league=''  gender=Male  state=CA
+    id=6ff677d8  team_name='Total Futbol Academy - TFA-IE 2013'  orig='Total Futbol Academy - TFA-IE B2013'
+    id=40828191  team_name='TFA-AV B2013/14'  orig=None
+    id=5df0f68b  team_name='TFA-IE 2013'  orig='TFA-IE B2013'
+    id=c2c57f1d  team_name='TFA-SFV 2013'  orig='TFA-SFV B2013'
+
+[4] club='rebels soccer club'  age=u11  league=''  gender=Male  state=CA
+    id=d8f717c6  team_name='U7 Academy'  orig='BU07 Academy'
+    id=378bb614  team_name='2015'  orig=None
+    id=803543de  team_name='U8 Academy B18'  orig='BU08 Academy (B18)'
+    id=f0ff377a  team_name='U8 Academy'  orig='GU08 Academy'
+
+[4] club='charlotte soccer academy'  age=u17  league='ECNL'  gender=Male  state=NC
+    id=f06920b0  team_name='Charlotte SA ECNL 2009'  orig='Charlotte SA ECNL B09'
+    id=042cab2a  team_name='Academy ECNL 2009'  orig='Academy ECNL B09'
+    id=95d88e3d  team_name='ECNL 2009'  orig='ECNL B09'
+    id=7eedddf8  team_name='Charlotte SA Academy ECNL 2009'  orig='Charlotte SA Academy ECNL B09'
+
+[4] club='total futbol academy'  age=u19  league=''  gender=Male  state=CA
+    id=4ca4971b  team_name='Total Futbol Academy MLS 2008'  orig=None
+    id=0242f2f6  team_name='TFA-SFV 2008'  orig='TFA-SFV B2008'
+    id=0b26062b  team_name='TFA AV 2008'  orig='TFA AV B2008'
+    id=554fe3b5  team_name='TFA 2008'  orig='TFA 08B'
+
+[3] club='legends fc (ca)'  age=u19  league=''  gender=Female  state=CA
+    id=0c699365  team_name='Legends FC CA - AV 2008 FC'  orig='Legends FC (CA) - AV G08 FC'
+    id=4326cd6e  team_name='2008 FC'  orig='G08 FC'
+    id=5aa15162  team_name='Legends FC CA - LA 2008 FC'  orig='Legends FC (CA) - LA G08 FC'
+
+[3] club='steel city fc'  age=u19  league='ECNL_RL'  gender=Male  state=PA
+    id=e01a708d  team_name='Steel City FC ECNL RL 2008'  orig='Steel City FC ECNL RL B08'
+    id=2b9a9006  team_name='Steel City FC ECNL RL B07/06'  orig=None
+    id=925fc2c1  team_name='Steel City FC 2007/08B Academy ECNL-RL'  orig=None
+
+[3] club='legends fc (ca)'  age=u19  league='ECNL'  gender=Female  state=CA
+    id=6a0c1fa4  team_name='ECNL G07/08'  orig=None
+    id=b805c8c8  team_name='Legends FC U19 ECNL'  orig='Legends FC GU19 ECNL'
+    id=2cf6e86e  team_name='ECNL G07/06'  orig=None
+
+[3] club='eastside fc'  age=u19  league='ECNL_RL'  gender=Male  state=WA
+    id=6d4ca1df  team_name='Eastside FC RL 2007'  orig='Eastside FC RL B07'
+    id=2d1405d9  team_name='Eastside FC ECNL RL B07/06'  orig=None
+    id=95b01e16  team_name='Eastside FC ECNL RL B07/08'  orig=None
+
+[3] club='lonestar'  age=u19  league='ECNL_RL'  gender=Female  state=TX
+    id=32744f2c  team_name='Lonestar Soccer Club - Lonestar 2006 ECRL'  orig='Lonestar Soccer Club - Lonestar 06/07 ECRL'
+    id=90041633  team_name='Lonestar SC ECNL RL G06/07'  orig=None
+    id=1141c98a  team_name='Lonestar SC ECNL-RL 2008'  orig='Lonestar SC ECNL-RL G08'
+
+[3] club='sporting queen city'  age=u19  league=''  gender=Female  state=OH
+    id=e1846b0b  team_name='Sporting Queen City 2007'  orig='Sporting Queen City G07'
+    id=b73b2741  team_name='Sporting Queen City - Sporting Queen City G07/G08'  orig=None
+    id=1773070d  team_name='Sporting Queen City - Sporting Queen City U18/U19'  orig=None
+
+[3] club='fc united iowa'  age=u14  league=''  gender=Male  state=IA
+    id=7d3d60df  team_name='FC United U13/14B'  orig=None
+    id=29419296  team_name='FC United U14'  orig='FC United U14B'
+    id=358eb6bd  team_name='FC United Iowa - FC United 2012'  orig='FC United (Iowa) - FC United 2012B'
+
+[3] club='pittsburgh riverhounds'  age=u19  league='ECNL_RL'  gender=Male  state=PA
+    id=12ff79de  team_name='Pittsburgh Riverhounds Academy RL 2008'  orig='Pittsburgh Riverhounds Academy RL 2008 Boys'
+    id=5995cdc1  team_name='Pittsburgh Riverhounds - RL 2007'  orig='Pittsburgh Riverhounds - RL B07'
+    id=6eb788e0  team_name='Pittsburgh Riverhounds - Pittsburgh Riverhounds 2008/2007 ECNL RL'  orig='Pittsburgh Riverhounds - Pittsburgh Riverhounds 2008/2007 ECNL RL Boys'
+
+[3] club='nc fusion'  age=u19  league='ECNL'  gender=Female  state=NC
+    id=1925d96c  team_name='NC Fusion ECNL G07/08'  orig=None
+    id=682ad2bb  team_name='NC Fusion ECNL G07/06'  orig=None
+    id=f563d53a  team_name='NC Fusion ECNL 2008'  orig='NC Fusion ECNL (08G)'
+
+[3] club='lenawee united fc'  age=u10  league=''  gender=Male  state=MI
+    id=bbb4d99a  team_name='Lenawee United FC U9/U10 - 2016/2017'  orig='Lenawee United FC Boys U9/U10 - 2016/2017'
+    id=b4cf29d2  team_name='Lenawee United FC U10 - 2016'  orig='Lenawee United FC Boys U10 - 2016'
+    id=741c160e  team_name='Lenawee United FC - Lenawee United FC - U9 2016'  orig='Lenawee United FC - Lenawee United FC - BU9 2016'

--- a/docs/superpowers/specs/2026-05-28-team-name-distinction-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-28-team-name-distinction-cleanup-design.md
@@ -1,0 +1,104 @@
+# Team-Name Distinction Cleanup — Design
+
+**Date:** 2026-05-28
+**Status:** Approved (Phase 0 scoped; later phases decided by data)
+**Owner:** Dallas Heidt
+
+## Goal
+
+Produce clean, human-readable team names for public display in the format:
+
+> **Club Name + League/Distinction + Age Group + (State Code)**
+
+…and, where it can be done safely, improve the underlying data so the
+duplicate-matching/dedup system also benefits — **without** breaking it and
+**without** a large, churny rewrite.
+
+## Background — why this isn't a fresh build
+
+The display composer **already exists**: `frontend/lib/utils.ts` →
+`composeTeamDisplay` / `formatLeague` / `formatDistinction` /
+`abbreviateClubName`. It builds the name from structured columns
+(`club_name`, `league`, `distinction`, age) and already special-cases
+Modular11 (MLS NEXT) via `has_modular11_alias` to keep those names verbatim.
+
+It shipped in PR #722, then PR #743 **reverted it on the two flagship
+surfaces** (rankings table + global search) while keeping it live on Compare,
+TeamSelector, RecentMovers, infographics, and UnknownOpponentLink. The
+composer logic is sound; what looked bad on the scrutinized surfaces was the
+**input data quality** — chiefly the `distinction` field carrying junk
+(club abbreviations like `pbg`/`lpfc`, the literal `unknown`, league-redundant
+tokens) and `club_name` gaps.
+
+**Conclusion:** rebuilding the display layer would just re-ship the reverted
+code. The real unblock is improving **distinction data quality at the source.**
+
+## Key architecture facts (risk map)
+
+- `extract_distinctions()` (parser, `src/utils/team_name_utils.py`) is the
+  shared root. It feeds **both**:
+  - `should_skip_pair()` — the merge/dedup gate. Recomputes from raw team
+    names; **does not read** the stored `distinction` column. **Highest risk**
+    to change (gates merges on ~170K teams).
+  - `resolve_distinction()` — composes the stored `teams.distinction` string.
+    Feeds display + the identity-grouping key. **Medium risk** (stored value +
+    5 ingest matchers + weekly backfill write it; merge gate unaffected).
+- So there's a risk ladder: **display formatter (read-only) < resolve_distinction (composer) < extract_distinctions (parser).**
+- Matcher-logic changes have a history of being reverted when they regress
+  (e.g. `Revert united/real from NOISE_WORDS`, `Revert protected division…`).
+  The missing ingredient last time was a **regression safety net.**
+
+## Scope decisions (locked)
+
+- **Modular11 / MLS NEXT (AD/HD):** leave the format untouched. `ad`/`hd` are
+  load-bearing there, never blocklisted.
+- **`unknown` rows (8,074):** out of scope here. These are GotSport
+  placeholder/stub teams (`team_name = "unknown_<id>"`, no club/league). They
+  need an identity **backfill**, tracked separately — not a distinction fix.
+- **Bias:** public display first; matcher/dedup gains taken only where free of
+  churn/breakage.
+
+## Approach — phased, diagnostic-first (decide as we go)
+
+- **Phase 0 — Characterization harness (measure only; no changes).** ← current
+- **Phase 1 — Enhance the logic, gated by the harness.** Scope (composer-only
+  vs. root parser) decided after reading Phase 0.
+- **Phase 2 — Re-run the distinction backfill** on the improved logic; measure
+  the drop in junk rates.
+- **Phase 3 — Re-enable `composeTeamDisplay`** on rankings + global search
+  (un-revert the #743 surfaces) once quality clears an agreed bar.
+
+## Phase 0 detail (this increment)
+
+Two read-only artifacts, both **reusing existing scripts**:
+
+**A. Distinction quality report** — modernize `scripts/dryrun_team_distinction.py`:
+- Run the **canonical** `resolve_distinction` (from
+  `src/utils/team_name_utils.py`, not the script's drifted local copy) over all
+  active teams.
+- Report coverage (non-null %), the `(club, age, league, gender, state,
+  distinction)` uniqueness-key **collision rate**, and **problem-bucket counts
+  with examples**: club-abbreviation leakage, `unknown`, league-redundant
+  tokens, multi-token composites, single-char tokens.
+
+**B. Merge-verdict baseline** — rewire `scripts/validate_normalizer.py`:
+- Corpus: historically merged pairs (`team_merge_map` deprecated↔canonical,
+  which *should* match) + a sample of real same-club/cohort pairs.
+- Snapshot the current `should_skip_pair()` verdict per pair → frozen baseline.
+- Headline safety metric: **how often the gate would block a real historical
+  merge** (a regression if it worsens after any Phase 1 change).
+- Fix the stale hardcoded path; wire to `should_skip_pair` / `extract_distinctions`.
+
+**Deliverable:** a committed report (counts, collision rate, problem buckets
+with examples, merge-verdict baseline) + the two refreshed scripts. We review
+it together, then decide Phase 1 scope.
+
+**Explicitly NOT in Phase 0:** no changes to `resolve_distinction` /
+`extract_distinctions`, no DB writes, no display/frontend changes.
+
+## Open questions (deferred to data)
+
+- Phase 1 scope: composer-only (`resolve_distinction`) vs. root parser
+  (`extract_distinctions`) — decided by what the Phase 0 report shows.
+- The quality bar that gates Phase 3 (re-enabling composed names on
+  rankings/search).

--- a/frontend/components/GlobalSearch.tsx
+++ b/frontend/components/GlobalSearch.tsx
@@ -12,6 +12,7 @@ import { useTeamSearch } from '@/hooks/useTeamSearch';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackSearchUsed, trackSearchResultClicked } from '@/lib/events';
 import { formatGender } from '@/lib/constants';
+import { composeTeamDisplay } from '@/lib/utils';
 
 /**
  * Escape special regex characters in a string
@@ -244,9 +245,11 @@ export function GlobalSearch() {
                       className={`w-full text-left p-3 rounded-md transition-colors duration-200 focus-visible:outline-primary focus-visible:ring-2 focus-visible:ring-primary min-h-[44px] ${
                         index === selectedIndex ? 'bg-accent font-semibold' : 'hover:bg-accent/50'
                       }`}
-                      aria-label={`Select ${team.team_name}`}
+                      aria-label={`Select ${composeTeamDisplay(team)}`}
                     >
-                      <div className="font-medium truncate">{highlightMatch(team.team_name, deferredSearchQuery)}</div>
+                      <div className="font-medium truncate">
+                        {highlightMatch(composeTeamDisplay(team), deferredSearchQuery)}
+                      </div>
                       <div className="text-xs text-muted-foreground mt-1">
                         {team.state && <span>{team.state.toUpperCase()}</span>}
                         {team.rank_in_cohort_final && <span> • Rank #{team.rank_in_cohort_final}</span>}

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -10,7 +10,7 @@ import { usePrefetchTeam } from '@/lib/hooks';
 import Link from 'next/link';
 import { ArrowUp, ArrowDown, ArrowUpDown, ChevronRight, Search, X } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatPowerScore } from '@/lib/utils';
+import { formatPowerScore, composeTeamDisplay, formatLeague } from '@/lib/utils';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackRankingsViewed, trackSortUsed, trackTeamRowClicked } from '@/lib/events';
 import { RankingsSchema } from '@/components/RankingsSchema';
@@ -137,8 +137,8 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
           bValue = getDisplayRank(b) ?? Infinity;
           break;
         case 'team':
-          aValue = a.team_name.toLowerCase();
-          bValue = b.team_name.toLowerCase();
+          aValue = composeTeamDisplay(a).toLowerCase();
+          bValue = composeTeamDisplay(b).toLowerCase();
           break;
         case 'powerScore':
           aValue = a.power_score_final ?? 0;
@@ -189,7 +189,9 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     const tokens = normalize(deferredQuery).split(' ').filter(Boolean);
     if (tokens.length === 0) return sortedRankings;
     return sortedRankings.filter((team) => {
-      const haystack = normalize(`${team.team_name ?? ''} ${team.club_name ?? ''}`);
+      const haystack = normalize(
+        `${team.team_name ?? ''} ${team.club_name ?? ''} ${formatLeague(team.league) ?? ''} ${(team.distinction ?? '').replace(/\|/g, ' ')}`
+      );
       return tokens.every((t) => haystack.includes(t));
     });
   }, [sortedRankings, deferredQuery]);
@@ -321,7 +323,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     .filter((team) => getDisplayRank(team) != null)
     .slice(0, 10)
     .map((team) => ({
-      teamName: team.team_name,
+      teamName: composeTeamDisplay(team),
       clubName: team.club_name ?? undefined,
       rank: getDisplayRank(team)!,
       powerScore: team.power_score_final ?? undefined,
@@ -566,7 +568,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                           </div>
                           <div className="px-1 sm:px-4 py-2 sm:py-3 min-w-0 overflow-hidden">
                             <span className="font-medium text-primary group-hover:text-primary/80 transition-colors duration-300 text-xs sm:text-sm truncate block w-full">
-                              {team.team_name}
+                              {composeTeamDisplay(team)}
                             </span>
                             {(team.club_name || team.state) && (
                               <div className="text-xs sm:text-sm text-muted-foreground truncate w-full">

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -511,7 +511,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
                               rank_in_state_final: team.rank_in_state_final ?? undefined,
                             })
                           }
-                          aria-label={`View ${team.team_name} team details`}
+                          aria-label={`View ${composeTeamDisplay(team)} team details`}
                           className={`
                             rankings-row-link touch-auto
                             grid grid-cols-[40px_1fr_50px_64px] sm:grid-cols-[70px_2fr_1fr_1fr_100px] border-b group

--- a/frontend/components/RankingsTable.tsx
+++ b/frontend/components/RankingsTable.tsx
@@ -10,7 +10,7 @@ import { usePrefetchTeam } from '@/lib/hooks';
 import Link from 'next/link';
 import { ArrowUp, ArrowDown, ArrowUpDown, ChevronRight, Search, X } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatPowerScore, composeTeamDisplay, formatLeague } from '@/lib/utils';
+import { formatPowerScore, composeTeamDisplay, formatLeague, formatDistinction } from '@/lib/utils';
 import type { RankingRow } from '@/types/RankingRow';
 import { trackRankingsViewed, trackSortUsed, trackTeamRowClicked } from '@/lib/events';
 import { RankingsSchema } from '@/components/RankingsSchema';
@@ -190,7 +190,7 @@ export function RankingsTable({ region, ageGroup, gender }: RankingsTableProps) 
     if (tokens.length === 0) return sortedRankings;
     return sortedRankings.filter((team) => {
       const haystack = normalize(
-        `${team.team_name ?? ''} ${team.club_name ?? ''} ${formatLeague(team.league) ?? ''} ${(team.distinction ?? '').replace(/\|/g, ' ')}`
+        `${team.team_name ?? ''} ${team.club_name ?? ''} ${formatLeague(team.league) ?? ''} ${(team.distinction ?? '').replace(/\|/g, ' ')} ${formatDistinction(team.distinction) ?? ''}`
       );
       return tokens.every((t) => haystack.includes(t));
     });

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,6 +27,7 @@ tqdm==4.67.1
 # Web scraping
 requests==2.32.5
 certifi==2025.8.3
+truststore==0.10.4
 beautifulsoup4==4.14.2
 lxml==6.0.2
 Scrapy==2.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ tqdm>=4.66.0
 # Web scraping
 requests>=2.31.0
 certifi>=2023.0.0  # SSL certificates for better SSL error handling
+truststore>=0.9.0  # Use OS trust store for SSL (fixes Windows intermediate-cert chain for Supabase)
 beautifulsoup4>=4.12.0
 lxml>=4.9.0
 scrapy>=2.13.0  # For Modular11 scraper

--- a/scripts/backfill_team_distinction.py
+++ b/scripts/backfill_team_distinction.py
@@ -31,18 +31,18 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
+import truststore
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 
-from src.utils.team_name_utils import resolve_distinction
 from supabase import create_client
 
-import truststore
-
 truststore.inject_into_ssl()
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from src.utils.team_name_utils import resolve_distinction  # noqa: E402
 
 console = Console()
 

--- a/scripts/backfill_team_distinction.py
+++ b/scripts/backfill_team_distinction.py
@@ -40,6 +40,10 @@ from rich.table import Table
 from src.utils.team_name_utils import resolve_distinction
 from supabase import create_client
 
+import truststore
+
+truststore.inject_into_ssl()
+
 console = Console()
 
 env_local = Path(__file__).resolve().parent.parent / ".env.local"

--- a/scripts/dryrun_team_distinction.py
+++ b/scripts/dryrun_team_distinction.py
@@ -51,6 +51,10 @@ _PROGRAM_DISTINCTIONS = {
     "division", "reserve", "copa", "tal", "stxcl", "fdl", "sccl",
 }
 
+# NOTE: `_LEAGUE_EQUIVS` above belongs to the legacy local resolve_distinction
+# (removed in the next task); this `_LEAGUE_TOKENS` set is the diagnostic's own.
+# They intentionally differ (this one flags `mls`/`nl`, omits `aspire`). The
+# duplication goes away when the legacy resolver is deleted.
 # League-equivalent tokens that are redundant with the `league` column.
 # Deliberately EXCLUDES "ad"/"hd" — those are load-bearing for Modular11
 # (MLS NEXT) display and must never be flagged. See the cleanup design spec.
@@ -80,7 +84,7 @@ def _club_tokens(club_name: Optional[str]) -> set:
     return out
 
 
-def _club_acronym(club_name):
+def _club_acronym(club_name: Optional[str]) -> str:
     """First-letter acronym of all words in the club name (>=3 words required).
 
     'California Odyssey Soccer Club' -> 'cosc'. Returns '' when the club has
@@ -100,7 +104,7 @@ def _club_acronym(club_name):
     return "".join(t[0] for t in words)
 
 
-def classify_distinction_problems(distinction, club_name):
+def classify_distinction_problems(distinction: Optional[str], club_name: Optional[str]) -> set:
     """Return the set of problem buckets a resolved distinction falls into.
 
     Buckets: 'unknown', 'league_token', 'club_acronym', 'multi_token',

--- a/scripts/dryrun_team_distinction.py
+++ b/scripts/dryrun_team_distinction.py
@@ -27,6 +27,9 @@ from dotenv import load_dotenv
 load_dotenv("C:/PitchRank/.env.local")
 load_dotenv("C:/PitchRank/.env")
 
+import truststore
+truststore.inject_into_ssl()
+
 # Importable from the repo
 sys.path.insert(0, "C:/PitchRank")
 from src.utils.team_name_utils import extract_distinctions, resolve_distinction  # noqa: E402

--- a/scripts/dryrun_team_distinction.py
+++ b/scripts/dryrun_team_distinction.py
@@ -29,7 +29,7 @@ load_dotenv("C:/PitchRank/.env")
 
 # Importable from the repo
 sys.path.insert(0, "C:/PitchRank")
-from src.utils.team_name_utils import extract_distinctions  # noqa: E402
+from src.utils.team_name_utils import extract_distinctions, resolve_distinction  # noqa: E402
 from supabase import create_client  # noqa: E402
 
 _CLUB_NOISE = {
@@ -38,23 +38,8 @@ _CLUB_NOISE = {
     "the", "of", "and", "association",
 }
 
-# Programs that legitimately distinguish squads (Premier vs Select etc.)
-# Exclude league-equivalents — those are captured in the `league` column.
-_LEAGUE_EQUIVS = {
-    "ecnl", "ecnl-rl", "ecrl", "rl", "ga", "npl", "dpl", "dplo",
-    "scdsl", "nal", "mlsnext", "mls-next", "next", "ea", "ea2",
-    "pre-ecnl", "aspire",
-}
-_PROGRAM_DISTINCTIONS = {
-    "premier", "select", "elite", "classic", "competitive", "comp",
-    "recreational", "development", "showcase", "challenge",
-    "division", "reserve", "copa", "tal", "stxcl", "fdl", "sccl",
-}
-
-# NOTE: `_LEAGUE_EQUIVS` above belongs to the legacy local resolve_distinction
-# (removed in the next task); this `_LEAGUE_TOKENS` set is the diagnostic's own.
-# They intentionally differ (this one flags `mls`/`nl`, omits `aspire`). The
-# duplication goes away when the legacy resolver is deleted.
+# NOTE: `_LEAGUE_TOKENS` is the diagnostic's own token set used by
+# classify_distinction_problems to flag league-redundant distinctions.
 # League-equivalent tokens that are redundant with the `league` column.
 # Deliberately EXCLUDES "ad"/"hd" — those are load-bearing for Modular11
 # (MLS NEXT) display and must never be flagged. See the cleanup design spec.
@@ -130,105 +115,6 @@ def classify_distinction_problems(distinction: Optional[str], club_name: Optiona
     return problems
 
 
-def resolve_distinction(name: str, club_name: Optional[str] = None) -> Optional[str]:
-    """Composite distinction: ordered concat of every distinguisher.
-
-    Order (deterministic): coach | number | colors(sorted) | directions(sorted) | squad_words(sorted, club-stripped)
-    Joined with '|'. NULL when no distinguishers remain.
-
-    Club-token strip: any squad_word that matches a token of the team's own
-    club_name is dropped (the club extractor sometimes leaves the club bleeding
-    into team_name; we don't want that fragment counted as a distinction).
-    """
-    if not name:
-        return None
-    d = extract_distinctions(name)
-    parts: list[str] = []
-
-    if d.get("coach_name"):
-        parts.append(d["coach_name"].lower())
-
-    if d.get("team_number"):
-        parts.append(str(d["team_number"]).lower())
-
-    colors = sorted(d.get("colors") or [])
-    parts.extend(c.lower() for c in colors)
-
-    directions = sorted(d.get("directions") or [])
-    parts.extend(dr.lower() for dr in directions)
-
-    club_toks = _club_tokens(club_name)
-    squad_words = sorted(d.get("squad_words") or [])
-    for sw in squad_words:
-        sw_l = sw.lower()
-        if sw_l in club_toks:
-            continue  # club leakage — drop
-        parts.append(sw_l)
-
-    # Programs that distinguish squads (Premier / Select / Elite / Classic / Copa / SCCL / ...)
-    # Skip league-equivalents (those live in the `league` column).
-    programs = sorted(p.lower() for p in (d.get("programs") or []))
-    for p in programs:
-        if p in _LEAGUE_EQUIVS:
-            continue
-        if p in _PROGRAM_DISTINCTIONS:
-            parts.append(p)
-
-    # Recover length-3 alpha tokens that extract_distinctions misclassifies as
-    # location_codes (Pass 4 dumps anything 2-3 chars there). Pull from the
-    # original name; only keep tokens not already accounted for, not in the
-    # *real* LOCATION_CODES set, not US states, not noise, not league markers.
-    import re as _re
-
-    from src.utils.team_name_utils import (
-        DIRECTION_CANONICAL,
-        LOCATION_CODES,
-        NOISE_WORDS,
-        PROGRAM_WORDS,
-        TEAM_COLORS,
-        US_STATES,
-    )
-    raw_toks = _re.split(r"[\s\-_./]+", (name or "").lower())
-    raw_toks = [t.strip("()[]'*.,") for t in raw_toks if t.strip("()[]'*.,")]
-    seen_so_far = set(parts)
-    for tok in raw_toks:
-        # Length 2 OR 3, alpha-only — extract_distinctions dumps these in
-        # location_codes (Pass 4) but most are real distinguishers (coach
-        # initials like 'KH', 'CV', 'NT'; or short squad words like 'Ace').
-        if len(tok) not in (2, 3) or not tok.isalpha():
-            continue
-        if tok in club_toks:
-            continue
-        if (
-            tok in LOCATION_CODES
-            or tok in US_STATES
-            or tok in NOISE_WORDS
-            or tok in TEAM_COLORS
-            or tok in DIRECTION_CANONICAL
-            or tok in PROGRAM_WORDS
-            or tok in _LEAGUE_EQUIVS
-        ):
-            continue
-        if tok in seen_so_far:
-            continue
-        if tok in {"the", "and", "for"}:
-            continue
-        parts.append(tok)
-        seen_so_far.add(tok)
-
-    if not parts:
-        return None
-
-    # Dedup while preserving order
-    seen = set()
-    out = []
-    for p in parts:
-        if p not in seen:
-            seen.add(p)
-            out.append(p)
-    return "|".join(out)
-
-
 def main():
     url = os.getenv("SUPABASE_URL")
     key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
@@ -264,12 +150,14 @@ def main():
     by_source = collections.Counter()
     samples_resolved = []
     samples_null = []
+    problem_buckets = collections.Counter()
+    problem_samples = collections.defaultdict(list)
 
     for t in teams:
         name = t.get("team_name") or ""
         club = t.get("club_name") or ""
         d = extract_distinctions(name)
-        dist = resolve_distinction(name, club)
+        dist = resolve_distinction(name, club, t.get("state_code"))
 
         # Track which categories contributed (composite — count all that fired)
         contributed = False
@@ -304,6 +192,10 @@ def main():
                 samples_null.append((t.get("club_name"), name))
 
         t["_distinction"] = dist
+        for bucket in classify_distinction_problems(dist, club):
+            problem_buckets[bucket] += 1
+            if len(problem_samples[bucket]) < 10 and not t.get("is_deprecated"):
+                problem_samples[bucket].append((club, name, dist))
 
     # 2. Coverage
     print("\n=== COVERAGE ===")
@@ -354,6 +246,16 @@ def main():
     random.seed(42)
     for club, name, dist in random.sample(samples_resolved, min(15, len(samples_resolved))):
         print(f"  club={club!r:35.35} name={name!r:55.55} → distinction={dist!r}")
+
+    print("\n=== PROBLEM BUCKETS (resolved distinctions only) ===")
+    print(f"  {'bucket':16} {'count':>8}  {'% of resolved':>14}")
+    for bucket, n in problem_buckets.most_common():
+        pct = (100 * n / resolved) if resolved else 0.0
+        print(f"  {bucket:16} {n:>8,}  {pct:>13.1f}%")
+    for bucket, _ in problem_buckets.most_common():
+        print(f"\n--- sample: {bucket} ---")
+        for club, name, dist in problem_samples[bucket][:10]:
+            print(f"  club={club!r:30.30} name={name!r:45.45} dist={dist!r}")
 
     # 6. Show NULL samples — sanity check NULL is right (or whether we're missing distinguishers)
     print("\n=== NULL SAMPLES (random 15 of 25) ===")

--- a/scripts/dryrun_team_distinction.py
+++ b/scripts/dryrun_team_distinction.py
@@ -21,19 +21,20 @@ import random
 import sys
 from typing import Optional
 
+import truststore
 from dotenv import load_dotenv
+
+from supabase import create_client
+
+truststore.inject_into_ssl()
 
 # Load env
 load_dotenv("C:/PitchRank/.env.local")
 load_dotenv("C:/PitchRank/.env")
 
-import truststore
-truststore.inject_into_ssl()
-
 # Importable from the repo
 sys.path.insert(0, "C:/PitchRank")
 from src.utils.team_name_utils import extract_distinctions, resolve_distinction  # noqa: E402
-from supabase import create_client  # noqa: E402
 
 _CLUB_NOISE = {
     "fc", "sc", "sa", "ac", "cf", "cd", "fcs", "ysa",

--- a/scripts/dryrun_team_distinction.py
+++ b/scripts/dryrun_team_distinction.py
@@ -51,6 +51,15 @@ _PROGRAM_DISTINCTIONS = {
     "division", "reserve", "copa", "tal", "stxcl", "fdl", "sccl",
 }
 
+# League-equivalent tokens that are redundant with the `league` column.
+# Deliberately EXCLUDES "ad"/"hd" — those are load-bearing for Modular11
+# (MLS NEXT) display and must never be flagged. See the cleanup design spec.
+_LEAGUE_TOKENS = {
+    "ecnl", "ecnl-rl", "ecrl", "rl", "ga", "npl", "dpl", "dplo",
+    "scdsl", "nal", "mlsnext", "mls-next", "next", "ea", "ea2",
+    "pre-ecnl", "mls", "nl",
+}
+
 
 def _club_tokens(club_name: Optional[str]) -> set:
     """Lowercase tokens of the club name, minus generic noise.
@@ -69,6 +78,52 @@ def _club_tokens(club_name: Optional[str]) -> set:
             continue
         out.add(t)
     return out
+
+
+def _club_acronym(club_name):
+    """First-letter acronym of all words in the club name (>=3 words required).
+
+    'California Odyssey Soccer Club' -> 'cosc'. Returns '' when the club has
+    fewer than 3 words (acronyms shorter than that are too collision-prone to
+    flag).
+    """
+    if not club_name:
+        return ""
+    import re as _re
+    raw_tokens = [
+        t.strip("()[]'*.,")
+        for t in _re.split(r"[\s\-_./]+", club_name.lower())
+    ]
+    words = [t for t in raw_tokens if t]
+    if len(words) < 3:
+        return ""
+    return "".join(t[0] for t in words)
+
+
+def classify_distinction_problems(distinction, club_name):
+    """Return the set of problem buckets a resolved distinction falls into.
+
+    Buckets: 'unknown', 'league_token', 'club_acronym', 'multi_token',
+    'single_char'. Empty set means the distinction looks clean. Pure function.
+    """
+    problems = set()
+    if not distinction:
+        return problems
+    tokens = [t for t in distinction.split("|") if t]
+    if len(tokens) >= 2:
+        problems.add("multi_token")
+    acronym = _club_acronym(club_name)
+    for t in tokens:
+        tl = t.lower()
+        if tl == "unknown":
+            problems.add("unknown")
+        if tl in _LEAGUE_TOKENS:
+            problems.add("league_token")
+        if len(tl) == 1:
+            problems.add("single_char")
+        if acronym and tl == acronym:
+            problems.add("club_acronym")
+    return problems
 
 
 def resolve_distinction(name: str, club_name: Optional[str] = None) -> Optional[str]:

--- a/scripts/validate_normalizer.py
+++ b/scripts/validate_normalizer.py
@@ -1,20 +1,50 @@
 #!/usr/bin/env python3
 """
 Validate team name normalizer against historical merges.
-Tests if the normalizer would have correctly identified the same merges.
+Replays every historical merge through the production dedup gate
+(should_skip_pair) and reports false_skip rate as a baseline.
 """
 
 import os
+import sys
 import time
 from collections import Counter
+from pathlib import Path
 
 from dotenv import load_dotenv
-from team_name_normalizer import parse_team_name, teams_match
-
 from supabase import create_client
 
-load_dotenv("/Users/pitchrankio-dev/Projects/PitchRank/.env")
-supabase = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_KEY"))
+load_dotenv("C:/PitchRank/.env.local")
+load_dotenv("C:/PitchRank/.env")
+
+import truststore  # noqa: E402
+truststore.inject_into_ssl()
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # scripts/ for _team_distinction
+from _team_distinction import should_skip_pair  # production masters-dedup gate  # noqa: E402
+
+
+def replay_merge_verdict(dep, can):
+    """Replay one historical merge through the production dedup gate.
+
+    dep/can are team rows (dicts) with 'team_name' and 'club_name', or None.
+    Returns:
+      'no_data'    - a row is missing or has a blank team_name
+      'allowed'    - gate would NOT skip the pair (a real merge stays reachable)
+      'false_skip' - gate WOULD skip the pair (it would block this real merge)
+
+    Uses require_age_token_match=True to mirror find_fuzzy_duplicate_teams.py
+    (the path that produces masters merges).
+    """
+    if not dep or not can:
+        return "no_data"
+    dep_name = (dep.get("team_name") or "").strip()
+    can_name = (can.get("team_name") or "").strip()
+    if not dep_name or not can_name:
+        return "no_data"
+    club = (can.get("club_name") or dep.get("club_name") or "")
+    skipped = should_skip_pair(dep_name, can_name, club_name=club, require_age_token_match=True)
+    return "false_skip" if skipped else "allowed"
 
 
 def safe_query(query_fn, retries=3, delay=2):

--- a/scripts/validate_normalizer.py
+++ b/scripts/validate_normalizer.py
@@ -62,14 +62,25 @@ def safe_query(query_fn, retries=3, delay=2):
 
 
 def main():
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_KEY")
+    if not (url and key):
+        print("Missing Supabase creds (need SUPABASE_URL + a service key)")
+        return
+    supabase = create_client(url, key)
+
     # Get all merges
     print("Fetching merge history...")
     all_merges = []
-    for start in range(0, 10000, 1000):
+    start = 0
+    while True:
         batch = safe_query(lambda s=start: supabase.table("team_merge_map").select("*").range(s, s + 999).execute())
         if not batch.data:
             break
         all_merges.extend(batch.data)
+        if len(batch.data) < 1000:
+            break
+        start += 1000
 
     print(f"Total merges: {len(all_merges)}")
 
@@ -87,125 +98,62 @@ def main():
 
     for i in range(0, len(team_ids_list), 50):
         batch_ids = team_ids_list[i : i + 50]
-        if i % 200 == 0:
+        if i % 1000 == 0:
             print(f"  Fetched {i}/{len(team_ids_list)} teams...")
-
-        for tid in batch_ids:
-            try:
-                result = safe_query(
-                    lambda t=tid: (
-                        supabase.table("teams")
-                        .select("team_name, club_name, state_code, gender, age_group")
-                        .eq("team_id_master", t)
-                        .limit(1)
-                        .execute()
-                    )
+        try:
+            result = safe_query(
+                lambda b=batch_ids: (
+                    supabase.table("teams")
+                    .select("team_id_master, team_name, club_name, state_code, gender, age_group")
+                    .in_("team_id_master", b)
+                    .execute()
                 )
-                if result.data:
-                    teams_cache[tid] = result.data[0]
-            except Exception as e:
-                print(f"    Failed to fetch team {tid}: {e}")
-
-        # Small delay to avoid rate limiting
-        time.sleep(0.1)
+            )
+            for row in (result.data or []):
+                teams_cache[row["team_id_master"]] = row
+        except Exception as e:
+            print(f"    Failed to fetch batch at {i}: {e}")
+        time.sleep(0.05)
 
     print(f"  Cached {len(teams_cache)} teams")
 
-    # Track results
-    results = {
-        "correct_match": [],  # Normalizer agrees these should merge
-        "missed_match": [],  # Normalizer says don't merge (but human did)
-        "no_parse": [],  # Couldn't parse one or both teams
-    }
+    verdicts = Counter()
+    false_skips = []
 
-    reasons = Counter()
-
-    print("\nValidating merges...")
-
+    print("\nReplaying merges through the production dedup gate...")
     for i, merge in enumerate(all_merges):
-        if i % 200 == 0:
+        if i % 500 == 0:
             print(f"  Processing {i}/{len(all_merges)}...")
-
-        dep_id = merge["deprecated_team_id"]
-        can_id = merge["canonical_team_id"]
-
-        dep = teams_cache.get(dep_id)
-        can = teams_cache.get(can_id)
-
-        if not dep or not can:
-            results["no_parse"].append({"merge_id": merge["id"], "reason": "Team not found in database"})
-            continue
-
-        # Parse team names
-        parsed_dep = parse_team_name(dep["team_name"], dep["club_name"])
-        parsed_can = parse_team_name(can["team_name"], can["club_name"])
-
-        # Check if normalizer would match
-        match, reason = teams_match(parsed_dep, parsed_can)
-
-        merge_info = {
-            "merge_id": merge["id"],
-            "deprecated_name": dep["team_name"],
-            "deprecated_club": dep["club_name"],
-            "canonical_name": can["team_name"],
-            "canonical_club": can["club_name"],
-            "state": dep.get("state_code"),
-            "parsed_dep": parsed_dep,
-            "parsed_can": parsed_can,
-            "reason": reason,
-        }
-
-        if match:
-            results["correct_match"].append(merge_info)
-        else:
-            if parsed_dep["age"] is None or parsed_can["age"] is None:
-                results["no_parse"].append(merge_info)
-            else:
-                results["missed_match"].append(merge_info)
-                reasons[reason] += 1
-
-    # Print summary
-    print("\n" + "=" * 60)
-    print("VALIDATION RESULTS")
-    print("=" * 60)
+        dep = teams_cache.get(merge["deprecated_team_id"])
+        can = teams_cache.get(merge["canonical_team_id"])
+        verdict = replay_merge_verdict(dep, can)
+        verdicts[verdict] += 1
+        if verdict == "false_skip" and len(false_skips) < 40:
+            false_skips.append((dep, can))
 
     total = len(all_merges)
-    correct = len(results["correct_match"])
-    missed = len(results["missed_match"])
-    no_parse = len(results["no_parse"])
+    allowed = verdicts["allowed"]
+    false_skip = verdicts["false_skip"]
+    no_data = verdicts["no_data"]
+    evaluable = total - no_data
 
-    print(f"\nTotal merges tested: {total}")
-    print(f"  ✅ Correctly matched:  {correct} ({100 * correct / total:.1f}%)")
-    print(f"  ❌ Missed (need human): {missed} ({100 * missed / total:.1f}%)")
-    print(f"  ⚠️  Could not parse:   {no_parse} ({100 * no_parse / total:.1f}%)")
-
-    print("\n" + "-" * 60)
-    print("REASONS FOR MISSED MATCHES")
-    print("-" * 60)
-    for reason, count in reasons.most_common(20):
-        print(f"  {count:4d} | {reason}")
-
-    print("\n" + "-" * 60)
-    print("SAMPLE MISSED MATCHES (first 30)")
-    print("-" * 60)
-    for m in results["missed_match"][:30]:
-        print(f"\n  Deprecated: {m['deprecated_name']}")
-        print(f"    Parsed: {m['parsed_dep']['normalized']}")
-        print(f"  Canonical: {m['canonical_name']}")
-        print(f"    Parsed: {m['parsed_can']['normalized']}")
-        print(f"  Reason: {m['reason']}")
+    print("\n" + "=" * 60)
+    print("MERGE-VERDICT BASELINE (production gate: should_skip_pair)")
+    print("=" * 60)
+    print(f"\nHistorical merges replayed: {total:,}")
+    if evaluable:
+        print(f"  allowed (gate keeps merge reachable): {allowed:,}  ({100*allowed/evaluable:.2f}% of evaluable)")
+        print(f"  false_skip (gate would BLOCK this merge): {false_skip:,}  ({100*false_skip/evaluable:.2f}% of evaluable)")
+    else:
+        print("  (no evaluable rows)")
+    print(f"  no_data (missing team rows): {no_data:,}")
 
     print("\n" + "-" * 60)
-    print("SAMPLE UNPARSED (first 10)")
+    print(f"SAMPLE FALSE-SKIPS (first {len(false_skips)})")
     print("-" * 60)
-    for m in results["no_parse"][:10]:
-        if "deprecated_name" in m:
-            print(f"\n  Deprecated: {m.get('deprecated_name')} ({m.get('deprecated_club')})")
-            print(f"    Parsed age: {m['parsed_dep']['age']}")
-            print(f"  Canonical: {m.get('canonical_name')} ({m.get('canonical_club')})")
-            print(f"    Parsed age: {m['parsed_can']['age']}")
-        else:
-            print(f"\n  {m['reason']}")
+    for dep, can in false_skips:
+        print(f"\n  deprecated: {dep.get('team_name')!r}  (club={dep.get('club_name')!r})")
+        print(f"  canonical : {can.get('team_name')!r}  (club={can.get('club_name')!r})")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_normalizer.py
+++ b/scripts/validate_normalizer.py
@@ -11,14 +11,15 @@ import time
 from collections import Counter
 from pathlib import Path
 
+import truststore
 from dotenv import load_dotenv
+
 from supabase import create_client
+
+truststore.inject_into_ssl()
 
 load_dotenv("C:/PitchRank/.env.local")
 load_dotenv("C:/PitchRank/.env")
-
-import truststore  # noqa: E402
-truststore.inject_into_ssl()
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # scripts/ for _team_distinction
 from _team_distinction import should_skip_pair  # production masters-dedup gate  # noqa: E402
@@ -143,7 +144,10 @@ def main():
     print(f"\nHistorical merges replayed: {total:,}")
     if evaluable:
         print(f"  allowed (gate keeps merge reachable): {allowed:,}  ({100*allowed/evaluable:.2f}% of evaluable)")
-        print(f"  false_skip (gate would BLOCK this merge): {false_skip:,}  ({100*false_skip/evaluable:.2f}% of evaluable)")
+        print(
+            f"  false_skip (gate would BLOCK this merge): {false_skip:,}  "
+            f"({100 * false_skip / evaluable:.2f}% of evaluable)"
+        )
     else:
         print("  (no evaluable rows)")
     print(f"  no_data (missing team rows): {no_data:,}")

--- a/src/utils/team_name_utils.py
+++ b/src/utils/team_name_utils.py
@@ -985,8 +985,6 @@ def resolve_distinction(
         sw_l = sw.lower()
         if sw_l in club_toks:
             continue  # club or state leakage — drop
-        if len(sw_l) == 1:
-            continue  # stray single letter (e.g. "C" from "F.C") — not a squad tag
         if club_acronym and sw_l == club_acronym:
             continue  # club's own initials — identifies the club, not the squad
         parts.append(sw_l)

--- a/src/utils/team_name_utils.py
+++ b/src/utils/team_name_utils.py
@@ -869,7 +869,7 @@ _CLUB_NOISE = frozenset({
 _LEAGUE_DISTINCTION_BLOCKLIST = frozenset({
     "ecnl", "ecnl-rl", "ecrl", "rl", "ga", "npl", "dpl", "dplo",
     "scdsl", "nal", "mlsnext", "mls-next", "next", "ea", "ea2",
-    "pre-ecnl", "aspire",
+    "pre-ecnl", "aspire", "mls", "nl",
 })
 
 # Programs that legitimately distinguish squads within the same cohort
@@ -898,6 +898,27 @@ def _club_tokens(club_name: Optional[str]) -> set:
             continue
         out.add(t)
     return out
+
+
+def _club_acronym(club_name: Optional[str]) -> str:
+    """First-letter acronym of a club's words (>=3 words), else ''.
+
+    'California Odyssey Soccer Club' -> 'cosc'. Used to drop a club's own
+    initials from its distinction — those identify the club, not the squad,
+    so they are noise in the composite. Includes noise words (soccer/club) so
+    the acronym matches how clubs actually abbreviate themselves. Returns ''
+    for <3-word clubs (short acronyms collide too easily to drop safely).
+    """
+    if not club_name:
+        return ""
+    words = [
+        w.strip("()[]'*.,")
+        for w in re.split(r"[\s\-_./]+", club_name.lower())
+        if w.strip("()[]'*.,")
+    ]
+    if len(words) < 3:
+        return ""
+    return "".join(w[0] for w in words)
 
 
 def resolve_distinction(
@@ -957,11 +978,17 @@ def resolve_distinction(
         except ImportError:
             pass
 
+    club_acronym = _club_acronym(club_name)
+
     squad_words = sorted(d.get("squad_words") or [])
     for sw in squad_words:
         sw_l = sw.lower()
         if sw_l in club_toks:
             continue  # club or state leakage — drop
+        if len(sw_l) == 1:
+            continue  # stray single letter (e.g. "C" from "F.C") — not a squad tag
+        if club_acronym and sw_l == club_acronym:
+            continue  # club's own initials — identifies the club, not the squad
         parts.append(sw_l)
 
     # Programs that distinguish squads (Premier / Select / Elite / Classic / Copa / SCCL / ...).
@@ -989,6 +1016,8 @@ def resolve_distinction(
             continue
         if tok in club_toks:
             continue
+        if club_acronym and tok == club_acronym:
+            continue  # club's own initials — drop
         if (
             tok in LOCATION_CODES
             or tok in US_STATES

--- a/tests/unit/test_distinction_phase0.py
+++ b/tests/unit/test_distinction_phase0.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+# scripts/ holds dryrun_team_distinction.py and validate_normalizer.py
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from dryrun_team_distinction import classify_distinction_problems  # noqa: E402
+
+
+def test_none_distinction_has_no_problems():
+    assert classify_distinction_problems(None, "Solar SC") == set()
+
+
+def test_clean_color_distinction_has_no_problems():
+    assert classify_distinction_problems("white", "Solar SC") == set()
+
+
+def test_unknown_token_flagged():
+    assert "unknown" in classify_distinction_problems("unknown", None)
+
+
+def test_league_token_flagged():
+    # "nl" is league-redundant; "mls" too. ad/hd are NOT flagged (Modular11 sacred).
+    assert "league_token" in classify_distinction_problems("martinez|north|nl", "DKSC")
+    assert "league_token" not in classify_distinction_problems("hd", "LA Bulls")
+    assert "league_token" not in classify_distinction_problems("ad", "Breakers FC")
+
+
+def test_club_acronym_flagged():
+    # "cosc" == initials of California Odyssey Soccer Club
+    assert "club_acronym" in classify_distinction_problems("cosc", "California Odyssey Soccer Club")
+    # a real color is not an acronym
+    assert "club_acronym" not in classify_distinction_problems("blue", "San Diego Surf Soccer Club")
+
+
+def test_multi_token_flagged():
+    assert "multi_token" in classify_distinction_problems("blue|alcaraz", "San Diego Surf")
+    assert "multi_token" not in classify_distinction_problems("blue", "San Diego Surf")
+
+
+def test_single_char_flagged():
+    assert "single_char" in classify_distinction_problems("a", "Some Club")
+    assert "single_char" not in classify_distinction_problems("white", "Some Club")

--- a/tests/unit/test_distinction_phase0.py
+++ b/tests/unit/test_distinction_phase0.py
@@ -42,3 +42,32 @@ def test_multi_token_flagged():
 def test_single_char_flagged():
     assert "single_char" in classify_distinction_problems("a", "Some Club")
     assert "single_char" not in classify_distinction_problems("white", "Some Club")
+
+
+from validate_normalizer import replay_merge_verdict  # noqa: E402
+
+
+def test_replay_no_data_when_missing_team():
+    assert replay_merge_verdict(None, {"team_name": "x", "club_name": "x"}) == "no_data"
+    assert replay_merge_verdict({"team_name": "x", "club_name": "x"}, None) == "no_data"
+
+
+def test_replay_no_data_when_missing_name():
+    dep = {"team_name": "", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "no_data"
+
+
+def test_replay_allowed_for_identical_names():
+    dep = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "allowed"
+
+
+def test_replay_false_skip_for_different_squads():
+    # The gate (correctly) skips different-color squads; replaying a *merge*
+    # of them is therefore a 'false_skip' from the replay's point of view —
+    # this verifies the True -> 'false_skip' mapping.
+    dep = {"team_name": "Phoenix FC 2012 Red", "club_name": "Phoenix FC"}
+    can = {"team_name": "Phoenix FC 2012 Blue", "club_name": "Phoenix FC"}
+    assert replay_merge_verdict(dep, can) == "false_skip"

--- a/tests/unit/test_resolve_distinction_cleanup.py
+++ b/tests/unit/test_resolve_distinction_cleanup.py
@@ -18,10 +18,10 @@ def test_drops_club_acronym_long():
     assert got is None
 
 
-def test_drops_stray_single_char():
-    # "c" left over from "F.C" is not a squad tag
-    got = resolve_distinction("MIDWEST GLADIATORS F.C", "MIDWEST GLADIATORS F.C", "TX")
-    assert got is None
+def test_preserves_team_letter():
+    # "A" after the age token is a real Team-A designator, not noise — keep it.
+    got = resolve_distinction("Washington Rush 2015 A", "Washington Rush", "WA")
+    assert got == "a"
 
 
 def test_drops_leftover_league_token():

--- a/tests/unit/test_resolve_distinction_cleanup.py
+++ b/tests/unit/test_resolve_distinction_cleanup.py
@@ -1,0 +1,41 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from src.utils.team_name_utils import resolve_distinction
+
+
+def test_drops_club_acronym_short():
+    # "vsa" = initials of Virginia Soccer Assocation -> not a squad tag
+    got = resolve_distinction("VSA 2014 Premier Red", "Virginia Soccer Assocation", "VA")
+    assert got == "red|premier"  # vsa dropped; red (color) before premier (program)
+
+
+def test_drops_club_acronym_long():
+    # "cosc" = initials of California Odyssey Soccer Club; ECNL is league, 2013 is age
+    got = resolve_distinction("COSC ECNL 2013", "California Odyssey Soccer Club", "CA")
+    assert got is None
+
+
+def test_drops_stray_single_char():
+    # "c" left over from "F.C" is not a squad tag
+    got = resolve_distinction("MIDWEST GLADIATORS F.C", "MIDWEST GLADIATORS F.C", "TX")
+    assert got is None
+
+
+def test_drops_leftover_league_token():
+    got = resolve_distinction("Hoover-Vestavia 2009 MLS NEXT", "Hoover-Vestavia Soccer", "AL")
+    assert got is None  # mls + next both dropped as league tokens
+
+
+def test_preserves_real_squad_tag():
+    # color + direction is a legitimate squad distinguisher
+    got = resolve_distinction("CCV Stars 2011 East Navy", "Ccv Stars", "AZ")
+    assert got == "navy|east"  # 2-word club -> no acronym; nothing stripped
+
+
+def test_preserves_modular11_ad_hd():
+    # HD must survive (Modular11 / MLS NEXT format is sacred)
+    got = resolve_distinction("Carolina Core FC U13 HD", "Carolina Core FC Youth", "NC")
+    assert got is not None and "hd" in got.split("|")


### PR DESCRIPTION
## Summary
Team-name distinction was accumulating noise: club acronyms, stray single characters, and league tokens duplicated from the league field. That made composed display names read badly, which is why #743 reverted the rankings table and global search back to raw `team_name`. This branch cleans the underlying data, then re-enables the composed display.

Three phases:
- **Phase 0.** Characterization harness and diagnostics (`classify_distinction_problems`, dry-run report, merge-verdict baseline) to see exactly what `resolve_distinction` was producing.
- **Phase 1.** `resolve_distinction` now drops club-acronym, single-character, and league tokens, while keeping legitimate `Team A` / `Team B` single-char distinctions. Cleaned values backfilled across the teams table.
- **Phase 1b.** Re-wired `composeTeamDisplay` into the rankings table (cell, team-column sort, SEO JSON-LD, in-table filter) and the global search dropdown (label + aria-label). MLS NEXT / Modular11 teams keep their verbatim name via the `has_modular11_alias` short-circuit, so there is no `MLS Next HD HD` style doubling.

## Display decision
```mermaid
flowchart TD
  A[Row] --> B{has_modular11_alias?}
  B -- yes --> C[Render raw team_name verbatim]
  B -- no --> D[abbreviateClubName + formatLeague + formatDistinction]
```

## Verification
- 230 vitest unit tests pass; new Python tests cover the resolver cleanup and Phase 0 diagnostics.
- `tsc --noEmit` and eslint clean on both components.
- Live smoke test: raw `VDA ECNL 2012` renders as `Virginia Development Academy ECNL`; MLS NEXT `U14 HD` teams render verbatim (no doubling, no pipe leak even with `red|hd` distinction); in-table filter matches the composed `ecnl` token, including `ECNL RL`.

## Test plan
- [ ] Rankings table shows clean composed names; MLS NEXT verbatim
- [ ] Global search dropdown shows composed names
- [ ] In-table filter matches league/distinction tokens
- [ ] Team rows still navigate (uses `team_id_master`)
