### PR TITLE
feat(marketing): state-cohort movers (re-merge of #876 to main)

### DIFF
--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -659,10 +659,13 @@ def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     # State and age posts label their movers by that scope, so fetch scoped movers.
     body_data = data
     if supabase is not None:
-        if topic.get("type") == "age_group":
-            body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
-        elif topic.get("type") == "state_rankings":
-            body_data = {**data, **fetch_state_movers(supabase, topic["state"])}
+        try:
+            if topic.get("type") == "age_group":
+                body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
+            elif topic.get("type") == "state_rankings":
+                body_data = {**data, **fetch_state_movers(supabase, topic["state"])}
+        except Exception as e:
+            log.warning(f"Scoped movers fetch failed ({topic.get('type')}); falling back to national movers: {e}")
 
     # Build body using the topic type's template
     body = _build_blog_body(body_data, topic)

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -219,10 +219,8 @@ def fetch_ranking_highlights(supabase) -> dict:
                     state_movement[st] = state_movement.get(st, 0) + abs(team.get("rank_change", 0))
             if state_movement:
                 spotlight_state = max(state_movement, key=state_movement.get)
-                # Top 3 teams from that state
-                spotlight_teams = [
-                    t for t in state_resp.data if (t.get("state_code") or t.get("state", "")) == spotlight_state
-                ][:3]
+                # Top movers within the spotlight state's cohorts (believable deltas)
+                spotlight_teams = fetch_state_movers(supabase, spotlight_state)["climbers"][:3]
     except Exception as e:
         log.warning(f"Could not determine state spotlight: {e}")
 
@@ -622,6 +620,23 @@ def fetch_age_group_movers(supabase, age_group: str, limit: int = 5) -> dict:
     return {"climbers": _movers("up"), "fallers": _movers("down")}
 
 
+def fetch_state_movers(supabase, state: str, limit: int = 5) -> dict:
+    """Fetch climbers/fallers scoped to one state cohort via get_biggest_state_movers.
+
+    State cohorts are far smaller than national ones, so the deltas are believable
+    and current_rank is the team's rank within its state, not nationally.
+    """
+
+    def _movers(direction: str) -> list[dict]:
+        resp = supabase.rpc(
+            "get_biggest_state_movers",
+            {"p_state": state, "p_limit": limit, "p_direction": direction},
+        ).execute()
+        return resp.data or []
+
+    return {"climbers": _movers("up"), "fallers": _movers("down")}
+
+
 def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     """Generate a weekly SEO-targeted blog post from ranking data.
 
@@ -641,10 +656,13 @@ def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     tags = topic.get("tags", ["Rankings"])
     target_keyword = topic.get("target_keyword", "youth soccer rankings")
 
-    # Age-group posts label their movers by age, so scope the movers to that age.
+    # State and age posts label their movers by that scope, so fetch scoped movers.
     body_data = data
-    if topic.get("type") == "age_group" and supabase is not None:
-        body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
+    if supabase is not None:
+        if topic.get("type") == "age_group":
+            body_data = {**data, **fetch_age_group_movers(supabase, topic["age_group"])}
+        elif topic.get("type") == "state_rankings":
+            body_data = {**data, **fetch_state_movers(supabase, topic["state"])}
 
     # Build body using the topic type's template
     body = _build_blog_body(body_data, topic)

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -219,8 +219,16 @@ def fetch_ranking_highlights(supabase) -> dict:
                     state_movement[st] = state_movement.get(st, 0) + abs(team.get("rank_change", 0))
             if state_movement:
                 spotlight_state = max(state_movement, key=state_movement.get)
-                # Top movers within the spotlight state's cohorts (believable deltas)
-                spotlight_teams = fetch_state_movers(supabase, spotlight_state)["climbers"][:3]
+                # Prefer state-cohort movers (believable deltas); fall back to the
+                # national movers filtered by state if the state RPC isn't available yet,
+                # so the spotlight stays populated instead of emitting a mismatched post.
+                try:
+                    spotlight_teams = fetch_state_movers(supabase, spotlight_state)["climbers"][:3]
+                except Exception as e:
+                    log.warning(f"State movers RPC unavailable for spotlight; using national movers: {e}")
+                    spotlight_teams = [
+                        t for t in state_resp.data if (t.get("state_code") or t.get("state", "")) == spotlight_state
+                    ][:3]
     except Exception as e:
         log.warning(f"Could not determine state spotlight: {e}")
 

--- a/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
+++ b/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
@@ -1,0 +1,89 @@
+-- Biggest movers within a state cohort (state_code x age_group x gender)
+-- rather than the national cohort.
+--
+-- The national get_biggest_movers ranks within huge national cohorts (thousands
+-- of teams per age/gender), so a legitimate weekly score change moves a team
+-- 1000+ positions -> "+2035 spots" copy. State cohorts are far smaller, so the
+-- deltas are believable and the movers are locally relevant.
+--
+-- current_rank is the team's rank within its state cohort, derived on the fly
+-- from rank_in_cohort_final (the published national-cohort rank already orders
+-- teams correctly, so ranking by it within a state yields the state position).
+-- rank_change is rank_change_state_7d/30d, computed by the ranking engine
+-- (ranking_history.py) and persisted in rankings_full.
+
+CREATE OR REPLACE FUNCTION get_biggest_state_movers(
+  p_state TEXT,
+  p_limit INT DEFAULT 5,
+  p_direction TEXT DEFAULT 'up',
+  p_days INT DEFAULT 7,
+  p_age_group TEXT DEFAULT NULL,
+  p_gender TEXT DEFAULT NULL,
+  p_max_state_rank INT DEFAULT 50
+)
+RETURNS TABLE (
+  team_id UUID,
+  team_name TEXT,
+  club_name TEXT,
+  state_code TEXT,
+  rank_change INT,
+  current_rank INT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH state_ranked AS (
+    SELECT
+      rf.team_id,
+      rf.state_code,
+      rf.games_played,
+      rf.status,
+      CASE WHEN p_days <= 7 THEN rf.rank_change_state_7d ELSE rf.rank_change_state_30d END AS rank_change,
+      RANK() OVER (
+        PARTITION BY rf.state_code, rf.age_group, rf.gender
+        ORDER BY rf.rank_in_cohort_final ASC
+      )::INT AS state_rank
+    FROM rankings_full rf
+    WHERE rf.state_code = p_state
+      AND rf.rank_in_cohort_final IS NOT NULL
+      AND (
+        p_age_group IS NULL
+        OR LOWER(rf.age_group) = LOWER(p_age_group)
+        OR rf.age_group = REPLACE(LOWER(p_age_group), 'u', '')
+      )
+      AND (
+        p_gender IS NULL
+        OR LOWER(rf.gender) = LOWER(p_gender)
+        OR (LOWER(p_gender) = 'male' AND rf.gender IN ('M', 'Male', 'Boys'))
+        OR (LOWER(p_gender) = 'female' AND rf.gender IN ('F', 'Female', 'Girls'))
+        OR (LOWER(p_gender) = 'm' AND rf.gender IN ('M', 'Male', 'Boys'))
+        OR (LOWER(p_gender) = 'f' AND rf.gender IN ('F', 'Female', 'Girls'))
+      )
+  )
+  SELECT
+    sr.team_id,
+    t.team_name,
+    t.club_name,
+    sr.state_code,
+    sr.rank_change,
+    sr.state_rank AS current_rank
+  FROM state_ranked sr
+  JOIN teams t ON t.team_id_master = sr.team_id
+  WHERE sr.rank_change IS NOT NULL
+    AND t.is_deprecated IS NOT TRUE
+    AND COALESCE(sr.games_played, 0) >= 8
+    AND COALESCE(sr.status, '') <> 'Not Enough Ranked Games'
+    AND (p_max_state_rank IS NULL OR sr.state_rank <= p_max_state_rank)
+    AND (
+      (p_direction = 'up' AND sr.rank_change > 0)
+      OR (p_direction = 'down' AND sr.rank_change < 0)
+    )
+  ORDER BY
+    CASE WHEN p_direction = 'up' THEN sr.rank_change END DESC NULLS LAST,
+    CASE WHEN p_direction = 'down' THEN sr.rank_change END ASC NULLS LAST
+  LIMIT p_limit;
+$$;
+
+-- Frontend infographic routes and the marketing pipeline call this with the
+-- anon/service keys; keep the grant self-contained.
+GRANT EXECUTE ON FUNCTION get_biggest_state_movers TO authenticated, anon;

--- a/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
+++ b/supabase/migrations/20260605000001_create_get_biggest_state_movers.sql
@@ -35,17 +35,23 @@ AS $$
   WITH state_ranked AS (
     SELECT
       rf.team_id,
+      t.team_name,
+      t.club_name,
       rf.state_code,
       rf.games_played,
-      rf.status,
       CASE WHEN p_days <= 7 THEN rf.rank_change_state_7d ELSE rf.rank_change_state_30d END AS rank_change,
       RANK() OVER (
         PARTITION BY rf.state_code, rf.age_group, rf.gender
         ORDER BY rf.rank_in_cohort_final ASC
       )::INT AS state_rank
     FROM rankings_full rf
+    JOIN teams t ON t.team_id_master = rf.team_id
+    -- Eligibility that affects the rank basis must be applied before RANK():
+    -- rank_in_cohort_final IS NOT NULL already excludes non-Active teams, and
+    -- excluding deprecated teams here keeps state_rank from being padded by them.
     WHERE rf.state_code = p_state
       AND rf.rank_in_cohort_final IS NOT NULL
+      AND t.is_deprecated IS NOT TRUE
       AND (
         p_age_group IS NULL
         OR LOWER(rf.age_group) = LOWER(p_age_group)
@@ -62,17 +68,14 @@ AS $$
   )
   SELECT
     sr.team_id,
-    t.team_name,
-    t.club_name,
+    sr.team_name,
+    sr.club_name,
     sr.state_code,
     sr.rank_change,
     sr.state_rank AS current_rank
   FROM state_ranked sr
-  JOIN teams t ON t.team_id_master = sr.team_id
   WHERE sr.rank_change IS NOT NULL
-    AND t.is_deprecated IS NOT TRUE
     AND COALESCE(sr.games_played, 0) >= 8
-    AND COALESCE(sr.status, '') <> 'Not Enough Ranked Games'
     AND (p_max_state_rank IS NULL OR sr.state_rank <= p_max_state_rank)
     AND (
       (p_direction = 'up' AND sr.rank_change > 0)


### PR DESCRIPTION
## Why this PR exists
#876 was merged with its base set to `fix/blog-topics-expansion` (the already-merged #874 branch) instead of `main`, so the state-cohort movers work **never reached `main`**. This re-applies it to `main` — and includes the codex-review fixes that landed just after #876 was merged (so they were never in it).

It's a clean replay of two commits onto current `main`; diff vs `main` is **only** the two state-movers files. #873, #874, #875 are unaffected.

## Contents
- **New RPC `get_biggest_state_movers`** (`20260605000001`): ranks within state cohorts (state × age × gender), state rank derived from `rank_in_cohort_final`, change from the engine's `rank_change_state_7d`. Far smaller, believable deltas (NJ max ~155 vs national ~2035) and local "now #N in <state>" context.
- **`fetch_state_movers`** + wiring into `state_rankings` blog posts and the state-spotlight social post.
- **Codex fixes included:** deprecated teams excluded inside the CTE (before `RANK()`); scoped-movers fetch guarded with a fallback to national movers if the RPC is unavailable.

## Verification (live MCP; local Python TLS is Norton-blocked)
- `py_compile` + `ruff` pass.
- RPC logic validated inline for NJ: believable state-scoped deltas; deprecated-exclusion changes nothing for NJ (only 53 deprecated nationwide).

## Deploy note
Migration `20260605000001` must be applied to the live DB to take effect; the Python falls back to national movers until then.