### PR TITLE
feat(marketing): trend research autopilot (rotation + routine spec)

### DIFF
--- a/brand/trend-topics.json
+++ b/brand/trend-topics.json
@@ -1,0 +1,86 @@
+[
+  {
+    "key": "ecnl-news",
+    "label": "ECNL news and storylines",
+    "search_prompt": "ECNL youth soccer news, controversies, results, expansion, and roster movement in the last 30 days. Look on Reddit (r/youthsoccer, r/USsoccer), X, YouTube, and youth soccer media. Focus on what parents and coaches are actually arguing about, not press releases.",
+    "voice_angle": "PitchRank tracks every ECNL team on the same scale as state-league teams. When ECNL teams over- or under-perform their reputation, the data shows it.",
+    "fallback_cta": "See how ECNL teams stack up: pitchrank.io/rankings"
+  },
+  {
+    "key": "mls-next-news",
+    "label": "MLS NEXT news and storylines",
+    "search_prompt": "MLS NEXT youth soccer news, results, club changes, controversies, and roster moves in the last 30 days. Reddit, X, YouTube, youth soccer media. What are parents debating?",
+    "voice_angle": "MLS NEXT and ECNL get treated as tiers, but the data shows enormous variance inside each. PitchRank ranks them apples-to-apples.",
+    "fallback_cta": "Compare MLS NEXT vs ECNL teams head to head: pitchrank.io/rankings"
+  },
+  {
+    "key": "youth-tournament-results",
+    "label": "Major youth tournament results and aftermath",
+    "search_prompt": "Recent youth soccer tournament results and post-event chatter from the last 30 days. Surf Cup, Disney Showcase, Generation adidas Cup, Jefferson Cup, Players College Showcase, ECNL national events, MLS NEXT Cup, state cups. Focus on standout teams, upsets, and recruiting narratives. Reddit, X, club Instagrams, soccer media.",
+    "voice_angle": "Tournament champions get the headlines. PitchRank shows whether they're actually that good or just rode a soft bracket. Margins, strength of schedule, season-long signal.",
+    "fallback_cta": "See if tournament winners hold up over a full season: pitchrank.io/rankings"
+  },
+  {
+    "key": "college-recruiting",
+    "label": "College soccer recruiting and commitments",
+    "search_prompt": "Youth soccer college recruiting and commitment news in the last 30 days. Class of 2026-2028 commitments, NIL, transfer portal trickle-down to youth, recruiting controversies. Reddit, X, TopDrawerSoccer-style coverage, Instagram, YouTube.",
+    "voice_angle": "Recruiting follows reputation as much as performance. PitchRank surfaces under-the-radar teams whose data outpaces their visibility — the kind college coaches should be tracking.",
+    "fallback_cta": "Find teams that out-perform their reputation: pitchrank.io/rankings"
+  },
+  {
+    "key": "girls-youth-soccer",
+    "label": "Girls youth soccer storylines",
+    "search_prompt": "Girls youth soccer news, results, recruiting, and parent-side debates in the last 30 days. ECNL Girls, GA, NWSL Academy news, women's college pipeline. Reddit (r/youthsoccer, r/USWNT), X, Instagram, soccer media.",
+    "voice_angle": "Girls youth rankings get a fraction of the coverage boys do. PitchRank ranks both with the same algorithm — girls teams move on the same leaderboard, no separate-but-equal disclaimer.",
+    "fallback_cta": "See the top girls teams nationally: pitchrank.io/rankings"
+  },
+  {
+    "key": "tryout-season",
+    "label": "Tryout season and club selection",
+    "search_prompt": "Youth soccer tryout season debates, club-switching stories, parent decision-making about where to play, fees and travel concerns, last 30 days. Reddit (r/youthsoccer), X, parent Facebook groups (via search), club Instagrams.",
+    "voice_angle": "Parents pick clubs on logos, friends, and word of mouth. PitchRank lets them check whether the team actually performs against the alternatives in their area.",
+    "fallback_cta": "Compare clubs before tryouts: pitchrank.io/rankings"
+  },
+  {
+    "key": "fees-travel-costs",
+    "label": "Youth soccer costs, fees, and travel debates",
+    "search_prompt": "Youth soccer cost-of-play debates in the last 30 days: club fees, tournament travel, ECNL/MLS NEXT pricing, pay-to-play criticism, financial accessibility. Reddit (r/youthsoccer, r/USsoccer), X, podcast clips, news coverage.",
+    "voice_angle": "Parents are spending $5K-$15K a year. PitchRank gives them one of the few objective ways to tell whether the team's actually delivering performance for the price.",
+    "fallback_cta": "See if your club's results match its fees: pitchrank.io/rankings"
+  },
+  {
+    "key": "rankings-controversy",
+    "label": "Youth soccer rankings methodology debates",
+    "search_prompt": "Debates and complaints about how youth soccer teams get ranked in the last 30 days. GotSoccer rankings, USClubSoccer rankings, TopDrawerSoccer rankings, ECNL/MLS NEXT power rankings, tournament seeding controversies. Reddit, X, coaching forums.",
+    "voice_angle": "Most ranking systems are reputation or tournament points. PitchRank uses actual game results, opponent strength, and margins. When other systems get it wrong, the data points to why.",
+    "fallback_cta": "See rankings that show their work: pitchrank.io/rankings"
+  },
+  {
+    "key": "coaching-development",
+    "label": "Coaching, training methodology, player development",
+    "search_prompt": "Youth soccer coaching debates, training methodology, player development pipeline news in the last 30 days. US Soccer policy, DOC moves, coaching education, club philosophies. Reddit (r/bootroom, r/youthsoccer), X, coaching podcasts.",
+    "voice_angle": "Good coaching shows up in results over time. PitchRank surfaces clubs whose teams consistently outperform — usually the development stories worth studying.",
+    "fallback_cta": "See clubs whose results compound year over year: pitchrank.io/rankings"
+  },
+  {
+    "key": "regional-powerhouses",
+    "label": "Regional youth soccer powerhouse storylines",
+    "search_prompt": "Stories about which states, regions, or specific clubs are dominating youth soccer right now, last 30 days. SoCal vs East Coast debates, Texas surge, Florida, Mid-Atlantic, Midwest. Reddit, X, regional soccer media, club Instagrams.",
+    "voice_angle": "Geography drives a lot of strength-of-schedule. PitchRank's cross-region calibration lets parents see whether their local 'top team' would hold up against the national field.",
+    "fallback_cta": "See your state's top teams against the national field: pitchrank.io/rankings"
+  },
+  {
+    "key": "pro-pathway-academy",
+    "label": "Pre-Academy, MLS NEXT Pro, pro pathway stories",
+    "search_prompt": "Youth-to-pro pathway news in the last 30 days: MLS NEXT Pro signings, academy contracts, homegrown players, USL Academy, USYNT call-ups, European trial trips. Reddit, X, soccer media, club press.",
+    "voice_angle": "The pro pathway is narrow and lopsided. PitchRank shows which youth teams are genuinely producing — not which clubs hire the best PR.",
+    "fallback_cta": "See which youth clubs actually produce: pitchrank.io/rankings"
+  },
+  {
+    "key": "youth-soccer-discourse",
+    "label": "Open-ended youth soccer parent and coach discourse",
+    "search_prompt": "Open-ended chatter and debates among youth soccer parents and coaches in the last 30 days. Anything trending — could be a viral X post, a Reddit thread that blew up, a podcast clip, a viral coach quote. Cast a wide net on Reddit, X, YouTube, TikTok.",
+    "voice_angle": "Whatever's trending, PitchRank's angle is always the same: data over vibes, results over reputation, every team on the same scale.",
+    "fallback_cta": "Settle the argument with data: pitchrank.io/rankings"
+  }
+]

