### PR TITLE
feat(marketing): replace Buffer + tweepy with unified Postiz drafts

### DIFF
--- a/.github/workflows/marketing-pipeline.yml
+++ b/.github/workflows/marketing-pipeline.yml
@@ -19,9 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # DISABLED: Marketing pipeline temporarily turned off
-    if: false
-    # Original condition (restore when re-enabling):
+    # Manual-dispatch only during Postiz migration validation.
+    # After two clean cycles, drop this `if:` so the workflow_run trigger re-enables.
+    if: github.event_name == 'workflow_dispatch'
+    # Original condition (restore when re-enabling auto-trigger):
     # if: >-
     #   github.event_name == 'workflow_dispatch' ||
     #   (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
@@ -55,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install supabase python-dotenv requests rich tweepy markdown
+          pip install supabase python-dotenv requests rich markdown
 
       # ---------------------------------------------------------------
       # 4. RUN PIPELINE
@@ -67,11 +68,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           BEEHIIV_API_KEY: ${{ secrets.BEEHIIV_API_KEY }}
           BEEHIIV_PUBLICATION_ID: ${{ secrets.BEEHIIV_PUBLICATION_ID }}
-          BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
-          X_CONSUMER_KEY: ${{ secrets.X_CONSUMER_KEY }}
-          X_CONSUMER_SECRET: ${{ secrets.X_CONSUMER_SECRET }}
-          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
-          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          POSTIZ_API_KEY: ${{ secrets.POSTIZ_API_KEY }}
+          POSTIZ_DRAFTS_ENABLED: ${{ vars.POSTIZ_DRAFTS_ENABLED || 'true' }}
           PITCHRANK_URL: 'https://pitchrank.io'
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |

--- a/brand/trend-research/2026-W23.json
+++ b/brand/trend-research/2026-W23.json
@@ -1,0 +1,11 @@
+{
+  "week": "2026-W23",
+  "posts": [
+    {
+      "topic": "ECNL national rankings drop",
+      "hook": "Rankings dropped — what the data actually shows.",
+      "suggested_tweet": "ECNL just released their national rankings. We ran the same 25K teams through PitchRank's algorithm and got a very different top 50. Receipts > vibes.\n\npitchrank.io/rankings",
+      "source_url": "https://example.com/ecnl-rankings"
+    }
+  ]
+}

--- a/frontend/app/api/infographic/_shared/assets.ts
+++ b/frontend/app/api/infographic/_shared/assets.ts
@@ -1,0 +1,18 @@
+const ORIGIN = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
+
+export async function loadBrandFonts() {
+  const [oswaldBold, oswaldReg, dmSansBold, dmSansReg] = await Promise.all([
+    fetch(`${ORIGIN}/fonts/Oswald-Bold.woff`).then((r) => r.arrayBuffer()),
+    fetch(`${ORIGIN}/fonts/Oswald-Regular.woff`).then((r) => r.arrayBuffer()),
+    fetch(`${ORIGIN}/fonts/DMSans-Bold.woff`).then((r) => r.arrayBuffer()),
+    fetch(`${ORIGIN}/fonts/DMSans-Regular.woff`).then((r) => r.arrayBuffer()),
+  ]);
+  return [
+    { name: 'Oswald', data: oswaldBold, weight: 700 as const, style: 'normal' as const },
+    { name: 'Oswald', data: oswaldReg, weight: 400 as const, style: 'normal' as const },
+    { name: 'DM Sans', data: dmSansBold, weight: 700 as const, style: 'normal' as const },
+    { name: 'DM Sans', data: dmSansReg, weight: 400 as const, style: 'normal' as const },
+  ];
+}
+
+export const LOGO_URL = `${ORIGIN}/logos/logo-primary.svg`;

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
+import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -83,19 +84,19 @@ export async function GET(request: Request) {
         flexDirection: 'column',
         background: `linear-gradient(135deg, ${BRAND_COLORS.forestGreen} 0%, ${BRAND_COLORS.darkGreen} 100%)`,
         padding: isStory ? 60 : 50,
-        fontFamily: 'Arial, sans-serif',
+        fontFamily: 'DM Sans, sans-serif',
       }}
     >
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: 30 }}>
-        <div style={{ fontSize: isStory ? 28 : 24, color: BRAND_COLORS.gold, fontWeight: 'bold', letterSpacing: 4 }}>
-          PITCHRANK
-        </div>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
         <div
           style={{
             fontSize: isStory ? 48 : isSquare ? 42 : 36,
             color: BRAND_COLORS.brightWhite,
             fontWeight: 'bold',
+            fontFamily: 'Oswald',
             marginTop: 10,
           }}
         >
@@ -217,6 +218,7 @@ export async function GET(request: Request) {
     {
       width: dimensions.width,
       height: dimensions.height,
+      fonts: await loadBrandFonts(),
     }
   );
 }

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
+import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -76,19 +77,19 @@ export async function GET(request: Request) {
         justifyContent: 'center',
         background: `linear-gradient(135deg, ${BRAND_COLORS.forestGreen} 0%, ${BRAND_COLORS.darkGreen} 100%)`,
         padding: isStory ? 60 : 50,
-        fontFamily: 'Arial, sans-serif',
+        fontFamily: 'DM Sans, sans-serif',
       }}
     >
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: isStory ? 50 : 30 }}>
-        <div style={{ fontSize: isStory ? 28 : 24, color: BRAND_COLORS.gold, fontWeight: 'bold', letterSpacing: 4 }}>
-          PITCHRANK
-        </div>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
         <div
           style={{
             fontSize: isStory ? 36 : isSquare ? 30 : 26,
             color: 'rgba(255,255,255,0.8)',
             fontWeight: 'bold',
+            fontFamily: 'Oswald',
             marginTop: 8,
             letterSpacing: 2,
           }}
@@ -192,6 +193,7 @@ export async function GET(request: Request) {
     {
       width: dimensions.width,
       height: dimensions.height,
+      fonts: await loadBrandFonts(),
     }
   );
 }

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
+import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -90,18 +91,18 @@ export async function GET(request: Request) {
         flexDirection: 'column',
         background: `linear-gradient(135deg, ${BRAND_COLORS.forestGreen} 0%, ${BRAND_COLORS.darkGreen} 100%)`,
         padding: isStory ? 60 : 50,
-        fontFamily: 'Arial, sans-serif',
+        fontFamily: 'DM Sans, sans-serif',
       }}
     >
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: isStory ? 50 : 30 }}>
-        <div style={{ fontSize: isStory ? 28 : 24, color: BRAND_COLORS.gold, fontWeight: 'bold', letterSpacing: 4 }}>
-          PITCHRANK
-        </div>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
         <div
           style={{
             fontSize: isStory ? 52 : isSquare ? 46 : 38,
             fontWeight: 'bold',
+            fontFamily: 'Oswald',
             color: BRAND_COLORS.brightWhite,
             marginTop: 10,
           }}
@@ -179,6 +180,7 @@ export async function GET(request: Request) {
     {
       width: dimensions.width,
       height: dimensions.height,
+      fonts: await loadBrandFonts(),
     }
   );
 }

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -34,7 +34,6 @@ if env_local.exists():
 if env_path.exists():
     load_dotenv(env_path, override=True)
 
-import markdown as md_lib  # noqa: E402
 import requests  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
@@ -245,7 +244,15 @@ def fetch_ranking_highlights(supabase) -> dict:
 
 
 def _markdown_to_email_html(md_text: str) -> str:
