### PR TITLE
fix(pipeline): backfill immutable null-score games via service_role RPC

### DIFF
--- a/src/etl/bulk_ops.py
+++ b/src/etl/bulk_ops.py
@@ -16,6 +16,7 @@ from postgrest.exceptions import APIError
 logger = logging.getLogger(__name__)
 
 BULK_UPDATE_RPC = "bulk_update_last_scraped_at"
+BACKFILL_SCORES_RPC = "batch_backfill_null_scores"
 BULK_UPDATE_CHUNK_SIZE = 2000
 BULK_UPDATE_MIN_CHUNK = 125
 PG_UNDEFINED_FUNCTION = "42883"
@@ -119,6 +120,75 @@ def bulk_update_last_scraped_at(
                 continue
             logger.warning(
                 "Error bulk updating last_scraped_at (chunk %d-%d): %s",
+                i,
+                i + len(chunk),
+                err,
+            )
+            # Advance by the chunk we actually attempted, not the pre-shrink
+            # `size`, so a non-413 error mid-halving doesn't skip rows.
+            i += len(chunk)
+            size = chunk_size
+
+    return total_updated
+
+
+def bulk_backfill_null_scores(
+    supabase,
+    updates: List[Dict[str, Any]],
+    *,
+    chunk_size: int = BULK_UPDATE_CHUNK_SIZE,
+    on_missing_function: Optional[Callable[[], int]] = None,
+    missing_function_log: str = "PERF REGRESSION: batch_backfill_null_scores RPC missing: %s",
+) -> int:
+    """Call `batch_backfill_null_scores` in chunks, halving on HTTP 413.
+
+    Returns total rows whose scores were written (may be < len(updates) when
+    the RPC's no-clobber guard skips rows that already have scores or that no
+    longer exist — logged as a warning).
+
+    If the RPC is missing (SQLSTATE 42883) and `on_missing_function` is
+    provided, it is invoked and its return value is returned as the count.
+    Without a fallback, 42883 re-raises.
+    """
+    if not updates:
+        return 0
+
+    total_updated = 0
+    i = 0
+    size = chunk_size
+    while i < len(updates):
+        chunk = updates[i : i + size]
+        try:
+            res = supabase.rpc(BACKFILL_SCORES_RPC, {"updates": chunk}).execute()
+            returned = res.data if isinstance(res.data, int) else len(chunk)
+            total_updated += returned
+            if returned < len(chunk):
+                logger.warning(
+                    "bulk_backfill_null_scores: %d of %d rows updated",
+                    returned,
+                    len(chunk),
+                )
+            i += len(chunk)
+            size = chunk_size
+        except APIError as err:
+            code = getattr(err, "code", None)
+            msg = str(err)
+            if code == PG_UNDEFINED_FUNCTION:
+                if on_missing_function is not None:
+                    logger.error(missing_function_log, err)
+                    return on_missing_function()
+                raise
+            if (code in HTTP_PAYLOAD_TOO_LARGE_CODES or "413" in msg) and size > BULK_UPDATE_MIN_CHUNK:
+                new_size = max(size // 2, BULK_UPDATE_MIN_CHUNK)
+                logger.warning(
+                    "bulk_backfill_null_scores: 413 on chunk size %d, halving to %d",
+                    size,
+                    new_size,
+                )
+                size = new_size
+                continue
+            logger.warning(
+                "Error backfilling null scores (chunk %d-%d): %s",
                 i,
                 i + len(chunk),
                 err,

--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -16,7 +16,11 @@ if _project_root not in sys.path:
     sys.path.append(_project_root)
 
 from config.settings import BUILD_ID, MATCHING_CONFIG, SUPABASE_KEY, SUPABASE_URL  # noqa: E402
-from src.etl.bulk_ops import bulk_update_last_scraped_at, call_rpc_with_fallback  # noqa: E402
+from src.etl.bulk_ops import (  # noqa: E402
+    bulk_backfill_null_scores,
+    bulk_update_last_scraped_at,
+    call_rpc_with_fallback,
+)
 from src.models.game_matcher import GameHistoryMatcher  # noqa: E402
 from src.utils.enhanced_validators import EnhancedDataValidator, parse_game_date  # noqa: E402
 from supabase import Client, create_client  # noqa: E402
@@ -59,6 +63,12 @@ class ImportMetrics:
     duplicate_key_violations: int = 0  # Games rejected due to unique constraint (already in DB)
     duplicate_links_backfilled: int = 0  # Duplicate games where missing master IDs were healed
     scores_backfilled: int = 0  # Null-score games updated with actual scores
+    # Shortfall on the above. Conflates three causes: the immutable-block bug,
+    # the transient missing-RPC deploy window (42883), and benign races where
+    # another worker scored the row first (no-clobber guard skips it). A
+    # non-zero value is a signal to investigate, not a definitive error, and
+    # should trend toward ~0 in steady state post-deploy.
+    scores_backfill_failed: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert metrics to dictionary for JSONB storage"""
@@ -85,6 +95,7 @@ class ImportMetrics:
             "duplicate_key_violations": self.duplicate_key_violations,
             "duplicate_links_backfilled": self.duplicate_links_backfilled,
             "scores_backfilled": self.scores_backfilled,
+            "scores_backfill_failed": self.scores_backfill_failed,
         }
 
 
@@ -751,6 +762,11 @@ class EnhancedETLPipeline:
                             getattr(batch_metrics, "scores_backfilled", 0) + score_bf
                         )
                         self.metrics.scores_backfilled += score_bf
+                        failed = len(null_score_updates) - score_bf
+                        batch_metrics.scores_backfill_failed = (
+                            getattr(batch_metrics, "scores_backfill_failed", 0) + failed
+                        )
+                        self.metrics.scores_backfill_failed += failed
 
                     regen_dupes = len(true_dupes)
                     if regen_dupes > 0:
@@ -1055,6 +1071,8 @@ class EnhancedETLPipeline:
                     f"  Quarantined:     {self.metrics.games_quarantined:,} games\n"
                     f"  Duplicates:      {self.metrics.duplicates_found:,} games (already in DB)\n"
                     f"  Links backfilled:{self.metrics.duplicate_links_backfilled:,} healed\n"
+                    f"  Scores backfilled:{self.metrics.scores_backfilled:,} "
+                    f"({self.metrics.scores_backfill_failed:,} failed)\n"
                     f"  Perspective dup: {self.metrics.duplicates_skipped:,} skipped\n"
                     f"  Processing rate: {games_per_sec:.1f} games/sec\n"
                     f"  Elapsed time:    {elapsed_time / 60:.1f} minutes\n"
@@ -1592,7 +1610,13 @@ class EnhancedETLPipeline:
     async def _update_null_score_games(
         self, games_to_update: List[Dict], game_uid_to_master_ids: Dict[str, Dict]
     ) -> int:
-        """Update existing games that have null scores with actual scores from a re-scrape."""
+        """Update existing games that have null scores with actual scores from a re-scrape.
+
+        Routes through the ``batch_backfill_null_scores`` RPC, which toggles
+        is_immutable off -> writes scores (only on rows still NULL) -> on. A raw
+        ``.update()`` is rejected by the prevent_game_updates trigger because
+        scheduled rows are inserted with is_immutable=True.
+        """
         if not games_to_update:
             return 0
 
@@ -1600,7 +1624,7 @@ class EnhancedETLPipeline:
             logger.info(f"[Pipeline] Dry run: would backfill scores on {len(games_to_update)} null-score games")
             return 0
 
-        updated = 0
+        payload = []
         for game in games_to_update:
             game_uid = game.get("game_uid")
             home_score = game.get("home_score")
@@ -1616,21 +1640,32 @@ class EnhancedETLPipeline:
             except (ValueError, TypeError):
                 continue
 
-            try:
-                self.supabase.table("games").update({
+            payload.append(
+                {
+                    "game_uid": game_uid,
                     "home_score": home_score_int,
                     "away_score": away_score_int,
                     "result": result,
                     "scraped_at": game.get("scraped_at"),
-                }).eq("game_uid", game_uid).execute()
-                updated += 1
-                logger.info(
-                    f"[Pipeline] Backfilled scores on {game_uid}: "
-                    f"{home_score_int}-{away_score_int} (result={result})"
-                )
-            except Exception as e:
-                logger.error(f"[Pipeline] Failed to backfill scores on {game_uid}: {e}")
+                }
+            )
 
+        if not payload:
+            return 0
+
+        updated = bulk_backfill_null_scores(self.supabase, payload, on_missing_function=lambda: 0)
+
+        # Surface, don't swallow: a shortfall is the immutable-block bug, the
+        # transient missing-RPC deploy window (42883 -> 0), or a benign race
+        # where another worker scored the row first (no-clobber guard skips it).
+        failed = len(payload) - updated
+        if failed > 0:
+            logger.warning(
+                "[Pipeline] %d/%d null-score backfills did not land "
+                "(immutable-block, missing RPC, or already-scored by a concurrent scrape)",
+                failed,
+                len(payload),
+            )
         if updated:
             logger.info(f"[Pipeline] Backfilled scores on {updated} previously null-score games")
         return updated
@@ -1951,6 +1986,9 @@ class EnhancedETLPipeline:
                 "provider_id": self.provider_id,
                 "source_url": game.get("source_url"),
                 "scraped_at": game.get("scraped_at"),
+                # Scheduled null-score rows are intentionally immutable; final
+                # scores are written via the batch_backfill_null_scores RPC
+                # (toggle off/on), not by flipping this to False.
                 "is_immutable": True,
                 "original_import_id": None,  # Can be set to build_id if needed
                 # CRITICAL: Include age_group and mls_division for Modular11 unique constraint

--- a/supabase/migrations/20260602000000_add_batch_backfill_null_scores.sql
+++ b/supabase/migrations/20260602000000_add_batch_backfill_null_scores.sql
@@ -36,6 +36,12 @@ BEGIN
     WHERE game_uid = ANY(v_targets);
 
     -- Statement 2: write scores while mutable, capturing rows actually changed.
+    -- The home_score/away_score IS NULL re-check here (not only at v_targets
+    -- resolution) makes the no-clobber guard hold under concurrency: if another
+    -- worker committed a score for this game after we built v_targets, READ
+    -- COMMITTED re-evaluates this predicate against the latest row version and
+    -- skips it, so a stale v_targets cannot overwrite a score another worker
+    -- already landed (both teams in a matchup can be scraped concurrently).
     -- result is CHAR(1) with CHECK (result IN ('W','L','D','U')). LEFT(u.result, 1)
     -- guards only the length error ("value too long for character(1)"); a single
     -- char outside the CHECK set (e.g. 'X') would still abort the whole chunk.
@@ -47,7 +53,10 @@ BEGIN
         scraped_at = COALESCE(u.scraped_at, now())
     FROM jsonb_to_recordset(updates)
         AS u(game_uid TEXT, home_score INTEGER, away_score INTEGER, result TEXT, scraped_at TIMESTAMPTZ)
-    WHERE g.game_uid = u.game_uid AND g.game_uid = ANY(v_targets);
+    WHERE g.game_uid = u.game_uid
+      AND g.game_uid = ANY(v_targets)
+      AND g.home_score IS NULL
+      AND g.away_score IS NULL;
 
     GET DIAGNOSTICS v_count = ROW_COUNT;
 

--- a/supabase/migrations/20260602000000_add_batch_backfill_null_scores.sql
+++ b/supabase/migrations/20260602000000_add_batch_backfill_null_scores.sql
@@ -1,0 +1,76 @@
+-- Backfill final scores onto previously null-score (scheduled) game rows.
+--
+-- Scheduled GotSport games are inserted ahead of kickoff with NULL scores and
+-- is_immutable=TRUE. The prevent_game_updates trigger blocks a raw score UPDATE
+-- on those rows, so a direct .update() silently fails. This RPC mirrors
+-- apply_game_correction's toggle sequence (off -> write -> on): each statement
+-- changes a disjoint field set, so each passes the trigger's Exception 1
+-- (is_immutable toggle with scores/teams/date unchanged).
+
+CREATE OR REPLACE FUNCTION batch_backfill_null_scores(
+    updates JSONB
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_targets TEXT[];
+    v_count INTEGER := 0;
+BEGIN
+    -- No-clobber guard: only rows that exist AND still have NULL scores are
+    -- eligible. A second call after scores land selects nothing and returns 0.
+    SELECT array_agg(g.game_uid) INTO v_targets
+    FROM games g
+    JOIN jsonb_to_recordset(updates) AS u(game_uid TEXT) ON g.game_uid = u.game_uid
+    WHERE g.home_score IS NULL AND g.away_score IS NULL;
+
+    IF v_targets IS NULL THEN
+        RETURN 0;
+    END IF;
+
+    -- Statement 1: toggle immutability off (passes trigger Exception 1).
+    UPDATE games
+    SET is_immutable = FALSE
+    WHERE game_uid = ANY(v_targets);
+
+    -- Statement 2: write scores while mutable, capturing rows actually changed.
+    -- result is CHAR(1) with CHECK (result IN ('W','L','D','U')). LEFT(u.result, 1)
+    -- guards only the length error ("value too long for character(1)"); a single
+    -- char outside the CHECK set (e.g. 'X') would still abort the whole chunk.
+    -- Current callers (GotSport) emit only W/L/D/None, all valid.
+    UPDATE games g
+    SET home_score = u.home_score,
+        away_score = u.away_score,
+        result = LEFT(u.result, 1)::CHAR(1),
+        scraped_at = COALESCE(u.scraped_at, now())
+    FROM jsonb_to_recordset(updates)
+        AS u(game_uid TEXT, home_score INTEGER, away_score INTEGER, result TEXT, scraped_at TIMESTAMPTZ)
+    WHERE g.game_uid = u.game_uid AND g.game_uid = ANY(v_targets);
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+
+    -- Statement 3: re-lock (passes Exception 1, scores now unchanged).
+    UPDATE games
+    SET is_immutable = TRUE
+    WHERE game_uid = ANY(v_targets);
+
+    RETURN v_count;
+END;
+$$;
+
+-- Restrict execution to service_role (the server-side ETL pipeline). This RPC
+-- is SECURITY DEFINER (bypasses RLS) and writes core result fields, so it must
+-- NOT be callable by anon/authenticated. Postgres grants EXECUTE to PUBLIC by
+-- default and anon/authenticated inherit PUBLIC, so REVOKE that before granting.
+REVOKE EXECUTE ON FUNCTION batch_backfill_null_scores(JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION batch_backfill_null_scores(JSONB) TO service_role;
+
+COMMENT ON FUNCTION batch_backfill_null_scores(JSONB) IS
+'Backfill final scores onto previously null-score (scheduled) game rows.
+Takes a JSONB array of {game_uid, home_score, away_score, result, scraped_at} objects.
+Toggles is_immutable off -> writes scores (only where existing scores are NULL,
+the no-clobber guard) -> toggles immutability back on, working with the
+prevent_game_updates trigger via its is_immutable-toggle exception.
+Returns the number of rows whose scores were written.';

--- a/tests/test_enhanced_pipeline.py
+++ b/tests/test_enhanced_pipeline.py
@@ -477,6 +477,136 @@ class TestBackfillDuplicateTeamLinks:
         assert result['duplicate_links_backfilled'] == 5
 
 
+class TestUpdateNullScoreGames:
+    """_update_null_score_games must route through the batch_backfill_null_scores
+    RPC (toggle-based) instead of the immutable-blocked raw .update()."""
+
+    @pytest.fixture
+    def mock_supabase(self):
+        """Mock Supabase client sufficient for pipeline construction."""
+        supabase = Mock()
+
+        provider_result = Mock()
+        provider_result.data = {'id': 'test-provider-uuid'}
+        supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = provider_result
+
+        supabase.table.return_value.insert.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.in_.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.limit.return_value.execute.return_value.data = []
+        supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.range.return_value.execute.return_value.data = []
+
+        return supabase
+
+    def _build_pipeline(self, supabase, dry_run=False):
+        return EnhancedETLPipeline(supabase, 'gotsport', dry_run=dry_run)
+
+    @pytest.mark.asyncio
+    async def test_calls_rpc_with_payload_not_raw_update(self, mock_supabase):
+        """Builds the JSONB payload and calls the RPC; the raw .update() is gone."""
+        pipeline = self._build_pipeline(mock_supabase)
+
+        rpc_result = Mock()
+        rpc_result.data = 1
+        mock_supabase.rpc.return_value.execute.return_value = rpc_result
+
+        games = [{
+            'game_uid': 'gs:2026-05-31:111:222',
+            'home_score': 2,
+            'away_score': 1,
+            'result': 'W',
+            'scraped_at': '2026-06-01T22:54:00+00:00',
+        }]
+
+        updated = await pipeline._update_null_score_games(games, {})
+
+        assert updated == 1
+        mock_supabase.rpc.assert_called_once_with(
+            'batch_backfill_null_scores',
+            {'updates': [{
+                'game_uid': 'gs:2026-05-31:111:222',
+                'home_score': 2,
+                'away_score': 1,
+                'result': 'W',
+                'scraped_at': '2026-06-01T22:54:00+00:00',
+            }]},
+        )
+        mock_supabase.table.return_value.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_coerces_float_scores_and_skips_invalid_rows(self, mock_supabase):
+        """Float/string scores are coerced to int; rows missing uid or scores are dropped."""
+        pipeline = self._build_pipeline(mock_supabase)
+
+        rpc_result = Mock()
+        rpc_result.data = 1
+        mock_supabase.rpc.return_value.execute.return_value = rpc_result
+
+        games = [
+            {'game_uid': 'g-ok', 'home_score': '3.0', 'away_score': 2.0, 'result': 'W', 'scraped_at': None},
+            {'game_uid': 'g-null', 'home_score': None, 'away_score': None, 'result': None},
+            {'game_uid': None, 'home_score': 1, 'away_score': 0, 'result': 'W'},
+            {'game_uid': 'g-bad', 'home_score': 'abc', 'away_score': 'xyz', 'result': 'U'},
+        ]
+
+        updated = await pipeline._update_null_score_games(games, {})
+
+        assert updated == 1
+        mock_supabase.rpc.assert_called_once_with(
+            'batch_backfill_null_scores',
+            {'updates': [{
+                'game_uid': 'g-ok',
+                'home_score': 3,
+                'away_score': 2,
+                'result': 'W',
+                'scraped_at': None,
+            }]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_valid_rows_skips_rpc(self, mock_supabase):
+        """An all-invalid batch makes no RPC call and returns 0."""
+        pipeline = self._build_pipeline(mock_supabase)
+
+        games = [{'game_uid': 'g-null', 'home_score': None, 'away_score': None, 'result': None}]
+        updated = await pipeline._update_null_score_games(games, {})
+
+        assert updated == 0
+        mock_supabase.rpc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shortfall_does_not_raise(self, mock_supabase):
+        """RPC writing fewer rows than submitted (no-clobber/race) is reported, not fatal."""
+        pipeline = self._build_pipeline(mock_supabase)
+
+        rpc_result = Mock()
+        rpc_result.data = 0  # No-clobber guard skipped an already-scored row
+        mock_supabase.rpc.return_value.execute.return_value = rpc_result
+
+        games = [{'game_uid': 'g1', 'home_score': 2, 'away_score': 1, 'result': 'W', 'scraped_at': None}]
+        updated = await pipeline._update_null_score_games(games, {})
+
+        assert updated == 0
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self, mock_supabase):
+        """Dry-run mode must not call the RPC."""
+        pipeline = self._build_pipeline(mock_supabase, dry_run=True)
+
+        games = [{'game_uid': 'g1', 'home_score': 2, 'away_score': 1, 'result': 'W'}]
+        updated = await pipeline._update_null_score_games(games, {})
+
+        assert updated == 0
+        mock_supabase.rpc.assert_not_called()
+
+    def test_metrics_includes_scores_backfill_failed(self):
+        """ImportMetrics.to_dict() must include scores_backfill_failed."""
+        metrics = ImportMetrics()
+        metrics.scores_backfill_failed = 3
+        result = metrics.to_dict()
+        assert result['scores_backfill_failed'] == 3
+
+
 class TestFutureDateHelper:
     """Tests for the _is_future_game helper used by the scheduled-game carveout."""
 

--- a/tests/unit/test_bulk_ops.py
+++ b/tests/unit/test_bulk_ops.py
@@ -10,6 +10,7 @@ from src.etl.bulk_ops import (
     BULK_UPDATE_CHUNK_SIZE,
     BULK_UPDATE_MIN_CHUNK,
     RPC_RESULT_LIMIT,
+    bulk_backfill_null_scores,
     bulk_update_last_scraped_at,
     call_rpc_with_fallback,
 )
@@ -174,6 +175,106 @@ def test_non_int_response_data_falls_back_to_chunk_length():
     sb = StubSupabase([SimpleNamespace(data=None)])
     payload = [{"team_id_master": f"t{i}", "last_scraped_at": "2026-04-22T00:00:00"} for i in range(4)]
     assert bulk_update_last_scraped_at(sb, payload) == 4
+
+
+# ---------- bulk_backfill_null_scores ----------
+
+
+def _score_updates(n: int):
+    return [
+        {"game_uid": f"g{i}", "home_score": 1, "away_score": 0, "result": "W", "scraped_at": None} for i in range(n)
+    ]
+
+
+def test_backfill_empty_payload_short_circuits_without_calling_supabase():
+    sb = StubSupabase()
+    assert bulk_backfill_null_scores(sb, []) == 0
+    assert sb.calls == []
+
+
+def test_backfill_single_chunk_happy_path_returns_rpc_rowcount():
+    sb = StubSupabase([SimpleNamespace(data=10)])
+    assert bulk_backfill_null_scores(sb, _score_updates(10)) == 10
+    assert len(sb.calls) == 1
+    assert sb.calls[0][0] == "batch_backfill_null_scores"
+    assert len(sb.calls[0][1]["updates"]) == 10
+
+
+def test_backfill_multiple_chunks_sum_returned_counts():
+    sb = StubSupabase([SimpleNamespace(data=10), SimpleNamespace(data=5)])
+    total = bulk_backfill_null_scores(sb, _score_updates(15), chunk_size=10)
+    assert total == 15
+    assert [len(call[1]["updates"]) for call in sb.calls] == [10, 5]
+
+
+def test_backfill_partial_rowcount_warns_but_still_accumulates(caplog):
+    # RPC writes 8 of 10 — the no-clobber guard skipped 2 already-scored rows.
+    sb = StubSupabase([SimpleNamespace(data=8)])
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="src.etl.bulk_ops")
+    assert bulk_backfill_null_scores(sb, _score_updates(10)) == 8
+    assert any("8 of 10 rows updated" in rec.message for rec in caplog.records)
+
+
+def test_backfill_42883_without_fallback_reraises():
+    sb = StubSupabase([_api_error(code="42883")])
+    with pytest.raises(APIError) as excinfo:
+        bulk_backfill_null_scores(sb, _score_updates(1))
+    assert getattr(excinfo.value, "code", None) == "42883"
+
+
+def test_backfill_42883_with_fallback_invokes_fallback_and_returns_its_count():
+    sb = StubSupabase([_api_error(code="42883")])
+    fallback_invocations = []
+
+    def fallback():
+        fallback_invocations.append(True)
+        return 7
+
+    total = bulk_backfill_null_scores(sb, _score_updates(3), on_missing_function=fallback)
+    assert total == 7
+    assert len(fallback_invocations) == 1
+    # Only one RPC attempt — the helper gives up immediately on 42883.
+    assert len(sb.calls) == 1
+
+
+def test_backfill_413_halves_chunk_and_retries():
+    sb = StubSupabase(
+        [
+            _api_error(code=413, message="payload too large 413"),
+            SimpleNamespace(data=125),
+            SimpleNamespace(data=75),
+        ]
+    )
+    total = bulk_backfill_null_scores(sb, _score_updates(200), chunk_size=200)
+    assert total == 200
+    assert [len(c[1]["updates"]) for c in sb.calls] == [200, 125, 75]
+
+
+def test_backfill_413_halving_floors_at_min_chunk():
+    # A 413 at the floor chunk size must skip the chunk, not infinite-loop.
+    sb = StubSupabase([_api_error(code=413, message="413 still too big")])
+    total = bulk_backfill_null_scores(sb, _score_updates(125), chunk_size=125)
+    assert total == 0
+    assert len(sb.calls) == 1
+
+
+def test_backfill_non_413_api_error_skips_chunk_and_continues():
+    sb = StubSupabase(
+        [
+            _api_error(code="23505", message="unique violation"),  # chunk 1 fails
+            SimpleNamespace(data=5),  # chunk 2 succeeds
+        ]
+    )
+    total = bulk_backfill_null_scores(sb, _score_updates(10), chunk_size=5)
+    assert total == 5
+    assert len(sb.calls) == 2
+
+
+def test_backfill_non_int_response_data_falls_back_to_chunk_length():
+    sb = StubSupabase([SimpleNamespace(data=None)])
+    assert bulk_backfill_null_scores(sb, _score_updates(4)) == 4
 
 
 # ---------- call_rpc_with_fallback ----------


### PR DESCRIPTION
PR #845's `_update_null_score_games` was a no-op in production. Scheduled GotSport games are inserted with `is_immutable=TRUE`, so its raw `.update()` hit the `prevent_game_updates` trigger ("Cannot update immutable game") and the exception was swallowed (`logger.error` then `continue`). Final scores silently never landed. At investigation time ~26k past-dated null-score immutable rows were stuck, plus ~16k future scheduled rows that would stick the same way once played.

## Fix

Route null to final score writes through a new `SECURITY DEFINER` RPC `batch_backfill_null_scores(updates jsonb)` (migration `20260602000000`). It resolves the still-NULL target rows (no-clobber guard), toggles `is_immutable` off, writes the scores, then toggles it back on. Each statement changes a disjoint field set, so each passes the trigger's is_immutable-toggle exception. Same mechanism as `apply_game_correction`. `result` is written as `LEFT(u.result, 1)::CHAR(1)` so a malformed multi-char value can't abort the whole chunk.

`_update_null_score_games` now builds a JSONB payload and calls a chunked `bulk_ops` helper (`bulk_backfill_null_scores`, mirroring `bulk_update_last_scraped_at`: 413 halving, 42883 fallback). Shortfalls surface via a new `scores_backfill_failed` metric in `ImportMetrics.to_dict()` and the PROGRESS UPDATE log instead of being swallowed.

The RPC is locked to `service_role` (`REVOKE EXECUTE FROM PUBLIC`, no anon/authenticated grant): it bypasses RLS and writes core result fields, and the only caller is the server-side pipeline.

## Flow

```mermaid
sequenceDiagram
  Scraper->>Pipeline: re-scrape full team history
  Pipeline->>RPC: batch_backfill_null_scores(updates)
  RPC->>games: is_immutable = FALSE (still-NULL targets)
  RPC->>games: write home/away/result
  RPC->>games: is_immutable = TRUE
  RPC-->>Pipeline: rows written
```

## Backlog

No backfill script. The ~26k stuck rows heal on each team's next full-history re-scrape (yesterday-enqueue, weekly discovery, 90-day safety net, or a user-clicked scrape), which routes their old null rows through the fixed path. Teams that never get scraped again stay blank, which is acceptable.

## Deploy ordering

Apply the migration before or with the pipeline code so the `42883` (RPC-missing) fallback window is minimized. If the code ships first, backfills are counted as failed (not lost) until the migration lands, then heal on the next scrape.

## Tests

Unit tests for `bulk_backfill_null_scores` (`tests/unit/test_bulk_ops.py`, branch parity with its sibling) and `_update_null_score_games` (`tests/test_enhanced_pipeline.py`). The 3 failing tests in `tests/test_enhanced_pipeline.py` (`test_game_validation`, `test_validate_game_edge_cases`, `test_validate_batch`) are already red on `main`, unrelated to this change.
