### PR TITLE
trend research: 2026-W23 (youth-focused) + youth-focus rule

### DIFF
--- a/brand/trend-research/2026-W23.json
+++ b/brand/trend-research/2026-W23.json
@@ -2,10 +2,10 @@
   "week": "2026-W23",
   "posts": [
     {
-      "topic": "MLS NEXT 2026-27 expansion (youth league)",
-      "hook": "Anchor = official MLS NEXT 2026-27 expansion (54 new clubs; 4 new conferences; now 318 clubs / 53,000+ youth players / 40 states). Already a youth subject (MLS NEXT is the top youth boys league). Angle: more youth teams = harder to tell who's good; one cross-conference scale.",
-      "suggested_tweet": "MLS NEXT just added 54 clubs for 2026-27 - now 318 clubs and 53,000+ youth players across 40 states. The bigger it gets, the harder it is to tell who's actually good. We rank every youth team on one scale, conference and reputation aside.\n\npitchrank.io/rankings",
-      "source_url": "https://www.mlssoccer.com/mlsnext/news/mls-next-announces-new-clubs-and-conferences-ahead-of-2026-27-season"
+      "topic": "2026 MLS NEXT Cup champions",
+      "hook": "Anchor = 2026 MLS NEXT Cup, Salt Lake City, May 23-31 (in-window); Sporting City won the inaugural U-17 Academy Division final (over Rochester NY FC, May 31). Replaces the stale March 9 expansion announcement flagged in Codex review. Angle: a champion is crowned, but the broader youth field never gets sorted - one scale fixes that. Distinct from W24's soft-bracket angle (this is scale/sorting).",
+      "suggested_tweet": "Sporting City's U-17s were just crowned MLS NEXT Cup champions in Salt Lake City. One trophy - but the rest of the youth field never really gets sorted. We rank every MLS NEXT team on one scale, conference and reputation aside.\n\npitchrank.io/rankings",
+      "source_url": "https://www.sportingkc.com/news/sporting-city-u-17-s-crowned-national-champions"
     },
     {
       "topic": "World Cup pipeline, told from the youth side",
@@ -15,7 +15,7 @@
     },
     {
       "topic": "U-19 youth national team June camp",
-      "hook": "Anchor = SBI Soccer (May 2026): USYNT U-19/U-18/U-17 June camps; U-19 faces Japan June 9 en route to the Concacaf U-20 Championship (qualifying for the 2027 U-20 World Cup). Squarely youth + current. Angle: youth-NT players earned it in youth leagues, not on reputation.",
+      "hook": "Anchor = SBI Soccer (May 2026): USYNT U-19/U-18/U-17 June camps; U-19 faces Japan June 9 en route to the Concacaf U-20 Championship (qualifying for the 2027 U-20 World Cup). Squarely youth + in-window. Angle: youth-NT players earned it in youth leagues, not on reputation.",
       "suggested_tweet": "USA's U-19s are in camp now, facing Japan June 9 as they chase a 2027 U-20 World Cup spot. None were hand-picked on reputation - they earned it in youth leagues first. See which youth teams actually produce:\n\npitchrank.io/rankings",
       "source_url": "https://sbisoccer.com/2026/05/usynt-under-19s-u-18s-u-17s-all-set-for-june-camps"
     }

--- a/brand/trend-research/2026-W23.json
+++ b/brand/trend-research/2026-W23.json
@@ -2,22 +2,22 @@
   "week": "2026-W23",
   "posts": [
     {
-      "topic": "MLS NEXT 2026-27 expansion",
-      "hook": "Anchor = official MLS NEXT 2026-27 expansion announcement (47 new Academy + 7 new Homegrown clubs = 54; 4 new conferences; now 318 clubs / 53,000+ players / 40 states). Angle: more teams = harder to tell who's actually good; one cross-conference scale is the fix. Pure rankings tie-in.",
-      "suggested_tweet": "MLS NEXT just added 54 clubs for 2026-27 - now 318 clubs and 53,000+ players across 40 states. The bigger it gets, the harder it is to tell who's actually good. We rank every team on one scale, conference and reputation aside.\n\npitchrank.io/rankings",
+      "topic": "MLS NEXT 2026-27 expansion (youth league)",
+      "hook": "Anchor = official MLS NEXT 2026-27 expansion (54 new clubs; 4 new conferences; now 318 clubs / 53,000+ youth players / 40 states). Already a youth subject (MLS NEXT is the top youth boys league). Angle: more youth teams = harder to tell who's good; one cross-conference scale.",
+      "suggested_tweet": "MLS NEXT just added 54 clubs for 2026-27 - now 318 clubs and 53,000+ youth players across 40 states. The bigger it gets, the harder it is to tell who's actually good. We rank every youth team on one scale, conference and reputation aside.\n\npitchrank.io/rankings",
       "source_url": "https://www.mlssoccer.com/mlsnext/news/mls-next-announces-new-clubs-and-conferences-ahead-of-2026-27-season"
     },
     {
-      "topic": "MLS academy pipeline in the 2026 World Cup roster",
-      "hook": "Anchor = USMNT 2026 World Cup roster breakdown (MLSsoccer): 21 of 26 (81%) have MLS roots; 13 (50%) are MLS homegrown/academy products. Home World Cup this summer. Angle: the pipeline pays off and it starts in youth leagues we already rank. Ties the pro dream to youth rankings.",
-      "suggested_tweet": "The USMNT's 2026 World Cup roster: 21 of 26 players have MLS roots, and half came up through an MLS academy. The next ones are in a youth league near you right now. We rank those teams on the same scale as everyone else.\n\npitchrank.io/rankings",
+      "topic": "World Cup pipeline, told from the youth side",
+      "hook": "Hook = USMNT 2026 World Cup roster (81% MLS roots, half via a youth academy; MLSsoccer). Pro milestone used ONLY as the hook; post lands on youth (every WC player was a club kid first; the next ones are in youth leagues we rank now). Home World Cup this summer.",
+      "suggested_tweet": "81% of the USMNT's 2026 World Cup roster came up through MLS, half through a youth academy. Every one was a club kid first - the next ones are in a youth league this weekend. See how today's top youth teams rank:\n\npitchrank.io/rankings",
       "source_url": "https://www.mlssoccer.com/news/aaronson-to-zendejas-every-mls-export-on-usmnt-2026-world-cup-roster-squad-usa"
     },
     {
-      "topic": "MLS prospects linked with Europe this summer",
-      "hook": "Anchor = FootballTransfers 'MLS players who could move to Europe this summer' (May 2026), 10 named candidates. Framed as 'linked' (speculative), not confirmed deals, to avoid fabricating transfers. Angle: transfers/recruiting follow hype; results show who earned it. Classic results-over-reputation.",
-      "suggested_tweet": "The MLS-to-Europe pipeline is back this summer - 10 players already linked with moves abroad on reputation and highlight reels. Buzz gets you the trial; results tell you who earned it. We rank youth teams on what they do on the field.\n\npitchrank.io/rankings",
-      "source_url": "https://www.footballtransfers.com/en/transfer-news/us-united-states-mls/2026/05/mls-players-europe-summer-2026"
+      "topic": "U-19 youth national team June camp",
+      "hook": "Anchor = SBI Soccer (May 2026): USYNT U-19/U-18/U-17 June camps; U-19 faces Japan June 9 en route to the Concacaf U-20 Championship (qualifying for the 2027 U-20 World Cup). Squarely youth + current. Angle: youth-NT players earned it in youth leagues, not on reputation.",
+      "suggested_tweet": "USA's U-19s are in camp now, facing Japan June 9 as they chase a 2027 U-20 World Cup spot. None were hand-picked on reputation - they earned it in youth leagues first. See which youth teams actually produce:\n\npitchrank.io/rankings",
+      "source_url": "https://sbisoccer.com/2026/05/usynt-under-19s-u-18s-u-17s-all-set-for-june-camps"
     }
   ]
 }