--- a/docs/marketing/trend-research-routine.md
+++ b/docs/marketing/trend-research-routine.md
@@ -1,0 +1,126 @@
+# Weekly Trend Research Routine
+
+This is the prompt to register with `/schedule` so the marketing pipeline has a
+trend-research file ready every Monday. The routine runs Sunday night MT, picks
+a topic from `brand/trend-topics.json`, researches what people are saying via
+`/last30days`, drafts three on-brand X posts, and commits the result to
+`brand/trend-research/<ISO-week>.json` on `main`.
+
+## Schedule
+
+Sunday 9:00 PM MT (cron in UTC: `0 3 * * 1` — Monday 03:00 UTC = Sunday 21:00 MDT)
+
+## Prompt to register
+
+```
+You are the weekly PitchRank trend research routine. Run this every Sunday night MT
+so brand/trend-research/<current-ISO-week>.json exists before the Monday marketing
+pipeline fires.
+
+Working directory: C:/PitchRank (or whatever the repo path is in this environment).
+Always work on a fresh branch off origin/main: `trend-research-<ISO-week>`.
+
+Steps:
+
+1. Compute the current ISO week:
+   `python -c "from datetime import datetime; print(datetime.now().strftime('%G-W%V'))"`
+   Call this WEEK_ISO (e.g., "2026-W24").
+
+2. Skip if brand/trend-research/<WEEK_ISO>.json already exists in origin/main.
+   Log "Trend research for <WEEK_ISO> already present, skipping" and exit 0.
+
+3. Read brand/trend-topics.json. Compute the rotation index:
+   ```python
+   import json
+   from datetime import datetime
+   topics = json.load(open("brand/trend-topics.json"))
+   week_num = int(datetime.now().strftime("%V"))
+   topic = topics[(week_num - 1) % len(topics)]
+   ```
+   Log the picked topic's `label`.
+
+4. Run /last30days with the topic's `search_prompt` as the query. The skill returns
+   real posts, engagement counts, and source URLs across Reddit, X, YouTube, TikTok,
+   Hacker News, Polymarket, GitHub, and the web.
+
+5. Synthesize 3 trend X posts from the research. Each post must:
+   - Be a single X post under 280 chars (no thread).
+   - Reference what people are actually saying or arguing about this week,
+     not a generic evergreen take.
+   - End with the topic's `fallback_cta` or a tighter brand-on CTA pointing
+     to pitchrank.io/rankings.
+   - Match PitchRank brand voice (see Brand Voice section below).
+   - Have a real `source_url` from the /last30days research output.
+
+6. If you can't produce 3 distinct, on-brand posts from the picked topic (rare
+   topic, slow week), fall back: ask yourself "what's the single most-discussed
+   youth-soccer storyline in the last 30 days?", run /last30days on that, and
+   try again. Log "fell back to dynamic topic: <topic>".
+
+7. Write brand/trend-research/<WEEK_ISO>.json with this exact shape:
+   ```json
+   {
+     "week": "2026-W24",
+     "posts": [
+       {
+         "topic": "<short label of what the post reacts to>",
+         "hook": "<one-line internal note on the angle>",
+         "suggested_tweet": "<the actual post text, < 280 chars>",
+         "source_url": "<URL of the post/article being reacted to>"
+       }
+     ]
+   }
+   ```
+
+8. Validate the file:
+   - Parses as JSON.
+   - `week` matches WEEK_ISO.
+   - Exactly 3 entries.
+   - Each `suggested_tweet` is non-empty, < 280 chars, references rankings or
+     pitchrank.io somewhere.
+
+9. Commit on the new branch, push, and open a PR titled
+   "trend research: <WEEK_ISO>" with body summarizing the topic picked and a
+   one-line preview of each tweet. Use [skip ci] in the commit message so the
+   marketing pipeline doesn't fire twice. Label the PR `auto-merge` if that
+   label exists; otherwise leave it for manual merge.
+
+10. Auto-merge if all checks pass and the auto-merge label is set. If anything
+    blocks merge, leave the PR open and ping the operator with a one-line
+    Telegram reply via the telegram skill.
+
+If anything fails fatally, exit 1 with a clear log line and ping the operator
+via the telegram skill. Do not commit a half-formed JSON.
+
+## Brand Voice
+
+Apply all PitchRank brand rules:
+
+- Domain is pitchrank.io, never pitchrank.com.
+- Never name the engine "Glicko-2" in user-facing copy. Say "rating engine"
+  or "rating algorithm".
+- Use "group" not "cohort" in user-facing copy.
+- Don't quote PowerScore tier thresholds in public posts.
+- Voice: data over vibes, results over reputation, every team on the same
+  scale. Confident but not cocky. No emojis unless the topic itself is
+  emoji-driven.
+- Don't fabricate product features. Cross-check against any product-marketing
+  spec if uncertain (.agents/product-marketing.md if present).
+
+## Failure modes to refuse
+
+- Never commit research that fabricates engagement numbers or invents source URLs.
+- Never invent quotes or attribute statements to real people.
+- If /last30days returns nothing useful for the topic, fall back per Step 6
+  instead of padding with generic evergreen content.
+- If the fallback also fails, leave the file uncreated. The pipeline handles
+  missing files gracefully (skips trend posts, logs an error).
+```
+
+## Reference
+
+- Pipeline consumer: `scripts/marketing_pipeline.py:generate_trend_posts`
+- Topic source: `brand/trend-topics.json`
+- Output target: `brand/trend-research/<ISO-week>.json`
+- Marketing pipeline schema (the `posts` array each entry needs `suggested_tweet`):
+  see `generate_trend_posts` validation in `scripts/marketing_pipeline.py`.