-    """Convert markdown to email-safe HTML with inline styles."""
+    """Convert markdown to email-safe HTML with inline styles.
+
+    `markdown` is imported lazily: the package is only listed in the GHA workflow's
+    explicit pip install line for the marketing pipeline, not in requirements.lock,
+    so the CI test runner doesn't have it. Tests cover the post-translation helpers
+    only and don't reach this path.
+    """
+    import markdown as md_lib
+
     raw_html = md_lib.markdown(md_text, extensions=["tables"])
 
     # Add inline styles for email clients

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Marketing Pipeline — Automated newsletter + social posting after rankings update
+Marketing Pipeline — Automated newsletter + social drafts after rankings update
 
 Chains to Calculate Rankings workflow. Fetches ranking highlights from Supabase,
-generates a newsletter, publishes to Beehiiv, and schedules social posts to Buffer.
+generates a newsletter, publishes to Beehiiv, and drafts X + Instagram + trend
+social posts to Postiz for operator approval before publish.
 
 Run: python3 scripts/marketing_pipeline.py [--dry-run]
 """
@@ -48,8 +49,8 @@ PITCHRANK_URL = os.getenv("PITCHRANK_URL", "https://pitchrank.io")
 # Use -6 during daylight saving (March-November)
 MT_OFFSET = timezone(timedelta(hours=-6))
 
-# Buffer API
-BUFFER_API_URL = "https://api.bufferapp.com/1"
+# Postiz API
+POSTIZ_API_URL = "https://api.postiz.com/public/v1"
 
 # Beehiiv API
 BEEHIIV_API_URL = "https://api.beehiiv.com/v2"
@@ -798,7 +799,7 @@ def generate_social_posts(data: dict) -> list[dict]:
         posts.append(
             {
                 "text": text,
-                "media_url": f"{PITCHRANK_URL}/api/infographic/spotlight?platform=twitter",
+                "media_url": f"{PITCHRANK_URL}/api/infographic/spotlight?platform=instagram",
                 "scheduled_at": wednesday,
                 "type": "mover_spotlight",
             }
@@ -835,106 +836,313 @@ def generate_social_posts(data: dict) -> list[dict]:
     return posts
 
 
-# ---------------------------------------------------------------------------
-# Buffer scheduling
-# ---------------------------------------------------------------------------
+def generate_trend_posts(week_iso: str, data: dict) -> list[dict]:
+    """Generate up to 3 trend-reaction X posts from brand/trend-research/<week>.json.
 
-
-def get_buffer_profiles() -> list[dict]:
-    """Get connected Buffer profiles."""
-    token = os.getenv("BUFFER_ACCESS_TOKEN")
-    if not token:
-        log.error("BUFFER_ACCESS_TOKEN not set")
+    User runs /last30days manually and writes the JSON each week. Schema:
+        {"week": "2026-W23", "posts": [{"topic": ..., "hook": ..., "suggested_tweet": ..., "source_url": ...}]}
+    """
+    path = PROJECT_ROOT / "brand" / "trend-research" / f"{week_iso}.json"
+    if not path.exists():
+        log.error(f"Trend research file missing for {week_iso}: brand/trend-research/{week_iso}.json")
         return []
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        log.error(f"Trend research file malformed ({path.name}): {e}")
+        return []
+
+    if payload.get("week") != week_iso:
+        log.error(f"Trend research week mismatch: expected {week_iso}, got {payload.get('week')}")
+        return []
+
+    entries = payload.get("posts") or []
+    valid: list[dict] = []
+    for entry in entries:
+        tweet = entry.get("suggested_tweet")
+        if not isinstance(tweet, str) or not tweet.strip():
+            log.warning(f"Skipping trend entry without suggested_tweet: {entry.get('topic', '?')}")
+            continue
+        valid.append(entry)
+
+    if not valid:
+        log.error(f"No valid trend entries in {path.name}")
+        return []
+
+    if len(valid) > 3:
+        log.warning(f"Trend research has {len(valid)} valid entries; using first 3")
+        valid = valid[:3]
+
+    # Schedule across the week (MT)
+    monday = data["date"].replace(hour=0, minute=0, second=0, microsecond=0)
+    while monday.weekday() != 0:
+        monday += timedelta(days=1)
+    slots = [
+        monday + timedelta(days=2, hours=12, minutes=30),  # Wed 12:30 PM MT
+        monday + timedelta(days=4, hours=9),  # Fri 9:00 AM MT
+        monday + timedelta(days=5, hours=11),  # Sat 11:00 AM MT
+    ]
+
+    posts = []
+    for entry, when in zip(valid, slots):
+        posts.append(
+            {
+                "text": entry["suggested_tweet"],
+                "media_url": None,
+                "scheduled_at": when,
+                "type": "trend",
+            }
+        )
+
+    log.info(f"Generated {len(posts)} trend posts for {week_iso}")
+    return posts
+
+
+# ---------------------------------------------------------------------------
+# Postiz drafting
+# ---------------------------------------------------------------------------
+
+
+_IG_IDENTIFIERS = ("instagram", "instagram-standalone")
+
+
+def get_postiz_integrations() -> dict[str, dict[str, str]]:
+    """Fetch Postiz integrations and return {platform: {"id", "__type"}} for the platforms we use.
+
+    `platform` is the logical name ("x" or "instagram"); `__type` carries the actual Postiz
+    identifier ("instagram" for FB-linked, "instagram-standalone" for Instagram Login).
+    Hardcoding `__type: "instagram"` would break drafts when the connected IG channel is
+    the standalone variant — carry the identifier through to the payload to stay in sync.
+
+    Fail-loud: returns {} on non-200, and only-found-platforms on partial discovery
+    so the router can log per-post errors and exit-code reflects the partial outage.
+    """
+    api_key = os.getenv("POSTIZ_API_KEY")
+    if not api_key:
+        log.error("POSTIZ_API_KEY not set")
+        return {}
 
     resp = requests.get(
-        f"{BUFFER_API_URL}/profiles.json",
-        params={"access_token": token},
-        timeout=30,
+        f"{POSTIZ_API_URL}/integrations",
+        headers={"Authorization": api_key},
+        timeout=60,
     )
+
     if resp.status_code != 200:
-        log.error(f"Buffer profiles error ({resp.status_code}): {resp.text[:300]}")
-        return []
+        log.error(f"Postiz integrations fetch failed ({resp.status_code}): {resp.text[:500]}")
+        return {}
 
-    return resp.json()
+    found: dict[str, dict[str, str]] = {}
+    for row in resp.json() or []:
+        ident = row.get("identifier")
+        rid = row.get("id")
+        if not ident or not rid:
+            continue
+        if ident == "x" and "x" not in found:
+            found["x"] = {"id": rid, "__type": "x"}
+        elif ident in _IG_IDENTIFIERS and "instagram" not in found:
+            found["instagram"] = {"id": rid, "__type": ident}
+
+    missing = [p for p in ("x", "instagram") if p not in found]
+    if missing:
+        log.error(f"Postiz integrations missing required platform(s): {missing}")
+
+    return found
 
 
-def schedule_to_buffer(posts: list[dict]) -> list[bool]:
-    """Schedule social posts to all connected Buffer profiles."""
-    token = os.getenv("BUFFER_ACCESS_TOKEN")
-    if not token:
-        log.error("BUFFER_ACCESS_TOKEN not set, skipping social posts")
+def _to_postiz_payload(post: dict, integration_id: str, settings_type: str) -> dict:
+    """Translate a canonical post dict into a Postiz POST /posts request envelope.
+
+    `settings_type` is the Postiz integration identifier ("x", "instagram", "instagram-standalone").
+    It becomes the post settings `__type`, and also selects which platform branch to build.
+    """
+    if settings_type == "x":
+        parts = post.get("thread_parts") or [post["text"]]
+        value = [{"content": t, "image": []} for t in parts]
+        settings = {"__type": "x", "who_can_reply_post": "everyone"}
+    elif settings_type in _IG_IDENTIFIERS:
+        image = [{"path": post["media_url"]}] if post.get("media_url") else []
+        value = [{"content": post["text"], "image": image}]
+        settings = {
+            "__type": settings_type,
+            "post_type": "post",
+            "is_trial_reel": False,
+            "collaborators": [],
+        }
+    else:
+        raise ValueError(f"Unsupported Postiz platform: {settings_type}")
+
+    return {
+        "type": "draft",
+        "date": post["scheduled_at"].isoformat(),
+        "shortLink": False,
+        "tags": [],
+        "posts": [
+            {
+                "integration": {"id": integration_id},
+                "value": value,
+                "settings": settings,
+            }
+        ],
+    }
+
+
+def draft_to_postiz(posts: list[dict], integrations: dict[str, dict[str, str]], dry_run: bool) -> list[bool]:
+    """Create Postiz drafts for each post; return per-post success list."""
+    api_key = os.getenv("POSTIZ_API_KEY") if not dry_run else None
+    if not dry_run and not api_key:
+        log.error("POSTIZ_API_KEY not set, skipping Postiz drafts")
         return [False] * len(posts)
-
-    profiles = get_buffer_profiles()
-    if not profiles:
-        log.error("No Buffer profiles found")
-        return [False] * len(posts)
-
-    profile_ids = [p["id"] for p in profiles]
-    profile_names = ", ".join(f"{p.get('service', '?')}:{p.get('formatted_username', '?')}" for p in profiles)
-    log.info(f"Buffer profiles: {profile_names}")
 
     results = []
     for post in posts:
-        scheduled_utc = post["scheduled_at"].astimezone(timezone.utc)
+        # Trend posts and X threads route to X; everything else to Instagram.
+        platform = "x" if post["type"] in ("x_thread", "trend") else "instagram"
+        integration = integrations.get(platform)
+        if not integration:
+            log.error(f"No Postiz integration for routed platform; skipping [{post['type']}]")
+            results.append(False)
+            continue
 
-        # Buffer API expects repeated profile_ids[] params as form data tuples
-        form_data = [
-            ("access_token", token),
-            ("text", post["text"]),
-            ("scheduled_at", scheduled_utc.strftime("%Y-%m-%dT%H:%M:%SZ")),
-        ]
-        for pid in profile_ids:
-            form_data.append(("profile_ids[]", pid))
+        payload = _to_postiz_payload(post, integration["id"], integration["__type"])
 
-        if post.get("media_url"):
-            form_data.append(("media[photo]", post["media_url"]))
+        if dry_run:
+            results.append(True)
+            continue
 
         resp = requests.post(
-            f"{BUFFER_API_URL}/updates/create.json",
-            data=form_data,
-            timeout=30,
+            f"{POSTIZ_API_URL}/posts",
+            headers={"Authorization": api_key, "Content-Type": "application/json"},
+            json=payload,
+            timeout=60,
         )
 
-        if resp.status_code == 200:
-            log.info(f"Scheduled [{post['type']}] for {post['scheduled_at'].strftime('%A %I:%M %p MT')}")
+        if resp.status_code in (200, 201):
+            log.info(
+                f"Drafted [{post['type']}] to Postiz ({integration['__type']}) "
+                f"for {post['scheduled_at'].strftime('%A %I:%M %p MT')}"
+            )
             results.append(True)
         else:
-            log.error(f"Buffer error for [{post['type']}] ({resp.status_code}): {resp.text[:300]}")
+            log.error(f"Postiz draft failed [{post['type']}] ({resp.status_code}): {resp.text[:500]}")
             results.append(False)
 
     return results
 
 
-# ---------------------------------------------------------------------------
-# X thread posting
-# ---------------------------------------------------------------------------
+def enrich_post_with_handles(post: dict, supabase, target_team_ids: list[str]) -> dict:
+    """Append `\\n\\nTagging: @h1 @h2 ...` to post['text'] using confirmed IG handles.
 