--- a/brand/trend-research/2026-W23.json
+++ b/brand/trend-research/2026-W23.json
@@ -2,10 +2,22 @@
   "week": "2026-W23",
   "posts": [
     {
-      "topic": "ECNL national rankings drop",
-      "hook": "Rankings dropped — what the data actually shows.",
-      "suggested_tweet": "ECNL just released their national rankings. We ran the same 25K teams through PitchRank's algorithm and got a very different top 50. Receipts > vibes.\n\npitchrank.io/rankings",
-      "source_url": "https://example.com/ecnl-rankings"
+      "topic": "MLS NEXT 2026-27 expansion",
+      "hook": "Anchor = official MLS NEXT 2026-27 expansion announcement (47 new Academy + 7 new Homegrown clubs = 54; 4 new conferences; now 318 clubs / 53,000+ players / 40 states). Angle: more teams = harder to tell who's actually good; one cross-conference scale is the fix. Pure rankings tie-in.",
+      "suggested_tweet": "MLS NEXT just added 54 clubs for 2026-27 - now 318 clubs and 53,000+ players across 40 states. The bigger it gets, the harder it is to tell who's actually good. We rank every team on one scale, conference and reputation aside.\n\npitchrank.io/rankings",
+      "source_url": "https://www.mlssoccer.com/mlsnext/news/mls-next-announces-new-clubs-and-conferences-ahead-of-2026-27-season"
+    },
+    {
+      "topic": "MLS academy pipeline in the 2026 World Cup roster",
+      "hook": "Anchor = USMNT 2026 World Cup roster breakdown (MLSsoccer): 21 of 26 (81%) have MLS roots; 13 (50%) are MLS homegrown/academy products. Home World Cup this summer. Angle: the pipeline pays off and it starts in youth leagues we already rank. Ties the pro dream to youth rankings.",
+      "suggested_tweet": "The USMNT's 2026 World Cup roster: 21 of 26 players have MLS roots, and half came up through an MLS academy. The next ones are in a youth league near you right now. We rank those teams on the same scale as everyone else.\n\npitchrank.io/rankings",
+      "source_url": "https://www.mlssoccer.com/news/aaronson-to-zendejas-every-mls-export-on-usmnt-2026-world-cup-roster-squad-usa"
+    },
+    {
+      "topic": "MLS prospects linked with Europe this summer",
+      "hook": "Anchor = FootballTransfers 'MLS players who could move to Europe this summer' (May 2026), 10 named candidates. Framed as 'linked' (speculative), not confirmed deals, to avoid fabricating transfers. Angle: transfers/recruiting follow hype; results show who earned it. Classic results-over-reputation.",
+      "suggested_tweet": "The MLS-to-Europe pipeline is back this summer - 10 players already linked with moves abroad on reputation and highlight reels. Buzz gets you the trial; results tell you who earned it. We rank youth teams on what they do on the field.\n\npitchrank.io/rankings",
+      "source_url": "https://www.footballtransfers.com/en/transfer-news/us-united-states-mls/2026/05/mls-players-europe-summer-2026"
     }
   ]
 }

