### PR TITLE
fix(rankings): fall back to raw team_name when distinction carries league/tier leakage

### DIFF
--- a/frontend/lib/utils.test.ts
+++ b/frontend/lib/utils.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { composeTeamDisplay, formatDistinction, formatLeague } from './utils';
+
+describe('composeTeamDisplay', () => {
+  it('composes club + league + distinction for clean data', () => {
+    expect(
+      composeTeamDisplay({
+        team_name: 'VDA ECNL 2012',
+        club_name: 'Virginia Development Academy',
+        league: 'ECNL',
+        distinction: null,
+      })
+    ).toBe('Virginia Development Academy ECNL');
+  });
+
+  it('composes a clean color/squad distinction', () => {
+    expect(
+      composeTeamDisplay({
+        team_name: 'OK Energy FC 2014 Black',
+        club_name: 'Oklahoma Energy FC',
+        league: null,
+        distinction: 'black',
+      })
+    ).toBe('Oklahoma Energy FC Black');
+  });
+
+  it('falls back to verbatim team_name for MLS NEXT (has_modular11_alias)', () => {
+    expect(
+      composeTeamDisplay({
+        team_name: 'Cedar Stars Academy Bergen U14 HD',
+        club_name: 'Cedar Stars Academy - Bergen',
+        league: 'MLS_NEXT_HD',
+        distinction: 'hd',
+        has_modular11_alias: true,
+      })
+    ).toBe('Cedar Stars Academy Bergen U14 HD');
+  });
+
+  it('falls back to team_name when club_name is missing', () => {
+    expect(composeTeamDisplay({ team_name: 'Some Raw Name', club_name: null, league: null, distinction: 'red' })).toBe(
+      'Some Raw Name'
+    );
+  });
+
+  // Safety net: when the distinction still carries league/tier leakage the
+  // resolver did not strip (e.g. "Pre-ECNL" leaves an orphaned "pre"), the
+  // composed name reads badly, so fall back to the raw team_name.
+  describe('league/tier leakage safety net', () => {
+    it('falls back for an orphaned "pre" prefix (Pre-ECNL)', () => {
+      expect(
+        composeTeamDisplay({
+          team_name: 'Dallas Texans PRE ECNL 2014 Salazar',
+          club_name: 'Dallas Texans',
+          league: null,
+          distinction: 'salazar|pre',
+        })
+      ).toBe('Dallas Texans PRE ECNL 2014 Salazar');
+    });
+
+    it('falls back for "i|pre" (numbered Pre-ECNL squad)', () => {
+      expect(
+        composeTeamDisplay({
+          team_name: 'OK Energy FC PRE-ECNL 2014 I',
+          club_name: 'Oklahoma Energy FC',
+          league: null,
+          distinction: 'i|pre',
+        })
+      ).toBe('OK Energy FC PRE-ECNL 2014 I');
+    });
+
+    it('falls back for "bv|pre|mls" (Pre-MLS-Next with club + league leakage)', () => {
+      expect(
+        composeTeamDisplay({
+          team_name: 'SPORTING BV Pre-MLS Next 2014',
+          club_name: 'Sporting Blue Valley',
+          league: null,
+          distinction: 'bv|pre|mls',
+        })
+      ).toBe('SPORTING BV Pre-MLS Next 2014');
+    });
+
+    it('falls back when a league token (ecnl) leaks into distinction', () => {
+      expect(
+        composeTeamDisplay({
+          team_name: 'Raw Team ECNL Name',
+          club_name: 'Some Club',
+          league: null,
+          distinction: 'ecnl',
+        })
+      ).toBe('Raw Team ECNL Name');
+    });
+
+    it.each(['preecnl', 'premls', 'ecnlrl', 'mls2', 'g08dpl', 'edpl', 'npl2'])(
+      'falls back for smushed/affixed league token "%s"',
+      (distinction) => {
+        expect(composeTeamDisplay({ team_name: 'RAW NAME', club_name: 'Some Club', league: null, distinction })).toBe(
+          'RAW NAME'
+        );
+      }
+    );
+
+    it.each(['white', 'premier', 'development', 'select', 'elite', 'smith'])(
+      'does NOT fall back for legitimate squad distinction "%s"',
+      (distinction) => {
+        const out = composeTeamDisplay({
+          team_name: 'RAW NAME',
+          club_name: 'Phoenix Rising',
+          league: null,
+          distinction,
+        });
+        expect(out).not.toBe('RAW NAME');
+        expect(out).toContain('Phoenix Rising');
+      }
+    );
+  });
+});
+
+describe('formatLeague', () => {
+  it('maps known league codes', () => {
+    expect(formatLeague('ECNL_RL')).toBe('ECNL RL');
+    expect(formatLeague('MLS_NEXT')).toBe('MLS Next');
+  });
+  it('returns null for empty input', () => {
+    expect(formatLeague(null)).toBeNull();
+  });
+});
+
+describe('formatDistinction', () => {
+  it('reverses words to reading order and converts roman to arabic', () => {
+    expect(formatDistinction('i|elite|pre')).toBe('Pre Elite 1');
+  });
+  it('keeps numerals last for a color + number distinction', () => {
+    expect(formatDistinction('white|2')).toBe('White 2');
+  });
+  it('returns null for empty input', () => {
+    expect(formatDistinction(null)).toBeNull();
+  });
+});

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -112,6 +112,38 @@ export function abbreviateClubName(clubName: string | null | undefined): string 
 }
 
 /**
+ * Detects a `distinction` that still carries league/tier leakage the resolver
+ * did not strip. These designators belong in the `league` column, not the squad
+ * distinction; when one leaks in (e.g. "Pre-ECNL" leaves an orphaned "pre", or a
+ * smushed "preecnl"/"premls"/"b08ecnl"), the composed name reads badly, so we
+ * fall back to the raw team_name.
+ *
+ * Two layers, because the leakage appears in many affixed forms:
+ *  - exact tokens for short/ambiguous designators — substring-matching these
+ *    would wrongly flag legitimate squad words ("pre" → "premier", "nl" →
+ *    "national", "ga" → a surname).
+ *  - substring stems for longer, unambiguous league names that also show up with
+ *    age/gender/numeric affixes ("preecnl", "ecnlrl", "mls2", "g08dpl", "edpl").
+ *
+ * "ad"/"hd" are intentionally excluded: they are load-bearing for MLS NEXT teams,
+ * which are already short-circuited upstream via has_modular11_alias. A false
+ * positive here is harmless (it just shows the raw team_name), so we err toward
+ * catching leakage.
+ */
+const DISTINCTION_LEAK_EXACT = new Set(['pre', 'rl', 'nl', 'ga', 'ea', 'ea2', 'nal', 'next']);
+const DISTINCTION_LEAK_STEMS = ['ecnl', 'ecrl', 'npl', 'mls', 'dpl', 'aspire', 'scdsl'];
+
+function distinctionHasLeakage(distinction?: string | null): boolean {
+  if (!distinction) return false;
+  return distinction.split('|').some((raw) => {
+    const token = raw.trim().toLowerCase();
+    if (!token) return false;
+    if (DISTINCTION_LEAK_EXACT.has(token)) return true;
+    return DISTINCTION_LEAK_STEMS.some((stem) => token.includes(stem));
+  });
+}
+
+/**
  * Compose a clean display name from structured team fields.
  * Format: "{club_name (abbreviated)} {league} {distinction}" — age is intentionally
  * dropped because it's already in the page's URL filter. Pieces are skipped when null.
@@ -132,6 +164,10 @@ export function composeTeamDisplay(team: {
 }): string {
   if (!team.club_name) return team.team_name;
   if (team.has_modular11_alias) return team.team_name;
+  // Dirty-data safety net: if the distinction still carries league/tier leakage
+  // (e.g. an orphaned "pre" from "Pre-ECNL"), the composed name reads badly, so
+  // show the raw team_name instead until the underlying data is cleaned.
+  if (distinctionHasLeakage(team.distinction)) return team.team_name;
   const parts: string[] = [abbreviateClubName(team.club_name)];
   const league = formatLeague(team.league);
   if (league) parts.push(league);


### PR DESCRIPTION
## Summary
Follow-up to #851. After re-enabling composed team names, ~7,100 "Pre-tier" teams (Pre-ECNL, Pre-MLS-Next, Pre-ECRL) render badly. The resolver strips the league code (ECNL/MLS) but leaves an orphaned `pre` in the `distinction`, and the `league` column is null, so `composeTeamDisplay` produced junk like `Oklahoma Energy FC Pre 1` or `Sporting Blue Valley MLS Pre BV`.

This adds a leakage guard to `composeTeamDisplay`: when the distinction still carries a league/tier token, fall back to the raw `team_name`. Two layers, because the leakage shows up in many forms:
- exact tokens for short/ambiguous designators (`pre`, `nl`, `rl`, `ga`, `ea`, `ea2`, `nal`, `next`) — `pre` stays exact so it doesn't flag `premier`.
- substring stems for the longer, unambiguous league names that also appear affixed: `ecnl`, `ecrl`, `npl`, `mls`, `dpl`, `aspire`, `scdsl`. This catches smushed forms like `preecnl`, `ecnlrl`, `mls2`, `g08dpl`, `edpl`.

A false positive is harmless (it just shows the raw name instead of a composed one), so the guard errs toward catching leakage. `ad`/`hd` are excluded on purpose — they are load-bearing for MLS NEXT teams, which are already short-circuited via `has_modular11_alias`.

**Scale:** ~7,137 live teams (5% of teams with a distinction) now show their raw name instead of a mangled composed one, across every surface that uses `composeTeamDisplay` (rankings, search, compare, infographics).

## Root cause (verified against the DB)
| team_name | `league` | `distinction` | was rendering |
|---|---|---|---|
| Dallas Texans PRE ECNL 2014 Salazar | null | `salazar\|pre` | Dallas Texans **Pre** Salazar |
| OK Energy FC PRE-ECNL 2014 I | null | `i\|pre` | Oklahoma Energy FC **Pre** 1 |
| SPORTING BV Pre-MLS Next 2014 | null | `bv\|pre\|mls` | Sporting Blue Valley **MLS Pre BV** |

## Not in scope (follow-ups)
- The proper fix is to recognize Pre-ECNL / Pre-MLS-Next / Pre-ECRL as leagues: populate the `league` column + `LEAGUE_DISPLAY`, blocklist bare `pre` in `resolve_distinction`, and re-backfill. This guard is the interim so the rankings table stops showing junk now.
- `formatDistinction` reverses word order, so `red|hd` renders as `HD Red` rather than `Red HD` (its own docstring example is wrong). Minor, deferred.

## Test plan
- [x] 26 unit tests in `frontend/lib/utils.test.ts` — the 3 real DB examples, smushed/affixed forms, and false-positive guards (`premier`/`select`/`development` still compose)
- [x] `tsc --noEmit` + eslint clean, 256 vitest tests pass
- [ ] Spot-check on the preview: a Pre-ECNL team shows its raw name; a clean Premier/Select team still composes
