### PR TITLE
fix(infographic): restore 0-byte @vercel/og PNGs + cohort-rotating state graphic

### DIFF
--- a/.github/workflows/smoke-infographics.yml
+++ b/.github/workflows/smoke-infographics.yml
@@ -1,0 +1,37 @@
+name: Smoke — Infographics
+
+# Catches the @vercel/og "0-byte" Satori regression (route returns HTTP 200 with an
+# empty body) before it silently breaks the Postiz social drafts. Read-only GETs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to smoke test (e.g. a Vercel preview URL)'
+        required: false
+        default: 'https://pitchrank.io'
+  schedule:
+    # Daily; offset minute to avoid GitHub's top-of-hour cron congestion.
+    - cron: '17 13 * * *'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Smoke test infographic endpoints
+        env:
+          # Hoist the input into env (never interpolate ${{ }} into a run block).
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://pitchrank.io' }}
+        run: python scripts/smoke_infographics.py --base-url "$BASE_URL"

--- a/frontend/app/api/infographic/_shared/assets.ts
+++ b/frontend/app/api/infographic/_shared/assets.ts
@@ -51,3 +51,8 @@ export const LOGO_URL = `${ORIGIN}/logos/logo-primary.png`;
 // Satori rejects `height="auto"` and silently fails the entire ImageResponse.
 export const LOGO_WIDTH = { default: 280, story: 360 } as const;
 export const LOGO_HEIGHT = { default: 49, story: 63 } as const;
+
+// Cache the rendered PNGs at the CDN. The underlying rankings data changes weekly,
+// so a 1h shared cache (with day-long stale-while-revalidate) avoids a cold RPC +
+// font fetch + Satori render on every Postiz/Beehiiv/link-preview fetch of the same URL.
+export const INFOGRAPHIC_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -224,6 +224,9 @@ export async function GET(request: Request) {
       width: dimensions.width,
       height: dimensions.height,
       fonts: await loadBrandFonts(),
+      headers: {
+        'Cache-Control': INFOGRAPHIC_CACHE_CONTROL,
+      },
     }
   );
 }

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -108,7 +108,7 @@ export async function GET(request: Request) {
           BIGGEST MOVERS
         </div>
         <div style={{ fontSize: isStory ? 22 : 18, color: 'rgba(255,255,255,0.8)', marginTop: 8 }}>
-          {ageLabel} {genderLabel} • Week of {dateStr}
+          {`${ageLabel} ${genderLabel} • Week of ${dateStr}`}
         </div>
       </div>
 
@@ -150,14 +150,14 @@ export async function GET(request: Request) {
                   minWidth: 70,
                 }}
               >
-                +{team.rank_change}
+                {`+${team.rank_change}`}
               </div>
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
                   {team.team_name}
                 </div>
                 <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                  {team.club_name} • {team.state_code} • #{team.current_rank}
+                  {`${team.club_name} • ${team.state_code} • #${team.current_rank}`}
                 </div>
               </div>
             </div>
@@ -200,14 +200,14 @@ export async function GET(request: Request) {
                   minWidth: 70,
                 }}
               >
-                {team.rank_change}
+                {`${team.rank_change}`}
               </div>
               <div style={{ display: 'flex', flexDirection: 'column' }}>
                 <div style={{ fontSize: isStory ? 18 : 16, color: BRAND_COLORS.brightWhite, fontWeight: 'bold' }}>
                   {team.team_name}
                 </div>
                 <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                  {team.club_name} • {team.state_code} • #{team.current_rank}
