### PR TITLE
fix(infographic): unblock @vercel/og rendering (height + resilient fonts)

### DIFF
--- a/frontend/app/api/infographic/_shared/assets.ts
+++ b/frontend/app/api/infographic/_shared/assets.ts
@@ -1,20 +1,53 @@
 const ORIGIN = process.env.NEXT_PUBLIC_SITE_URL || 'https://pitchrank.io';
 
-export async function loadBrandFonts() {
-  const [oswaldBold, oswaldReg, dmSansBold, dmSansReg] = await Promise.all([
-    fetch(`${ORIGIN}/fonts/Oswald-Bold.woff`).then((r) => r.arrayBuffer()),
-    fetch(`${ORIGIN}/fonts/Oswald-Regular.woff`).then((r) => r.arrayBuffer()),
-    fetch(`${ORIGIN}/fonts/DMSans-Bold.woff`).then((r) => r.arrayBuffer()),
-    fetch(`${ORIGIN}/fonts/DMSans-Regular.woff`).then((r) => r.arrayBuffer()),
+type SatoriFont = {
+  name: 'Oswald' | 'DM Sans';
+  data: ArrayBuffer;
+  weight: 400 | 700;
+  style: 'normal';
+};
+
+async function tryLoadFont(
+  url: string,
+  name: SatoriFont['name'],
+  weight: SatoriFont['weight']
+): Promise<SatoriFont | null> {
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      console.error(`[loadBrandFonts] ${url} returned ${resp.status}`);
+      return null;
+    }
+    const data = await resp.arrayBuffer();
+    if (data.byteLength === 0) {
+      console.error(`[loadBrandFonts] ${url} returned empty body`);
+      return null;
+    }
+    return { name, data, weight, style: 'normal' };
+  } catch (e) {
+    console.error(`[loadBrandFonts] ${url} threw: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+export async function loadBrandFonts(): Promise<SatoriFont[]> {
+  // Edge runtime can intermittently fail to fetch self-hosted assets. Any font
+  // that fails to load is dropped silently; Satori falls back to its default
+  // for that family. A blank result is preferable to a 0-byte ImageResponse.
+  const results = await Promise.all([
+    tryLoadFont(`${ORIGIN}/fonts/Oswald-Bold.woff`, 'Oswald', 700),
+    tryLoadFont(`${ORIGIN}/fonts/Oswald-Regular.woff`, 'Oswald', 400),
+    tryLoadFont(`${ORIGIN}/fonts/DMSans-Bold.woff`, 'DM Sans', 700),
+    tryLoadFont(`${ORIGIN}/fonts/DMSans-Regular.woff`, 'DM Sans', 400),
   ]);
-  return [
-    { name: 'Oswald', data: oswaldBold, weight: 700 as const, style: 'normal' as const },
-    { name: 'Oswald', data: oswaldReg, weight: 400 as const, style: 'normal' as const },
-    { name: 'DM Sans', data: dmSansBold, weight: 700 as const, style: 'normal' as const },
-    { name: 'DM Sans', data: dmSansReg, weight: 400 as const, style: 'normal' as const },
-  ];
+  return results.filter((f): f is SatoriFont => f !== null);
 }
 
 // PNG, not SVG: Satori (the @vercel/og renderer) does not support SVG inside <img>.
 // SVG logos render as a blank box and the entire ImageResponse returns 0 bytes.
 export const LOGO_URL = `${ORIGIN}/logos/logo-primary.png`;
+
+// Explicit logo dimensions matching the source PNG's 5.67:1 aspect ratio.
+// Satori rejects `height="auto"` and silently fails the entire ImageResponse.
+export const LOGO_WIDTH = { default: 280, story: 360 } as const;
+export const LOGO_HEIGHT = { default: 49, story: 63 } as const;

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -90,7 +90,12 @@ export async function GET(request: Request) {
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: 30 }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
+        <img
+          src={LOGO_URL}
+          width={isStory ? LOGO_WIDTH.story : LOGO_WIDTH.default}
+          height={isStory ? LOGO_HEIGHT.story : LOGO_HEIGHT.default}
+          alt=""
+        />
         <div
           style={{
             fontSize: isStory ? 48 : isSquare ? 42 : 36,

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -83,7 +83,12 @@ export async function GET(request: Request) {
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: isStory ? 50 : 30 }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
+        <img
+          src={LOGO_URL}
+          width={isStory ? LOGO_WIDTH.story : LOGO_WIDTH.default}
+          height={isStory ? LOGO_HEIGHT.story : LOGO_HEIGHT.default}
+          alt=""
+        />
         <div
           style={{
             fontSize: isStory ? 36 : isSquare ? 30 : 26,

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -97,7 +97,12 @@ export async function GET(request: Request) {
       {/* Header */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: isStory ? 50 : 30 }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={LOGO_URL} width={isStory ? 360 : 280} height="auto" alt="" />
+        <img
+          src={LOGO_URL}
+          width={isStory ? LOGO_WIDTH.story : LOGO_WIDTH.default}
+          height={isStory ? LOGO_HEIGHT.story : LOGO_HEIGHT.default}
+          alt=""
+        />
         <div
           style={{
             fontSize: isStory ? 52 : isSquare ? 46 : 38,


### PR DESCRIPTION
PR #859 wasn't enough. The infographic endpoints still returned 0-byte PNGs after deploy.

## Two real causes

1. **`height="auto"` on the logo `<img>`** — Satori (the @vercel/og renderer) doesn't accept string values for `height`, only numbers. Silent failure: the entire ImageResponse buffer comes back empty.

2. **`loadBrandFonts()` would crash the whole route on any single font fetch failure** — edge runtime fetches can transiently fail (returning a non-200 or empty body). One bad font and the route handler throws, ImageResponse returns 0 bytes.

## Fixes

- `assets.ts`: `tryLoadFont` wraps each fetch in try/catch, validates `resp.ok`, validates body byte length > 0, logs to `console.error` (visible in Vercel function logs) and returns `null` on any failure. `loadBrandFonts` filters out the nulls. Worst case: empty array, Satori falls back to its default font.
- `assets.ts`: new `LOGO_WIDTH` / `LOGO_HEIGHT` constants with explicit pixel values matching the source PNG's 5.67:1 aspect ratio.
- All 3 route files (movers, spotlight, state): import the new constants and pass explicit `height={...}` instead of `height="auto"`.

## Verification plan

After merge + Vercel deploy:

```bash
python -c "import requests; r = requests.get('https://pitchrank.io/api/infographic/movers?platform=instagram', timeout=60); print(f'{r.status_code} {len(r.content)} bytes {r.headers.get(\"Content-Type\")}')"
```

Expect >100KB PNG, not 0 bytes. Then re-run `python scripts/marketing_pipeline.py --postiz-only` and confirm 5/5 drafts including IG with valid `uploads.postiz.com` paths.