### PR TITLE
feat(mission-control): add lead-to-trial conversion metric for report card leads

### DIFF
--- a/frontend/app/mission-control/subscriptions/page.tsx
+++ b/frontend/app/mission-control/subscriptions/page.tsx
@@ -221,7 +221,7 @@ export default async function SubscriptionsDashboardPage() {
             </span>
           </div>
 
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
             <KpiCard label="Total Requests" value={metrics.reportCard.totalRequests.toLocaleString()} sub="all time" />
             <KpiCard
               label="Unique Emails"
@@ -232,6 +232,19 @@ export default async function SubscriptionsDashboardPage() {
               label="Last 7 Days"
               value={metrics.reportCard.last7Days.toLocaleString()}
               sub={`${metrics.reportCard.last30Days.toLocaleString()} in last 30d`}
+            />
+            <KpiCard
+              label="Lead → Trial"
+              value={
+                metrics.reportCard.trialConversion.percent === null
+                  ? '—'
+                  : `${metrics.reportCard.trialConversion.percent}%`
+              }
+              sub={
+                metrics.reportCard.trialConversion.percent === null
+                  ? `not enough data yet (${metrics.reportCard.trialConversion.leads} lead${metrics.reportCard.trialConversion.leads === 1 ? '' : 's'}, need ≥5)`
+                  : `${metrics.reportCard.trialConversion.trialed} of ${metrics.reportCard.trialConversion.leads} leads started a trial${metrics.reportCard.trialConversion.excluded > 0 ? ` (${metrics.reportCard.trialConversion.excluded} excluded)` : ''}`
+              }
             />
             <KpiCard
               label="Lead → Paid"

--- a/frontend/lib/admin/__tests__/subscription-metrics.test.ts
+++ b/frontend/lib/admin/__tests__/subscription-metrics.test.ts
@@ -11,6 +11,7 @@ import {
   computeConversion,
   dedupeEmails,
   computeLeadConversion,
+  computeLeadToTrial,
 } from '../subscription-metrics';
 
 const SECONDS_PER_DAY = 86_400;
@@ -374,5 +375,84 @@ describe('computeLeadConversion', () => {
   it('returns zero/null when no leads', () => {
     const result = computeLeadConversion(new Set(), [], [], excluded);
     expect(result).toEqual({ leads: 0, converted: 0, percent: null, excluded: 0 });
+  });
+});
+
+describe('computeLeadToTrial', () => {
+  const excluded = new Set<string>(['internal@pitchrank.io']);
+  const start = 1_700_000_000;
+
+  it('counts a lead whose email ever started a trial', () => {
+    const leads = new Set(['trialer@example.com', 'never@example.com']);
+    const subs = [makeSub({ status: 'trialing', email: 'trialer@example.com', trialStart: start })];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.leads).toBe(2);
+    expect(result.trialed).toBe(1);
+    expect(result.percent).toBeNull(); // sample < 5
+    expect(result.excluded).toBe(0);
+  });
+
+  it('counts a lead who trialed and later cancelled', () => {
+    // marina case: started a trial, then cancelled → sub is now canceled but
+    // still has trial_start, so she counts as having trialed.
+    const leads = new Set(['marina@example.com']);
+    const subs = [makeSub({ status: 'canceled', email: 'marina@example.com', trialStart: start })];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.trialed).toBe(1);
+  });
+
+  it('does not count a paid lead who never trialed', () => {
+    const leads = new Set(['direct@example.com']);
+    const subs = [makeSub({ status: 'active', email: 'direct@example.com', trialStart: null })];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.trialed).toBe(0);
+  });
+
+  it('returns rounded percent once sample >= 5', () => {
+    const leads = new Set(['a@example.com', 'b@example.com', 'c@example.com', 'd@example.com', 'e@example.com']);
+    const subs = [
+      makeSub({ status: 'trialing', email: 'a@example.com', trialStart: start }),
+      makeSub({ status: 'canceled', email: 'b@example.com', trialStart: start }),
+    ];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.leads).toBe(5);
+    expect(result.trialed).toBe(2);
+    expect(result.percent).toBe(40);
+  });
+
+  it('drops excluded emails from both numerator and denominator', () => {
+    const leads = new Set(['internal@pitchrank.io', 'real@example.com']);
+    const subs = [
+      makeSub({ status: 'trialing', email: 'internal@pitchrank.io', trialStart: start }),
+      makeSub({ status: 'trialing', email: 'real@example.com', trialStart: start }),
+    ];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.leads).toBe(1);
+    expect(result.trialed).toBe(1);
+    expect(result.excluded).toBe(1);
+  });
+
+  it('matches case-insensitively', () => {
+    const leads = new Set(['mixed@example.com']);
+    const subs = [makeSub({ status: 'canceled', email: 'MIXED@Example.com', trialStart: start })];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.trialed).toBe(1);
+  });
+
+  it('an excluded email trial sub does not bleed into another lead', () => {
+    // The trialed set is built before exclusion, so an excluded email's trial
+    // sub lands in it — but matching is by exact email, so it must not inflate
+    // a different, non-trialing lead's count.
+    const leads = new Set(['internal@pitchrank.io', 'real@example.com']);
+    const subs = [makeSub({ status: 'trialing', email: 'internal@pitchrank.io', trialStart: start })];
+    const result = computeLeadToTrial(leads, subs, excluded);
+    expect(result.leads).toBe(1); // only real@ counts toward denominator
+    expect(result.trialed).toBe(0); // real@ never trialed; excluded sub doesn't bleed over
+    expect(result.excluded).toBe(1);
+  });
+
+  it('returns zero/null when no leads', () => {
+    const result = computeLeadToTrial(new Set(), [], excluded);
+    expect(result).toEqual({ leads: 0, trialed: 0, percent: null, excluded: 0 });
   });
 });

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -169,17 +169,10 @@ export function computeLeadConversion(
  * denominator and reported separately. Percent is null when leads <
  * MIN_COHORT_SAMPLE so the UI can show "not enough data yet".
  *
- * Reuses the subscription lists already fetched by getSubscriptionMetrics
- * (active + trialing + past_due + cohort) — no extra Stripe calls.
- *
- * Coverage caveat: the "trialed" set is only as complete as the passed lists.
- * Currently-trialing and converted-to-paid trials are caught by the unbounded
- * active/trialing/past_due lists, but a trial that was started AND fully
- * cancelled lives only in `cohort`, which is bounded to the last
- * COHORT_LOOKBACK_DAYS of subscription creations. So a cancelled trial older
- * than that window is missed from the numerator while still counting in the
- * denominator (lead emails are unbounded). Same window limitation as
- * computeConversion.
+ * The caller passes the unbounded status lists that cover every bucket a
+ * trialer can land in — active + trialing + past_due + canceled — so the
+ * "trialed" set is date-complete: a lead who trialed and cancelled long ago is
+ * still counted, with no time-window blind spot.
  */
 export function computeLeadToTrial(
   leadEmails: Set<string>,
@@ -526,10 +519,11 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
   const errors: string[] = [];
   const nowSec = Math.floor(Date.now() / 1000);
 
-  const [active, trialing, pastDue, cohort, reportCardData] = await Promise.all([
+  const [active, trialing, pastDue, canceled, cohort, reportCardData] = await Promise.all([
     safeList({ status: 'active' }, 'active subscriptions', errors),
     safeList({ status: 'trialing' }, 'trialing subscriptions', errors),
     safeList({ status: 'past_due' }, 'past_due subscriptions', errors),
+    safeList({ status: 'canceled' }, 'canceled subscriptions', errors),
     safeList(
       { status: 'all', created: { gte: nowSec - COHORT_LOOKBACK_DAYS * SECONDS_PER_DAY } },
       'conversion cohort',
@@ -544,15 +538,15 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
   const pastDueOut = buildPastDue(pastDue);
   const conversion = computeConversion(cohort, nowSec);
   const leadConversion = computeLeadConversion(reportCardData.uniqueLeadEmails, active, pastDue);
-  // Union all four lists so "ever trialed" catches currently-trialing,
-  // converted-to-paid, AND cancelled trials. cohort overlaps the others but the
-  // Set dedup makes that harmless; it's the only list that surfaces cancelled
-  // trials (within COHORT_LOOKBACK_DAYS — see computeLeadToTrial caveat).
+  // Union the unbounded status lists so "ever trialed" is date-complete:
+  // currently-trialing (trialing), trialed-then-paid (active + past_due), and
+  // trialed-then-cancelled (canceled). No 90-day window, so a lead who trialed
+  // and cancelled long ago is still counted. Set dedup makes overlap harmless.
   const leadToTrial = computeLeadToTrial(reportCardData.uniqueLeadEmails, [
     ...active,
     ...trialing,
     ...pastDue,
-    ...cohort,
+    ...canceled,
   ]);
 
   return {

--- a/frontend/lib/admin/subscription-metrics.ts
+++ b/frontend/lib/admin/subscription-metrics.ts
@@ -37,6 +37,12 @@ export type ReportCardMetrics = {
     percent: number | null;
     excluded: number;
   };
+  trialConversion: {
+    leads: number;
+    trialed: number;
+    percent: number | null;
+    excluded: number;
+  };
   recentLeads: ReportCardLead[];
 };
 
@@ -150,6 +156,58 @@ export function computeLeadConversion(
 
   const percent = leads >= MIN_COHORT_SAMPLE ? Math.round((converted / leads) * 100) : null;
   return { leads, converted, percent, excluded };
+}
+
+/**
+ * Lead → trial conversion. Returns the share of unique lead emails that have
+ * EVER started a trial — currently trialing, already converted to paid, or
+ * cancelled. A subscription counts as "started a trial" when it has a
+ * `trial_start` set, regardless of its current status, so a lead who trialed
+ * and later cancelled still counts.
+ *
+ * Excluded (test/internal) emails are removed from both numerator and
+ * denominator and reported separately. Percent is null when leads <
+ * MIN_COHORT_SAMPLE so the UI can show "not enough data yet".
+ *
+ * Reuses the subscription lists already fetched by getSubscriptionMetrics
+ * (active + trialing + past_due + cohort) — no extra Stripe calls.
+ *
+ * Coverage caveat: the "trialed" set is only as complete as the passed lists.
+ * Currently-trialing and converted-to-paid trials are caught by the unbounded
+ * active/trialing/past_due lists, but a trial that was started AND fully
+ * cancelled lives only in `cohort`, which is bounded to the last
+ * COHORT_LOOKBACK_DAYS of subscription creations. So a cancelled trial older
+ * than that window is missed from the numerator while still counting in the
+ * denominator (lead emails are unbounded). Same window limitation as
+ * computeConversion.
+ */
+export function computeLeadToTrial(
+  leadEmails: Set<string>,
+  subs: Stripe.Subscription[],
+  excludedEmails: Set<string> = getExcludedEmails()
+): { leads: number; trialed: number; percent: number | null; excluded: number } {
+  // Build set of emails that ever started a trial (lowercased).
+  const trialedEmails = new Set<string>();
+  for (const sub of subs) {
+    if (sub.trial_start == null) continue;
+    trialedEmails.add(getCustomerEmail(sub).toLowerCase());
+  }
+
+  let leads = 0;
+  let trialed = 0;
+  let excluded = 0;
+  for (const raw of leadEmails) {
+    const email = raw.toLowerCase();
+    if (excludedEmails.has(email)) {
+      excluded += 1;
+      continue;
+    }
+    leads += 1;
+    if (trialedEmails.has(email)) trialed += 1;
+  }
+
+  const percent = leads >= MIN_COHORT_SAMPLE ? Math.round((trialed / leads) * 100) : null;
+  return { leads, trialed, percent, excluded };
 }
 
 function getInterval(sub: Stripe.Subscription): 'month' | 'year' | null {
@@ -486,6 +544,16 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
   const pastDueOut = buildPastDue(pastDue);
   const conversion = computeConversion(cohort, nowSec);
   const leadConversion = computeLeadConversion(reportCardData.uniqueLeadEmails, active, pastDue);
+  // Union all four lists so "ever trialed" catches currently-trialing,
+  // converted-to-paid, AND cancelled trials. cohort overlaps the others but the
+  // Set dedup makes that harmless; it's the only list that surfaces cancelled
+  // trials (within COHORT_LOOKBACK_DAYS — see computeLeadToTrial caveat).
+  const leadToTrial = computeLeadToTrial(reportCardData.uniqueLeadEmails, [
+    ...active,
+    ...trialing,
+    ...pastDue,
+    ...cohort,
+  ]);
 
   return {
     mrr,
@@ -505,6 +573,7 @@ export async function getSubscriptionMetrics(): Promise<SubscriptionMetrics> {
       last7Days: reportCardData.last7Days,
       last30Days: reportCardData.last30Days,
       conversion: leadConversion,
+      trialConversion: leadToTrial,
       recentLeads: reportCardData.recentLeads,
     },
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
Adds a "Lead → Trial" KPI to the mission-control subscriptions dashboard, sitting next to the existing "Lead → Paid". It shows the share of report-card lead emails that ever started a trial, counting anyone whose Stripe subscription has `trial_start` set regardless of current status, so leads who trialed and later cancelled still count.

`computeLeadToTrial` mirrors `computeLeadConversion`: same email dedup, same test/internal exclusions, same "need ≥5 leads" threshold. It reuses the `active + trialing + past_due + cohort` lists already fetched, so there are no extra Stripe calls. Seven unit tests cover the currently-trialing, converted, cancelled-after-trial, and never-trialed cases.

One caveat is documented in the code: fully-cancelled trials only surface via the 90-day `cohort` list, so a trial cancelled longer ago than that is missed from the numerator. Same window limitation as the existing trial-conversion metric.