### PR TITLE
fix(rankings): fail-loud fetches, self-game filter, null-gender cohorts, cache + batching integrity

### DIFF
--- a/src/etl/enhanced_pipeline.py
+++ b/src/etl/enhanced_pipeline.py
@@ -2079,7 +2079,13 @@ class EnhancedETLPipeline:
         ssl_error_count = 0
         current_batch_size = self.batch_size
 
-        for chunk in self._chunks(insert_records, current_batch_size):
+        # current_batch_size shrinks adaptively under 429/SSL pressure;
+        # re-slice each iteration so the reduction applies to the chunks
+        # still to come
+        chunk_offset = 0
+        while chunk_offset < len(insert_records):
+            chunk = insert_records[chunk_offset : chunk_offset + current_batch_size]
+            chunk_offset += len(chunk)
             # Enhanced retry logic: more retries for SSL errors, fewer for other errors
             max_retries = 5  # Increased from 3 for SSL errors
             retry_delay = 1.0

--- a/src/etl/glicko_engine.py
+++ b/src/etl/glicko_engine.py
@@ -620,7 +620,7 @@ def get_anchor(age, gender: str, cfg: GlickoConfig) -> float:
     """Look up the calibrated anchor for a given age and gender.
 
     Args:
-        age: Age as an int (14) or string like 'U14' / 'u14'.
+        age: Age as an int (14) or string like 'U14' / 'u14' / '14.0'.
         gender: Gender string — anything starting with 'M' (case-insensitive)
                 or equal to 'Male' is treated as male; all others as female.
         cfg: GlickoConfig containing MALE_ANCHORS and FEMALE_ANCHORS.
@@ -628,9 +628,13 @@ def get_anchor(age, gender: str, cfg: GlickoConfig) -> float:
     Returns:
         Anchor float from the config, or 1.0 for unknown ages.
     """
-    # Normalise age to int
+    # Normalise age to int. Parse via float so stringified floats ('14.0')
+    # resolve instead of crashing; unparseable ages take the unknown-age anchor.
     if isinstance(age, str):
-        age = int(age.lstrip("Uu"))
+        try:
+            age = int(float(age.lstrip("Uu")))
+        except ValueError:
+            return 1.0
 
     # Choose anchor dict by gender
     if gender.upper().startswith("M"):