+    Mutates post in place and writes post['_tag_stats'] for downstream visibility.
+    Picks one handle per team (team-level preferred, club-level fallback). Note:
+    this differs from the site's caption builder in
+    frontend/hooks/useInstagramHandles.ts:collectHandlesForCaption, which pushes
+    both team AND club handles when both exist — Postiz drafts stay lean.
+    """
+    target_count = len(target_team_ids)
+    if not target_team_ids:
+        post["_tag_stats"] = {"tagged_count": 0, "target_count": 0, "missing_team_ids": []}
+        return post
 
-def get_x_client():
-    """Initialize tweepy Client for X API v2. Returns None if not configured."""
+    statuses = ["confirmed"]
+    if os.getenv("POSTIZ_TAG_INCLUDE_AUTO_APPROVED", "false").lower() == "true":
+        statuses.append("auto_approved")
+
     try:
-        import tweepy  # noqa: E402 — optional dependency
-    except ImportError:
-        log.warning("tweepy not installed, skipping X thread")
-        return None
+        resp = (
+            supabase.from_("team_instagram_handles")
+            .select("team_id, handle, profile_level")
+            .in_("team_id", target_team_ids)
+            .in_("review_status", statuses)
+            .execute()
+        )
+        rows = resp.data or []
+    except Exception as e:
+        log.warning(f"IG handle lookup failed for [{post['type']}]: {e}")
+        post["_tag_stats"] = {
+            "tagged_count": 0,
+            "target_count": target_count,
+            "missing_team_ids": list(target_team_ids),
+            "error": str(e),
+        }
+        return post
 
-    consumer_key = os.getenv("X_CONSUMER_KEY")
-    consumer_secret = os.getenv("X_CONSUMER_SECRET")
-    access_token = os.getenv("X_ACCESS_TOKEN")
-    access_token_secret = os.getenv("X_ACCESS_TOKEN_SECRET")
+    # Bucket by team_id: prefer team-level, fall back to club-level
+    per_team: dict[str, dict[str, str]] = {}
+    for row in rows:
+        bucket = per_team.setdefault(row["team_id"], {"team": None, "club": None})
+        bucket[row["profile_level"]] = row["handle"]
 
-    if not all([consumer_key, consumer_secret, access_token, access_token_secret]):
-        log.warning("X API credentials not configured, skipping X thread")
-        return None
+    seen: set[str] = set()
+    handles: list[str] = []
+    tagged_ids: set[str] = set()
+    for tid in target_team_ids:
+        bucket = per_team.get(tid)
+        if not bucket:
+            continue
+        chosen = bucket.get("team") or bucket.get("club")
+        if not chosen:
+            continue
+        key = chosen.lower()
+        if key in seen:
+            tagged_ids.add(tid)
+            continue
+        seen.add(key)
+        handles.append(f"@{chosen}")
+        tagged_ids.add(tid)
 
-    return tweepy.Client(
-        consumer_key=consumer_key,
-        consumer_secret=consumer_secret,
-        access_token=access_token,
-        access_token_secret=access_token_secret,
-    )
+    if not handles:
+        post["_tag_stats"] = {
+            "tagged_count": 0,
+            "target_count": target_count,
+            "missing_team_ids": list(target_team_ids),
+        }
+        return post
+
+    # Cap mentions at 10 for naturalness (IG hard limit is 20)
+    if len(handles) > 10:
+        handles = handles[:10]
+
+    # IG caption hard limit is 2,200 chars
+    suffix = "\n\nTagging: " + " ".join(handles)
+    dropped = 0
+    while handles and len(post["text"]) + len(suffix) > 2200:
+        handles.pop()
+        dropped += 1
+        suffix = "\n\nTagging: " + " ".join(handles)
+    if dropped:
+        log.warning(f"Truncated {dropped} IG @-mentions to stay under 2,200 chars [{post['type']}]")
+
+    if handles:
+        post["text"] = post["text"] + suffix
+
+    missing = [tid for tid in target_team_ids if tid not in tagged_ids]
+    post["_tag_stats"] = {
+        "tagged_count": len(handles),
+        "target_count": target_count,
+        "missing_team_ids": missing,
+    }
+    return post
+
+
+def _resolve_tag_targets(post_type: str, data: dict) -> list[str]:
+    """Pick which team_ids to tag for a given post type."""
+    if post_type == "rankings_live":
+        return [c["team_id"] for c in data["climbers"][:3] if c.get("team_id")]
+    if post_type == "mover_spotlight":
+        target = (
+            data["climbers"][1] if len(data["climbers"]) > 1 else (data["climbers"][0] if data["climbers"] else None)
+        )
+        return [target["team_id"]] if target and target.get("team_id") else []
+    if post_type == "state_spotlight":
+        return [t["team_id"] for t in (data.get("spotlight_teams") or [])[:3] if t.get("team_id")]
+    return []  # data_flex, x_thread, trend — no tagging
+
+
+# ---------------------------------------------------------------------------
+# X thread composition
+# ---------------------------------------------------------------------------
 
 
 def _format_cohort(team: dict) -> str:
@@ -955,11 +1163,15 @@ def _milestone_line(m: dict) -> str:
     return f"• {name} ({label}) → now #{rank}"
 
 
-def generate_thread_tweets(data: dict) -> list[str]:
-    """Generate a 4-tweet thread focused on milestone crossings (top 10/25/50/100 in cohort)."""
+def generate_x_thread_posts(data: dict) -> dict:
+    """Compose a 4-tweet thread (milestone-driven) into the canonical post-dict shape.
+
+    Returns a single dict with `thread_parts` carrying the per-tweet split; downstream
+    Postiz translation reads `thread_parts` for chained replies.
+    """
     milestones = data.get("milestones", [])
     total = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
-    tweets = []
+    tweets: list[str] = []
 
     # Group milestones by tier
     by_tier: dict[int, list[dict]] = {}
@@ -975,7 +1187,6 @@ def generate_thread_tweets(data: dict) -> list[str]:
 
     # Tweet 1: Hook
     if milestone_count > 0:
-        # Lead with the most impressive milestone
         if top10:
             lead = top10[0]
             tweets.append(
@@ -1028,35 +1239,20 @@ def generate_thread_tweets(data: dict) -> list[str]:
     # Tweet 4 (final): CTA
     tweets.append(f"{total} teams ranked every Monday.\n\npitchrank.io/rankings")
 
+    # Scheduled at Monday noon MT (same as the rankings_live post)
+    monday = data["date"].replace(hour=12, minute=0, second=0, microsecond=0)
+    while monday.weekday() != 0:
+        monday += timedelta(days=1)
+
+    joined = "\n---\n".join(tweets)
     log.info(f"Generated {len(tweets)}-tweet thread ({milestone_count} milestones)")
-    return tweets
-
-
-def post_thread_to_x(tweets: list[str], dry_run: bool = False) -> bool:
-    """Post a thread to X by chaining tweets with in_reply_to_tweet_id."""
-    if dry_run:
-        for i, tweet in enumerate(tweets):
-            log.info(f"[DRY RUN] Thread tweet {i + 1}/{len(tweets)}: {tweet}")
-        return True
-
-    client = get_x_client()
-    if not client:
-        return False
-
-    previous_tweet_id = None
-    for i, tweet_text in enumerate(tweets):
-        try:
-            response = client.create_tweet(
-                text=tweet_text,
-                in_reply_to_tweet_id=previous_tweet_id,
-            )
-            previous_tweet_id = response.data["id"]
-            log.info(f"Posted thread tweet {i + 1}/{len(tweets)} (id={previous_tweet_id})")
-        except Exception as e:
-            log.error(f"Failed to post thread tweet {i + 1}: {e}")
-            return False
-
-    return True
+    return {
+        "text": joined,
+        "media_url": None,
+        "scheduled_at": monday,
+        "type": "x_thread",
+        "thread_parts": tweets,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1064,7 +1260,7 @@ def post_thread_to_x(tweets: list[str], dry_run: bool = False) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def save_artifacts(newsletter_html: str, social_posts: list[dict], data: dict):
+def save_artifacts(newsletter_html: str, drafts: list[dict], data: dict):
     """Save generated content as artifacts for debugging."""
     ARTIFACTS_DIR.mkdir(exist_ok=True)
     date_str = data["date"].strftime("%Y%m%d")
@@ -1075,15 +1271,18 @@ def save_artifacts(newsletter_html: str, social_posts: list[dict], data: dict):
 
     posts_path = ARTIFACTS_DIR / f"social_posts_{date_str}.json"
     serializable = []
-    for p in social_posts:
-        serializable.append(
-            {
-                "type": p["type"],
-                "text": p["text"],
-                "media_url": p.get("media_url"),
-                "scheduled_at": p["scheduled_at"].isoformat(),
-            }
-        )
+    for p in drafts:
+        entry = {
+            "type": p["type"],
+            "text": p["text"],
+            "media_url": p.get("media_url"),
+            "scheduled_at": p["scheduled_at"].isoformat(),
+        }
+        if p.get("thread_parts"):
+            entry["thread_parts"] = p["thread_parts"]
+        if p.get("_tag_stats"):
+            entry["_tag_stats"] = p["_tag_stats"]
+        serializable.append(entry)
     posts_path.write_text(json.dumps(serializable, indent=2), encoding="utf-8")
     log.info(f"Saved social posts JSON: {posts_path}")
 
@@ -1133,18 +1332,34 @@ def main():
     subject = generate_newsletter_subject(data, blog_title)
     log.info(f"Subject: {subject}")
 
-    # Step 4: Generate social posts
-    social_posts = generate_social_posts(data)
-
-    # Step 5: Generate X thread
-    thread_tweets = []
-    try:
-        thread_tweets = generate_thread_tweets(data)
-    except Exception as e:
-        log.error(f"Thread generation failed: {e}")
+    # Step 4-5: Generate all social drafts (kill-switch gated)
+    drafts_enabled = os.getenv("POSTIZ_DRAFTS_ENABLED", "true").lower() == "true"
+    current_iso_week = data["date"].strftime("%G-W%V")
+    social_posts: list[dict] = []
+    x_thread_post: dict = {"thread_parts": []}
+    all_drafts: list[dict] = []
+    if drafts_enabled:
+        social_posts = generate_social_posts(data)
+        # Enrich IG-bound posts with team handles (post-pass; keeps generators platform-agnostic)
+        for post in social_posts:
+            targets = _resolve_tag_targets(post["type"], data)
+            if targets:
+                enrich_post_with_handles(post, supabase, targets)
+        try:
+            x_thread_post = generate_x_thread_posts(data)
+        except Exception as e:
+            log.error(f"X thread generation failed: {e}")
+            x_thread_post = {"thread_parts": []}
+        trend_posts = generate_trend_posts(current_iso_week, data)
+        all_drafts = list(social_posts)
+        if x_thread_post.get("thread_parts"):
+            all_drafts.append(x_thread_post)
+        all_drafts.extend(trend_posts)
+    else:
+        log.warning("POSTIZ_DRAFTS_ENABLED=false — skipping social drafts entirely")
 
     # Save artifacts (always, for debugging)
-    save_artifacts(newsletter_html, social_posts, data)
+    save_artifacts(newsletter_html, all_drafts, data)
 
     if args.dry_run:
         log.info("")
@@ -1161,12 +1376,19 @@ def main():
                 log.info(f"  Image: {post['media_url']}")
             log.info(post["text"])
             log.info("")
-        if thread_tweets:
+        if x_thread_post.get("thread_parts"):
             log.info("--- X THREAD ---")
-            for i, tweet in enumerate(thread_tweets):
-                log.info(f"Tweet {i + 1}/{len(thread_tweets)}: {tweet}")
+            for i, tweet in enumerate(x_thread_post["thread_parts"]):
+                log.info(f"Tweet {i + 1}/{len(x_thread_post['thread_parts'])}: {tweet}")
                 log.info("")
-        log.info("Artifacts saved. No API calls made.")
+        if drafts_enabled:
+            stub_integrations = {
+                "x": {"id": "DRY_RUN_X_ID", "__type": "x"},
+                "instagram": {"id": "DRY_RUN_IG_ID", "__type": "instagram"},
+            }
+            dry_draft_results = draft_to_postiz(all_drafts, stub_integrations, dry_run=True)
+            log.info(f"DRY RUN: {sum(dry_draft_results)}/{len(dry_draft_results)} would be drafted to Postiz")
+        log.info("Artifacts saved. No Postiz API calls made (Supabase reads ran for data fetch + handle enrichment).")
         return
 
     # Step 6: Publish newsletter to Beehiiv
@@ -1184,20 +1406,14 @@ def main():
     except Exception as e:
         log.error(f"Blog publishing failed: {e}")
 
-    # Step 8: Schedule social posts to Buffer
-    buffer_results = []
+    # Step 8: Draft all social posts to Postiz (X thread + Instagram + trend)
+    draft_results: list[bool] = []
     try:
-        buffer_results = schedule_to_buffer(social_posts)
+        if drafts_enabled and all_drafts:
+            integrations = get_postiz_integrations()
+            draft_results = draft_to_postiz(all_drafts, integrations, dry_run=False)
     except Exception as e:
-        log.error(f"Social scheduling failed: {e}")
-
-    # Step 9: Post X thread
-    thread_ok = False
-    try:
-        if thread_tweets:
-            thread_ok = post_thread_to_x(thread_tweets)
-    except Exception as e:
-        log.error(f"X thread posting failed: {e}")
+        log.error(f"Postiz drafting failed: {e}")
 
     # Summary
     log.info("")
@@ -1205,13 +1421,13 @@ def main():
     log.info("PIPELINE COMPLETE")
     log.info(f"  Newsletter: {'SENT' if newsletter_ok else 'FAILED'}")
     log.info(f"  Blog: {'PUBLISHED' if blog_ok else 'SKIPPED'}")
-    log.info(f"  Social: {sum(buffer_results)}/{len(buffer_results)} posts scheduled")
-    log.info(f"  X Thread: {'POSTED' if thread_ok else 'SKIPPED'}")
+    log.info(f"  Social Drafts: {sum(draft_results)}/{len(draft_results)} drafted to Postiz")
     log.info("=" * 60)
 
-    # Exit 0 even with partial failures — the workflow should show as success
-    # with logged warnings, not block the next run
-    if not newsletter_ok and not any(buffer_results):
+    # Exit 1 only if newsletter AND every draft failed — partial outages surface via non-zero
+    # entries in draft_results (collapsed from old Buffer + tweepy split, so X-thread failures
+    # now contribute to the exit code).
+    if not newsletter_ok and not any(draft_results):
         sys.exit(1)
 
 

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -951,18 +951,65 @@ def get_postiz_integrations() -> dict[str, dict[str, str]]:
     return found
 
 
+def _upload_to_postiz(media_url: str, api_key: str) -> dict | None:
+    """Fetch a public media URL and upload it to Postiz, returning {"id", "path"}.
+
+    Postiz's POST /posts endpoint does NOT accept arbitrary public URLs in the
+    image array — it requires a pre-uploaded media object from POST /upload.
+    Returns None on any failure; caller should treat that as a draft failure.
+    """
+    try:
+        media_resp = requests.get(media_url, timeout=60)
+    except Exception as e:
+        log.error(f"Media fetch failed for {media_url}: {e}")
+        return None
+
+    if media_resp.status_code != 200:
+        log.error(f"Media fetch failed for {media_url} ({media_resp.status_code})")
+        return None
+
+    filename = media_url.rsplit("/", 1)[-1].split("?")[0] or "image.png"
+    content_type = media_resp.headers.get("Content-Type", "image/png")
+
+    try:
+        upload_resp = requests.post(
+            f"{POSTIZ_API_URL}/upload",
+            headers={"Authorization": api_key},
+            files={"file": (filename, media_resp.content, content_type)},
+            timeout=120,
+        )
+    except Exception as e:
+        log.error(f"Postiz upload exception: {e}")
+        return None
+
+    if upload_resp.status_code not in (200, 201):
+        log.error(f"Postiz upload failed ({upload_resp.status_code}): {upload_resp.text[:500]}")
+        return None
+
+    data = upload_resp.json()
+    if not data.get("id") or not data.get("path"):
+        log.error(f"Postiz upload returned unexpected shape: {str(data)[:300]}")
+        return None
+    return {"id": data["id"], "path": data["path"]}
+
+
 def _to_postiz_payload(post: dict, integration_id: str, settings_type: str) -> dict:
     """Translate a canonical post dict into a Postiz POST /posts request envelope.
 
     `settings_type` is the Postiz integration identifier ("x", "instagram", "instagram-standalone").
     It becomes the post settings `__type`, and also selects which platform branch to build.
