### PR TITLE
ci(marketing): trigger Vercel deploy after blog push

### DIFF
--- a/.github/workflows/marketing-pipeline.yml
+++ b/.github/workflows/marketing-pipeline.yml
@@ -80,7 +80,25 @@ jobs:
           python scripts/marketing_pipeline.py $DRY_RUN_FLAG
 
       # ---------------------------------------------------------------
-      # 5. UPLOAD ARTIFACTS
+      # 5. TRIGGER VERCEL DEPLOY
+      # The blog commit is pushed with GITHUB_TOKEN, which does not fire
+      # Vercel's git webhook — the post would not go live until the next
+      # deploy. POST the deploy hook to ship it. No-ops if the secret is
+      # not configured, and is skipped on dry runs.
+      # ---------------------------------------------------------------
+      - name: Trigger Vercel deploy
+        if: success() && github.event.inputs.dry_run != 'true'
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -n "$VERCEL_DEPLOY_HOOK_URL" ]; then
+            curl -fsS -X POST "$VERCEL_DEPLOY_HOOK_URL" && echo "Vercel deploy triggered"
+          else
+            echo "VERCEL_DEPLOY_HOOK_URL not set — skipping deploy trigger"
+          fi
+
+      # ---------------------------------------------------------------
+      # 6. UPLOAD ARTIFACTS
       # ---------------------------------------------------------------
       - name: Upload marketing artifacts
         if: always()


### PR DESCRIPTION
## What & why
The weekly blog post (Step 2) is committed to `main` with `GITHUB_TOKEN`, which **does not fire Vercel's git webhook** — so a freshly generated post wouldn't deploy until the next human/PAT push. This adds a workflow step that POSTs a Vercel **deploy hook** after the pipeline runs, so the post ships immediately.

## Behavior
- Runs after `Run marketing pipeline`, before artifact upload.
- **Guarded**: no-ops with a log line if `VERCEL_DEPLOY_HOOK_URL` is unset → safe to merge before the secret exists.
- **Skipped on dry runs** (`github.event.inputs.dry_run != 'true'`).

## Required to activate (one-time, dashboard)
1. Vercel → Project **pitchrank** → Settings → Git → **Deploy Hooks** → create one for branch `main`.
2. Add the URL as repo secret **`VERCEL_DEPLOY_HOOK_URL`** (`gh secret set VERCEL_DEPLOY_HOOK_URL`).

Until then the step is a harmless no-op. No app/DB code touched.