--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -510,12 +510,14 @@ def _compute_publication_cap_scores(teams_age: pd.DataFrame, base_scores: pd.Ser
     pre_cap_df["pre_cap_base"] = pd.to_numeric(base_scores, errors="coerce")
 
     age_cap_lookup: dict[int, float] = {}
-    for cap_rank in sorted(cap_rank_series.dropna().astype(int).unique()):
-        age_cap_lookup[int(cap_rank)] = _score_cutoff_for_rank(pre_cap_df, "pre_cap_base", cap_rank)
 
-    result.loc[cap_rank_series.notna()] = cap_rank_series.loc[cap_rank_series.notna()].map(
-        lambda val: age_cap_lookup[int(val)]
-    )
+    def _cap_for_rank(val: float) -> float:
+        rank = int(val)
+        if rank not in age_cap_lookup:
+            age_cap_lookup[rank] = _score_cutoff_for_rank(pre_cap_df, "pre_cap_base", rank)
+        return age_cap_lookup[rank]
+
+    result.loc[cap_rank_series.notna()] = cap_rank_series.loc[cap_rank_series.notna()].map(_cap_for_rank)
     return result
 
 
@@ -2122,8 +2124,12 @@ async def compute_rankings_with_ml(
                 if cache_file_games.exists():
                     try:
                         cached_games_used = pd.read_parquet(cache_file_games)
-                    except Exception:
-                        pass  # games_used cache failed, use empty
+                    except Exception as error:
+                        # A partial hit (cached ratings + freshly fetched ML inputs)
+                        # would mix two game universes, so a failed games_used load
+                        # invalidates the entire cached set
+                        logger.warning("games_used cache load failed; rebuilding rankings: %s", error)
+                        raise
                 if use_glicko:
                     if cache_file_explain.exists():
                         try:

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -100,6 +100,11 @@ def batch_fetch_rows(
 
     Returns:
         Flat list of row dicts from all batches.
+
+    Raises:
+        Exception: If any batch still fails after retries. Callers feed the
+            rankings universe, so returning partial rows would silently shrink
+            the dataset instead of surfacing the failure.
     """
     rows: list[dict] = []
     for i in range(0, len(filter_values), batch_size):
@@ -111,11 +116,11 @@ def batch_fetch_rows(
                 initial_delay=2.0,
                 description=f"Fetching {table} batch {i}-{i + batch_size}",
             )
-            if getattr(result, "data", None):
-                rows.extend(result.data)
         except Exception as e:
-            logger.warning(f"⚠️  {table} batch failed ({i}-{i + batch_size}) after retries: {str(e)[:100]}")
-            continue
+            logger.error(f"❌ {table} batch failed ({i}-{i + batch_size}) after retries: {str(e)[:100]}")
+            raise
+        if getattr(result, "data", None):
+            rows.extend(result.data)
     return rows
 
 
@@ -213,19 +218,27 @@ async def fetch_games_for_rankings(
     )  # Order for consistent pagination
 
     if provider_filter:
-        # Get provider ID with retry logic
+        # Get provider ID with retry logic. A failed lookup must abort rather
+        # than degrade to unfiltered all-provider rankings.
         try:
+            # maybe_single returns None on no match instead of raising PGRST116
+            # like single() would, so the no-provider case reaches the explicit
+            # check below rather than the retry/except path
             provider_result = retry_supabase_query(
-                lambda: db.table("providers").select("id").eq("code", provider_filter).single().execute(),
+                lambda: db.table("providers").select("id").eq("code", provider_filter).maybe_single().execute(),
                 max_retries=4,
                 initial_delay=2.0,
                 description=f"Fetching provider filter '{provider_filter}'",
             )
-            if getattr(provider_result, "data", None):
-                base_query = base_query.eq("provider_id", provider_result.data["id"])
         except Exception as e:
-            logger.warning(f"⚠️  Failed to fetch provider filter '{provider_filter}' after retries: {str(e)[:100]}")
-            # Continue without provider filter
+            logger.error(f"❌ Failed to fetch provider filter '{provider_filter}' after retries: {str(e)[:100]}")
+            raise RuntimeError(
+                f"Provider filter '{provider_filter}' could not be resolved; "
+                "refusing to fall back to unfiltered all-provider rankings"
+            ) from e
+        if not getattr(provider_result, "data", None):
+            raise RuntimeError(f"Provider filter '{provider_filter}' matched no provider")
+        base_query = base_query.eq("provider_id", provider_result.data["id"])
 
     # Paginate to fetch all games (Supabase max is 1000 per query)
     games_data = []
@@ -493,6 +506,14 @@ async def fetch_games_for_rankings(
                 f"✅ Deprecated filter: 0 rows removed "
                 f"(all {len(deprecated_team_ids)} deprecated teams properly merged)"
             )
+
+    # Filter out self-games (team_id == opp_id). These arise when merge
+    # resolution maps both sides of an alias-vs-alias game onto the same
+    # canonical team, leaving a team playing itself.
+    self_game_mask = v53e_df["team_id"].astype(str) == v53e_df["opp_id"].astype(str)
+    if self_game_mask.any():
+        logger.warning(f"🚫 Removed {int(self_game_mask.sum()):,} self-game perspective rows (alias-vs-alias merges)")
+        v53e_df = v53e_df[~self_game_mask]
 
     # Filter out rows with missing scores
     before_filter = len(v53e_df)

--- a/src/rankings/data_adapter.py
+++ b/src/rankings/data_adapter.py
@@ -551,7 +551,11 @@ def supabase_to_v53e_format(games_df: pd.DataFrame, teams_df: pd.DataFrame) -> p
     # Normalize gender values
     teams_df["gender"] = normalize_gender(teams_df["gender"])
     team_age_map = dict(zip(teams_df["team_id_master"], teams_df["age"]))
-    team_gender_map = dict(zip(teams_df["team_id_master"], teams_df["gender"]))
+    # Exclude null genders so the falsy guard below drops those teams' games —
+    # a mapped NaN would slip through it, since bool(nan) is True
+    team_gender_map = {
+        tid: gender for tid, gender in zip(teams_df["team_id_master"], teams_df["gender"]) if pd.notna(gender)
+    }
 
     # Convert to v53e format (perspective-based)
     v53e_rows = []

--- a/src/rankings/shared.py
+++ b/src/rankings/shared.py
@@ -26,8 +26,12 @@ def sos_ml_blend(ps_adj: float, ps_ml: float, sos_norm: float) -> float:
 
 
 def normalize_gender(series: pd.Series) -> pd.Series:
-    """Normalize gender labels: boys/girls → male/female."""
-    return (
+    """Normalize gender labels: boys/girls → male/female.
+
+    Nulls stay null — ``astype(str)`` would stringify them to ``"nan"``/
+    ``"none"``, leaking unknown-gender rows into phantom cohorts.
+    """
+    normalized = (
         series.astype(str)
         .str.lower()
         .str.strip()
@@ -40,6 +44,7 @@ def normalize_gender(series: pd.Series) -> pd.Series:
             }
         )
     )
+    return normalized.mask(series.isna())
 
 
 # --------------------------------------------------------------------

--- a/tests/test_enhanced_pipeline.py
+++ b/tests/test_enhanced_pipeline.py
@@ -878,5 +878,62 @@ class TestShouldAcceptForInsertStrictness:
         assert pipeline._should_accept_for_insert(game) is True
 
 
+class _RecordingInsertClient:
+    """Fake Supabase client that records insert chunk sizes and fails once."""
+
+    def __init__(self, fail_first_with: str):
+        self.insert_sizes: List[int] = []
+        self._fail_first_with = fail_first_with
+        self._calls = 0
+        self._pending: List[Dict] = []
+
+    def table(self, name):
+        assert name == 'games'
+        return self
+
+    def insert(self, chunk, returning=None):
+        self._pending = chunk if isinstance(chunk, list) else [chunk]
+        return self
+
+    def execute(self):
+        self._calls += 1
+        self.insert_sizes.append(len(self._pending))
+        if self._calls == 1:
+            raise Exception(self._fail_first_with)
+        return Mock(data=[])
+
+
+class TestAdaptiveBatchSizing:
+    """The insert loop must re-chunk remaining records after a batch-size reduction."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_reduction_rechunks_remaining_records(self, monkeypatch):
+        monkeypatch.setattr('src.etl.enhanced_pipeline.time.sleep', lambda _s: None)
+
+        client = _RecordingInsertClient(fail_first_with='429 Too Many Requests')
+        pipeline = EnhancedETLPipeline(client, 'gotsport', dry_run=False)
+        pipeline.batch_size = 2000
+
+        records = [
+            {
+                'game_uid': f'uid-{idx}',
+                'home_provider_id': f'home-{idx}',
+                'away_provider_id': f'away-{idx}',
+                'home_score': 1,
+                'away_score': 0,
+                'game_date': '2026-01-15',
+                'age_group': 'u14',
+            }
+            for idx in range(6000)
+        ]
+
+        inserted = await pipeline._bulk_insert_games(records)
+
+        assert inserted == 6000
+        # After the 429 halves the batch size to 1000, the remaining records
+        # must re-slice at 1000, not the original 2000
+        assert client.insert_sizes == [2000, 2000, 1000, 1000, 1000, 1000]
+
+
 # Run with: pytest tests/test_enhanced_pipeline.py -v
 

--- a/tests/unit/test_normalize_gender.py
+++ b/tests/unit/test_normalize_gender.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from src.rankings.shared import normalize_gender
+
+
+def test_normalize_gender_maps_labels():
+    series = pd.Series(["Boys", "girl", " MALE ", "Female"])
+
+    assert normalize_gender(series).tolist() == ["male", "female", "male", "female"]
+
+
+def test_normalize_gender_keeps_nulls_null():
+    series = pd.Series(["Boys", None, np.nan, "Girls"])
+
+    result = normalize_gender(series)
+
+    assert result.isna().tolist() == [False, True, True, False]
+    # Nulls must not be stringified into phantom "nan"/"none" cohorts
+    assert set(result.dropna()) == {"male", "female"}

--- a/tests/unit/test_normalize_gender.py
+++ b/tests/unit/test_normalize_gender.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+from src.rankings.data_adapter import supabase_to_v53e_format
 from src.rankings.shared import normalize_gender
 
 
@@ -18,3 +19,40 @@ def test_normalize_gender_keeps_nulls_null():
     assert result.isna().tolist() == [False, True, True, False]
     # Nulls must not be stringified into phantom "nan"/"none" cohorts
     assert set(result.dropna()) == {"male", "female"}
+
+
+def test_supabase_to_v53e_format_drops_null_gender_teams():
+    games_df = pd.DataFrame(
+        [
+            {
+                "id": "game-1",
+                "game_date": "2026-04-01",
+                "home_team_master_id": "team-known",
+                "away_team_master_id": "team-nullgender",
+                "home_score": 2,
+                "away_score": 1,
+            },
+            {
+                "id": "game-2",
+                "game_date": "2026-04-02",
+                "home_team_master_id": "team-known",
+                "away_team_master_id": "team-known2",
+                "home_score": 1,
+                "away_score": 1,
+            },
+        ]
+    )
+    teams_df = pd.DataFrame(
+        [
+            {"team_id_master": "team-known", "age_group": "u12", "gender": "Male"},
+            {"team_id_master": "team-known2", "age_group": "u12", "gender": "Boys"},
+            {"team_id_master": "team-nullgender", "age_group": "u12", "gender": None},
+        ]
+    )
+
+    result = supabase_to_v53e_format(games_df, teams_df)
+
+    # The null-gender team's game is dropped entirely; no NaN cohort rows leak
+    assert set(result["game_id"]) == {"game-2"}
+    assert result["gender"].notna().all()
+    assert set(result["gender"]) == {"male"}

--- a/tests/unit/test_rankings_data_adapter_fetch.py
+++ b/tests/unit/test_rankings_data_adapter_fetch.py
@@ -47,6 +47,9 @@ class _FakeQuery:
         self.in_values = list(values)
         return self
 
+    def maybe_single(self):
+        return self
+
     def range(self, start, end):
         clone = _FakeQuery(self.client, self.table_name)
         clone.select_columns = self.select_columns
@@ -63,15 +66,28 @@ class _FakeQuery:
             return _FakeResult(page or [])
 
         if self.table_name == "teams":
-            return _FakeResult([self.client.team_rows[team_id] for team_id in self.in_values if team_id in self.client.team_rows])
+            return _FakeResult(
+                [self.client.team_rows[team_id] for team_id in self.in_values if team_id in self.client.team_rows]
+            )
+
+        if self.table_name == "providers":
+            row = self.client.provider_row
+            if isinstance(row, Exception):
+                raise row
+            # Real maybe_single().execute() returns bare None on zero rows,
+            # not a response object with data=None
+            if row is None:
+                return None
+            return _FakeResult(row)
 
         raise AssertionError(f"Unexpected table {self.table_name}")
 
 
 class _FakeSupabase:
-    def __init__(self, games_pages=None, team_rows=None):
+    def __init__(self, games_pages=None, team_rows=None, provider_row=None):
         self.games_pages = games_pages or {}
         self.team_rows = team_rows or {}
+        self.provider_row = provider_row
         self.last_games_select = None
 
     def table(self, table_name: str):
@@ -154,3 +170,108 @@ async def test_fetch_games_for_rankings_uses_id_when_game_uid_is_not_selected(mo
     assert len(result) == 2
     assert set(result["game_id"]) == {"game-1"}
     assert "game_uid" not in fake_db.last_games_select
+
+
+@pytest.mark.asyncio
+async def test_fetch_games_for_rankings_raises_when_provider_lookup_fails(monkeypatch):
+    monkeypatch.setattr(data_adapter, "retry_supabase_query", lambda query_func, **_kwargs: query_func())
+
+    fake_db = _FakeSupabase(games_pages={0: []}, provider_row=RuntimeError("connection reset"))
+
+    with pytest.raises(RuntimeError, match="refusing to fall back"):
+        await data_adapter.fetch_games_for_rankings(
+            fake_db,
+            provider_filter="gotsport",
+            today=pd.Timestamp("2026-04-14", tz="UTC"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_games_for_rankings_raises_when_provider_filter_matches_nothing(monkeypatch):
+    monkeypatch.setattr(data_adapter, "retry_supabase_query", lambda query_func, **_kwargs: query_func())
+
+    fake_db = _FakeSupabase(games_pages={0: []}, provider_row=None)
+
+    with pytest.raises(RuntimeError, match="matched no provider"):
+        await data_adapter.fetch_games_for_rankings(
+            fake_db,
+            provider_filter="gotsport",
+            today=pd.Timestamp("2026-04-14", tz="UTC"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_games_for_rankings_drops_self_games(monkeypatch):
+    monkeypatch.setattr(data_adapter, "retry_supabase_query", lambda query_func, **_kwargs: query_func())
+
+    fake_db = _FakeSupabase(
+        games_pages={
+            0: [
+                {
+                    "id": "game-self",
+                    "game_date": "2026-04-01",
+                    "home_team_master_id": "team-a",
+                    "away_team_master_id": "team-a",
+                    "home_score": 1,
+                    "away_score": 1,
+                    "provider_id": "provider-1",
+                },
+                {
+                    "id": "game-real",
+                    "game_date": "2026-04-02",
+                    "home_team_master_id": "team-a",
+                    "away_team_master_id": "team-b",
+                    "home_score": 2,
+                    "away_score": 0,
+                    "provider_id": "provider-1",
+                },
+            ]
+        },
+        team_rows={
+            "team-a": {
+                "team_id_master": "team-a",
+                "age_group": "u12",
+                "gender": "Male",
+                "is_deprecated": False,
+                "league": None,
+            },
+            "team-b": {
+                "team_id_master": "team-b",
+                "age_group": "u12",
+                "gender": "Male",
+                "is_deprecated": False,
+                "league": None,
+            },
+        },
+    )
+
+    result = await data_adapter.fetch_games_for_rankings(
+        fake_db,
+        today=pd.Timestamp("2026-04-14", tz="UTC"),
+    )
+
+    assert set(result["game_id"]) == {"game-real"}
+    assert len(result) == 2
+
+
+def test_batch_fetch_rows_raises_after_exhausted_retries(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_retry(query_func, **_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise RuntimeError("server disconnected")
+        return _FakeResult([{"team_id_master": "team-1"}])
+
+    monkeypatch.setattr(data_adapter, "retry_supabase_query", fake_retry)
+
+    # 150 values -> two batches of 100; the second batch fails and must
+    # propagate instead of returning the partial first batch
+    with pytest.raises(RuntimeError, match="server disconnected"):
+        data_adapter.batch_fetch_rows(
+            _FakeSupabase(),
+            "teams",
+            "team_id_master",
+            "team_id_master",
+            [f"team-{idx}" for idx in range(150)],
+        )


### PR DESCRIPTION
Integrity fixes in the rankings data pipeline. The theme: places where a partial failure used to degrade silently now either fail loudly or filter correctly.

**Note for review: two of these change which games feed the ratings** (self-game filter, null-gender handling). Worth eyeballing the next ranking run's diagnostics before this merges, per the usual algorithm-change protocol. The rest are fail-loud or robustness changes with no effect on a healthy run.

- `fetch_games_for_rankings` aborts when a provider filter cannot be resolved or matches nothing, instead of silently expanding to unfiltered all-provider rankings. The lookup uses `maybe_single()` so "provider doesn't exist" is distinguishable from a transient failure.
- `batch_fetch_rows` raises after retries are exhausted instead of returning partial rows, which silently shrank the rankings universe.
- Self-games (team_id == opp_id, produced when merge resolution maps both sides of an alias-vs-alias game onto one canonical team) are dropped from the v53e dataset.
- `normalize_gender` keeps nulls null instead of stringifying them to "nan"/"none", which leaked unknown-gender teams into phantom cohorts.
- A cache hit with an unreadable `games_used` parquet now invalidates the whole hit and rebuilds, instead of mixing cached ratings with freshly fetched ML inputs.
- The bulk-insert loop re-slices by offset, so adaptive batch-size reductions under 429/SSL pressure actually apply to the remaining chunks instead of letting oversized batches keep failing.
- `get_anchor()` parses stringified float ages ('14.0') and falls back to the unknown-age anchor instead of crashing mid-pass.
- Publication-cap rank lookup computes cutoffs lazily per rank, removing a latent KeyError in the anchor-scaling pass.

New tests pin the fail-loud contracts, the self-game filter, null-gender preservation, and the batch re-chunking behavior (6 new tests; full relevant suites at 175 passing). Live-DB smoke verified the provider filter resolves correctly and a bogus provider aborts. The 3 pre-existing failures in `test_enhanced_pipeline.py` validation tests are unchanged on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
