### PR TITLE
trend research: 2026-W24 (youth-focused)

### DIFF
--- a/brand/trend-research/2026-W24.json
+++ b/brand/trend-research/2026-W24.json
@@ -1,0 +1,23 @@
+{
+  "week": "2026-W24",
+  "posts": [
+    {
+      "topic": "Referee shortage and sideline abuse",
+      "hook": "Salvaged from the prior W24 draft per user. Trust/community 'good of the game' post (light rankings tie); claims align with the US Soccer referee abuse-prevention policy source, no precise stat attributed. Summer-tournament timely. Soft brand sign-off.",
+      "suggested_tweet": "Summer tournaments are here, and youth soccer is short on refs - sideline abuse is a big reason they quit, which is why US Soccer rolled out a referee abuse-prevention policy. Be the sideline that keeps them in the game.\n\npitchrank.io",
+      "source_url": "https://www.soccerparenting.com/blog/referee-abuse-prevention-policy/"
+    },
+    {
+      "topic": "ECNL national playoffs seeding",
+      "hook": "Anchor = ECNL Boys post-season structure (national playoffs June 25-Jul 2, San Diego). Seeds come from within-conference points only, with no cross-conference normalization - PitchRank's accurate angle. Previewed for the week of June 8-14. Youth subject.",
+      "suggested_tweet": "ECNL's national playoffs start June 25. Seeds come from your record inside your own conference - which never weighs how strong each conference actually is. We rank every youth team in ECNL on one cross-conference scale.\n\npitchrank.io/rankings",
+      "source_url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/ecnlschool.sidearmsports.com/documents/2025/9/27/_2025-26_ECNL_Boys_Post-Season_Structure.pdf"
+    },
+    {
+      "topic": "Youth soccer age-group change for 2026-27",
+      "hook": "Anchor = US Club Soccer 2026-27 age group formation: youth soccer shifts from birth-year (Jan-Dec) to school-year (Aug 1-Jul 31) age groups, effective fall 2026, starting at June 2026 tryouts. Major current parent debate. Angle: rosters reshuffle, so reputation matters even less - check where teams actually stand.",
+      "suggested_tweet": "Big shift this tryout season: US youth soccer moves to Aug 1-Jul 31 age groups for 2026-27, reshuffling rosters nationwide. When teams scramble, last year's reputation means even less. See where your team actually stands now:\n\npitchrank.io/rankings",
+      "source_url": "https://usclubsoccer.org/resources/registration/2026-27-season-age-group-formation/"
+    }
+  ]
+}


### PR DESCRIPTION
Regenerated **2026-W24** (week of June 8-14) end-to-end under the youth-focus rule from #866. Replaces the prior W24 draft (closed #865), dropping its MLS NEXT Cup lead - now owned by W23 (#866) and aging out of the 30-day window by this week - to avoid back-to-back overlap.

3 youth-centered posts (each <280, links pitchrank.io, source-aligned, in-window):
1. **Referee shortage / sideline abuse** - salvaged trust post; summer-tournament timely. ([soccerparenting.com](https://www.soccerparenting.com/blog/referee-abuse-prevention-policy/))
2. **ECNL national playoffs seeding** - playoffs start June 25; seeds from within-conference points, no cross-conference normalization -> one scale. ([ECNL post-season structure](https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/ecnlschool.sidearmsports.com/documents/2025/9/27/_2025-26_ECNL_Boys_Post-Season_Structure.pdf))
3. **2026-27 youth age-group change** - birth-year -> Aug 1-Jul 31 reshuffles rosters this tryout season; reputation matters less. ([usclubsoccer.org](https://usclubsoccer.org/resources/registration/2026-27-season-age-group-formation/))

Sourced via WebSearch (the /last30days engine has no credentials on this host). Not enabling auto-merge - manual review per repo merge policy.