+
+    For IG posts, the caller is responsible for uploading media via _upload_to_postiz first
+    and stashing the result in post["_uploaded_media"]. We do NOT pass raw media_url through
+    here — Postiz rejects arbitrary URLs in the image array.
     """
     if settings_type == "x":
         parts = post.get("thread_parts") or [post["text"]]
         value = [{"content": t, "image": []} for t in parts]
         settings = {"__type": "x", "who_can_reply_post": "everyone"}
     elif settings_type in _IG_IDENTIFIERS:
-        image = [{"path": post["media_url"]}] if post.get("media_url") else []
+        uploaded = post.get("_uploaded_media")
+        image = [{"id": uploaded["id"], "path": uploaded["path"]}] if uploaded else []
         value = [{"content": post["text"], "image": image}]
         settings = {
             "__type": settings_type,
@@ -1004,6 +1051,15 @@ def draft_to_postiz(posts: list[dict], integrations: dict[str, dict[str, str]], 
             log.error(f"No Postiz integration for routed platform; skipping [{post['type']}]")
             results.append(False)
             continue
+
+        # IG posts must upload media to Postiz first; raw URLs are rejected by POST /posts.
+        if not dry_run and platform == "instagram" and post.get("media_url"):
+            uploaded = _upload_to_postiz(post["media_url"], api_key)
+            if not uploaded:
+                log.error(f"IG media upload failed; skipping draft [{post['type']}]")
+                results.append(False)
+                continue
+            post["_uploaded_media"] = uploaded
 
         payload = _to_postiz_payload(post, integration["id"], integration["__type"])
 

--- a/supabase/migrations/20260602000000_add_team_id_to_get_biggest_movers.sql
+++ b/supabase/migrations/20260602000000_add_team_id_to_get_biggest_movers.sql
@@ -78,3 +78,10 @@ AS $$
     END ASC NULLS LAST
   LIMIT p_limit;
 $$;
+
+-- Re-grant execute to authenticated and anon roles. DROP wiped the explicit
+-- grants from 20260206000001_create_get_biggest_movers_rpc.sql; Supabase's
+-- default privileges happen to re-add them, but the migration should be
+-- self-contained so a fresh deploy doesn't depend on env-level defaults.
+-- Frontend infographic routes call this RPC with NEXT_PUBLIC_SUPABASE_ANON_KEY.
+GRANT EXECUTE ON FUNCTION get_biggest_movers TO authenticated, anon;

--- a/supabase/migrations/20260602000000_add_team_id_to_get_biggest_movers.sql
+++ b/supabase/migrations/20260602000000_add_team_id_to_get_biggest_movers.sql
@@ -1,0 +1,80 @@
+-- Extend get_biggest_movers to also return team_id (UUID, sourced from rf.team_id).
+-- Required by the marketing pipeline (Postiz migration) so generators can drive
+-- Instagram @-handle enrichment via team_instagram_handles.
+--
+-- rf.team_id is teams.team_id_master per gotcha_rankings_full_fk_team_id_master.
+--
+-- DROP FUNCTION first: Postgres rejects CREATE OR REPLACE when RETURNS TABLE
+-- changes (42P13: cannot change return type of existing function).
+
+DROP FUNCTION IF EXISTS get_biggest_movers(integer, integer, text, text, text);
+
+CREATE OR REPLACE FUNCTION get_biggest_movers(
+  p_days INT DEFAULT 7,
+  p_limit INT DEFAULT 5,
+  p_direction TEXT DEFAULT 'up',
+  p_age_group TEXT DEFAULT NULL,
+  p_gender TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  team_id UUID,
+  team_name TEXT,
+  club_name TEXT,
+  state_code TEXT,
+  rank_change INT,
+  current_rank INT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    rf.team_id,
+    t.team_name,
+    t.club_name,
+    t.state_code,
+    CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END AS rank_change,
+    COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) AS current_rank
+  FROM rankings_full rf
+  JOIN teams t ON t.team_id_master = rf.team_id
+  WHERE COALESCE(rf.rank_in_cohort_ml, rf.rank_in_cohort) IS NOT NULL
+    AND CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END IS NOT NULL
+    AND (
+      (p_direction = 'up' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END > 0)
+      OR
+      (p_direction = 'down' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END < 0)
+    )
+    AND (
+      p_age_group IS NULL
+      OR LOWER(rf.age_group) = LOWER(p_age_group)
+      OR rf.age_group = REPLACE(LOWER(p_age_group), 'u', '')
+    )
+    AND (
+      p_gender IS NULL
+      OR LOWER(rf.gender) = LOWER(p_gender)
+      OR (LOWER(p_gender) = 'male' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'female' AND rf.gender IN ('F', 'Female', 'Girls'))
+      OR (LOWER(p_gender) = 'm' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'f' AND rf.gender IN ('F', 'Female', 'Girls'))
+    )
+    AND t.is_deprecated IS NOT TRUE
+    -- Exclude teams with fewer than 8 games (unreliable rank swings)
+    AND COALESCE(rf.games_played, 0) >= 8
+    -- Exclude teams that just became ranked
+    AND COALESCE(rf.status, '') != 'Not Enough Ranked Games'
+  ORDER BY
+    CASE
+      WHEN p_direction = 'up' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END DESC NULLS LAST,
+    CASE
+      WHEN p_direction = 'down' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END ASC NULLS LAST
+  LIMIT p_limit;
+$$;

--- a/tests/unit/test_marketing_pipeline.py
+++ b/tests/unit/test_marketing_pipeline.py
@@ -64,21 +64,32 @@ def test_to_postiz_payload_x_single_no_thread_parts():
     assert payload["posts"][0]["value"] == [{"content": "single tweet", "image": []}]
 
 
-def test_to_postiz_payload_instagram_fb_linked_with_media():
-    payload = _to_postiz_payload(_ig_post(), "ig_int_1", "instagram")
+def test_to_postiz_payload_instagram_fb_linked_with_uploaded_media():
+    post = _ig_post()
+    post["_uploaded_media"] = {"id": "u_abc", "path": "https://uploads.postiz.com/x.png"}
+    payload = _to_postiz_payload(post, "ig_int_1", "instagram")
     settings = payload["posts"][0]["settings"]
     assert settings["__type"] == "instagram"
     assert settings["post_type"] == "post"
     assert settings["is_trial_reel"] is False
     assert settings["collaborators"] == []
     assert payload["posts"][0]["value"] == [
-        {"content": "ig caption", "image": [{"path": "https://example.com/img.png"}]}
+        {"content": "ig caption", "image": [{"id": "u_abc", "path": "https://uploads.postiz.com/x.png"}]}
     ]
 
 
 def test_to_postiz_payload_instagram_standalone_uses_identifier_as_type():
-    payload = _to_postiz_payload(_ig_post(), "ig_int_1", "instagram-standalone")
+    post = _ig_post()
+    post["_uploaded_media"] = {"id": "u_abc", "path": "https://uploads.postiz.com/x.png"}
+    payload = _to_postiz_payload(post, "ig_int_1", "instagram-standalone")
     assert payload["posts"][0]["settings"]["__type"] == "instagram-standalone"
+
+
+def test_to_postiz_payload_instagram_raw_media_url_is_ignored_without_upload():
+    # Regression guard: Postiz rejects raw URLs in the image array. Without
+    # _uploaded_media set by the caller, image must be empty even when media_url is present.
+    payload = _to_postiz_payload(_ig_post(media_url="https://example.com/img.png"), "ig_int_1", "instagram")
+    assert payload["posts"][0]["value"][0]["image"] == []
 
 
 def test_to_postiz_payload_instagram_without_media_emits_empty_image():

--- a/tests/unit/test_marketing_pipeline.py
+++ b/tests/unit/test_marketing_pipeline.py
@@ -1,0 +1,400 @@
+"""Unit tests for new pure helpers in scripts/marketing_pipeline.py (Postiz migration)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts import marketing_pipeline as mp
+from scripts.marketing_pipeline import (
+    _resolve_tag_targets,
+    _to_postiz_payload,
+    enrich_post_with_handles,
+    generate_trend_posts,
+)
+
+MT = timezone(timedelta(hours=-6))
+
+
+# ---------------------------------------------------------------------------
+# _to_postiz_payload
+# ---------------------------------------------------------------------------
+
+
+def _x_thread_post():
+    return {
+        "text": "tweet 1\n---\ntweet 2",
+        "media_url": None,
+        "scheduled_at": datetime(2026, 6, 1, 12, 0, tzinfo=MT),
+        "type": "x_thread",
+        "thread_parts": ["tweet 1", "tweet 2"],
+    }
+
+
+def _ig_post(media_url: str | None = "https://example.com/img.png"):
+    return {
+        "text": "ig caption",
+        "media_url": media_url,
+        "scheduled_at": datetime(2026, 6, 1, 12, 0, tzinfo=MT),
+        "type": "rankings_live",
+    }
+
+
+def test_to_postiz_payload_x_thread_multi_entry():
+    payload = _to_postiz_payload(_x_thread_post(), "x_int_1", "x")
+    assert payload["type"] == "draft"
+    assert payload["posts"][0]["integration"]["id"] == "x_int_1"
+    assert payload["posts"][0]["settings"] == {"__type": "x", "who_can_reply_post": "everyone"}
+    assert payload["posts"][0]["value"] == [
+        {"content": "tweet 1", "image": []},
+        {"content": "tweet 2", "image": []},
+    ]
+
+
+def test_to_postiz_payload_x_single_no_thread_parts():
+    post = {
+        "text": "single tweet",
+        "media_url": None,
+        "scheduled_at": datetime(2026, 6, 1, 12, 0, tzinfo=MT),
+        "type": "trend",
+    }
+    payload = _to_postiz_payload(post, "x_int_1", "x")
+    assert payload["posts"][0]["value"] == [{"content": "single tweet", "image": []}]
+
+
+def test_to_postiz_payload_instagram_fb_linked_with_media():
+    payload = _to_postiz_payload(_ig_post(), "ig_int_1", "instagram")
+    settings = payload["posts"][0]["settings"]
+    assert settings["__type"] == "instagram"
+    assert settings["post_type"] == "post"
+    assert settings["is_trial_reel"] is False
+    assert settings["collaborators"] == []
+    assert payload["posts"][0]["value"] == [
+        {"content": "ig caption", "image": [{"path": "https://example.com/img.png"}]}
+    ]
+
+
+def test_to_postiz_payload_instagram_standalone_uses_identifier_as_type():
+    payload = _to_postiz_payload(_ig_post(), "ig_int_1", "instagram-standalone")
+    assert payload["posts"][0]["settings"]["__type"] == "instagram-standalone"
+
+
+def test_to_postiz_payload_instagram_without_media_emits_empty_image():
+    payload = _to_postiz_payload(_ig_post(media_url=None), "ig_int_1", "instagram")
+    assert payload["posts"][0]["value"][0]["image"] == []
+
+
+def test_to_postiz_payload_unknown_platform_raises():
+    with pytest.raises(ValueError, match="Unsupported Postiz platform"):
+        _to_postiz_payload(_ig_post(), "id", "linkedin")
+
+
+def test_to_postiz_payload_envelope_shape():
+    payload = _to_postiz_payload(_x_thread_post(), "id", "x")
+    assert set(payload.keys()) == {"type", "date", "shortLink", "tags", "posts"}
+    assert payload["shortLink"] is False
+    assert payload["tags"] == []
+    assert payload["date"] == "2026-06-01T12:00:00-06:00"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_tag_targets
+# ---------------------------------------------------------------------------
+
+
+def _data(climbers=None, spotlight_teams=None):
+    return {
+        "climbers": climbers if climbers is not None else [],
+        "spotlight_teams": spotlight_teams if spotlight_teams is not None else [],
+    }
+
+
+def test_resolve_tag_targets_rankings_live_picks_first_three_climbers():
+    data = _data(
+        climbers=[
+            {"team_id": "a"},
+            {"team_id": "b"},
+            {"team_id": "c"},
+            {"team_id": "d"},
+        ]
+    )
+    assert _resolve_tag_targets("rankings_live", data) == ["a", "b", "c"]
+
+
+def test_resolve_tag_targets_rankings_live_skips_missing_team_ids():
+    data = _data(climbers=[{"team_id": "a"}, {"team_name": "no id"}, {"team_id": "c"}])
+    assert _resolve_tag_targets("rankings_live", data) == ["a", "c"]
+
+
+def test_resolve_tag_targets_mover_spotlight_prefers_second_climber():
+    data = _data(climbers=[{"team_id": "first"}, {"team_id": "second"}, {"team_id": "third"}])
+    assert _resolve_tag_targets("mover_spotlight", data) == ["second"]
+
+
+def test_resolve_tag_targets_mover_spotlight_falls_back_to_first_when_only_one():
+    data = _data(climbers=[{"team_id": "first"}])
+    assert _resolve_tag_targets("mover_spotlight", data) == ["first"]
+
+
+def test_resolve_tag_targets_mover_spotlight_empty_climbers():
+    data = _data(climbers=[])
+    assert _resolve_tag_targets("mover_spotlight", data) == []
+
+
+def test_resolve_tag_targets_state_spotlight_picks_first_three():
+    data = _data(spotlight_teams=[{"team_id": "x"}, {"team_id": "y"}, {"team_id": "z"}, {"team_id": "w"}])
+    assert _resolve_tag_targets("state_spotlight", data) == ["x", "y", "z"]
+
+
+def test_resolve_tag_targets_state_spotlight_none_returns_empty():
+    data = {"climbers": [], "spotlight_teams": None}
+    assert _resolve_tag_targets("state_spotlight", data) == []
+
+
+@pytest.mark.parametrize("post_type", ["data_flex", "x_thread", "trend", "unknown_future_type"])
+def test_resolve_tag_targets_other_types_return_empty(post_type):
+    data = _data(climbers=[{"team_id": "a"}], spotlight_teams=[{"team_id": "b"}])
+    assert _resolve_tag_targets(post_type, data) == []
+
+
+# ---------------------------------------------------------------------------
+# enrich_post_with_handles
+# ---------------------------------------------------------------------------
+
+
+class _FakeQuery:
+    """Mocks supabase.from_().select().in_().in_().execute()."""
+
+    def __init__(self, rows, raise_on_execute: Exception | None = None):
+        self._rows = rows
+        self._raise = raise_on_execute
+
+    def select(self, *args, **kwargs):
+        return self
+
+    def in_(self, *args, **kwargs):
+        return self
+
+    def execute(self):
+        if self._raise:
+            raise self._raise
+        return type("R", (), {"data": self._rows})()
+
+
+class _FakeSupabase:
+    def __init__(self, rows=None, raise_on_execute: Exception | None = None):
+        self._query = _FakeQuery(rows or [], raise_on_execute)
+
+    def from_(self, table):
+        return self._query
+
+
+def _post(text="caption", post_type="rankings_live"):
+    return {
+        "text": text,
+        "media_url": "https://example.com/img.png",
+        "scheduled_at": datetime(2026, 6, 1, 12, 0, tzinfo=MT),
+        "type": post_type,
+    }
+
+
+def test_enrich_with_empty_targets_writes_zero_stats():
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(), [])
+    assert post["_tag_stats"] == {"tagged_count": 0, "target_count": 0, "missing_team_ids": []}
+    assert post["text"] == "caption"  # unchanged
+
+
+def test_enrich_prefers_team_handle_over_club_for_same_team():
+    rows = [
+        {"team_id": "t1", "handle": "club_a", "profile_level": "club"},
+        {"team_id": "t1", "handle": "team_a", "profile_level": "team"},
+    ]
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows), ["t1"])
+    assert "@team_a" in post["text"]
+    assert "@club_a" not in post["text"]
+    assert post["_tag_stats"]["tagged_count"] == 1
+
+
+def test_enrich_falls_back_to_club_when_no_team_handle():
+    rows = [{"team_id": "t1", "handle": "club_a", "profile_level": "club"}]
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows), ["t1"])
+    assert "@club_a" in post["text"]
+    assert post["_tag_stats"]["missing_team_ids"] == []
+
+
+def test_enrich_dedupes_shared_club_handle_across_siblings():
+    rows = [
+        {"team_id": "t1", "handle": "shared_club", "profile_level": "club"},
+        {"team_id": "t2", "handle": "shared_club", "profile_level": "club"},
+    ]
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows), ["t1", "t2"])
+    # @shared_club appears only once
+    assert post["text"].count("@shared_club") == 1
+    # Both teams are considered "covered" — missing_team_ids is empty
+    assert post["_tag_stats"]["missing_team_ids"] == []
+    # tagged_count reflects unique handles emitted, not unique teams covered
+    assert post["_tag_stats"]["tagged_count"] == 1
+
+
+def test_enrich_dedupe_is_case_insensitive():
+    rows = [
+        {"team_id": "t1", "handle": "Club_A", "profile_level": "team"},
+        {"team_id": "t2", "handle": "club_a", "profile_level": "team"},
+    ]
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows), ["t1", "t2"])
+    assert post["_tag_stats"]["tagged_count"] == 1
+
+
+def test_enrich_caps_at_ten_mentions():
+    rows = [{"team_id": f"t{i}", "handle": f"team_{i}", "profile_level": "team"} for i in range(12)]
+    post = _post()
+    targets = [f"t{i}" for i in range(12)]
+    enrich_post_with_handles(post, _FakeSupabase(rows), targets)
+    assert post["_tag_stats"]["tagged_count"] == 10
+
+
+def test_enrich_truncates_when_caption_would_exceed_2200_chars():
+    rows = [{"team_id": f"t{i}", "handle": "x" * 200, "profile_level": "team"} for i in range(10)]
+    post = _post(text="y" * 2100)  # leaves ~100 chars before 2200 limit
+    enrich_post_with_handles(post, _FakeSupabase(rows), [f"t{i}" for i in range(10)])
+    assert len(post["text"]) <= 2200
+    assert post["_tag_stats"]["tagged_count"] < 10
+
+
+def test_enrich_missing_team_ids_lists_targets_with_no_handle_at_all():
+    rows = [{"team_id": "t1", "handle": "team_a", "profile_level": "team"}]
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows), ["t1", "t2", "t3"])
+    assert set(post["_tag_stats"]["missing_team_ids"]) == {"t2", "t3"}
+    assert post["_tag_stats"]["target_count"] == 3
+
+
+def test_enrich_supabase_exception_writes_error_in_stats_and_leaves_text_unchanged():
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(raise_on_execute=RuntimeError("connection refused")), ["t1", "t2"])
+    assert post["text"] == "caption"
+    stats = post["_tag_stats"]
+    assert stats["tagged_count"] == 0
+    assert stats["target_count"] == 2
+    assert stats["missing_team_ids"] == ["t1", "t2"]
+    assert "connection refused" in stats["error"]
+
+
+def test_enrich_no_handles_found_writes_all_missing():
+    post = _post()
+    enrich_post_with_handles(post, _FakeSupabase(rows=[]), ["t1", "t2"])
+    assert post["_tag_stats"]["tagged_count"] == 0
+    assert post["_tag_stats"]["missing_team_ids"] == ["t1", "t2"]
+    assert "Tagging:" not in post["text"]
+
+
+# ---------------------------------------------------------------------------
+# generate_trend_posts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def trend_root(tmp_path, monkeypatch):
+    """Point PROJECT_ROOT at a tmp_path with an empty brand/trend-research/ dir."""
+    (tmp_path / "brand" / "trend-research").mkdir(parents=True)
+    monkeypatch.setattr(mp, "PROJECT_ROOT", tmp_path)
+    return tmp_path
+
+
+def _trend_data(date: datetime | None = None) -> dict:
+    return {"date": date or datetime(2026, 6, 1, 12, 0, tzinfo=MT)}
+
+
+def _write_trend(root, week: str, payload):
+    path = root / "brand" / "trend-research" / f"{week}.json"
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_generate_trend_posts_missing_file_returns_empty(trend_root):
+    assert generate_trend_posts("2026-W23", _trend_data()) == []
+
+
+def test_generate_trend_posts_malformed_json_returns_empty(trend_root):
+    _write_trend(trend_root, "2026-W23", "not json {")
+    assert generate_trend_posts("2026-W23", _trend_data()) == []
+
+
+def test_generate_trend_posts_week_mismatch_returns_empty(trend_root):
+    _write_trend(trend_root, "2026-W23", {"week": "2099-W01", "posts": [{"suggested_tweet": "x"}]})
+    assert generate_trend_posts("2026-W23", _trend_data()) == []
+
+
+def test_generate_trend_posts_no_valid_entries_returns_empty(trend_root):
+    _write_trend(
+        trend_root,
+        "2026-W23",
+        {"week": "2026-W23", "posts": [{"topic": "no tweet"}, {"suggested_tweet": "   "}]},
+    )
+    assert generate_trend_posts("2026-W23", _trend_data()) == []
+
+
+def test_generate_trend_posts_single_valid_entry(trend_root):
+    _write_trend(
+        trend_root,
+        "2026-W23",
+        {"week": "2026-W23", "posts": [{"suggested_tweet": "tweet content"}]},
+    )
+    posts = generate_trend_posts("2026-W23", _trend_data())
+    assert len(posts) == 1
+    assert posts[0]["text"] == "tweet content"
+    assert posts[0]["type"] == "trend"
+    assert posts[0]["media_url"] is None
+
+
+def test_generate_trend_posts_skips_entries_without_suggested_tweet(trend_root):
+    _write_trend(
+        trend_root,
+        "2026-W23",
+        {
+            "week": "2026-W23",
+            "posts": [
+                {"topic": "no tweet"},
+                {"suggested_tweet": "valid 1"},
+                {"suggested_tweet": ""},
+                {"suggested_tweet": "valid 2"},
+            ],
+        },
+    )
+    posts = generate_trend_posts("2026-W23", _trend_data())
+    assert [p["text"] for p in posts] == ["valid 1", "valid 2"]
+
+
+def test_generate_trend_posts_caps_at_three(trend_root):
+    _write_trend(
+        trend_root,
+        "2026-W23",
+        {"week": "2026-W23", "posts": [{"suggested_tweet": f"tweet {i}"} for i in range(5)]},
+    )
+    posts = generate_trend_posts("2026-W23", _trend_data())
+    assert len(posts) == 3
+    assert [p["text"] for p in posts] == ["tweet 0", "tweet 1", "tweet 2"]
+
+
+def test_generate_trend_posts_schedules_wed_fri_sat_mt(trend_root):
+    # Run from a Monday so the monday-advancement loop is a no-op.
+    monday_jun1 = datetime(2026, 6, 1, 9, 0, tzinfo=MT)
+    _write_trend(
+        trend_root,
+        "2026-W23",
+        {"week": "2026-W23", "posts": [{"suggested_tweet": f"t{i}"} for i in range(3)]},
+    )
+    posts = generate_trend_posts("2026-W23", _trend_data(monday_jun1))
+    # Wed 12:30 PM MT, Fri 9:00 AM MT, Sat 11:00 AM MT
+    assert posts[0]["scheduled_at"] == datetime(2026, 6, 3, 12, 30, tzinfo=MT)
+    assert posts[1]["scheduled_at"] == datetime(2026, 6, 5, 9, 0, tzinfo=MT)
+    assert posts[2]["scheduled_at"] == datetime(2026, 6, 6, 11, 0, tzinfo=MT)


