### PR TITLE
fix(marketing): use published final rank in movers RPC + milestone movers

### DIFF
--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -102,31 +102,35 @@ MILESTONE_THRESHOLDS = [10, 25, 50, 100]
 def fetch_milestone_movers(supabase) -> list[dict]:
     """Find teams that crossed into top 10/25/50/100 in their cohort this week.
 
-    Uses rank_in_cohort (current) and rank_change_7d to compute previous rank.
+    Uses the published final rank (current) and rank_change_7d to compute previous rank.
     A milestone crossing means: current <= threshold AND previous > threshold.
     """
     log.info("Fetching milestone movers from Supabase...")
 
-    # All teams in top 100 that improved this week
+    # All teams in top 100 that improved this week, with >= 8 games (matches the
+    # get_biggest_movers reliability gate). rank_in_cohort_final is the published rank
+    # and the basis rank_change_7d is computed against (ranking_history.py), so
+    # `previous = current + change` only holds when current is the final rank.
     resp = (
         supabase.table("rankings_full")
-        .select("team_id, age_group, gender, state_code, rank_in_cohort, rank_change_7d")
-        .lte("rank_in_cohort", max(MILESTONE_THRESHOLDS))
+        .select("team_id, age_group, gender, state_code, rank_in_cohort_final, rank_change_7d")
+        .lte("rank_in_cohort_final", max(MILESTONE_THRESHOLDS))
         .gt("rank_change_7d", 0)
+        .gte("games_played", 8)
         .neq("status", "Not Enough Ranked Games")
-        .order("rank_in_cohort")
+        .order("rank_in_cohort_final")
         .execute()
     )
 
     # Detect milestone crossings — assign highest threshold crossed
     milestones = []
     for team in resp.data or []:
-        current = team.get("rank_in_cohort") or 0
+        current = team.get("rank_in_cohort_final") or 0
         change = team.get("rank_change_7d") or 0
         previous = current + change  # rank_change_7d = previous - current (positive = improved)
         for threshold in MILESTONE_THRESHOLDS:
             if current <= threshold < previous:
-                milestones.append({**team, "milestone": threshold, "previous_rank": previous})
+                milestones.append({**team, "rank_in_cohort": current, "milestone": threshold, "previous_rank": previous})
                 break  # Only count the highest (most impressive) milestone
 
     if not milestones:

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -130,7 +130,9 @@ def fetch_milestone_movers(supabase) -> list[dict]:
         previous = current + change  # rank_change_7d = previous - current (positive = improved)
         for threshold in MILESTONE_THRESHOLDS:
             if current <= threshold < previous:
-                milestones.append({**team, "rank_in_cohort": current, "milestone": threshold, "previous_rank": previous})
+                milestones.append(
+                    {**team, "rank_in_cohort": current, "milestone": threshold, "previous_rank": previous}
+                )
                 break  # Only count the highest (most impressive) milestone
 
     if not milestones:

--- a/supabase/migrations/20260605000000_biggest_movers_use_final_rank.sql
+++ b/supabase/migrations/20260605000000_biggest_movers_use_final_rank.sql
@@ -1,0 +1,86 @@
+-- Align get_biggest_movers.current_rank to the published rank.
+--
+-- current_rank was COALESCE(rank_in_cohort_ml, rank_in_cohort), but the site and
+-- every rank-dependent feature use rank_in_cohort_final (power_score_final ordering;
+-- see rankings_full.rank_in_cohort_final). The movers/spotlight infographics and the
+-- marketing pipeline therefore displayed a rank that did not match pitchrank.io, and
+-- mixed bases with rank_change (which ranking_history.py computes from the final rank
+-- with the final ?? ml ?? base fallback).
+--
+-- Switch to COALESCE(rank_in_cohort_final, rank_in_cohort_ml, rank_in_cohort) so the
+-- displayed rank matches the published rank and the rank_change basis. Return type is
+-- unchanged, so no DROP is needed (only the SELECT/WHERE expressions change).
+
+CREATE OR REPLACE FUNCTION get_biggest_movers(
+  p_days INT DEFAULT 7,
+  p_limit INT DEFAULT 5,
+  p_direction TEXT DEFAULT 'up',
+  p_age_group TEXT DEFAULT NULL,
+  p_gender TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  team_id UUID,
+  team_name TEXT,
+  club_name TEXT,
+  state_code TEXT,
+  rank_change INT,
+  current_rank INT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    rf.team_id,
+    t.team_name,
+    t.club_name,
+    t.state_code,
+    CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END AS rank_change,
+    COALESCE(rf.rank_in_cohort_final, rf.rank_in_cohort_ml, rf.rank_in_cohort) AS current_rank
+  FROM rankings_full rf
+  JOIN teams t ON t.team_id_master = rf.team_id
+  WHERE COALESCE(rf.rank_in_cohort_final, rf.rank_in_cohort_ml, rf.rank_in_cohort) IS NOT NULL
+    AND CASE
+      WHEN p_days <= 7 THEN rf.rank_change_7d
+      ELSE rf.rank_change_30d
+    END IS NOT NULL
+    AND (
+      (p_direction = 'up' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END > 0)
+      OR
+      (p_direction = 'down' AND CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END < 0)
+    )
+    AND (
+      p_age_group IS NULL
+      OR LOWER(rf.age_group) = LOWER(p_age_group)
+      OR rf.age_group = REPLACE(LOWER(p_age_group), 'u', '')
+    )
+    AND (
+      p_gender IS NULL
+      OR LOWER(rf.gender) = LOWER(p_gender)
+      OR (LOWER(p_gender) = 'male' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'female' AND rf.gender IN ('F', 'Female', 'Girls'))
+      OR (LOWER(p_gender) = 'm' AND rf.gender IN ('M', 'Male', 'Boys'))
+      OR (LOWER(p_gender) = 'f' AND rf.gender IN ('F', 'Female', 'Girls'))
+    )
+    AND t.is_deprecated IS NOT TRUE
+    -- Exclude teams with fewer than 8 games (unreliable rank swings)
+    AND COALESCE(rf.games_played, 0) >= 8
+    -- Exclude teams that just became ranked
+    AND COALESCE(rf.status, '') != 'Not Enough Ranked Games'
+  ORDER BY
+    CASE
+      WHEN p_direction = 'up' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END DESC NULLS LAST,
+    CASE
+      WHEN p_direction = 'down' THEN
+        CASE WHEN p_days <= 7 THEN rf.rank_change_7d ELSE rf.rank_change_30d END
+    END ASC NULLS LAST
+  LIMIT p_limit;
+$$;
+
+-- Frontend infographic routes call this RPC with NEXT_PUBLIC_SUPABASE_ANON_KEY;
+-- keep the grant self-contained so a fresh deploy does not depend on env defaults.
+GRANT EXECUTE ON FUNCTION get_biggest_movers TO authenticated, anon;


### PR DESCRIPTION
## What & why

Step 1 of the marketing pipeline (ranking-data fetch) surfaced ranks that **don't match what the site publishes**, and the milestone math mixed two different rank bases.

- `get_biggest_movers` RPC set `current_rank = COALESCE(rank_in_cohort_ml, rank_in_cohort)`
- `fetch_milestone_movers` used `rank_in_cohort`
- …but the site and **`rank_change_7d` itself** (computed in `src/rankings/ranking_history.py:538-554`) use `rank_in_cohort_final` with the `final ?? ml ?? base` fallback.

So `previous = rank_in_cohort + rank_change_7d` was adding a **final-based delta to the wrong base field**, and newsletter/social/infographics displayed ranks off from pitchrank.io (e.g. a team the site shows at **#591** appeared as **#996**).

## Changes
- **RPC** (`supabase/migrations/20260605000000_biggest_movers_use_final_rank.sql`): `current_rank` → `COALESCE(rank_in_cohort_final, rank_in_cohort_ml, rank_in_cohort)` (+ matching `WHERE` guard). Return type unchanged → plain `CREATE OR REPLACE`, preserves the `team_id` column and games filter from #859-era migrations. Also fixes the **movers** and **spotlight** infographic API routes, which share this RPC.
- **`fetch_milestone_movers`**: filter/compute on `rank_in_cohort_final`; add `games_played >= 8` to match the RPC's reliability gate. Side effect: milestones are now Active-only (`rank_in_cohort_final` is NULL for non-Active) — appropriate for "brag" content.

## Verification (live DB via Supabase MCP — local `--dry-run` is TLS-blocked on this machine)
- New `current_rank` is populated for Active climbers and matches `rank_in_cohort_final` (vs the old ml value, e.g. 591 vs 996).
- Milestone query returns sane crossings: non-null final rank, `games_played` 17–30, believable deltas (e.g. *"now #1, was #17"*).

## Deploy note
The migration must be **applied to the live DB** (Supabase) to take effect — not auto-applied by merge. Holding for explicit OK before applying.

## Out of scope (flagged, not fixed here)
`rank_change_7d` shows implausible values for some top climbers in the RPC path (e.g. **+4721**), which would produce "jumped 4721 spots" copy. This is pre-existing (old code used the same field) and confined to the climbers/fallers ordering — the milestone path's top-100 filter avoids it. Worth a separate look at how `rank_change_7d` handles newly-ranked / cohort-changed teams.