### PR TITLE
fix(security): close P0 privilege-escalation and trial-recycling paths

### DIFF
--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,4 +1,5 @@
 import { stripe, getStripePriceIds } from '@/lib/stripe/server';
+import { getSupabaseAdmin } from '@/lib/supabase/service';
 import { optionalAuth } from '@/lib/api/optionalAuth';
 import { NextResponse } from 'next/server';
 import type Stripe from 'stripe';
@@ -76,8 +77,10 @@ export async function POST(req: Request) {
 
         customerId = customer.id;
 
-        // Save customer ID to profile - this MUST succeed for webhooks to work
-        const { error: updateError } = await supabase
+        // Save customer ID to profile - this MUST succeed for webhooks to work.
+        // API roles no longer have UPDATE on user_profiles; write via the admin
+        // client (user identity comes from the validated session above).
+        const { error: updateError } = await getSupabaseAdmin()
           .from('user_profiles')
           .update({ stripe_customer_id: customerId })
           .eq('id', user.id);

--- a/frontend/app/api/stripe/sync/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/sync/__tests__/route.test.ts
@@ -167,7 +167,7 @@ describe('POST /api/stripe/sync', () => {
       metadata: { supabase_user_id: 'user-real' },
     });
     const update = updateChain({ error: null });
-    mockServerFrom.mockReturnValue(update.client);
+    mockAdminFrom.mockReturnValue(update.client);
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
@@ -178,7 +178,9 @@ describe('POST /api/stripe/sync', () => {
     // Critical: must update the profile keyed by user.id from the verified
     // session, never by stripe_customer_id directly (otherwise a forged session
     // pointing at another user's customer_id would mutate that user's row).
-    expect(mockServerFrom).toHaveBeenCalledWith('user_profiles');
+    // The write goes through the admin client — API roles have no UPDATE
+    // privilege on user_profiles since the P0 lockdown.
+    expect(mockAdminFrom).toHaveBeenCalledWith('user_profiles');
     expect(update.eq).toHaveBeenCalledWith('id', 'user-real');
   });
 

--- a/frontend/app/api/stripe/sync/route.ts
+++ b/frontend/app/api/stripe/sync/route.ts
@@ -74,7 +74,9 @@ export async function POST(req: Request) {
         }
       }
 
