### PR TITLE
fix(api): correct RPC contracts, GA4/GSC queries, and percentile guards in admin + analytics routes

### DIFF
--- a/frontend/app/api/analytics/funnel/route.ts
+++ b/frontend/app/api/analytics/funnel/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: Request) {
 
     const [eventsRes, pageViewsRes] = await Promise.all([
       client.properties.runReport({
-        property: propertyId,
+        property: `properties/${propertyId}`,
         requestBody: {
           dateRanges: [{ startDate, endDate }],
           dimensions: [{ name: 'eventName' }],
@@ -42,7 +42,7 @@ export async function GET(req: Request) {
         },
       }),
       client.properties.runReport({
-        property: propertyId,
+        property: `properties/${propertyId}`,
         requestBody: {
           dateRanges: [{ startDate, endDate }],
           metrics: [{ name: 'screenPageViews' }],

--- a/frontend/app/api/analytics/search-console/route.ts
+++ b/frontend/app/api/analytics/search-console/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { getSearchConsoleClient } from '@/lib/google-auth';
 import { getDateRange } from '@/lib/analytics-utils';
-import type { SearchConsoleData, SearchConsoleRow, SearchConsolePageRow } from '@/types/analytics';
+import type { SearchConsoleData, SearchConsoleRow, SearchConsolePageRow, SearchConsoleTotals } from '@/types/analytics';
 
 export async function GET(req: Request) {
   const auth = await requireAdmin();
@@ -20,7 +20,7 @@ export async function GET(req: Request) {
 
     const client = getSearchConsoleClient();
 
-    const [queriesRes, pagesRes] = await Promise.all([
+    const [queriesRes, pagesRes, totalsRes] = await Promise.all([
       client.searchanalytics.query({
         siteUrl,
         requestBody: {
@@ -37,6 +37,18 @@ export async function GET(req: Request) {
           endDate,
           dimensions: ['page'],
           rowLimit: 25,
+        },
+      }),
+      // Totals need their own date-dimension query: query/page rows are
+      // privacy-thresholded (and capped at 25 here), so summing them
+      // materially understates clicks and impressions
+      client.searchanalytics.query({
+        siteUrl,
+        requestBody: {
+          startDate,
+          endDate,
+          dimensions: ['date'],
+          rowLimit: 1000,
         },
       }),
     ]);
@@ -57,10 +69,11 @@ export async function GET(req: Request) {
       position: row.position || 0,
     }));
 
-    const totals = topQueries.reduce(
+    const totalRows = totalsRes.data.rows || [];
+    const totals = totalRows.reduce<SearchConsoleTotals>(
       (acc, row) => ({
-        clicks: acc.clicks + row.clicks,
-        impressions: acc.impressions + row.impressions,
+        clicks: acc.clicks + (row.clicks || 0),
+        impressions: acc.impressions + (row.impressions || 0),
         ctr: 0,
         position: 0,
       }),
@@ -70,7 +83,8 @@ export async function GET(req: Request) {
     // Compute weighted averages for CTR and position
     if (totals.impressions > 0) {
       totals.ctr = totals.clicks / totals.impressions;
-      totals.position = topQueries.reduce((sum, row) => sum + row.position * row.impressions, 0) / totals.impressions;
+      totals.position =
+        totalRows.reduce((sum, row) => sum + (row.position || 0) * (row.impressions || 0), 0) / totals.impressions;
     }
 
     const data: SearchConsoleData = {

--- a/frontend/app/api/analytics/traffic/route.ts
+++ b/frontend/app/api/analytics/traffic/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: Request) {
 
     const [overviewRes, referralsRes, pagesRes] = await Promise.all([
       client.properties.runReport({
-        property: propertyId,
+        property: `properties/${propertyId}`,
         requestBody: {
           dateRanges: [{ startDate, endDate }],
           metrics: [
@@ -34,7 +34,7 @@ export async function GET(req: Request) {
         },
       }),
       client.properties.runReport({
-        property: propertyId,
+        property: `properties/${propertyId}`,
         requestBody: {
           dateRanges: [{ startDate, endDate }],
           dimensions: [{ name: 'sessionSource' }],
@@ -44,7 +44,7 @@ export async function GET(req: Request) {
         },
       }),
       client.properties.runReport({
-        property: propertyId,
+        property: `properties/${propertyId}`,
         requestBody: {
           dateRanges: [{ startDate, endDate }],
           dimensions: [{ name: 'pagePath' }],

--- a/frontend/app/api/create-team/route.ts
+++ b/frontend/app/api/create-team/route.ts
@@ -116,17 +116,6 @@ export async function POST(request: NextRequest) {
     let awayUpdated = 0;
     const providerIdIsNull = game.provider_id === null;
 
-    // Count games where opponent is HOME team first
-    let homeCountQuery = supabase
-      .from('games')
-      .select('id', { count: 'exact', head: true })
-      .eq('home_provider_id', providerTeamIdStr)
-      .is('home_team_master_id', null);
-    homeCountQuery = providerIdIsNull
-      ? homeCountQuery.is('provider_id', null)
-      : homeCountQuery.eq('provider_id', game.provider_id);
-    const { count: homeCount } = await homeCountQuery;
-
     // Update games where opponent is HOME team
     let homeUpdateQuery = supabase
       .from('games')
@@ -136,24 +125,13 @@ export async function POST(request: NextRequest) {
     homeUpdateQuery = providerIdIsNull
       ? homeUpdateQuery.is('provider_id', null)
       : homeUpdateQuery.eq('provider_id', game.provider_id);
-    const { error: homeUpdateError } = await homeUpdateQuery;
+    const { error: homeUpdateError, data: homeUpdateData } = await homeUpdateQuery.select('id');
 
     if (homeUpdateError) {
       console.error('[create-team] Failed to update home games:', homeUpdateError);
     } else {
-      homeUpdated = homeCount || 0;
+      homeUpdated = homeUpdateData?.length || 0;
     }
-
-    // Count games where opponent is AWAY team first
-    let awayCountQuery = supabase
-      .from('games')
-      .select('id', { count: 'exact', head: true })
-      .eq('away_provider_id', providerTeamIdStr)
-      .is('away_team_master_id', null);
-    awayCountQuery = providerIdIsNull
-      ? awayCountQuery.is('provider_id', null)
-      : awayCountQuery.eq('provider_id', game.provider_id);
-    const { count: awayCount } = await awayCountQuery;
 
     // Update games where opponent is AWAY team
     let awayUpdateQuery = supabase
@@ -164,12 +142,12 @@ export async function POST(request: NextRequest) {
     awayUpdateQuery = providerIdIsNull
       ? awayUpdateQuery.is('provider_id', null)
       : awayUpdateQuery.eq('provider_id', game.provider_id);
-    const { error: awayUpdateError } = await awayUpdateQuery;
+    const { error: awayUpdateError, data: awayUpdateData } = await awayUpdateQuery.select('id');
 
     if (awayUpdateError) {
       console.error('[create-team] Failed to update away games:', awayUpdateError);
     } else {
-      awayUpdated = awayCount || 0;
+      awayUpdated = awayUpdateData?.length || 0;
     }
 
     gamesUpdated = homeUpdated + awayUpdated;

--- a/frontend/app/api/insights/[teamId]/route.ts
+++ b/frontend/app/api/insights/[teamId]/route.ts
@@ -157,6 +157,26 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
       console.error('Error fetching ranking history:', historyError);
     }
 
+    // PostgREST caps un-ranged selects at 1,000 rows, which silently truncates
+    // large cohorts and skews totals/percentiles/medians — page through the set
+    const cohortPageSize = 1000;
+    async function fetchAllRows<T>(
+      buildPage: (from: number, to: number) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+    ): Promise<T[] | null> {
+      const rows: T[] = [];
+      for (let offset = 0; ; offset += cohortPageSize) {
+        const { data, error } = await buildPage(offset, offset + cohortPageSize - 1);
+        if (error) {
+          console.error('Error fetching cohort page:', error);
+          return null;
+        }
+        const batch = (data ?? []) as T[];
+        rows.push(...batch);
+        if (batch.length < cohortPageSize) break;
+      }
+      return rows;
+    }
+
     // Get cohort statistics for context
     let cohortStats = {
       totalTeams: 100,
@@ -167,15 +187,18 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     if (ranking?.age && ranking?.gender) {
       // Only include Active teams in cohort stats to match v53e ranking logic
       // v53e only assigns rank_in_cohort to Active teams (8+ games in 180 days)
-      const { data: cohortData, error: cohortError } = await supabase
-        .from('rankings_view')
-        .select('power_score_final')
-        .eq('age', ranking.age)
-        .eq('gender', ranking.gender)
-        .eq('status', 'Active')
-        .order('power_score_final', { ascending: false });
+      const cohortData = await fetchAllRows<CohortRow>((from, to) =>
+        supabase
+          .from('rankings_view')
+          .select('power_score_final')
+          .eq('age', ranking.age)
+          .eq('gender', ranking.gender)
+          .eq('status', 'Active')
+          .order('power_score_final', { ascending: false })
+          .range(from, to)
+      );
 
-      if (!cohortError && cohortData && cohortData.length > 0) {
+      if (cohortData && cohortData.length > 0) {
         const scores = (cohortData as CohortRow[])
           .map((d: CohortRow) => d.power_score_final)
           .filter((s: number | null): s is number => s !== null);
@@ -198,19 +221,21 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     // State-cohort rank (for state-leaderboard persona trait)
     let stateCohort: InsightInputData['stateCohort'] = null;
     if (team.state_code && ranking?.age && ranking?.gender) {
-      const { data: stateCohortData, error: stateCohortError } = await supabase
-        .from('rankings_view')
-        .select('team_id_master, power_score_final')
-        .eq('age', ranking.age)
-        .eq('gender', ranking.gender)
-        .eq('state', team.state_code)
-        .eq('status', 'Active')
-        .order('power_score_final', { ascending: false });
+      const stateCohortData = await fetchAllRows<{ team_id_master: string; power_score_final: number | null }>(
+        (from, to) =>
+          supabase
+            .from('rankings_view')
+            .select('team_id_master, power_score_final')
+            .eq('age', ranking.age)
+            .eq('gender', ranking.gender)
+            .eq('state', team.state_code)
+            .eq('status', 'Active')
+            .order('power_score_final', { ascending: false })
+            .range(from, to)
+      );
 
-      if (!stateCohortError && stateCohortData && stateCohortData.length >= 5) {
-        const idx = (stateCohortData as Array<{ team_id_master: string }>).findIndex(
-          (r) => r.team_id_master === teamId
-        );
+      if (stateCohortData && stateCohortData.length >= 5) {
+        const idx = stateCohortData.findIndex((r) => r.team_id_master === teamId);
         if (idx >= 0) {
           stateCohort = { rank: idx + 1, totalTeams: stateCohortData.length };
         }

--- a/frontend/app/api/link-opponent/route.ts
+++ b/frontend/app/api/link-opponent/route.ts
@@ -92,27 +92,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 3. Create or update alias mapping (upsert)
-
-    const { error: aliasError } = await supabase.from('team_alias_map').upsert(
-      {
-        provider_id: game.provider_id,
-        provider_team_id: providerTeamIdStr,
-        team_id_master: teamIdMaster,
-        match_method: 'manual', // Valid values: auto, manual, import, direct_id, fuzzy_auto, fuzzy_review
-        match_confidence: 1.0,
-        review_status: 'approved',
-      },
-      {
-        onConflict: 'provider_id,provider_team_id',
-      }
-    );
-
-    if (aliasError) {
-      console.error('[link-opponent] Failed to create alias:', aliasError);
-      return NextResponse.json({ error: 'Failed to create team alias mapping' }, { status: 500 });
-    }
-
     let gamesUpdated = 0;
     let homeUpdated = 0;
     let awayUpdated = 0;
@@ -122,7 +101,7 @@ export async function POST(request: NextRequest) {
     // Note: isOpponentHome, isOpponentAway are already defined above
     // At this point, we know the opponent needs linking (validated in early check)
 
-    // 4. FIRST: Always update the specific game the user clicked on (by ID)
+    // 3. FIRST: Always update the specific game the user clicked on (by ID)
     // This ensures the clicked game gets updated regardless of any type issues with provider_id matching
     if (isOpponentHome) {
       // Try using RPC function first (handles immutability properly)
@@ -272,6 +251,28 @@ export async function POST(request: NextRequest) {
           { status: 500 }
         );
       }
+    }
+
+    // 4. Create or update alias mapping — only after the specific game link is
+    // proven, so a failed link can't leave behind a permanent approved alias
+    // that future imports would auto-apply
+    const { error: aliasError } = await supabase.from('team_alias_map').upsert(
+      {
+        provider_id: game.provider_id,
+        provider_team_id: providerTeamIdStr,
+        team_id_master: teamIdMaster,
+        match_method: 'manual', // Valid values: auto, manual, import, direct_id, fuzzy_auto, fuzzy_review
+        match_confidence: 1.0,
+        review_status: 'approved',
+      },
+      {
+        onConflict: 'provider_id,provider_team_id',
+      }
+    );
+
+    if (aliasError) {
+      console.error('[link-opponent] Failed to create alias:', aliasError);
+      return NextResponse.json({ error: 'Game linked, but creating the team alias mapping failed' }, { status: 500 });
     }
 
     // 5. Backfill OTHER games with this provider_team_id (only the unknown side)

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -53,7 +53,9 @@ export async function POST(request: NextRequest) {
       .eq('team_id_master', teamId)
       .single();
 
-    if (rankingError || !ranking || ranking.power_score_final == null) {
+    // rank_in_cohort_final is null for non-Active teams; without it the
+    // percentile math below degenerates to "top 100% nationally"
+    if (rankingError || !ranking || ranking.power_score_final == null || ranking.rank_in_cohort_final == null) {
       return NextResponse.json(
         { error: 'Not enough ranking data for this team. Check back after they have played more games.' },
         { status: 400 }

--- a/frontend/app/api/team-merge/route.ts
+++ b/frontend/app/api/team-merge/route.ts
@@ -60,25 +60,36 @@ export async function POST(request: NextRequest) {
 
     const supabase = createServiceSupabase();
 
-    // Execute the merge via PostgreSQL function
-    const { data: mergeId, error } = await supabase.rpc('execute_team_merge', {
+    // Execute the merge via PostgreSQL function. It returns jsonb:
+    // { success: true, merge_id, ... } on success, or { success: false, error }
+    // for business failures, which arrive without a PostgREST error.
+    const { data, error } = await supabase.rpc('execute_team_merge', {
       p_deprecated_team_id: deprecatedTeamId,
       p_canonical_team_id: canonicalTeamId,
       p_merged_by: mergedBy,
       p_merge_reason: mergeReason || null,
+      p_confidence_score: confidenceScore ?? null,
+      p_suggestion_signals: suggestionSignals ?? null,
     });
 
-    if (error) {
-      console.error('[team-merge] Merge failed:', error);
+    const mergeResult = data as {
+      success?: boolean;
+      merge_id?: string;
+      already_merged?: boolean;
+      message?: string;
+      error?: string;
+    } | null;
+
+    if (error || !mergeResult?.success) {
+      const message = error?.message || mergeResult?.error || 'Unknown error';
+      console.error('[team-merge] Merge failed:', message);
 
       // Parse PostgreSQL error messages for user-friendly responses
-      const message = error.message || 'Unknown error';
-
       if (message.includes('already deprecated') || message.includes('already merged')) {
         return NextResponse.json({ error: 'This team has already been merged' }, { status: 409 });
       }
 
-      if (message.includes('circular merge') || message.includes('chain')) {
+      if (message.includes('circular merge') || message.includes('chain') || message.includes('marked as deprecated')) {
         return NextResponse.json(
           { error: 'Cannot create circular or chain merges. The canonical team is already deprecated.' },
           { status: 400 }
@@ -92,16 +103,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Merge failed due to an internal error' }, { status: 500 });
     }
 
-    // If confidence score and signals were provided (from Option 8), update the merge record
-    if (mergeId && (confidenceScore !== undefined || suggestionSignals)) {
-      await supabase
-        .from('team_merge_map')
-        .update({
-          confidence_score: confidenceScore || null,
-          suggestion_signals: suggestionSignals || null,
-        })
-        .eq('id', mergeId);
-    }
+    const mergeId = mergeResult.merge_id ?? null;
 
     // Fetch both team names for the response
     const { data: teams } = await supabase
@@ -169,17 +171,35 @@ export async function DELETE(request: NextRequest) {
       .eq('team_id_master', deprecatedTeamId)
       .single();
 
-    // Execute the revert via PostgreSQL function
-    const { error } = await supabase.rpc('revert_team_merge', {
-      p_deprecated_team_id: deprecatedTeamId,
+    // revert_team_merge takes the merge record ID, so resolve it from the team
+    const { data: mergeRecord, error: mergeLookupError } = await supabase
+      .from('team_merge_map')
+      .select('id')
+      .eq('deprecated_team_id', deprecatedTeamId)
+      .maybeSingle();
+
+    if (mergeLookupError) {
+      console.error('[team-merge] Merge lookup failed:', mergeLookupError);
+      return NextResponse.json({ error: 'Revert failed due to an internal error' }, { status: 500 });
+    }
+
+    if (!mergeRecord) {
+      return NextResponse.json({ error: 'This team is not currently merged' }, { status: 404 });
+    }
+
+    // Execute the revert via PostgreSQL function. It returns jsonb:
+    // { success: true, ... } or { success: false, error } for business failures.
+    const { data, error } = await supabase.rpc('revert_team_merge', {
+      p_merge_id: mergeRecord.id,
       p_reverted_by: revertedBy,
       p_revert_reason: revertReason || null,
     });
 
-    if (error) {
-      console.error('[team-merge] Revert failed:', error);
+    const revertResult = data as { success?: boolean; error?: string } | null;
 
-      const message = error.message || 'Unknown error';
+    if (error || !revertResult?.success) {
+      const message = error?.message || revertResult?.error || 'Unknown error';
+      console.error('[team-merge] Revert failed:', message);
 
       if (message.includes('not found') || message.includes('not merged')) {
         return NextResponse.json({ error: 'This team is not currently merged' }, { status: 404 });

--- a/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
@@ -24,25 +24,31 @@ export type Ga4UpgradeSourcesRow = {
 async function fetchRaw(range: DateRange, limit: number) {
   try {
     const client = getAnalyticsDataClient();
-    const res = await client.properties.runReport({
-      property: `properties/${GA4_PROPERTY_ID}`,
-      requestBody: {
-        dateRanges: [{ startDate: range.start, endDate: range.end }],
-        dimensions: [{ name: 'customEvent:source' }, { name: 'eventName' }],
-        metrics: [{ name: 'eventCount' }],
-        dimensionFilter: {
-          filter: {
-            fieldName: 'eventName',
-            inListFilter: {
-              values: ['upgrade_page_viewed', 'subscription_completed'],
+    // One report per event type: a single globally-sorted report truncates at
+    // its row limit, and view rows dwarf subscription rows, so subscription
+    // counts near the cutoff silently vanish
+    const reportFor = (eventName: string) =>
+      client.properties.runReport({
+        property: `properties/${GA4_PROPERTY_ID}`,
+        requestBody: {
+          dateRanges: [{ startDate: range.start, endDate: range.end }],
+          dimensions: [{ name: 'customEvent:source' }, { name: 'eventName' }],
+          metrics: [{ name: 'eventCount' }],
+          dimensionFilter: {
+            filter: {
+              fieldName: 'eventName',
+              stringFilter: { matchType: 'EXACT', value: eventName },
             },
           },
+          orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+          limit: String(limit),
         },
-        orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
-        limit: String(limit * 2), // 2 event types per source
-      },
-    });
-    return res.data;
+      });
+    const [views, subscriptions] = await Promise.all([
+      reportFor('upgrade_page_viewed'),
+      reportFor('subscription_completed'),
+    ]);
+    return { rows: [...(views.data.rows ?? []), ...(subscriptions.data.rows ?? [])] };
   } catch (e) {
     const err = e as { code?: number; status?: number };
     if (err?.code === 400 || err?.status === 400) {

--- a/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
+++ b/frontend/lib/internal-analytics/queries/ga4-upgrade-sources.ts
@@ -27,7 +27,7 @@ async function fetchRaw(range: DateRange, limit: number) {
     // One report per event type: a single globally-sorted report truncates at
     // its row limit, and view rows dwarf subscription rows, so subscription
     // counts near the cutoff silently vanish
-    const reportFor = (eventName: string) =>
+    const reportFor = (eventName: string, rowLimit: number) =>
       client.properties.runReport({
         property: `properties/${GA4_PROPERTY_ID}`,
         requestBody: {
@@ -41,12 +41,15 @@ async function fetchRaw(range: DateRange, limit: number) {
             },
           },
           orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
-          limit: String(limit),
+          limit: String(rowLimit),
         },
       });
+    // Subscriptions get a high cap: the displayed set is the top `limit`
+    // sources by views, and a converting source whose subscription count
+    // ranks below `limit` would otherwise show a false 0% conversion
     const [views, subscriptions] = await Promise.all([
-      reportFor('upgrade_page_viewed'),
-      reportFor('subscription_completed'),
+      reportFor('upgrade_page_viewed', limit),
+      reportFor('subscription_completed', 10000),
     ]);
     return { rows: [...(views.data.rows ?? []), ...(subscriptions.data.rows ?? [])] };
   } catch (e) {


### PR DESCRIPTION
Batch of correctness fixes across the admin and analytics API routes, all confirmed against the live database and Google API contracts.

**Team data admin routes**
- `team-merge` POST now parses the jsonb result of `execute_team_merge` (business failures used to return HTTP 200), passes confidence score and suggestion signals directly to the RPC instead of a broken follow-up update, and maps the "already merged elsewhere" and "deprecated canonical" cases to proper statuses.
- `team-merge` DELETE now resolves the merge record ID and calls `revert_team_merge(p_merge_id, ...)`, matching the live signature. Admin merge-revert was broken: the route sent `p_deprecated_team_id`, which the function does not accept.
- `create-team` reports backfill counts from `.update().select()` row counts instead of a separate pre-count query, so the audit log reflects what actually changed.
- `link-opponent` upserts the alias only after the game link is proven, so a failed link can no longer leave behind a permanent approved alias that future imports would auto-apply.

**Reports and insights**
- `reports/team-card` guards `rank_in_cohort_final` being null. Teams without a published cohort rank used to get a "top 100% nationally" email.
- `insights/[teamId]` pages through cohort and state queries, which were silently truncated at PostgREST's 1,000-row cap and skewed totals, percentiles, and medians for large cohorts.

**Analytics**
- `analytics/funnel` and `analytics/traffic` prefix the GA4 property as `properties/{id}`, matching the rest of the codebase. These legacy routes were failing with the bare env var.
- `analytics/search-console` computes site totals from a date-dimension query instead of summing the top 25 privacy-thresholded rows, which materially understated clicks and impressions.
- `ga4-upgrade-sources` runs one report per event type so subscription rows are no longer crowded out of the globally sorted result near the row limit.

No schema or behavior changes outside these routes. Verified with tsc, eslint, the full vitest suite (268 passing), and a manual smoke pass on every changed route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