### PR DESCRIPTION
Replaces the weekly marketing pipeline's two-path social posting (Buffer for Instagram, tweepy for X) with a single Postiz draft flow. Every social artifact now lands in Postiz as a draft; the operator approves in the Postiz UI before publish.

New pieces:
- Postiz REST client (`get_postiz_integrations`, `_to_postiz_payload`, `draft_to_postiz`) following the existing Beehiiv REST pattern.
- Instagram @-handle enrichment via `team_instagram_handles` view, confirmed-only by default.
- Weekly trend posts sourced from `brand/trend-research/<ISO-week>.json` (manual operator input from `/last30days`).
- Supabase migration extending `get_biggest_movers` with `team_id` so the enrichment pipeline can join handles.
- Brand fonts (Oswald + DM Sans) and primary logo wired into the three `@vercel/og` infographic routes.

Workflow gated to `workflow_dispatch` only during validation. After two clean cycles, a one-line follow-up PR re-enables the `workflow_run` auto-trigger. Old `BUFFER_ACCESS_TOKEN` and `X_*` GH secrets left in place as rollback insurance, user-gated deletion later.

Coverage: 36 unit tests for the three new pure helpers (`_to_postiz_payload`, `_resolve_tag_targets`, `enrich_post_with_handles`, `generate_trend_posts`).

## Flow

```mermaid
sequenceDiagram
  participant GHA as marketing-pipeline.yml
  participant Pipe as marketing_pipeline.py
  participant DB as Supabase
  participant Postiz
  GHA->>Pipe: python scripts/marketing_pipeline.py
  Pipe->>DB: get_biggest_movers + team_instagram_handles
  Pipe->>Pipe: generate IG + X thread + trend posts
  Pipe->>Pipe: enrich IG captions with @handles
  Pipe->>Postiz: GET /integrations
  Pipe->>Postiz: POST /posts (type=draft) x N
  Postiz-->>Pipe: postId per draft
  Note over Postiz: Operator approves in UI before publish
```

## Test plan

- [x] `pytest tests/unit/test_marketing_pipeline.py` (36 pass)
- [x] `python scripts/marketing_pipeline.py --dry-run` (5/5 drafts, tag stats populated)
- [x] Kill switch (`POSTIZ_DRAFTS_ENABLED=false`) skips all drafts
- [x] Missing trend file falls back to 4/4 drafts
- [ ] One live `gh workflow run marketing-pipeline.yml -f dry_run=false` after PR merge; verify drafts appear in Postiz UI with correct platform routing
- [ ] Operator approves drafts; verify scheduled publish at MT slot windows