-      const { error: updateError } = await supabase.from('user_profiles').update(updates).eq('id', user.id);
+      // Ownership verified above; API roles no longer have UPDATE on user_profiles,
+      // so billing writes go through the admin client.
+      const { error: updateError } = await getSupabaseAdmin().from('user_profiles').update(updates).eq('id', user.id);
 
       if (updateError) {
         console.error('Sync: error updating profile:', updateError);

--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/stripe/server', () => ({
     },
     subscriptions: {
       retrieve: vi.fn(),
+      cancel: vi.fn().mockResolvedValue({ id: 'sub_123', status: 'canceled' }),
     },
     customers: {
       retrieve: vi.fn().mockResolvedValue({ id: 'cus_123', email: 'test@example.com' }),
@@ -53,6 +54,10 @@ vi.mock('@/lib/email/password-setup', () => ({
   sendPasswordSetupEmail: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock('@/lib/email/returning-subscriber', () => ({
+  sendReturningSubscriberEmail: vi.fn().mockResolvedValue(true),
+}));
+
 // Mock @supabase/supabase-js (used directly in webhook route for admin client).
 // Builder supports both:
 //   - update(...).eq(...).select() → returns rows for updateUserProfile-style writes
@@ -64,6 +69,17 @@ function setPriorState(row: Record<string, unknown> | null) {
   priorStateRow = row;
 }
 
+// When set, successive .maybeSingle() calls consume this queue instead of
+// priorStateRow — lets a test return different rows for the customer-ID
+// lookup vs the email lookup in handleCheckoutCompleted.
+let maybeSingleQueue: Array<Record<string, unknown> | null> | null = null;
+function queueMaybeSingle(rows: Array<Record<string, unknown> | null>) {
+  maybeSingleQueue = rows;
+}
+function nextMaybeSingle() {
+  return maybeSingleQueue && maybeSingleQueue.length > 0 ? maybeSingleQueue.shift()! : priorStateRow;
+}
+
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
     from: vi.fn(() => {
@@ -71,13 +87,13 @@ vi.mock('@supabase/supabase-js', () => ({
         update: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockImplementation(() => Promise.resolve({ data: priorStateRow, error: null })),
+        maybeSingle: vi.fn().mockImplementation(() => Promise.resolve({ data: nextMaybeSingle(), error: null })),
         then: undefined,
       };
       // For .eq() chains that terminate in a second .select() (updateUserProfile pattern)
       builder.eq = vi.fn().mockReturnValue({
         select: vi.fn().mockResolvedValue({ data: [{ id: '1' }], error: null }),
-        maybeSingle: vi.fn().mockImplementation(() => Promise.resolve({ data: priorStateRow, error: null })),
+        maybeSingle: vi.fn().mockImplementation(() => Promise.resolve({ data: nextMaybeSingle(), error: null })),
       });
       return builder;
     }),
@@ -96,6 +112,8 @@ import { POST } from '../route';
 import { headers } from 'next/headers';
 import { stripe, updateUserProfile } from '@/lib/stripe/server';
 import { setLifecycle, setSubscriberCustomField, enrollInAutomation } from '@/lib/beehiiv';
+import { sendReturningSubscriberEmail } from '@/lib/email/returning-subscriber';
+import { notifyAdmin } from '@/lib/notifications/admin';
 
 function makeRequest(body = ''): Request {
   return new Request('http://localhost/api/stripe/webhook', {
@@ -107,6 +125,7 @@ function makeRequest(body = ''): Request {
 describe('POST /api/stripe/webhook', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    maybeSingleQueue = null;
     // Reset env vars
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
@@ -268,6 +287,52 @@ describe('POST /api/stripe/webhook', () => {
     );
   });
 
+  it('cancels anonymous trial checkout for a returning subscriber instead of charging', async () => {
+    vi.mocked(headers).mockResolvedValue(
+      new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<ReturnType<typeof headers>>
+    );
+
+    const fakeEvent = {
+      id: 'evt_returning_trial',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_returning',
+          customer: 'cus_new',
+          subscription: 'sub_new',
+        } as unknown as Stripe.Checkout.Session,
+      },
+    } as Stripe.Event;
+
+    vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(fakeEvent);
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_new',
+      status: 'trialing',
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
+
+    // First maybeSingle: lookup by new stripe_customer_id → no profile (anonymous path).
+    // Second maybeSingle: lookup by email → existing account WITH billing history.
+    queueMaybeSingle([
+      null,
+      { id: 'user-returning', stripe_customer_id: 'cus_old', stripe_subscription_id: 'sub_old' },
+    ]);
+
+    const res = await POST(makeRequest('valid body'));
+
+    expect(res.status).toBe(200);
+    // The trial subscription is canceled — never converted to a charge.
+    expect(vi.mocked(stripe.subscriptions.cancel)).toHaveBeenCalledWith('sub_new');
+    // User is told to log in and re-subscribe; admin is notified.
+    expect(vi.mocked(sendReturningSubscriberEmail)).toHaveBeenCalledWith('test@example.com');
+    expect(vi.mocked(notifyAdmin)).toHaveBeenCalledWith(expect.stringContaining('Returning subscriber'));
+    // The profile keeps its existing billing state, and no lifecycle
+    // routing fires for the canceled checkout.
+    expect(vi.mocked(updateUserProfile)).not.toHaveBeenCalled();
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+  });
+
   it('returns 200 for unknown event types (acknowledge receipt)', async () => {
     vi.mocked(headers).mockResolvedValue(
       new Map([['stripe-signature', 'sig_valid']]) as unknown as Awaited<ReturnType<typeof headers>>
@@ -291,6 +356,7 @@ describe('POST /api/stripe/webhook', () => {
 describe('Beehiiv lifecycle routing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    maybeSingleQueue = null;
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
@@ -454,6 +520,7 @@ describe('Beehiiv lifecycle routing', () => {
 describe('Beehiiv automation enrollment', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    maybeSingleQueue = null;
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
@@ -530,6 +597,7 @@ describe('Beehiiv automation enrollment', () => {
 describe('Idempotency on Stripe webhook re-delivery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    maybeSingleQueue = null;
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -259,15 +259,35 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     // Check if a user already exists with this email (signed up but checked out anonymously)
     const { data: profileByEmail } = await getSupabaseAdmin()
       .from('user_profiles')
-      .select('id, stripe_customer_id')
+      .select('id, stripe_customer_id, stripe_subscription_id')
       .eq('email', email)
       .maybeSingle();
 
     if (profileByEmail) {
-      // Existing user — link Stripe subscription to their account
+      // Existing user — link Stripe subscription to their account.
+      // Anonymous checkout always starts a 7-day trial (the email isn't known
+      // until Stripe collects it), so a returning subscriber could recycle
+      // trials by checking out logged-out. If this account already has billing
+      // history, end the trial now — Stripe invoices the first period
+      // immediately and the profile gets the post-trial status.
+      let linkUpdates = anonymousUpdates;
+      const hasBillingHistory = Boolean(profileByEmail.stripe_customer_id || profileByEmail.stripe_subscription_id);
+      if (subscription.status === 'trialing' && hasBillingHistory) {
+        const endedTrial = await stripe.subscriptions.update(subscriptionId, { trial_end: 'now' });
+        linkUpdates = {
+          ...anonymousUpdates,
+          subscription_status: endedTrial.status,
+          plan: mapStatusToPlan(endedTrial.status),
+          subscription_period_end: extractPeriodEnd(endedTrial),
+        };
+        console.log(
+          `[webhook] Ended trial for returning subscriber ${profileByEmail.id} (anonymous checkout with billing history)`
+        );
+      }
+
       await getSupabaseAdmin()
         .from('user_profiles')
-        .update({ ...anonymousUpdates, updated_at: new Date().toISOString() })
+        .update({ ...linkUpdates, updated_at: new Date().toISOString() })
         .eq('id', profileByEmail.id);
 
       await stripe.customers.update(customerId, {

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -13,6 +13,10 @@ import {
   type Lifecycle,
 } from '@/lib/beehiiv';
 import { sendPasswordSetupEmail } from '@/lib/email/password-setup';
+import { sendReturningSubscriberEmail } from '@/lib/email/returning-subscriber';
+
+// Escape HTML to prevent injection via Stripe-sourced strings (customer name/email)
+const escapeHtml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 /**
  * Permanent errors that won't resolve on retry — return 200 so Stripe
@@ -215,10 +219,8 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     return;
   }
 
-  // Fetch subscription details to get period end and status (may be "trialing" for
-  // free trials). Reassigned below if the trial is stripped for a returning
-  // subscriber, so the admin notification and Beehiiv routing see the real status.
-  let subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  // Fetch subscription details to get period end and status (may be "trialing" for free trials)
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
   const baseUpdates = {
     stripe_subscription_id: subscriptionId,
@@ -266,30 +268,38 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       .maybeSingle();
 
     if (profileByEmail) {
-      // Existing user — link Stripe subscription to their account.
       // Anonymous checkout always starts a 7-day trial (the email isn't known
-      // until Stripe collects it), so a returning subscriber could recycle
-      // trials by checking out logged-out. If this account already has billing
-      // history, end the trial now — Stripe invoices the first period
-      // immediately and the profile gets the post-trial status.
-      let linkUpdates = anonymousUpdates;
+      // until Stripe collects it), but trials are for first-time subscribers
+      // only. Don't silently convert the promised trial into an immediate
+      // charge — cancel the subscription (no invoice exists during a trial,
+      // so nothing is charged), leave the profile untouched, and email them
+      // to log in, where checkout offers monthly/annual without a trial.
       const hasBillingHistory = Boolean(profileByEmail.stripe_customer_id || profileByEmail.stripe_subscription_id);
       if (subscription.status === 'trialing' && hasBillingHistory) {
-        subscription = await stripe.subscriptions.update(subscriptionId, { trial_end: 'now' });
-        linkUpdates = {
-          ...anonymousUpdates,
-          subscription_status: subscription.status,
-          plan: mapStatusToPlan(subscription.status),
-          subscription_period_end: extractPeriodEnd(subscription),
-        };
+        await stripe.subscriptions.cancel(subscriptionId);
         console.log(
-          `[webhook] Ended trial for returning subscriber ${profileByEmail.id} (anonymous checkout with billing history)`
+          `[webhook] Canceled anonymous trial for returning subscriber ${profileByEmail.id} (trial already used); sent re-subscribe email`
         );
+
+        try {
+          await sendReturningSubscriberEmail(email);
+        } catch (emailError) {
+          console.error('[webhook] Returning-subscriber email failed (non-fatal):', emailError);
+        }
+
+        await notifyAdmin(
+          `<b>Returning subscriber blocked from second trial</b>\n` +
+            `<b>Email:</b> ${escapeHtml(email)}\n` +
+            `Anonymous trial checkout canceled (no charge); emailed log-in-and-resubscribe link.`
+        );
+        return;
       }
 
+      // Existing account with no billing history (signed up but never
+      // subscribed) — first trial is legitimate; link the subscription.
       await getSupabaseAdmin()
         .from('user_profiles')
-        .update({ ...linkUpdates, updated_at: new Date().toISOString() })
+        .update({ ...anonymousUpdates, updated_at: new Date().toISOString() })
         .eq('id', profileByEmail.id);
 
       await stripe.customers.update(customerId, {
@@ -348,7 +358,6 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   console.log(`[webhook] Subscription activated for customer ${customerId}`);
 
   // Notify admin of new signup — escape HTML to prevent injection via Stripe customer name
-  const escapeHtml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const displayName = escapeHtml((customer as Stripe.Customer).name ?? 'Unknown');
   const displayEmail = escapeHtml((customer as Stripe.Customer).email ?? 'N/A');
   const statusLabel = subscription.status === 'trialing' ? '🆓 Free Trial' : '💳 Paid';

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -215,8 +215,10 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     return;
   }
 
-  // Fetch subscription details to get period end and status (may be "trialing" for free trials)
-  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  // Fetch subscription details to get period end and status (may be "trialing" for
+  // free trials). Reassigned below if the trial is stripped for a returning
+  // subscriber, so the admin notification and Beehiiv routing see the real status.
+  let subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
   const baseUpdates = {
     stripe_subscription_id: subscriptionId,
@@ -273,12 +275,12 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       let linkUpdates = anonymousUpdates;
       const hasBillingHistory = Boolean(profileByEmail.stripe_customer_id || profileByEmail.stripe_subscription_id);
       if (subscription.status === 'trialing' && hasBillingHistory) {
-        const endedTrial = await stripe.subscriptions.update(subscriptionId, { trial_end: 'now' });
+        subscription = await stripe.subscriptions.update(subscriptionId, { trial_end: 'now' });
         linkUpdates = {
           ...anonymousUpdates,
-          subscription_status: endedTrial.status,
-          plan: mapStatusToPlan(endedTrial.status),
-          subscription_period_end: extractPeriodEnd(endedTrial),
+          subscription_status: subscription.status,
+          plan: mapStatusToPlan(subscription.status),
+          subscription_period_end: extractPeriodEnd(subscription),
         };
         console.log(
           `[webhook] Ended trial for returning subscriber ${profileByEmail.id} (anonymous checkout with billing history)`

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -45,13 +45,15 @@ function LoginForm() {
         throw signInError;
       }
 
-      // Session is automatically established by Supabase client
-      // The middleware will refresh it on the next request
-      // Redirect to rankings page (accessible to all users)
-      // Premium users can navigate to their watchlist from there
-      // This avoids the confusing redirect chain for free users:
-      // login -> /watchlist -> middleware redirect -> /upgrade
-      router.push('/rankings');
+      // Session is automatically established by Supabase client; the
+      // middleware will refresh it on the next request.
+      // Honor a same-origin ?next= target (e.g. the returning-subscriber
+      // email links to /login?next=/upgrade). Default to /rankings, which is
+      // accessible to all tiers — avoids the confusing redirect chain for
+      // free users: login -> /watchlist -> middleware redirect -> /upgrade
+      const rawNext = searchParams.get('next');
+      const nextPath = rawNext && rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/rankings';
+      router.push(nextPath);
       router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Login failed. Please try again.');

--- a/frontend/lib/email/returning-subscriber.ts
+++ b/frontend/lib/email/returning-subscriber.ts
@@ -1,0 +1,75 @@
+import { resend } from './resend';
+
+const RETURNING_SUBSCRIBER_HTML = (loginUrl: string) => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome back to PitchRank</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="text-align: center; margin-bottom: 30px;">
+    <h1 style="color: #10b981; margin: 0;">⚽ PitchRank</h1>
+  </div>
+
+  <h2 style="color: #1f2937;">Welcome back!</h2>
+
+  <p>It looks like you already have a PitchRank account with this email address, so we couldn't start a new free trial — trials are for first-time subscribers.</p>
+
+  <p><b>You haven't been charged.</b> To pick up your PitchRank+ subscription again, just log in and choose a monthly or annual plan:</p>
+
+  <div style="text-align: center; margin: 30px 0;">
+    <a href="${loginUrl}" style="display: inline-block; background-color: #10b981; color: #ffffff; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">Log In &amp; Re-Subscribe</a>
+  </div>
+
+  <p style="color: #6b7280; font-size: 14px;">Forgot your password? Use the "Forgot password" option on the sign-in page.</p>
+
+  <p style="margin-top: 30px;">See you on the pitch!</p>
+
+  <p style="color: #6b7280; font-size: 14px;">— The PitchRank Team</p>
+
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+
+  <p style="color: #9ca3af; font-size: 12px; text-align: center;">
+    You're receiving this because a checkout was started with your email address.<br>
+    <a href="https://pitchrank.io" style="color: #9ca3af;">pitchrank.io</a>
+  </p>
+</body>
+</html>
+`;
+
+/**
+ * Sent when a returning subscriber starts an anonymous checkout: the trial-only
+ * anonymous flow is canceled (no charge) and they're asked to log in, where
+ * checkout offers monthly/annual without a trial.
+ * Returns true if sent successfully, false otherwise.
+ * Errors are logged but not thrown - the cancellation stands even if email fails.
+ */
+export async function sendReturningSubscriberEmail(email: string): Promise<boolean> {
+  if (!resend) {
+    console.warn('Resend not configured - skipping returning-subscriber email');
+    return false;
+  }
+
+  try {
+    const loginUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/login?next=/upgrade`;
+    const { error } = await resend.emails.send({
+      from: 'PitchRank <noreply@mail.pitchrank.io>',
+      to: email,
+      subject: 'Welcome back — log in to re-subscribe to PitchRank+',
+      html: RETURNING_SUBSCRIBER_HTML(loginUrl),
+    });
+
+    if (error) {
+      console.error('Failed to send returning-subscriber email:', error);
+      return false;
+    }
+
+    console.log(`Returning-subscriber email sent successfully`);
+    return true;
+  } catch (err) {
+    console.error('Error sending returning-subscriber email:', err);
+    return false;
+  }
+}

--- a/supabase/migrations/20260610120000_p0_lockdown_user_profiles_and_rpc_grants.sql
+++ b/supabase/migrations/20260610120000_p0_lockdown_user_profiles_and_rpc_grants.sql
@@ -1,0 +1,31 @@
+-- P0 security lockdown (audit 2026-06-10)
+--
+-- P0-1: user_profiles allowed anon/authenticated to UPDATE every column on the
+-- caller's own row — including plan, stripe_customer_id, subscription_status —
+-- via the unrestricted self-update RLS policy plus table-wide column grants.
+-- Any signed-in user could self-promote to plan='admin'/'premium', defeating
+-- requireAdmin()/requirePremium() on every gated surface. All legitimate
+-- writes go through the service role (webhook/sync/checkout routes now use the
+-- admin client), so API roles need no INSERT/UPDATE at all. Profile creation
+-- happens in the SECURITY DEFINER handle_new_user trigger.
+
+REVOKE INSERT, UPDATE ON public.user_profiles FROM anon, authenticated;
+
+-- The write policies are unreachable without privileges; drop them so a future
+-- table-level re-grant cannot silently reopen the escalation path.
+DROP POLICY IF EXISTS "Users can update own profile" ON public.user_profiles;
+DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.user_profiles;
+
+-- P0-2: these RPCs were executable by PUBLIC/anon/authenticated.
+-- link_game_team/unlink_game_team are SECURITY DEFINER (they bypass RLS and
+-- the immutable-game trigger), so any visitor could rewrite team-game
+-- mappings directly. The merge/enqueue functions are SECURITY INVOKER but
+-- have no business being callable by API roles either. Every legitimate
+-- caller (Next.js service-client routes, dashboard.py, the enqueue_* scripts
+-- in GitHub Actions) uses the service role, which keeps its explicit grant.
+
+REVOKE EXECUTE ON FUNCTION public.link_game_team(uuid, uuid, boolean) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.unlink_game_team(uuid, uuid, boolean) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.execute_team_merge(uuid, uuid, text, text, double precision, jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.revert_team_merge(uuid, text, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enqueue_scrape_request(uuid, text, uuid, text, date, text, smallint) FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Summary

Closes the three P0 findings from today's full security audit, all verified against the live database before fixing:

1. **Privilege escalation (P0-1):** `user_profiles` granted column-level UPDATE on every column, including `plan` and the Stripe billing columns, to `anon`/`authenticated`, with an unrestricted self-update RLS policy. Any signed-in user could make themselves admin/premium with one PostgREST call. Fixed by revoking INSERT/UPDATE from API roles and dropping the dead write policies.
2. **Public RPC mutation (P0-2):** `link_game_team`/`unlink_game_team` are SECURITY DEFINER and were executable by PUBLIC/anon/authenticated (plus `execute_team_merge`, `revert_team_merge`, `enqueue_scrape_request`). EXECUTE revoked from API roles; `service_role` keeps its grant. All legitimate callers (API routes, dashboard.py, GH Actions enqueue scripts) verified service-role.
3. **Trial recycling (P0-3):** anonymous checkout always granted a 7-day trial and the webhook linked it to any existing profile by email with no history check, so a churned subscriber could recycle trials by checking out logged-out. The webhook now cancels that trial subscription outright (no invoice exists during a trial, so nothing is charged), leaves the profile's billing state untouched, emails the user a log-in-and-resubscribe link, and notifies the admin. Trials stay first-timer-only; returning subscribers re-subscribe through the logged-in flow, which already offers monthly/annual with no trial.

Supporting changes:

- The checkout customer-link and authenticated-sync writes to `user_profiles` move to the admin client (API roles no longer hold UPDATE); ownership checks unchanged and still enforced before each write.
- New `lib/email/returning-subscriber.ts` email, styled after the password-setup email.
- The login page now honors a validated same-origin `?next=` param, so the email's `/login?next=/upgrade` link lands on the plan picker after sign-in.

## Flow

```mermaid
sequenceDiagram
  participant U as Returning subscriber (logged out)
  participant S as Stripe Checkout
  participant W as Webhook
  participant E as Email
  U->>S: completes checkout (7-day trial)
  S->>W: checkout.session.completed
  W->>W: email matches profile with billing history
  W->>S: subscriptions.cancel (no charge)
  W->>E: "log in to re-subscribe" (/login?next=/upgrade)
  U->>U: logs in, picks monthly/annual (no trial)
```

## ⚠️ Deploy urgency

**The migration is already applied to the live database.** Until this deploys, first-time authenticated checkout (customer-ID link) and the authenticated sync fallback hit the revoked grant and return 500. Anonymous checkout, webhooks, and all reads are unaffected. Merging + Vercel deploy restores them.

## Verification

- Live DB re-queried after migration: `user_profiles` INSERT/UPDATE = `postgres`/`service_role` only; all five RPCs EXECUTE = `postgres`/`service_role` only; only the SELECT policy remains.
- `vitest run app/api/stripe`: 46/46 pass, including a new webhook test asserting the returning-subscriber path cancels the subscription, sends the email, and skips profile/lifecycle writes.
- `tsc --noEmit`: clean.
- Review note on stale subscription status in notifications/lifecycle routing is resolved: the returning-subscriber path now returns before the signup notification and lifecycle enrollment, so they can no longer fire with trial state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