--- a/docs/marketing/trend-research-routine.md
+++ b/docs/marketing/trend-research-routine.md
@@ -81,9 +81,12 @@ Steps:
 
 9. Commit on the new branch, push, and open a PR titled
    "trend research: <WEEK_ISO>" with body summarizing the topic picked and a
-   one-line preview of each tweet. Use [skip ci] in the commit message so the
-   marketing pipeline doesn't fire twice. Label the PR `auto-merge` if that
-   label exists; otherwise leave it for manual merge.
+   one-line preview of each tweet. Do NOT use [skip ci] — `.github/workflows/ci.yml`
+   runs on both push and pull_request, and skipping it leaves the required check
+   pending, which blocks auto-merge and branch protection. The marketing pipeline
+   does not fire on pushes (it's `workflow_dispatch`-only or chained to Calculate
+   Rankings), so [skip ci] gains nothing. Label the PR `auto-merge` if that label
+   exists; otherwise leave it for manual merge.
 
 10. Auto-merge if all checks pass and the auto-merge label is set. If anything
     blocks merge, leave the PR open and ping the operator with a one-line


### PR DESCRIPTION
Adds the inputs the weekly trend-research routine needs so social posting can run autopilot. Lands on a separate branch off main since it doesn't depend on the Postiz migration code (#856) being merged.

Two files:
- `brand/trend-topics.json` — 12 evergreen youth-soccer angles with search prompts + brand voice notes + fallback CTAs. Rotates by ISO week.
- `docs/marketing/trend-research-routine.md` — the prompt to register with `/schedule`. Spec covers: weekly cron, topic picking, `/last30days` research, 3-tweet synthesis, dynamic fallback, JSON validation, [skip ci] commit + auto-merge.

The routine itself isn't registered yet — `/schedule` is temporarily unavailable. Will register the cron once it's back. Then the loop is closed: Sunday night the routine produces `brand/trend-research/<ISO-week>.json`; Monday the marketing pipeline (from #856) consumes it.

## Test plan

- [x] `brand/trend-topics.json` parses as JSON, 12 entries, each with key/label/search_prompt/voice_angle/fallback_cta.
- [ ] Register `/schedule` cron with the prompt from `docs/marketing/trend-research-routine.md` once the service is back.
- [ ] First Sunday run produces a valid trend-research JSON; PR auto-merges; Monday pipeline picks it up.