### PR TITLE
fix(security): harden Stripe payment flows and lock down public endpoints (audit batch)

### DIFF
--- a/frontend/app/api/feedback/__tests__/route.test.ts
+++ b/frontend/app/api/feedback/__tests__/route.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/email', () => ({
 
 vi.mock('@/lib/api/rateLimit', () => ({
   checkRateLimit: mockCheckRateLimit,
+  getClientIp: (request: Request) => request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
 }));
 
 vi.mock('@/lib/supabase/server', () => ({

--- a/frontend/app/api/feedback/route.ts
+++ b/frontend/app/api/feedback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { parseJsonBody } from '@/lib/api/parseJsonBody';
-import { checkRateLimit } from '@/lib/api/rateLimit';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createServerSupabase } from '@/lib/supabase/server';
 import { sendFeedbackEmail, type FeedbackCategory, type FeedbackIdentity } from '@/lib/email';
 
@@ -56,7 +56,7 @@ function isStringWithLen(v: unknown, min: number, max: number): v is string {
 
 export async function POST(request: NextRequest) {
   try {
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = getClientIp(request);
 
     const parsed = await parseJsonBody<IncomingBody>(request);
     if (parsed.error) return parsed.error;

--- a/frontend/app/api/feedback/route.ts
+++ b/frontend/app/api/feedback/route.ts
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Rate limit by IP
-    if (!checkRateLimit(ip, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+    if (!checkRateLimit(`feedback:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
       return NextResponse.json(
         { error: 'rate_limited' },
         { status: 429, headers: { 'Retry-After': String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)) } }

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, platformDims } from '../_shared/theme';
@@ -86,6 +87,11 @@ function MoverSection({
 }
 
 export async function GET(request: Request) {
+  // CPU-heavy public image rendering - throttle to limit denial-of-wallet
+  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+    return new Response('Too many requests', { status: 429 });
+  }
+
   const { searchParams, origin } = new URL(request.url);
   const platform = searchParams.get('platform') || 'instagram';
   const ageGroup = searchParams.get('age_group') || undefined;

--- a/frontend/app/api/infographic/movers/route.tsx
+++ b/frontend/app/api/infographic/movers/route.tsx
@@ -88,7 +88,7 @@ function MoverSection({
 
 export async function GET(request: Request) {
   // CPU-heavy public image rendering - throttle to limit denial-of-wallet
-  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+  if (!checkRateLimit(`infographic:${getClientIp(request)}`, 10, 60_000)) {
     return new Response('Too many requests', { status: 429 });
   }
 

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, platformDims, formatScore, formatRecord } from '../_shared/theme';
@@ -60,6 +61,11 @@ async function getSpotlightTeam(): Promise<SpotlightTeam | null> {
 }
 
 export async function GET(request: Request) {
+  // CPU-heavy public image rendering - throttle to limit denial-of-wallet
+  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+    return new Response('Too many requests', { status: 429 });
+  }
+
   const { origin, searchParams } = new URL(request.url);
   const platform = searchParams.get('platform') || 'instagram';
   const isStory = platform === 'story';

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -62,7 +62,7 @@ async function getSpotlightTeam(): Promise<SpotlightTeam | null> {
 
 export async function GET(request: Request) {
   // CPU-heavy public image rendering - throttle to limit denial-of-wallet
-  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+  if (!checkRateLimit(`infographic:${getClientIp(request)}`, 10, 60_000)) {
     return new Response('Too many requests', { status: 429 });
   }
 

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, MEDAL, platformDims, formatScore, formatRecord } from '../_shared/theme';
@@ -75,6 +76,11 @@ const STATE_NAMES: Record<string, string> = {
 };
 
 export async function GET(request: Request) {
+  // CPU-heavy public image rendering - throttle to limit denial-of-wallet
+  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+    return new Response('Too many requests', { status: 429 });
+  }
+
   const { searchParams, origin } = new URL(request.url);
   const state = searchParams.get('state') || 'TX';
   const ageParam = searchParams.get('age') || 'u14';

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -77,7 +77,7 @@ const STATE_NAMES: Record<string, string> = {
 
 export async function GET(request: Request) {
   // CPU-heavy public image rendering - throttle to limit denial-of-wallet
-  if (!checkRateLimit(getClientIp(request), 10, 60_000)) {
+  if (!checkRateLimit(`infographic:${getClientIp(request)}`, 10, 60_000)) {
     return new Response('Too many requests', { status: 429 });
   }
 

--- a/frontend/app/api/instagram-review/route.ts
+++ b/frontend/app/api/instagram-review/route.ts
@@ -54,7 +54,7 @@ export async function GET() {
 
       if (error) {
         console.error('[instagram-review] GET error:', error.message);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: 'Failed to load review queue' }, { status: 500 });
       }
 
       if (!data || data.length === 0) break;
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
 
     const { handle, action } = body;
 
-    if (!handle || !action || !['approve', 'reject'].includes(action)) {
+    if (!handle || typeof handle !== 'string' || !action || !['approve', 'reject'].includes(action)) {
       return NextResponse.json(
         { error: 'Required: { handle: string, action: "approve" | "reject" }' },
         { status: 400 }
@@ -131,7 +131,7 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       console.error('[instagram-review] POST error:', error.message);
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ error: 'Failed to update review status' }, { status: 500 });
     }
 
     return NextResponse.json({

--- a/frontend/app/api/internal/analytics/chat/route.ts
+++ b/frontend/app/api/internal/analytics/chat/route.ts
@@ -1,4 +1,5 @@
 import { streamText, convertToModelMessages, stepCountIs, type UIMessage, isTextUIPart } from 'ai';
+import { NextResponse } from 'next/server';
 import { anthropic } from '@ai-sdk/anthropic';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { resolveDateRange } from '@/lib/internal-analytics/dates';
@@ -17,11 +18,33 @@ export async function POST(req: Request) {
   const auth = await requireAdmin();
   if (auth.error) return auth.error;
 
+  // Reject oversized payloads before req.json() buffers and parses them
+  const contentLength = Number(req.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > 500_000) {
+    return NextResponse.json({ error: 'Payload too large — start a new conversation' }, { status: 413 });
+  }
+
   const body = await req.json();
   const { messages, range = 'last_7_days' } = body as {
     messages: UIMessage[];
     range?: DateRangePreset;
   };
+
+  // Bound the payload before it reaches the model — unbounded histories are
+  // pure token-cost amplification on this endpoint
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return NextResponse.json({ error: 'messages array is required' }, { status: 400 });
+  }
+  if (messages.length > 50) {
+    return NextResponse.json({ error: 'Too many messages — start a new conversation' }, { status: 400 });
+  }
+  const totalChars = messages.reduce(
+    (sum, m) => sum + (m.parts ?? []).reduce((s, p) => s + (isTextUIPart(p) ? p.text.length : 0), 0),
+    0
+  );
+  if (totalChars > 100_000) {
+    return NextResponse.json({ error: 'Conversation too large — start a new conversation' }, { status: 400 });
+  }
 
   const lastMessage = messages[messages.length - 1];
   const lastContent = lastMessage?.parts?.find(isTextUIPart)?.text ?? '';

--- a/frontend/app/api/match-prediction/__tests__/route.test.ts
+++ b/frontend/app/api/match-prediction/__tests__/route.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/api/requirePremium', () => ({
 
 vi.mock('@/lib/api/rateLimit', () => ({
   checkRateLimit: mockCheckRateLimit,
+  getClientIp: (request: Request) => request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
 }));
 
 vi.mock('@/lib/matchPredictionService', () => ({

--- a/frontend/app/api/match-prediction/route.ts
+++ b/frontend/app/api/match-prediction/route.ts
@@ -1,5 +1,5 @@
 import { parseJsonBody } from '@/lib/api/parseJsonBody';
-import { checkRateLimit } from '@/lib/api/rateLimit';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { requirePremium } from '@/lib/api/requirePremium';
 import { AppError } from '@/lib/errors';
 import { buildMatchPredictionWithShadowContext } from '@/lib/matchPredictionService';
@@ -15,7 +15,7 @@ interface MatchPredictionRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = getClientIp(request);
     if (!checkRateLimit(ip, 10, 60_000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }

--- a/frontend/app/api/match-prediction/route.ts
+++ b/frontend/app/api/match-prediction/route.ts
@@ -16,7 +16,7 @@ interface MatchPredictionRequest {
 export async function POST(request: NextRequest) {
   try {
     const ip = getClientIp(request);
-    if (!checkRateLimit(ip, 10, 60_000)) {
+    if (!checkRateLimit(`match-prediction:${ip}`, 10, 60_000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }
 

--- a/frontend/app/api/newsletter/route.ts
+++ b/frontend/app/api/newsletter/route.ts
@@ -1,11 +1,11 @@
 import { createServerSupabase } from '@/lib/supabase/server';
 import { sendWelcomeEmail } from '@/lib/email';
-import { checkRateLimit } from '@/lib/api/rateLimit';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
   try {
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = getClientIp(request);
     if (!checkRateLimit(ip)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }

--- a/frontend/app/api/newsletter/route.ts
+++ b/frontend/app/api/newsletter/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(request: NextRequest) {
   try {
     const ip = getClientIp(request);
-    if (!checkRateLimit(ip)) {
+    if (!checkRateLimit(`newsletter:${ip}`)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }
 

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -15,7 +15,7 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export async function POST(request: NextRequest) {
   try {
     const ip = getClientIp(request);
-    if (!checkRateLimit(ip, 3, 60000)) {
+    if (!checkRateLimit(`team-card:${ip}`, 3, 60000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }
 

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -1,6 +1,6 @@
 import { createServerSupabase } from '@/lib/supabase/server';
 import { sendReportCardEmail } from '@/lib/email';
-import { checkRateLimit } from '@/lib/api/rateLimit';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { optionalAuth } from '@/lib/api/optionalAuth';
 import { subscribeFreeLead, enrollInAutomation } from '@/lib/beehiiv';
 import { NextRequest, NextResponse } from 'next/server';
@@ -14,7 +14,7 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request: NextRequest) {
   try {
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = getClientIp(request);
     if (!checkRateLimit(ip, 3, 60000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }

--- a/frontend/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/checkout/__tests__/route.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Use vi.hoisted so mock fns are available inside vi.mock factories (which are hoisted)
-const { mockGetUser, mockFrom, mockCustomersCreate, mockCheckoutSessionsCreate } = vi.hoisted(() => ({
-  mockGetUser: vi.fn(),
-  mockFrom: vi.fn(),
-  mockCustomersCreate: vi.fn(),
-  mockCheckoutSessionsCreate: vi.fn(),
-}));
+const { mockGetUser, mockFrom, mockCustomersCreate, mockCheckoutSessionsCreate, mockCheckRateLimit } = vi.hoisted(
+  () => ({
+    mockGetUser: vi.fn(),
+    mockFrom: vi.fn(),
+    mockCustomersCreate: vi.fn(),
+    mockCheckoutSessionsCreate: vi.fn(),
+    mockCheckRateLimit: vi.fn(() => true),
+  })
+);
 
 // Mock next/headers (needed by supabase/server)
 vi.mock('next/headers', () => ({
@@ -17,6 +20,14 @@ vi.mock('next/headers', () => ({
 }));
 
 // Mock supabase server
+// Mock the rate limiter so tests are deterministic — the real limiter keys all
+// requests on the 'unknown' IP (no x-real-ip/x-forwarded-for here) and caps at 5,
+// so the 6th request in a run would otherwise flake to a 429.
+vi.mock('@/lib/api/rateLimit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => '203.0.113.1'),
+}));
+
 vi.mock('@/lib/supabase/server', () => ({
   createServerSupabase: vi.fn().mockResolvedValue({
     auth: {
@@ -61,7 +72,18 @@ function makeRequest(body: Record<string, unknown> = {}): Request {
 describe('POST /api/stripe/checkout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
     process.env.NEXT_PUBLIC_SITE_URL = 'https://pitchrank.io';
+  });
+
+  it('returns 429 when the rate limiter denies the request', async () => {
+    mockCheckRateLimit.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ priceId: 'price_monthly' }));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
   });
 
   it('creates anonymous checkout session when not authenticated', async () => {

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     // Unauthenticated endpoint that creates Stripe customers/sessions —
     // throttle to blunt cost/DoS amplification
     const ip = getClientIp(req);
-    if (!checkRateLimit(ip, 5, 60_000)) {
+    if (!checkRateLimit(`stripe-checkout:${ip}`, 5, 60_000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }
 

--- a/frontend/app/api/stripe/checkout/route.ts
+++ b/frontend/app/api/stripe/checkout/route.ts
@@ -1,6 +1,7 @@
 import { stripe, getStripePriceIds } from '@/lib/stripe/server';
 import { getSupabaseAdmin } from '@/lib/supabase/service';
 import { optionalAuth } from '@/lib/api/optionalAuth';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { NextResponse } from 'next/server';
 import type Stripe from 'stripe';
 
@@ -17,6 +18,13 @@ function baseSessionParams(priceId: string): Partial<Stripe.Checkout.SessionCrea
 
 export async function POST(req: Request) {
   try {
+    // Unauthenticated endpoint that creates Stripe customers/sessions —
+    // throttle to blunt cost/DoS amplification
+    const ip = getClientIp(req);
+    if (!checkRateLimit(ip, 5, 60_000)) {
+      return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
+    }
+
     const { user, supabase } = await optionalAuth();
 
     const { priceId } = await req.json();

--- a/frontend/app/api/stripe/sync/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/sync/__tests__/route.test.ts
@@ -1,21 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Hoisted mock fns so they're available inside vi.mock factories
-const { mockGetUser, mockServerFrom, mockAdminFrom, mockSessionsRetrieve, mockSubscriptionsRetrieve } = vi.hoisted(
-  () => ({
-    mockGetUser: vi.fn(),
-    mockServerFrom: vi.fn(),
-    mockAdminFrom: vi.fn(),
-    mockSessionsRetrieve: vi.fn(),
-    mockSubscriptionsRetrieve: vi.fn(),
-  })
-);
+const {
+  mockGetUser,
+  mockServerFrom,
+  mockAdminFrom,
+  mockSessionsRetrieve,
+  mockSubscriptionsRetrieve,
+  mockCheckRateLimit,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockServerFrom: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockSessionsRetrieve: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => true),
+}));
 
 vi.mock('next/headers', () => ({
   cookies: vi.fn().mockResolvedValue({
     getAll: vi.fn().mockReturnValue([]),
     set: vi.fn(),
   }),
+}));
+
+vi.mock('@/lib/api/rateLimit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => '203.0.113.1'),
 }));
 
 vi.mock('@/lib/supabase/server', () => ({
@@ -36,6 +47,8 @@ vi.mock('@/lib/stripe/server', () => ({
   },
   extractPeriodEnd: vi.fn(() => '2026-12-31T00:00:00.000Z'),
   mapStatusToPlan: vi.fn((status: string) => (status === 'active' ? 'premium' : 'free')),
+  isSessionPaymentSettled: (s: { payment_status?: string }) =>
+    s.payment_status === 'paid' || s.payment_status === 'no_payment_required',
 }));
 
 import { POST } from '../route';
@@ -46,6 +59,20 @@ function makeRequest(body: unknown): Request {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+/**
+ * Build a retrieved Stripe checkout session for the happy path
+ * (complete + paid + active subscription). Override any field per test.
+ */
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'complete',
+    payment_status: 'paid',
+    customer: 'cus_123',
+    subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
+    ...overrides,
+  };
 }
 
 /**
@@ -76,6 +103,7 @@ function updateChain(final: { error?: unknown } = { error: null }) {
 describe('POST /api/stripe/sync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
   });
 
   it('returns 400 when sessionId is missing', async () => {
@@ -97,7 +125,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('returns 400 when session has no subscription', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null } });
-    mockSessionsRetrieve.mockResolvedValue({ customer: 'cus_123', subscription: null });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ subscription: null }));
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
@@ -107,11 +135,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('authenticated: returns 403 when session metadata user does not match', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_123',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-      metadata: { supabase_user_id: 'user-attacker' },
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ metadata: { supabase_user_id: 'user-attacker' } }));
 
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
@@ -121,11 +145,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('authenticated: returns 403 when no metadata and customer_id mismatch on profile', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_attacker',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-      metadata: {},
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ customer: 'cus_attacker', metadata: {} }));
     const chain = selectChain({ data: { stripe_customer_id: 'cus_real' }, error: null });
     mockServerFrom.mockReturnValue(chain.client);
 
@@ -143,11 +163,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('authenticated: returns 403 when profile has no customer_id (cannot verify)', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_123',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-      metadata: {},
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ metadata: {} }));
     const chain = selectChain({ data: { stripe_customer_id: null }, error: null });
     mockServerFrom.mockReturnValue(chain.client);
 
@@ -161,11 +177,10 @@ describe('POST /api/stripe/sync', () => {
 
   it('authenticated: syncs profile by user.id when metadata matches', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_123',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-      metadata: { supabase_user_id: 'user-real' },
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ metadata: { supabase_user_id: 'user-real' } }));
+    // Metadata path also cross-checks the stored customer ID
+    const profileChain = selectChain({ data: { stripe_customer_id: 'cus_123' }, error: null });
+    mockServerFrom.mockReturnValue(profileChain.client);
     const update = updateChain({ error: null });
     mockAdminFrom.mockReturnValue(update.client);
 
@@ -186,10 +201,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('anonymous: returns 202 when no profile exists yet (webhook pending)', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_anon',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ customer: 'cus_anon' }));
     const chain = selectChain({ data: null, error: null });
     mockAdminFrom.mockReturnValue(chain.client);
 
@@ -209,10 +221,7 @@ describe('POST /api/stripe/sync', () => {
 
   it('anonymous: syncs by stripe_customer_id when profile exists', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null } });
-    mockSessionsRetrieve.mockResolvedValue({
-      customer: 'cus_anon',
-      subscription: { id: 'sub_1', status: 'active', cancel_at_period_end: false },
-    });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ customer: 'cus_anon' }));
     const lookup = selectChain({ data: { id: 'profile-99' }, error: null });
     const update = updateChain({ error: null });
     mockAdminFrom
@@ -239,5 +248,85 @@ describe('POST /api/stripe/sync', () => {
     const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
 
     expect(res.status).toBe(500);
+  });
+
+  it('returns 400 when the checkout session is not complete', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockResolvedValueOnce(makeSession({ status: 'open', payment_status: 'unpaid' }));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_open' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not complete/i);
+  });
+
+  it('returns 202 when payment is still processing (async method)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockSessionsRetrieve.mockResolvedValueOnce(makeSession({ payment_status: 'unpaid' }));
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_unpaid' }));
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({ synced: false });
+  });
+
+  it('authenticated: returns 403 when metadata matches but stored customer differs', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValueOnce(
+      makeSession({ customer: 'cus_other', metadata: { supabase_user_id: 'user-real' } })
+    );
+    // Profile already linked to a different Stripe customer — must not be re-pointed
+    const profileChain = selectChain({ data: { stripe_customer_id: 'cus_real' }, error: null });
+    mockServerFrom.mockReturnValue(profileChain.client);
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_mismatch' }));
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/billing profile/i);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: trial checkout (no_payment_required) passes the paid guard and syncs', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    // A trial checkout settles with payment_status 'no_payment_required' — the
+    // guard must treat it like 'paid' so trials can sync, not reject as unpaid.
+    mockSessionsRetrieve.mockResolvedValueOnce(
+      makeSession({ customer: 'cus_anon', payment_status: 'no_payment_required' })
+    );
+    const lookup = selectChain({ data: { id: 'profile-99' }, error: null });
+    const update = updateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(lookup.client) // SELECT to find profile by customer
+      .mockReturnValueOnce(update.client); // UPDATE that profile
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_trial' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ synced: true });
+    expect(lookup.eq).toHaveBeenCalledWith('stripe_customer_id', 'cus_anon');
+    expect(update.eq).toHaveBeenCalledWith('id', 'profile-99');
+  });
+
+  it('returns 429 when the rate limiter denies', async () => {
+    mockCheckRateLimit.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('returns 500 when the billing-profile verification lookup fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-real' } } });
+    mockSessionsRetrieve.mockResolvedValue(makeSession({ metadata: { supabase_user_id: 'user-real' } }));
+    // The ownership-verification lookup errors — fail closed (writing without
+    // completing verification would reopen the de-link hole).
+    const chain = selectChain({ data: null, error: { message: 'boom' } });
+    mockServerFrom.mockReturnValue(chain.client);
+
+    const res = await POST(makeRequest({ sessionId: 'cs_test_abc' }));
+
+    expect(res.status).toBe(500);
+    // Must never reach the admin write when verification couldn't complete.
+    expect(mockAdminFrom).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/api/stripe/sync/route.ts
+++ b/frontend/app/api/stripe/sync/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
     // Unauthenticated endpoint that fans out to Stripe — throttle to blunt
     // cost amplification and session-ID replay probing
     const ip = getClientIp(req);
-    if (!checkRateLimit(ip, 5, 60_000)) {
+    if (!checkRateLimit(`stripe-sync:${ip}`, 5, 60_000)) {
       return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
     }
 

--- a/frontend/app/api/stripe/sync/route.ts
+++ b/frontend/app/api/stripe/sync/route.ts
@@ -1,6 +1,7 @@
-import { stripe, extractPeriodEnd, mapStatusToPlan } from '@/lib/stripe/server';
+import { stripe, extractPeriodEnd, mapStatusToPlan, isSessionPaymentSettled } from '@/lib/stripe/server';
 import { getSupabaseAdmin } from '@/lib/supabase/service';
 import { optionalAuth } from '@/lib/api/optionalAuth';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { NextResponse } from 'next/server';
 
 /**
@@ -16,6 +17,13 @@ import { NextResponse } from 'next/server';
  */
 export async function POST(req: Request) {
   try {
+    // Unauthenticated endpoint that fans out to Stripe — throttle to blunt
+    // cost amplification and session-ID replay probing
+    const ip = getClientIp(req);
+    if (!checkRateLimit(ip, 5, 60_000)) {
+      return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
+    }
+
     const { user, supabase } = await optionalAuth();
 
     const { sessionId } = await req.json();
@@ -27,6 +35,20 @@ export async function POST(req: Request) {
     const session = await stripe.checkout.sessions.retrieve(sessionId, {
       expand: ['subscription'],
     });
+
+    // Only completed, paid (or trial) sessions may drive profile writes —
+    // open/expired/unpaid sessions must not grant a plan
+    if (session.status !== 'complete') {
+      return NextResponse.json({ error: 'Checkout session is not complete' }, { status: 400 });
+    }
+    if (!isSessionPaymentSettled(session)) {
+      // Async payment methods settle after checkout completes; the webhook
+      // fulfills on async_payment_succeeded and flags async_payment_failed.
+      // A failed delayed payment also reads 'unpaid' here — subscription-mode
+      // sessions expose no field to tell the two apart, so this stays 202 and
+      // the webhook owns the terminal outcome.
+      return NextResponse.json({ synced: false, error: 'Payment still processing' }, { status: 202 });
+    }
 
     if (!session.customer || !session.subscription) {
       return NextResponse.json({ error: 'Session has no subscription' }, { status: 400 });
@@ -56,6 +78,22 @@ export async function POST(req: Request) {
       if (sessionUserId) {
         if (sessionUserId !== user.id) {
           return NextResponse.json({ error: 'Session does not belong to you' }, { status: 403 });
+        }
+        // A profile already linked to a different Stripe customer must not be
+        // re-pointed by a session sync — that would de-link the live billing row.
+        // Fail closed if the lookup errors: writing without completing the
+        // verification would reopen exactly that hole.
+        const { data: profile, error: profileLookupError } = await supabase
+          .from('user_profiles')
+          .select('stripe_customer_id')
+          .eq('id', user.id)
+          .maybeSingle();
+        if (profileLookupError) {
+          console.error('Sync: error verifying billing profile:', profileLookupError);
+          return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
+        }
+        if (profile?.stripe_customer_id && profile.stripe_customer_id !== customerId) {
+          return NextResponse.json({ error: 'Session does not match your billing profile' }, { status: 403 });
         }
       } else {
         const { data: profile } = await supabase

--- a/frontend/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/frontend/app/api/stripe/webhook/__tests__/route.test.ts
@@ -23,6 +23,8 @@ vi.mock('@/lib/stripe/server', () => ({
   },
   WEBHOOK_EVENTS: {
     CHECKOUT_COMPLETED: 'checkout.session.completed',
+    CHECKOUT_ASYNC_PAYMENT_SUCCEEDED: 'checkout.session.async_payment_succeeded',
+    CHECKOUT_ASYNC_PAYMENT_FAILED: 'checkout.session.async_payment_failed',
     SUBSCRIPTION_UPDATED: 'customer.subscription.updated',
     SUBSCRIPTION_DELETED: 'customer.subscription.deleted',
     INVOICE_PAID: 'invoice.paid',
@@ -35,6 +37,8 @@ vi.mock('@/lib/stripe/server', () => ({
     status === 'active' || status === 'trialing' || status === 'past_due' ? 'premium' : 'free'
   ),
   updateUserProfile: vi.fn().mockResolvedValue([{ id: '1' }]),
+  isSessionPaymentSettled: (s: { payment_status?: string }) =>
+    s.payment_status === 'paid' || s.payment_status === 'no_payment_required',
 }));
 
 // Mock the Beehiiv client — assert lifecycle routing without hitting the API
@@ -275,6 +279,14 @@ describe('POST /api/stripe/webhook', () => {
     } as Stripe.Event;
 
     vi.mocked(stripe.webhooks.constructEvent).mockReturnValue(fakeEvent);
+    // The handler re-fetches current state instead of trusting the payload
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'active',
+      cancel_at_period_end: true,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
     vi.mocked(updateUserProfile).mockResolvedValueOnce([{ id: '1' }]);
 
     const res = await POST(makeRequest('valid body'));
@@ -300,6 +312,7 @@ describe('POST /api/stripe/webhook', () => {
           id: 'cs_returning',
           customer: 'cus_new',
           subscription: 'sub_new',
+          payment_status: 'no_payment_required',
         } as unknown as Stripe.Checkout.Session,
       },
     } as Stripe.Event;
@@ -417,13 +430,20 @@ describe('Beehiiv lifecycle routing', () => {
     await fireEvent('charge.refunded', {
       id: 'ch_123',
       customer: 'cus_123',
+      refunded: true,
     });
 
     expect(vi.mocked(setLifecycle)).toHaveBeenCalledWith('test@example.com', 'paid_canceled');
   });
 
   it('skips charge.refunded for guest checkouts without a customer', async () => {
-    await fireEvent('charge.refunded', { id: 'ch_guest', customer: null });
+    await fireEvent('charge.refunded', { id: 'ch_guest', customer: null, refunded: true });
+
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+  });
+
+  it('ignores partial refunds (charge.refunded false)', async () => {
+    await fireEvent('charge.refunded', { id: 'ch_partial', customer: 'cus_123', refunded: false });
 
     expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
   });
@@ -439,6 +459,13 @@ describe('Beehiiv lifecycle routing', () => {
 
   it('routes canceling when cancel_at_period_end flips true', async () => {
     setPriorState({ subscription_status: 'active', cancel_at_period_end: false });
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'active',
+      cancel_at_period_end: true,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
 
     await fireEvent('customer.subscription.updated', {
       id: 'sub_123',
@@ -453,6 +480,13 @@ describe('Beehiiv lifecycle routing', () => {
 
   it('routes paid when cancel_at_period_end flips false (reactivation)', async () => {
     setPriorState({ subscription_status: 'active', cancel_at_period_end: true });
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'active',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
 
     await fireEvent('customer.subscription.updated', {
       id: 'sub_123',
@@ -463,6 +497,32 @@ describe('Beehiiv lifecycle routing', () => {
     });
 
     expect(vi.mocked(setLifecycle)).toHaveBeenCalledWith('test@example.com', 'paid');
+  });
+
+  it('writes current subscription state when a stale update event replays', async () => {
+    setPriorState({ subscription_status: 'canceled', cancel_at_period_end: false });
+    // The replayed event claims active, but Stripe's current truth is canceled
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'canceled',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
+
+    await fireEvent('customer.subscription.updated', {
+      id: 'sub_123',
+      customer: 'cus_123',
+      status: 'active',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    });
+
+    expect(vi.mocked(updateUserProfile)).toHaveBeenCalledWith(
+      expect.anything(),
+      'cus_123',
+      expect.objectContaining({ subscription_status: 'canceled', plan: 'free' })
+    );
   });
 
   it('flips lifecycle to paid only on first invoice after trial', async () => {
@@ -561,6 +621,7 @@ describe('Beehiiv automation enrollment', () => {
     await fireEvent('checkout.session.completed', {
       customer: 'cus_123',
       subscription: 'sub_123',
+      payment_status: 'paid',
     });
 
     expect(vi.mocked(enrollInAutomation)).toHaveBeenCalledWith('test@example.com', 'aut_test_trial');
@@ -591,6 +652,61 @@ describe('Beehiiv automation enrollment', () => {
     });
 
     expect(vi.mocked(enrollInAutomation)).toHaveBeenCalledWith('test@example.com', 'aut_test_trial_cancel');
+  });
+
+  it('flags async payment failure without provisioning anything', async () => {
+    await fireEvent('checkout.session.async_payment_failed', {
+      id: 'cs_failed',
+      customer: 'cus_123',
+      subscription: 'sub_123',
+      payment_status: 'unpaid',
+    });
+
+    expect(vi.mocked(updateUserProfile)).not.toHaveBeenCalled();
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+    expect(vi.mocked(notifyAdmin)).toHaveBeenCalledWith(expect.stringContaining('Async payment failed'));
+  });
+
+  it('skips fulfillment when checkout session is unpaid', async () => {
+    await fireEvent('checkout.session.completed', {
+      customer: 'cus_123',
+      subscription: 'sub_123',
+      payment_status: 'unpaid',
+    });
+
+    // An async payment method completed checkout but hasn't settled yet — the
+    // route must defer activation entirely (no profile write, no Beehiiv routing,
+    // and no subscription fetch) until checkout.session.async_payment_succeeded.
+    expect(vi.mocked(updateUserProfile)).not.toHaveBeenCalled();
+    expect(vi.mocked(setLifecycle)).not.toHaveBeenCalled();
+    expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();
+    expect(vi.mocked(stripe.subscriptions.retrieve)).not.toHaveBeenCalled();
+  });
+
+  it('fulfills async payments via checkout.session.async_payment_succeeded', async () => {
+    process.env.BEEHIIV_PAID_AUTOMATION_ID = 'aut_test_paid';
+    // A profile already exists for this customer (authenticated checkout path)
+    setPriorState({ id: '1', subscription_status: null });
+    vi.mocked(stripe.subscriptions.retrieve).mockResolvedValueOnce({
+      id: 'sub_123',
+      status: 'active',
+      cancel_at_period_end: false,
+      items: { data: [{ current_period_end: 1735689600 }] },
+    } as unknown as Stripe.Response<Stripe.Subscription>);
+
+    await fireEvent('checkout.session.async_payment_succeeded', {
+      customer: 'cus_123',
+      subscription: 'sub_123',
+      payment_status: 'paid',
+    });
+
+    // The async-success event runs the same fulfillment handler as a synchronous
+    // checkout — the existing profile is activated to premium.
+    expect(vi.mocked(updateUserProfile)).toHaveBeenCalledWith(
+      expect.anything(),
+      'cus_123',
+      expect.objectContaining({ plan: 'premium' })
+    );
   });
 });
 
@@ -639,6 +755,7 @@ describe('Idempotency on Stripe webhook re-delivery', () => {
     await fireEvent('checkout.session.completed', {
       customer: 'cus_123',
       subscription: 'sub_123',
+      payment_status: 'paid',
     });
 
     expect(vi.mocked(enrollInAutomation)).not.toHaveBeenCalled();

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -1,4 +1,11 @@
-import { stripe, WEBHOOK_EVENTS, extractPeriodEnd, mapStatusToPlan, updateUserProfile } from '@/lib/stripe/server';
+import {
+  stripe,
+  WEBHOOK_EVENTS,
+  extractPeriodEnd,
+  mapStatusToPlan,
+  updateUserProfile,
+  isSessionPaymentSettled,
+} from '@/lib/stripe/server';
 import { getSupabaseAdmin } from '@/lib/supabase/service';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
@@ -147,6 +154,26 @@ export async function POST(req: Request) {
         break;
       }
 
+      // Async payment methods complete checkout with payment_status='unpaid';
+      // fulfillment is skipped then and happens here once the payment settles
+      case WEBHOOK_EVENTS.CHECKOUT_ASYNC_PAYMENT_SUCCEEDED: {
+        const session = event.data.object as Stripe.Checkout.Session;
+        await handleCheckoutCompleted(session);
+        break;
+      }
+
+      // Terminal failure of a delayed payment. Nothing was provisioned (the
+      // unpaid completed event was skipped), so no profile write is needed —
+      // Stripe emails the customer; surface it for ops visibility
+      case WEBHOOK_EVENTS.CHECKOUT_ASYNC_PAYMENT_FAILED: {
+        const session = event.data.object as Stripe.Checkout.Session;
+        console.warn(`[webhook] Async payment failed for session ${session.id} (customer ${session.customer})`);
+        await notifyAdmin(
+          `<b>Async payment failed</b>\nCheckout session ${escapeHtml(session.id)} — no access was granted.`
+        );
+        break;
+      }
+
       case WEBHOOK_EVENTS.SUBSCRIPTION_UPDATED: {
         const subscription = event.data.object as Stripe.Subscription;
         await handleSubscriptionUpdated(subscription);
@@ -216,6 +243,15 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
   if (!customerId || !subscriptionId) {
     console.error('[webhook] Missing customer or subscription ID in checkout session');
+    return;
+  }
+
+  // checkout.session.completed also fires for unpaid async payment methods;
+  // only paid (or trialing, no_payment_required) sessions may activate premium
+  if (!isSessionPaymentSettled(session)) {
+    console.log(
+      `[webhook] Checkout session ${session.id} completed with payment_status=${session.payment_status}; skipping fulfillment`
+    );
     return;
   }
 
@@ -407,18 +443,23 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
  * dashboard can show the user as "canceling" rather than misleadingly "active".
  */
 async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
-  const customerId = subscription.customer as string;
-  const status = subscription.status;
+  // Stripe delivers events at-least-once and out of order: a stale
+  // subscription.updated (status=active) replayed after cancellation would
+  // restore premium. Re-fetch so the write reflects the subscription's
+  // current state, not the event payload's snapshot.
+  const current = await stripe.subscriptions.retrieve(subscription.id);
+  const customerId = current.customer as string;
+  const status = current.status;
   const plan = mapStatusToPlan(status);
-  const canceling = subscription.cancel_at_period_end ?? false;
+  const canceling = current.cancel_at_period_end ?? false;
 
   const prior = await getPriorState(customerId);
 
   await updateUserProfile(getSupabaseAdmin(), customerId, {
-    stripe_subscription_id: subscription.id,
+    stripe_subscription_id: current.id,
     subscription_status: status,
     plan,
-    subscription_period_end: extractPeriodEnd(subscription),
+    subscription_period_end: extractPeriodEnd(current),
     cancel_at_period_end: canceling,
   });
 
@@ -581,6 +622,12 @@ async function handleChargeRefunded(charge: Stripe.Charge) {
   const customerId = charge.customer as string;
   if (!customerId) {
     console.log('[webhook] Charge refunded without a customer (guest checkout); skipping');
+    return;
+  }
+  // charge.refunded fires for partial refunds too, but is only true when the
+  // charge is fully refunded — a partial refund leaves the subscriber active
+  if (!charge.refunded) {
+    console.log(`[webhook] Partial refund for customer ${customerId} (charge ${charge.id}); lifecycle unchanged`);
     return;
   }
   console.log(`[webhook] Charge refunded for customer ${customerId} (charge ${charge.id})`);

--- a/frontend/app/api/watchlist/remove/__tests__/route.test.ts
+++ b/frontend/app/api/watchlist/remove/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted so they're available inside the vi.mock factory (which is hoisted)
+const { mockRequirePremium, mockSupabaseFrom } = vi.hoisted(() => ({
+  mockRequirePremium: vi.fn(),
+  mockSupabaseFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/api/requirePremium', () => ({
+  requirePremium: mockRequirePremium,
+}));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/watchlist/remove', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/watchlist/remove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Authorized premium user with a supabase client whose `from` we can assert on
+    mockRequirePremium.mockResolvedValue({
+      user: { id: 'user-1' },
+      supabase: { from: mockSupabaseFrom },
+      error: null,
+    });
+  });
+
+  it('rejects a non-UUID teamIdMaster carrying PostgREST filter syntax before any query', async () => {
+    const res = await POST(makeRequest({ teamIdMaster: 'not-a-uuid; or=(1,1)' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid team id/i);
+    // The injection guard fires before any supabase query — no .from() call.
+    expect(mockSupabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when teamIdMaster is missing', async () => {
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(mockSupabaseFrom).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/api/watchlist/remove/route.ts
+++ b/frontend/app/api/watchlist/remove/route.ts
@@ -22,6 +22,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'teamIdMaster is required' }, { status: 400 });
     }
 
+    // Validate UUID — teamIdMaster is interpolated into the .or() filter below,
+    // so reject anything that could carry PostgREST filter syntax
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(teamIdMaster)) {
+      return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
+    }
+
     // Get user's default watchlist
     const { data: watchlist, error: watchlistError } = await supabase
       .from('watchlists')

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -25,7 +25,10 @@ export default function ForgotPasswordPage() {
       // Set a cookie so the auth callback knows this is a password reset flow.
       // With PKCE, query params on redirectTo can get lost during Supabase's
       // server-side redirect, so we use a cookie as a reliable signal.
-      document.cookie = 'password_reset_pending=true; path=/; max-age=3600; SameSite=Lax; Secure';
+      // Secure cookies are dropped on plain-http origins (local dev), which
+      // silently kills the signal — only mark Secure on https.
+      const secureSuffix = window.location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `password_reset_pending=true; path=/; max-age=3600; SameSite=Lax${secureSuffix}`;
 
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(email.trim().toLowerCase(), {
         redirectTo: `${window.location.origin}/auth/callback?next=/reset-password`,

--- a/frontend/app/logout/route.ts
+++ b/frontend/app/logout/route.ts
@@ -2,28 +2,11 @@ import { NextResponse } from 'next/server';
 import { createServerSupabase } from '@/lib/supabase/server';
 
 /**
- * GET /logout
- *
- * Signs the user out and redirects to the home page.
- * Can also accept a `next` query parameter for custom redirect.
- */
-export async function GET(request: Request) {
-  const requestUrl = new URL(request.url);
-  const rawNext = requestUrl.searchParams.get('next') ?? '/';
-  // Prevent open redirect: only allow relative paths (not protocol-relative //)
-  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/';
-
-  const supabase = await createServerSupabase();
-  await supabase.auth.signOut();
-
-  // Redirect to the specified page or home
-  return NextResponse.redirect(new URL(next, requestUrl.origin));
-}
-
-/**
  * POST /logout
  *
- * Alternative logout via POST request (useful for forms)
+ * Signs the user out and redirects to the home page. POST only — a GET
+ * handler here would let any third-party page force-sign-out users via a
+ * cross-site image or link (CSRF).
  */
 export async function POST(request: Request) {
   const requestUrl = new URL(request.url);

--- a/frontend/app/reset-password/__tests__/actions.test.ts
+++ b/frontend/app/reset-password/__tests__/actions.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted so they're available inside the vi.mock factory (which is hoisted)
+const { mockGetUser, mockUpdateUser } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockUpdateUser: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: mockGetUser,
+      updateUser: mockUpdateUser,
+    },
+  }),
+}));
+
+import { updatePassword } from '../actions';
+
+describe('updatePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to a valid recovery session unless a test overrides it
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    mockUpdateUser.mockResolvedValue({ error: null });
+  });
+
+  it('rejects passwords shorter than 8 characters before touching the session', async () => {
+    const res = await updatePassword('short');
+
+    expect(res.error).toMatch(/8 characters/i);
+    // Length is checked first — no session lookup or write should occur
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the recovery session has expired (no user)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const res = await updatePassword('a-valid-password');
+
+    expect(res.error).toMatch(/expired/i);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('returns a friendly message and hides the raw Supabase text on same_password', async () => {
+    mockUpdateUser.mockResolvedValue({ error: { code: 'same_password', message: 'raw-supabase-text' } });
+
+    const res = await updatePassword('a-valid-password');
+
+    expect(res.error).toMatch(/different/i);
+    expect(res.error).not.toContain('raw-supabase-text');
+  });
+
+  it('returns a generic message on weak_password without leaking internal detail', async () => {
+    mockUpdateUser.mockResolvedValue({ error: { code: 'weak_password', message: 'internal-detail' } });
+
+    const res = await updatePassword('a-valid-password');
+
+    expect(res.error).not.toBeNull();
+    expect(res.error).not.toContain('internal-detail');
+  });
+
+  it('returns { error: null } on success', async () => {
+    mockUpdateUser.mockResolvedValue({ error: null });
+
+    const res = await updatePassword('a-valid-password');
+
+    expect(res).toEqual({ error: null });
+  });
+});

--- a/frontend/app/reset-password/actions.ts
+++ b/frontend/app/reset-password/actions.ts
@@ -9,10 +9,24 @@ export async function updatePassword(password: string): Promise<{ error: string 
 
   const supabase = await createServerSupabase();
 
+  // Require the session established by the recovery link before touching the
+  // password, and keep failure responses generic — raw Supabase error strings
+  // stay in the server logs
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: 'Your reset link has expired. Please request a new one.' };
+  }
+
   const { error } = await supabase.auth.updateUser({ password });
 
   if (error) {
-    return { error: error.message };
+    console.error('[reset-password] updateUser failed:', error.code, error.message);
+    if (error.code === 'same_password') {
+      return { error: 'New password must be different from your current password.' };
+    }
+    return { error: 'Could not update password. Please request a new reset link and try again.' };
   }
 
   return { error: null };

--- a/frontend/app/upgrade/success/page.tsx
+++ b/frontend/app/upgrade/success/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef, Suspense } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Check, Crown, ArrowRight, Sparkles, Search, Eye, BarChart3, Share2, Mail } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -43,6 +43,7 @@ export default function UpgradeSuccessPage() {
 }
 
 function UpgradeSuccessContent() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { user, isLoading: userLoading } = useUser();
   const [shareStatus, setShareStatus] = useState<string | null>(null);
@@ -56,6 +57,13 @@ function UpgradeSuccessContent() {
     if (!sessionId || syncStarted.current) return;
 
     syncStarted.current = true;
+
+    // The session_id is the bearer secret for /api/stripe/sync — scrub it from
+    // the URL immediately (before the sync round-trip) so history, referrers,
+    // and analytics pageviews don't carry it. The captured value keeps this
+    // in-flight sync working; the webhook remains the primary fulfillment path.
+    router.replace('/upgrade/success', { scroll: false });
+
     fetch('/api/stripe/sync', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -77,7 +85,7 @@ function UpgradeSuccessContent() {
       .catch((err) => {
         console.error('Sync fetch error:', err);
       });
-  }, [searchParams]);
+  }, [searchParams, router]);
 
   const handleShare = async () => {
     const shareData = {

--- a/frontend/components/GoogleAnalytics.tsx
+++ b/frontend/components/GoogleAnalytics.tsx
@@ -30,10 +30,12 @@ function GoogleAnalyticsContent({ measurementId }: GoogleAnalyticsProps) {
     params.delete('session_id');
     const url = params.toString() ? `${pathname}?${params.toString()}` : pathname;
 
-    // Send pageview event to GA4
+    // Send pageview event to GA4. page_location must be pinned too — GA4
+    // otherwise derives it from document.location, re-leaking stripped params
     if (window.gtag) {
       window.gtag('config', measurementId, {
         page_path: url,
+        page_location: `${window.location.origin}${url}`,
       });
     }
   }, [pathname, searchParams, measurementId]);
@@ -52,8 +54,13 @@ function GoogleAnalyticsContent({ measurementId }: GoogleAnalyticsProps) {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
+          // Strip session_id (the /api/stripe/sync bearer secret) before the
+          // initial pageview — GA4 derives page_location from document.location
+          var sanitized = new URL(window.location.href);
+          sanitized.searchParams.delete('session_id');
           gtag('config', '${measurementId}', {
             page_path: window.location.pathname,
+            page_location: sanitized.toString(),
           });
         `}
       </Script>

--- a/frontend/components/GoogleAnalytics.tsx
+++ b/frontend/components/GoogleAnalytics.tsx
@@ -24,8 +24,11 @@ function GoogleAnalyticsContent({ measurementId }: GoogleAnalyticsProps) {
       return;
     }
 
-    // Construct full URL with search params
-    const url = searchParams?.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
+    // Construct full URL with search params. session_id is the bearer secret
+    // for /api/stripe/sync — never report it off-origin.
+    const params = new URLSearchParams(searchParams);
+    params.delete('session_id');
+    const url = params.toString() ? `${pathname}?${params.toString()}` : pathname;
 
     // Send pageview event to GA4
     if (window.gtag) {

--- a/frontend/components/Navigation.tsx
+++ b/frontend/components/Navigation.tsx
@@ -26,8 +26,10 @@ export function Navigation() {
       router.refresh();
     } catch (error) {
       console.error('Sign out error:', error);
-      // Fallback to logout route if signOut fails
-      router.push('/logout');
+      // Fallback to the logout endpoint if client signOut fails (POST only —
+      // GET logout is not exposed, to prevent forced-logout CSRF)
+      await fetch('/logout', { method: 'POST' });
+      router.push('/');
       router.refresh();
     } finally {
       setIsSigningOut(false);

--- a/frontend/lib/api/__tests__/rateLimit.test.ts
+++ b/frontend/lib/api/__tests__/rateLimit.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getClientIp, checkRateLimit } from '../rateLimit';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/anything', { headers });
+}
+
+describe('getClientIp', () => {
+  it('prefers x-real-ip over x-forwarded-for', () => {
+    const req = makeRequest({ 'x-real-ip': '198.51.100.7', 'x-forwarded-for': '203.0.113.9' });
+
+    expect(getClientIp(req)).toBe('198.51.100.7');
+  });
+
+  it('takes the first comma-separated x-forwarded-for segment, trimmed', () => {
+    const req = makeRequest({ 'x-forwarded-for': '  203.0.113.9 , 70.41.3.18 , 150.172.238.178' });
+
+    expect(getClientIp(req)).toBe('203.0.113.9');
+  });
+
+  it("returns 'unknown' when neither header is present", () => {
+    expect(getClientIp(makeRequest())).toBe('unknown');
+  });
+});
+
+describe('checkRateLimit', () => {
+  // The limiter keeps a module-level Map keyed by IP, so each test uses a
+  // unique key to stay independent of every other test in this file.
+
+  it('allows up to maxRequests within the window, then denies', () => {
+    const key = 'rl-allow-then-deny';
+
+    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
+    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
+    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
+    // 4th request exceeds the cap of 3
+    expect(checkRateLimit(key, 3, 60_000)).toBe(false);
+  });
+
+  it('keys are independent — exhausting one does not affect another', () => {
+    const keyA = 'rl-independent-a';
+    const keyB = 'rl-independent-b';
+
+    expect(checkRateLimit(keyA, 1, 60_000)).toBe(true);
+    expect(checkRateLimit(keyA, 1, 60_000)).toBe(false);
+
+    // keyB has its own counter and is still allowed
+    expect(checkRateLimit(keyB, 1, 60_000)).toBe(true);
+  });
+});

--- a/frontend/lib/api/rateLimit.ts
+++ b/frontend/lib/api/rateLimit.ts
@@ -1,5 +1,24 @@
 const requests = new Map<string, { count: number; resetAt: number }>();
 
+/**
+ * Resolve the client IP for rate-limit keying. On Vercel both x-real-ip and
+ * x-forwarded-for are overwritten by the platform with the real client IP
+ * (incoming values from external clients are discarded to prevent spoofing),
+ * so these headers are safe keys in production.
+ */
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('x-real-ip')?.trim() ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+/**
+ * Best-effort limiter: the Map is per serverless instance, so the cap applies
+ * per instance rather than globally. Good enough to blunt bursts and abuse;
+ * a shared store would be needed for a hard global limit.
+ */
 export function checkRateLimit(ip: string, maxRequests = 5, windowMs = 60000): boolean {
   const now = Date.now();
   const entry = requests.get(ip);

--- a/frontend/lib/internal-analytics/queries/__tests__/_error.test.ts
+++ b/frontend/lib/internal-analytics/queries/__tests__/_error.test.ts
@@ -22,10 +22,11 @@ describe('toTaxonomyError', () => {
     expect(t.retryable).toBe(false);
   });
 
-  it('maps 400 to VALIDATION with the original message', () => {
-    const t = toTaxonomyError({ code: 400, message: 'Invalid metric' });
+  it('maps 400 to VALIDATION without echoing the upstream message', () => {
+    const t = toTaxonomyError({ code: 400, message: 'Invalid metric: secret-internal-detail' });
     expect(t.type).toBe('VALIDATION');
-    expect(t.message).toContain('Invalid metric');
+    // Raw Google error text stays in server logs, never in the client payload
+    expect(t.message).not.toContain('secret-internal-detail');
     expect(t.retryable).toBe(false);
   });
 

--- a/frontend/lib/internal-analytics/queries/_error.ts
+++ b/frontend/lib/internal-analytics/queries/_error.ts
@@ -11,28 +11,31 @@ function isGoogleLikeError(e: unknown): e is GoogleLikeError {
 }
 
 export function toTaxonomyError(err: unknown): TaxonomyError {
+  // Raw upstream error text stays in server logs; clients get the taxonomy
+  // label and a fixed description only
   if (!isGoogleLikeError(err)) {
+    console.error('[internal-analytics] Upstream error:', err);
     return {
       type: 'API_ERROR',
-      message: typeof err === 'string' ? err : 'Unknown error',
+      message: 'Upstream analytics request failed',
       retryable: false,
     };
   }
 
-  const message = err.message ?? 'Unknown error';
+  console.error(`[internal-analytics] Google API error ${err.code}:`, err.message);
   switch (err.code) {
     case 429: {
       const retryAfter = err.response?.headers?.['retry-after'];
       const ms = retryAfter ? Number(retryAfter) * 1000 : undefined;
-      return { type: 'RATE_LIMIT', message, retryable: true, retry_after_ms: ms };
+      return { type: 'RATE_LIMIT', message: 'Google API rate limit reached', retryable: true, retry_after_ms: ms };
     }
     case 401:
     case 403:
-      return { type: 'AUTH', message, retryable: false };
+      return { type: 'AUTH', message: 'Google API authorization failed', retryable: false };
     case 400:
-      return { type: 'VALIDATION', message, retryable: false };
+      return { type: 'VALIDATION', message: 'Google API rejected the request', retryable: false };
     default:
-      return { type: 'API_ERROR', message, retryable: true };
+      return { type: 'API_ERROR', message: 'Google API request failed', retryable: true };
   }
 }
 

--- a/frontend/lib/stripe/__tests__/server.test.ts
+++ b/frontend/lib/stripe/__tests__/server.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import type Stripe from 'stripe';
+import { isSessionPaymentSettled } from '../server';
+
+const session = (payment_status: string) => ({ payment_status }) as Stripe.Checkout.Session;
+
+describe('isSessionPaymentSettled', () => {
+  it('settles on paid', () => {
+    expect(isSessionPaymentSettled(session('paid'))).toBe(true);
+  });
+
+  it('settles on no_payment_required (trial)', () => {
+    expect(isSessionPaymentSettled(session('no_payment_required'))).toBe(true);
+  });
+
+  it('does not settle on unpaid (async pending or failed)', () => {
+    expect(isSessionPaymentSettled(session('unpaid'))).toBe(false);
+  });
+});

--- a/frontend/lib/stripe/server.ts
+++ b/frontend/lib/stripe/server.ts
@@ -54,6 +54,8 @@ export function getStripePriceIds() {
  */
 export const WEBHOOK_EVENTS = {
   CHECKOUT_COMPLETED: 'checkout.session.completed',
+  CHECKOUT_ASYNC_PAYMENT_SUCCEEDED: 'checkout.session.async_payment_succeeded',
+  CHECKOUT_ASYNC_PAYMENT_FAILED: 'checkout.session.async_payment_failed',
   SUBSCRIPTION_UPDATED: 'customer.subscription.updated',
   SUBSCRIPTION_DELETED: 'customer.subscription.deleted',
   INVOICE_PAID: 'invoice.paid',
@@ -61,6 +63,15 @@ export const WEBHOOK_EVENTS = {
   TRIAL_WILL_END: 'customer.subscription.trial_will_end',
   CHARGE_REFUNDED: 'charge.refunded',
 } as const;
+
+/**
+ * A checkout session may drive fulfillment only once payment is settled
+ * ('paid') or no payment is due (trial). Unpaid sessions from async payment
+ * methods settle later via checkout.session.async_payment_succeeded.
+ */
+export function isSessionPaymentSettled(session: Stripe.Checkout.Session): boolean {
+  return session.payment_status === 'paid' || session.payment_status === 'no_payment_required';
+}
 
 /**
  * Extract subscription period end as an ISO string, handling both item-level

--- a/frontend/lib/supabase/service.ts
+++ b/frontend/lib/supabase/service.ts
@@ -1,4 +1,15 @@
+import 'server-only';
+
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+function getServiceConfig(): { supabaseUrl: string; serviceRoleKey: string } {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(`Missing Supabase service environment variables (url=${!!supabaseUrl}, key=${!!serviceRoleKey})`);
+  }
+  return { supabaseUrl, serviceRoleKey };
+}
 
 /**
  * Create a Supabase client with the service-role key for admin operations.
@@ -7,12 +18,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
  * Throws if environment variables are missing (caught by route-level try/catch).
  */
 export function createServiceSupabase(): SupabaseClient {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    throw new Error(`Missing Supabase service environment variables (url=${!!supabaseUrl}, key=${!!serviceRoleKey})`);
-  }
+  const { supabaseUrl, serviceRoleKey } = getServiceConfig();
 
   return createClient(supabaseUrl, serviceRoleKey, {
     auth: {
@@ -36,11 +42,7 @@ let _adminSingleton: SupabaseClient | null = null;
 
 export function getSupabaseAdmin(): SupabaseClient {
   if (!_adminSingleton) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!supabaseUrl || !serviceRoleKey) {
-      throw new Error(`Missing Supabase environment variables (url=${!!supabaseUrl}, key=${!!serviceRoleKey})`);
-    }
+    const { supabaseUrl, serviceRoleKey } = getServiceConfig();
     _adminSingleton = createClient(supabaseUrl, serviceRoleKey);
   }
   return _adminSingleton;

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -120,7 +120,8 @@ export async function middleware(request: NextRequest) {
     }
 
     if (isAdminRoute) {
-      if (!profile || profile.plan !== 'admin') {
+      // Fail closed on lookup errors, matching the premium branch above
+      if (profileError || !profile || profile.plan !== 'admin') {
         return NextResponse.redirect(new URL('/', request.url));
       }
     }

--- a/frontend/test/server-only-stub.ts
+++ b/frontend/test/server-only-stub.ts
@@ -1,0 +1,3 @@
+// Vitest stand-in for the `server-only` package, which throws when imported
+// outside a React Server Components build.
+export {};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      'server-only': path.resolve(__dirname, 'test/server-only-stub.ts'),
     },
   },
 });

--- a/src/providers/athleteone_html_parser.py
+++ b/src/providers/athleteone_html_parser.py
@@ -135,11 +135,21 @@ DATE_PATTERN_MONTH_NAME = re.compile(r"([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})", re.I
 TIME_PATTERN = re.compile(r"(\d{1,2}):(\d{2})\s*(AM|PM)", re.IGNORECASE)
 
 
-def _normalize_text(text: str) -> str:
-    """Normalize text: strip whitespace and collapse spaces"""
+# Scraped free-text flows into DB inserts unmodified; the cap keeps a
+# malformed or hostile page from producing unbounded field values
+_MAX_TEXT_LENGTH = 256
+
+
+def _normalize_text(text: str, max_length: Optional[int] = _MAX_TEXT_LENGTH) -> str:
+    """Normalize text: strip whitespace, collapse spaces, and cap length.
+
+    Pass ``max_length=None`` for intermediate text that is searched rather
+    than stored — a full row's concatenated text legitimately exceeds the cap.
+    """
     if not text:
         return ""
-    return " ".join(text.strip().split())
+    normalized = " ".join(text.strip().split())
+    return normalized if max_length is None else normalized[:max_length]
 
 
 def _find_game_rows(soup: BeautifulSoup) -> List[Tag]:
@@ -245,8 +255,9 @@ def _extract_score(row: Tag) -> Tuple[Optional[int], Optional[int]]:
         except (ValueError, AttributeError):
             pass
 
-    # Fallback: Search entire row text for score pattern
-    row_text = _normalize_text(row.get_text())
+    # Fallback: Search entire row text for score pattern (uncapped — the score
+    # often sits at the end of a long concatenated row)
+    row_text = _normalize_text(row.get_text(), max_length=None)
     match = SCORE_PATTERN.search(row_text)
     if match:
         try:

--- a/tests/unit/test_athleteone_normalize_text.py
+++ b/tests/unit/test_athleteone_normalize_text.py
@@ -1,0 +1,24 @@
+"""Unit tests for ``_normalize_text`` in the AthleteOne/TGS HTML parser.
+
+Scraped free-text flows into DB inserts unmodified, so ``_normalize_text``
+caps stored values at ``_MAX_TEXT_LENGTH`` by default while leaving searched-but-
+not-stored text uncapped via ``max_length=None``.
+"""
+
+from __future__ import annotations
+
+from src.providers.athleteone_html_parser import _MAX_TEXT_LENGTH, _normalize_text
+
+
+def test_normalize_text_caps_at_max_length_by_default():
+    long_text = "x" * 500
+    assert len(_normalize_text(long_text)) == _MAX_TEXT_LENGTH
+
+
+def test_normalize_text_uncapped_when_max_length_none():
+    long_text = "x" * 500
+    assert len(_normalize_text(long_text, max_length=None)) == 500
+
+
+def test_normalize_text_collapses_whitespace():
+    assert _normalize_text("  a   b  ") == "a b"


### PR DESCRIPTION
Second installment of the audit findings: the Stripe correctness cluster plus the security batch. Everything below is verified by 295 vitest tests (34 new), live smoke runs against the dev server, and the Python suites.

**Stripe payment integrity**
- Sync and webhook fulfillment now run only for settled sessions, via a shared `isSessionPaymentSettled()`: `paid` or `no_payment_required` (trials). Unpaid async checkouts defer to `checkout.session.async_payment_succeeded` (new handler), and `async_payment_failed` alerts ops without provisioning anything. Sync returns 202 for in-flight async payments instead of a terminal 400.
- `subscription.updated` re-fetches the subscription before writing, so a stale replayed `active` event can no longer restore premium after a cancellation.
- `charge.refunded` routes the win-back lifecycle only on full refunds. Partial refunds leave active subscribers alone.
- Sync verifies the session against the stored billing profile (and fails closed on lookup errors), so a checkout session can no longer re-point a profile that is already linked to a different Stripe customer. It also rejects open, expired, and unpaid sessions outright.
- The success page scrubs `session_id` (the bearer secret for sync) from the URL before the sync round-trip, and `GoogleAnalytics` strips it from reported pageviews so it never leaves the origin.

## Flow

```mermaid
sequenceDiagram
  Stripe->>Webhook: checkout.session.completed (unpaid, async method)
  Webhook-->>Stripe: 200 (no fulfillment)
  Stripe->>Webhook: checkout.session.async_payment_succeeded
  Webhook->>DB: activate premium
  Stripe->>Webhook: checkout.session.async_payment_failed
  Webhook->>Ops: admin alert (nothing provisioned)
```

**Endpoint security**
- Rate limiting on the unauthenticated Stripe endpoints (checkout, sync) and the CPU-heavy OG image routes, keyed on the platform-set client IP via a shared `getClientIp()` (Vercel overwrites `x-forwarded-for`/`x-real-ip`, so they are not spoofable in production).
- `/logout` is POST-only now: a GET handler let any third-party page force-sign-out users via a cross-site image. The nav fallback sends POST.
- Admin middleware fails closed on profile-lookup errors, matching the premium branch.
- `watchlist/remove` validates the team ID as a UUID before it reaches a PostgREST `.or()` filter.
- Reset-password requires the recovery session before updating and returns generic errors; instagram-review and the internal analytics error mapper stop echoing raw upstream error text; the admin chat endpoint bounds message count, total size, and Content-Length; the service-role Supabase module is fenced with `server-only`; the forgot-password cookie works on plain-http dev; AthleteOne scraped fields are length-capped.

Tests: new suites for the settlement helper, rate limiter (`getClientIp` precedence), reset-password action, watchlist UUID guard, plus webhook/sync cases for unpaid skip, async success/failure, stale-replay re-fetch, partial refunds, 429s, and fail-closed lookups. The `server-only` package is stubbed for vitest via a config alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