--- a/brand/trend-topics.json
+++ b/brand/trend-topics.json
@@ -71,9 +71,9 @@
   },
   {
     "key": "pro-pathway-academy",
-    "label": "Pre-Academy, MLS NEXT Pro, pro pathway stories",
-    "search_prompt": "Youth-to-pro pathway news in the last 30 days: MLS NEXT Pro signings, academy contracts, homegrown players, USL Academy, USYNT call-ups, European trial trips. Reddit, X, soccer media, club press.",
-    "voice_angle": "The pro pathway is narrow and lopsided. PitchRank shows which youth teams are genuinely producing — not which clubs hire the best PR.",
+    "label": "Pro pathway stories, told from the youth side",
+    "search_prompt": "Youth-to-pro pathway news in the last 30 days, focused on the YOUTH end: MLS NEXT and academy prospects, U-15/U-17/U-19 academy standouts, youth national team (U-17/U-19/U-20) call-ups and camps, teenage homegrown signings, youth players earning trials abroad. Use any senior/pro milestone (the World Cup, first-team transfers) ONLY as a hook to talk about the youth teams that produced them. Reddit (r/youthsoccer), X, soccer media, club press. What are parents and coaches debating about how kids actually reach the next level?",
+    "voice_angle": "The pro pathway is narrow and lopsided, and it starts in youth leagues. PitchRank shows which YOUTH teams are genuinely producing the players who reach academies and national teams — not which clubs hire the best PR.",
     "fallback_cta": "See which youth clubs actually produce: pitchrank.io/rankings"
   },
   {

--- a/docs/marketing/trend-research-routine.md
+++ b/docs/marketing/trend-research-routine.md
@@ -47,6 +47,15 @@ Steps:
    - Be a single X post under 280 chars (no thread).
    - Reference what people are actually saying or arguing about this week,
      not a generic evergreen take.
+   - CENTER A YOUTH ANGLE (non-negotiable). PitchRank ranks youth soccer, so
+     every post's subject must be a youth team, youth league, age group, youth
+     national team, or youth rankings. Pro/senior storylines (the World Cup,
+     senior transfers, MLS first-team signings) may be used ONLY as the opening
+     hook - never the subject. Always pivot to the youth teams/players behind
+     the story and land on pitchrank.io/rankings. Practical test: the post
+     should contain a youth signal ("youth", an age group like U-15/U-19,
+     "club", a youth league/national team). If the only honest angle is pro,
+     pick a different story.
    - End with the topic's `fallback_cta` or a tighter brand-on CTA pointing
      to pitchrank.io/rankings.
    - Match PitchRank brand voice (see Brand Voice section below).
@@ -114,6 +123,9 @@ Apply all PitchRank brand rules:
 
 - Never commit research that fabricates engagement numbers or invents source URLs.
 - Never invent quotes or attribute statements to real people.
+- Never let a post's subject be senior/pro soccer. Pro news is a hook only;
+  the post must land on youth (see Step 5). If a story has no honest youth
+  angle, drop it and pick another.
 - If /last30days returns nothing useful for the topic, fall back per Step 6
   instead of padding with generic evergreen content.
 - If the fallback also fails, leave the file uncreated. The pipeline handles


### PR DESCRIPTION
Replaces the placeholder `brand/trend-research/2026-W23.json` (a single generic post with a fabricated `https://example.com` source, committed during autopilot setup #858 and live on main for the active ISO week) with 3 **youth-centered, in-window** sourced posts, and bakes youth-focus into the routine so future weeks don't drift pro.

### This week's posts (each <280, links pitchrank.io/rankings, carries a youth angle, source within last 30 days)
1. **2026 MLS NEXT Cup champions** - Sporting City U-17s crowned in SLC (May 31); the rest of the youth field never gets sorted -> one scale. ([sportingkc.com](https://www.sportingkc.com/news/sporting-city-u-17-s-crowned-national-champions))
2. **World Cup pipeline, youth side** - 81% of the USMNT WC roster came up through MLS, half via a youth academy; every one was a club kid first. ([mlssoccer.com](https://www.mlssoccer.com/news/aaronson-to-zendejas-every-mls-export-on-usmnt-2026-world-cup-roster-squad-usa))
3. **U-19 youth national team** - U-19s in camp now, face Japan June 9 chasing a 2027 U-20 World Cup spot. ([sbisoccer.com](https://sbisoccer.com/2026/05/usynt-under-19s-u-18s-u-17s-all-set-for-june-camps))

### Durable changes
- `docs/marketing/trend-research-routine.md`: new non-negotiable rule - every post must center a youth team/league/age group/youth-NT/rankings; pro/senior news (World Cup, transfers, first-team signings) may be a **hook only**, never the subject.
- `brand/trend-topics.json`: youth-anchored the `pro-pathway-academy` topic (search prompt + voice angle).

Note: the first draft cited the MLS NEXT 2026-27 expansion (announced Mar 9, 2026) - out of the 30-day window, flagged by Codex review - now swapped for the in-window MLS NEXT Cup. Sourced via WebSearch (the /last30days engine has no credentials on this host; social retrieval TLS-blocked).

Not enabling auto-merge - manual review per repo merge policy.