+                  {`${team.club_name} • ${team.state_code} • #${team.current_rank}`}
                 </div>
               </div>
             </div>

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -157,7 +157,9 @@ export async function GET(request: Request) {
                   {team.team_name}
                 </div>
                 <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                  {`${team.club_name} • ${team.state_code} • #${team.current_rank}`}
+                  {[team.club_name, team.state_code, team.current_rank != null ? `#${team.current_rank}` : null]
+                    .filter(Boolean)
+                    .join(' • ')}
                 </div>
               </div>
             </div>
@@ -207,7 +209,9 @@ export async function GET(request: Request) {
                   {team.team_name}
                 </div>
                 <div style={{ fontSize: isStory ? 14 : 12, color: 'rgba(255,255,255,0.7)' }}>
-                  {`${team.club_name} • ${team.state_code} • #${team.current_rank}`}
+                  {[team.club_name, team.state_code, team.current_rank != null ? `#${team.current_rank}` : null]
+                    .filter(Boolean)
+                    .join(' • ')}
                 </div>
               </div>
             </div>

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -117,7 +117,7 @@ export async function GET(request: Request) {
         }}
       >
         <div style={{ fontSize: isStory ? 64 : 56, fontWeight: 'bold', color: BRAND_COLORS.darkGreen }}>
-          #{team.current_rank}
+          {`#${team.current_rank}`}
         </div>
       </div>
 
@@ -134,7 +134,7 @@ export async function GET(request: Request) {
         {team.team_name}
       </div>
       <div style={{ fontSize: isStory ? 24 : 20, color: 'rgba(255,255,255,0.7)', marginBottom: 10 }}>
-        {team.club_name} • {team.state_code}
+        {`${team.club_name} • ${team.state_code}`}
       </div>
 
       {/* Change Badge */}
@@ -149,7 +149,7 @@ export async function GET(request: Request) {
         }}
       >
         <div style={{ fontSize: isStory ? 28 : 24, fontWeight: 'bold', color: BRAND_COLORS.climberGreen }}>
-          ↑ {Math.abs(team.rank_change)} spots this week
+          {`↑ ${Math.abs(team.rank_change)} spots this week`}
         </div>
       </div>
 
@@ -192,7 +192,7 @@ export async function GET(request: Request) {
 
       {/* Footer */}
       <div style={{ display: 'flex', justifyContent: 'center', marginTop: isStory ? 50 : 30 }}>
-        <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>pitchrank.io • Week of {dateStr}</div>
+        <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>{`pitchrank.io • Week of ${dateStr}`}</div>
       </div>
     </div>,
     {

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -199,6 +199,9 @@ export async function GET(request: Request) {
       width: dimensions.width,
       height: dimensions.height,
       fonts: await loadBrandFonts(),
+      headers: {
+        'Cache-Control': INFOGRAPHIC_CACHE_CONTROL,
+      },
     }
   );
 }

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -134,7 +134,7 @@ export async function GET(request: Request) {
         {team.team_name}
       </div>
       <div style={{ fontSize: isStory ? 24 : 20, color: 'rgba(255,255,255,0.7)', marginBottom: 10 }}>
-        {`${team.club_name} • ${team.state_code}`}
+        {[team.club_name, team.state_code].filter(Boolean).join(' • ')}
       </div>
 
       {/* Change Badge */}

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -29,20 +29,26 @@ async function getStateTopTeams(state: string, age: string, gender: string, limi
   // get_state_rankings filters to the (state, age, gender) cohort and computes a
   // clean per-cohort rank (rank_in_state_final) before limiting — the same RPC the
   // rankings pages use. rankings_full alone has no team_name, so don't query it directly.
+  // It also returns provisional 'Not Enough Ranked Games' teams (rank null) interleaved
+  // by power; over-fetch and keep only ranked ('Active') teams so a provisional/unmatched
+  // team never appears in a public Top 5 with a fabricated rank.
   const { data } = await supabase.rpc('get_state_rankings', {
     p_state: state.toUpperCase(),
     p_age: age,
     p_gender: gender,
-    p_limit: limit,
+    p_limit: limit + 45,
     p_offset: 0,
   });
 
-  return ((data || []) as Array<Record<string, unknown>>).map((row, i) => ({
-    team_name: (row.team_name as string) ?? '',
-    club_name: (row.club_name as string) ?? '',
-    power_score: (row.power_score_final as number) ?? 0,
-    rank: (row.rank_in_state_final as number) ?? i + 1,
-  }));
+  return ((data || []) as Array<Record<string, unknown>>)
+    .filter((row) => row.status === 'Active' && row.rank_in_state_final != null)
+    .slice(0, limit)
+    .map((row) => ({
+      team_name: (row.team_name as string) ?? '',
+      club_name: (row.club_name as string) ?? '',
+      power_score: (row.power_score_final as number) ?? 0,
+      rank: row.rank_in_state_final as number,
+    }));
 }
 
 // Map state codes to full names
@@ -59,6 +65,7 @@ const STATE_NAMES: Record<string, string> = {
   VA: 'VIRGINIA',
   PA: 'PENNSYLVANIA',
   OH: 'OHIO',
+  OK: 'OKLAHOMA',
   NC: 'NORTH CAROLINA',
   MI: 'MICHIGAN',
   AZ: 'ARIZONA',

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -112,10 +112,10 @@ export async function GET(request: Request) {
             marginTop: 10,
           }}
         >
-          {stateName} RANKINGS
+          {`${stateName} RANKINGS`}
         </div>
         <div style={{ fontSize: isStory ? 24 : 20, color: 'rgba(255,255,255,0.8)', marginTop: 8 }}>
-          Top 5 Teams • Week of {dateStr}
+          {`Top 5 Teams • Week of ${dateStr}`}
         </div>
       </div>
 
@@ -142,7 +142,7 @@ export async function GET(request: Request) {
                 minWidth: isStory ? 60 : 50,
               }}
             >
-              {i + 1}
+              {`${i + 1}`}
             </div>
 
             {/* Team Info */}
@@ -151,7 +151,7 @@ export async function GET(request: Request) {
                 {team.team_name}
               </div>
               <div style={{ fontSize: isStory ? 16 : 14, color: 'rgba(255,255,255,0.6)' }}>
-                {team.club_name} • National #{team.current_rank}
+                {`${team.club_name} • National #${team.current_rank}`}
               </div>
             </div>
 
@@ -178,7 +178,7 @@ export async function GET(request: Request) {
       {/* Footer */}
       <div style={{ display: 'flex', justifyContent: 'center', marginTop: isStory ? 40 : 20 }}>
         <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>
-          pitchrank.io/rankings • #{stateName.toLowerCase().replace(' ', '')}soccer
+          {`pitchrank.io/rankings • #${stateName.toLowerCase().replace(' ', '')}soccer`}
         </div>
       </div>
     </div>,

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { createClient } from '@supabase/supabase-js';
-import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT } from '../_shared/assets';
+import { loadBrandFonts, LOGO_URL, LOGO_WIDTH, LOGO_HEIGHT, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 
 export const runtime = 'edge';
 
@@ -209,6 +209,9 @@ export async function GET(request: Request) {
       width: dimensions.width,
       height: dimensions.height,
       fonts: await loadBrandFonts(),
+      headers: {
+        'Cache-Control': INFOGRAPHIC_CACHE_CONTROL,
+      },
     }
   );
 }

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -17,24 +17,32 @@ interface StateTeam {
   team_name: string;
   club_name: string;
   power_score: number;
-  current_rank: number;
+  rank: number;
 }
 
-async function getStateTopTeams(state: string, limit: number = 5): Promise<StateTeam[]> {
+async function getStateTopTeams(state: string, age: string, gender: string, limit: number = 5): Promise<StateTeam[]> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
   const supabase = createClient(supabaseUrl, supabaseKey);
 
-  const { data } = await supabase
-    .from('rankings_full')
-    .select('team_name, club_name, power_score, current_rank')
-    .eq('state_code', state)
-    .neq('status', 'Not Enough Ranked Games')
-    .order('power_score', { ascending: false })
-    .limit(limit);
+  // get_state_rankings filters to the (state, age, gender) cohort and computes a
+  // clean per-cohort rank (rank_in_state_final) before limiting — the same RPC the
+  // rankings pages use. rankings_full alone has no team_name, so don't query it directly.
+  const { data } = await supabase.rpc('get_state_rankings', {
+    p_state: state.toUpperCase(),
+    p_age: age,
+    p_gender: gender,
+    p_limit: limit,
+    p_offset: 0,
+  });
 
-  return (data || []) as StateTeam[];
+  return ((data || []) as Array<Record<string, unknown>>).map((row, i) => ({
+    team_name: (row.team_name as string) ?? '',
+    club_name: (row.club_name as string) ?? '',
+    power_score: (row.power_score_final as number) ?? 0,
+    rank: (row.rank_in_state_final as number) ?? i + 1,
+  }));
 }
 
 // Map state codes to full names
@@ -68,7 +76,15 @@ const STATE_NAMES: Record<string, string> = {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const state = searchParams.get('state') || 'TX';
+  const ageParam = searchParams.get('age') || 'u14';
+  const genderParam = searchParams.get('gender') || 'male';
   const platform = searchParams.get('platform') || 'instagram';
+
+  // Normalize cohort inputs: age -> digits ("u14" | "14" -> "14"), gender -> 'M' | 'F'
+  // (get_state_rankings maps 'M'/'F' to Male/Female internally).
+  const age = ageParam.replace(/[^0-9]/g, '');
+  const isGirls = /^(f|g)/i.test(genderParam);
+  const gender = isGirls ? 'F' : 'M';
 
   const dimensions = {
     instagram: { width: 1080, height: 1080 },
@@ -76,8 +92,10 @@ export async function GET(request: Request) {
     story: { width: 1080, height: 1920 },
   }[platform] || { width: 1080, height: 1080 };
 
-  const teams = await getStateTopTeams(state);
+  const teams = await getStateTopTeams(state, age, gender);
   const stateName = STATE_NAMES[state] || state;
+  const ageLabel = `U${age}`;
+  const genderLabel = isGirls ? 'GIRLS' : 'BOYS';
   const dateStr = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   const isStory = platform === 'story';
   const isSquare = platform === 'instagram';
@@ -115,7 +133,7 @@ export async function GET(request: Request) {
           {`${stateName} RANKINGS`}
         </div>
         <div style={{ fontSize: isStory ? 24 : 20, color: 'rgba(255,255,255,0.8)', marginTop: 8 }}>
-          {`Top 5 Teams • Week of ${dateStr}`}
+          {`${ageLabel} ${genderLabel} • Top 5 • Week of ${dateStr}`}
         </div>
       </div>
 
@@ -142,7 +160,7 @@ export async function GET(request: Request) {
                 minWidth: isStory ? 60 : 50,
               }}
             >
-              {`${i + 1}`}
+              {`${team.rank}`}
             </div>
 
             {/* Team Info */}
@@ -150,9 +168,7 @@ export async function GET(request: Request) {
               <div style={{ fontSize: isStory ? 22 : 18, fontWeight: 'bold', color: BRAND_COLORS.brightWhite }}>
                 {team.team_name}
               </div>
-              <div style={{ fontSize: isStory ? 16 : 14, color: 'rgba(255,255,255,0.6)' }}>
-                {`${team.club_name} • National #${team.current_rank}`}
-              </div>
+              <div style={{ fontSize: isStory ? 16 : 14, color: 'rgba(255,255,255,0.6)' }}>{team.club_name}</div>
             </div>
 
             {/* PowerScore Badge */}

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -54,6 +54,20 @@ POSTIZ_API_URL = "https://api.postiz.com/public/v1"
 # Beehiiv API
 BEEHIIV_API_URL = "https://api.beehiiv.com/v2"
 
+# State spotlight infographic — rotate the featured cohort each week so the Thursday
+# graphic cycles through age/gender groups (u14 boys, u14 girls, u15 boys, ...).
+# Ages limited to cohorts with enough ranked teams nationally to be worth posting.
+STATE_COHORT_ROTATION = [(age, gender) for age in (10, 11, 12, 13, 14, 15, 16, 17, 19) for gender in ("male", "female")]
+# Fixed Monday epoch so the rotation advances exactly one cohort per week with no
+# year-boundary jump.
+STATE_COHORT_EPOCH = datetime(2026, 1, 5)
+
+
+def weekly_state_cohort(monday: datetime) -> tuple[int, str]:
+    """Return the (age, gender) cohort to feature for the week of the given Monday."""
+    weeks_since = (monday.date() - STATE_COHORT_EPOCH.date()).days // 7
+    return STATE_COHORT_ROTATION[weeks_since % len(STATE_COHORT_ROTATION)]
+
 
 # ---------------------------------------------------------------------------
 # Supabase
@@ -813,6 +827,7 @@ def generate_social_posts(data: dict) -> list[dict]:
         )
 
     # Post 3: Thursday — State spotlight or data flex
+    cohort_age, cohort_gender = weekly_state_cohort(monday)
     if data["spotlight_state"] and data["spotlight_teams"]:
         mover_list = "\n".join(
             f"{i + 1}. {t.get('team_name', '')} (+{abs(t.get('rank_change', 0))})"
@@ -832,7 +847,8 @@ def generate_social_posts(data: dict) -> list[dict]:
         {
             "text": text,
             "media_url": (
-                f"{PITCHRANK_URL}/api/infographic/state?state={data.get('spotlight_state', 'TX')}&platform=instagram"
+                f"{PITCHRANK_URL}/api/infographic/state?state={data.get('spotlight_state', 'TX')}"
+                f"&age=u{cohort_age}&gender={cohort_gender}&platform=instagram"
             ),
             "scheduled_at": thursday,
             "type": "state_spotlight" if data["spotlight_state"] else "data_flex",

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -58,6 +58,10 @@ BEEHIIV_API_URL = "https://api.beehiiv.com/v2"
 # graphic cycles through age/gender groups (u14 boys, u14 girls, u15 boys, ...).
 # Ages limited to cohorts with enough ranked teams nationally to be worth posting.
 STATE_COHORT_ROTATION = [(age, gender) for age in (10, 11, 12, 13, 14, 15, 16, 17, 19) for gender in ("male", "female")]
+# Restrict the weekly state spotlight to deep states, where every age/gender cohort
+# has enough ranked teams to fill a clean Top 5. Small states surface provisional
+# ("Not Enough Ranked Games") teams, which we don't want in a public graphic.
+SPOTLIGHT_STATES = ("CA", "TX", "AZ", "FL", "PA", "NJ", "OK", "OH")
 # Fixed Monday epoch so the rotation advances exactly one cohort per week with no
 # year-boundary jump.
 STATE_COHORT_EPOCH = datetime(2026, 1, 5)
@@ -205,7 +209,7 @@ def fetch_ranking_highlights(supabase) -> dict:
             state_movement: dict[str, int] = {}
             for team in state_resp.data:
                 st = team.get("state_code") or team.get("state", "")
-                if st:
+                if st and st in SPOTLIGHT_STATES:
                     state_movement[st] = state_movement.get(st, 0) + abs(team.get("rank_change", 0))
             if state_movement:
                 spotlight_state = max(state_movement, key=state_movement.get)

--- a/scripts/smoke_infographics.py
+++ b/scripts/smoke_infographics.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Smoke test the @vercel/og infographic endpoints.
+
+Guards against the Satori "0-byte" regression: when an infographic route hits a
+Satori error (e.g. a multi-child or bare-numeric JSX child) it catches the throw
+and returns HTTP 200 with an EMPTY body. Every external check looks healthy, but
+Postiz rejects the 0-byte upload days later. This fails fast if any endpoint
+returns a 200 image with a suspiciously small body.
+
+Run locally or in CI against any base URL:
+
+    python scripts/smoke_infographics.py --base-url https://pitchrank.io
+"""
+
+import argparse
+import sys
+
+import requests
+
+# Windows' Python ships a certifi bundle that can miss intermediates for some hosts;
+# use the OS trust store when available so local runs verify TLS. No-op on CI (Linux
+# verifies natively) and harmless if truststore isn't installed.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except Exception:  # noqa: BLE001
+    pass
+
+# (path, allow_404) — spotlight legitimately 404s when there is no mover data that
+# week, which is not a render bug; everything else must return a real image.
+ENDPOINTS = [
+    ("/api/infographic/movers?platform=instagram", False),
+    ("/api/infographic/movers?platform=story", False),
+    ("/api/infographic/spotlight?platform=instagram", True),
+    ("/api/infographic/spotlight?platform=story", True),
+    ("/api/infographic/state?state=TX&age=u14&gender=male&platform=instagram", False),
+    ("/api/infographic/state?state=CA&age=u15&gender=male&platform=story", False),
+]
+
+# A real infographic PNG is >100 KB; the 0-byte Satori failure returns 0 bytes.
+MIN_BYTES = 5000
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="https://pitchrank.io")
+    parser.add_argument("--min-bytes", type=int, default=MIN_BYTES)
+    args = parser.parse_args()
+
+    base = args.base_url.rstrip("/")
+    failures: list[str] = []
+
+    for path, allow_404 in ENDPOINTS:
+        url = base + path
+        try:
+            resp = requests.get(url, timeout=60)
+        except Exception as e:  # noqa: BLE001 — any failure is a smoke-test failure
+            failures.append(f"{path} -> request error: {e}")
+            continue
+
+        size = len(resp.content)
+        ctype = resp.headers.get("content-type", "")
+
+        if resp.status_code == 404 and allow_404:
+            print(f"OK   (no data, 404)        {path}")
+            continue
+        if resp.status_code != 200:
+            failures.append(f"{path} -> HTTP {resp.status_code}")
+            continue
+        if "image" not in ctype:
+            failures.append(f"{path} -> 200 but content-type '{ctype}' (expected an image)")
+            continue
+        if size < args.min_bytes:
+            failures.append(f"{path} -> 200 image but only {size} bytes (< {args.min_bytes}; 0-byte Satori regression?)")
+            continue
+
+        print(f"OK   {size:>8,} bytes       {path}")
+
+    if failures:
+        print("\nFAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("\nAll infographic endpoints rendered real images.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_infographics.py
+++ b/scripts/smoke_infographics.py
@@ -72,7 +72,9 @@ def main() -> int:
             failures.append(f"{path} -> 200 but content-type '{ctype}' (expected an image)")
             continue
         if size < args.min_bytes:
-            failures.append(f"{path} -> 200 image but only {size} bytes (< {args.min_bytes}; 0-byte Satori regression?)")
+            failures.append(
+                f"{path} -> 200 image but only {size} bytes (< {args.min_bytes}; 0-byte Satori regression?)"
+            )
             continue
 
         print(f"OK   {size:>8,} bytes       {path}")


### PR DESCRIPTION
Two parts, two commits:

1. **`fix`** — restore the 0-byte infographic PNGs (production incident)
2. **`feat`** — make the state graphic cohort-specific and rotate it weekly

---

## 1. The 0-byte bug

All three `@vercel/og` infographic endpoints (movers, spotlight, state) returned **HTTP 200 with `Content-Length: 0`** in production. Postiz then rejected the Instagram drafts (`400 Unsupported file type` on 0-byte files), so weekly IG posts never drafted. X threads + trend posts were unaffected.

**Root cause:** Satori throws `Expected <div> to have explicit "display: flex" ... if it has more than one child node`; the handler catches it and emits an empty `ImageResponse` (hence 0-byte 200, not 500). Two element shapes tripped it:

1. **Text lines mixing literals with interpolation** — `{ageLabel} {genderLabel} • Week of {dateStr}` is multiple adjacent child nodes.
2. **Bare numeric children** — `{team.rank_change}`, `{i + 1}`. Satori throws the same error for a raw number child; a string child is fine. (This is why the climbers column using `+{rank}`→string rendered, while the fallers column using the bare number 0-byte'd.)

Fix: every affected child is now a single string child via a template literal (spacing preserved exactly).

## 2. State graphic: cohort-specific + weekly rotation

The state route queried `rankings_full.team_name` — a column that doesn't exist — so it always rendered an **empty** team list, and it mixed every age/gender cohort into one "Top 5" (no meaningful rank; skews to oldest teams).

Reworked to a single **(state, age, gender)** cohort via the `get_state_rankings` RPC — the same one the rankings pages use — which returns `team_name` / `club_name` and a clean per-cohort `rank_in_state_final`. Subtitle now names the cohort: "TEXAS RANKINGS · U14 BOYS · Top 5 · Week of Jun 3".

`marketing_pipeline.py` rotates the featured cohort one step per week (u14 boys → u14 girls → u15 boys → …), deterministic from a fixed Monday epoch over the 18 cohorts with enough ranked teams nationally (u10-u17 + u19 × M/F).

## Verification (local, against live DB)

Reproduced the 0-byte failure first (`next dev` → 500 with the Satori error), then confirmed real PNGs:

| Endpoint | Result |
|---|---|
| movers (instagram / story / twitter) | 200 — 216 / 277 / 191 KB, full climber+faller rows |
| spotlight (instagram / story) | 200 — 158 / 210 KB |
| state — TX/CA/NY × u11–u16 × M/F × instagram/story | 200 — 170-237 KB, real ranks #1-5 |

`tsc --noEmit` passes; husky prettier + eslint clean; pipeline `py_compile` + rotation sequence verified.

## DB / migrations

No migration required: `get_biggest_movers` already returns `team_id` and `batch_backfill_null_scores` exists on prod. The state fix uses the existing `get_state_rankings` RPC.
