### PR TITLE
feat(marketing): state-cohort movers for state blog posts + spotlight

### DIFF
--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -213,10 +213,8 @@ def fetch_ranking_highlights(supabase) -> dict:
                     state_movement[st] = state_movement.get(st, 0) + abs(team.get("rank_change", 0))
             if state_movement:
                 spotlight_state = max(state_movement, key=state_movement.get)
-                # Top 3 teams from that state
-                spotlight_teams = [
-                    t for t in state_resp.data if (t.get("state_code") or t.get("state", "")) == spotlight_state
-                ][:3]
+                # Top movers within the spotlight state's cohorts (believable deltas)
+                spotlight_teams = fetch_state_movers(supabase, spotlight_state)["climbers"][:3]
     except Exception as e:
         log.warning(f"Could not determine state spotlight: {e}")
 
@@ -616,6 +614,23 @@ def fetch_age_group_movers(supabase, age_group: str, limit: int = 5) -> dict:
     return {"climbers": _movers("up"), "fallers": _movers("down")}
 
 
+def fetch_state_movers(supabase, state: str, limit: int = 5) -> dict:
+    """Fetch climbers/fallers scoped to one state cohort via get_biggest_state_movers.
+
+    State cohorts are far smaller than national ones, so the deltas are believable
+    and current_rank is the team's rank within its state, not nationally.
+    """
+
+    def _movers(direction: str) -> list[dict]:
+        resp = supabase.rpc(
+            "get_biggest_state_movers",
+            {"p_state": state, "p_limit": limit, "p_direction": direction},
+        ).execute()
+        return resp.data or []
+
+    return {"climbers": _movers("up"), "fallers": _movers("down")}
+
+
 def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     """Generate a weekly SEO-targeted blog post from ranking data.
 
@@ -635,10 +650,13 @@ def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     tags = topic.get("tags", ["Rankings"])
     target_keyword = topic.get("target_keyword", "youth soccer rankings")
 
-    # Age-group posts label their movers by age, so scope the movers to that age.
+    # State and age posts label their movers by that scope, so fetch scoped movers.
     body_data = data
-    if topic.get("type") == "age_group" and supabase is not None:
-        body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
+    if supabase is not None:
+        if topic.get("type") == "age_group":
+            body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
+        elif topic.get("type") == "state_rankings":
+            body_data = {**data, **fetch_state_movers(supabase, topic["state"])}
 
     # Build body using the topic type's template
     body = _build_blog_body(body_data, topic)

--- a/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
+++ b/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
@@ -1,0 +1,89 @@
+-- Biggest movers within a state cohort (state_code x age_group x gender)
+-- rather than the national cohort.
+--
+-- The national get_biggest_movers ranks within huge national cohorts (thousands
+-- of teams per age/gender), so a legitimate weekly score change moves a team
+-- 1000+ positions -> "+2035 spots" copy. State cohorts are far smaller, so the
+-- deltas are believable and the movers are locally relevant.
+--
+-- current_rank is the team's rank within its state cohort, derived on the fly
+-- from rank_in_cohort_final (the published national-cohort rank already orders
+-- teams correctly, so ranking by it within a state yields the state position).
+-- rank_change is rank_change_state_7d/30d, computed by the ranking engine
+-- (ranking_history.py) and persisted in rankings_full.
+
+CREATE OR REPLACE FUNCTION get_biggest_state_movers(
+  p_state TEXT,
+  p_limit INT DEFAULT 5,
+  p_direction TEXT DEFAULT 'up',
+  p_days INT DEFAULT 7,
+  p_age_group TEXT DEFAULT NULL,
+  p_gender TEXT DEFAULT NULL,
+  p_max_state_rank INT DEFAULT 50
+)
+RETURNS TABLE (
+  team_id UUID,
+  team_name TEXT,
+  club_name TEXT,
+  state_code TEXT,
+  rank_change INT,
+  current_rank INT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH state_ranked AS (
+    SELECT
+      rf.team_id,
+      rf.state_code,
+      rf.games_played,
+      rf.status,
+      CASE WHEN p_days <= 7 THEN rf.rank_change_state_7d ELSE rf.rank_change_state_30d END AS rank_change,
+      RANK() OVER (
+        PARTITION BY rf.state_code, rf.age_group, rf.gender
+        ORDER BY rf.rank_in_cohort_final ASC
+      )::INT AS state_rank
+    FROM rankings_full rf
+    WHERE rf.state_code = p_state
+      AND rf.rank_in_cohort_final IS NOT NULL
+      AND (
+        p_age_group IS NULL
+        OR LOWER(rf.age_group) = LOWER(p_age_group)
+        OR rf.age_group = REPLACE(LOWER(p_age_group), 'u', '')
+      )
+      AND (
+        p_gender IS NULL
+        OR LOWER(rf.gender) = LOWER(p_gender)
+        OR (LOWER(p_gender) = 'male' AND rf.gender IN ('M', 'Male', 'Boys'))
+        OR (LOWER(p_gender) = 'female' AND rf.gender IN ('F', 'Female', 'Girls'))
+        OR (LOWER(p_gender) = 'm' AND rf.gender IN ('M', 'Male', 'Boys'))
+        OR (LOWER(p_gender) = 'f' AND rf.gender IN ('F', 'Female', 'Girls'))
+      )
+  )
+  SELECT
+    sr.team_id,
+    t.team_name,
+    t.club_name,
+    sr.state_code,
+    sr.rank_change,
+    sr.state_rank AS current_rank
+  FROM state_ranked sr
+  JOIN teams t ON t.team_id_master = sr.team_id
+  WHERE sr.rank_change IS NOT NULL
+    AND t.is_deprecated IS NOT TRUE
+    AND COALESCE(sr.games_played, 0) >= 8
+    AND COALESCE(sr.status, '') <> 'Not Enough Ranked Games'
+    AND (p_max_state_rank IS NULL OR sr.state_rank <= p_max_state_rank)
+    AND (
+      (p_direction = 'up' AND sr.rank_change > 0)
+      OR (p_direction = 'down' AND sr.rank_change < 0)
+    )
+  ORDER BY
+    CASE WHEN p_direction = 'up' THEN sr.rank_change END DESC NULLS LAST,
+    CASE WHEN p_direction = 'down' THEN sr.rank_change END ASC NULLS LAST
+  LIMIT p_limit;
+$$;
+
+-- Frontend infographic routes and the marketing pipeline call this with the
+-- anon/service keys; keep the grant self-contained.
+GRANT EXECUTE ON FUNCTION get_biggest_state_movers TO authenticated, anon;


### PR DESCRIPTION
> **Stacked on #874** (base = `fix/blog-topics-expansion`). Merge #874 first, then this retargets to `main`.

## What & why
Follow-up to the `rank_change_7d` investigation: national rank deltas are computed within **huge national cohorts** (thousands of teams), so a legitimate weekly move reads as "+2035 spots." This adds **state-cohort movers** — far smaller, believable deltas and locally relevant "now #N in <state>" context that reinforces the state-pillar SEO.

## How it works (no engine change)
- **New RPC `get_biggest_state_movers`**: current state rank is derived on the fly via `RANK() OVER (PARTITION BY state_code, age_group, gender ORDER BY rank_in_cohort_final)` — because `state_rank` is **not persisted** in `rankings_full` (the engine computes it transiently to derive the change, then drops it). The change comes from the engine's already-persisted `rank_change_state_7d/30d`. `p_max_state_rank` (default 50) keeps featured teams near the top of their state.
- **`fetch_state_movers`** + wiring: `state_rankings` blog posts (previously reused national climbers filtered by state) and the **state-spotlight** social post now use true state movers.

## Verification (live MCP; local Python TLS is Norton-blocked)
- `rank_change_state_7d` is engine-computed and sane: **max 358** vs national's thousands.
- NJ (densest state) sample: max delta **~155** vs national **~2035** (~13× smaller), e.g. "now #22 in NJ U13 Boys, was #105."

## Honest caveat
Dense youth cohorts (e.g. NJ U11–U14) still show double/triple-digit weekly moves — the underlying rankings are genuinely volatile week-to-week. The `p_max_state_rank` threshold is tunable, and milestone-style framing ("broke into the NJ top 10") remains available if you want to suppress raw deltas entirely on these surfaces.

## Deploy note
The RPC needs to be **applied to the live DB** to take effect (held for your OK, like the other migrations). The Python falls back to national-filtered movers if the RPC/Supabase is unavailable.