### PR TITLE
chore(dead-code): drop unused email barrel re-exports (audit)

### DIFF
--- a/frontend/lib/email/index.ts
+++ b/frontend/lib/email/index.ts
@@ -1,6 +1,4 @@
-export { resend } from './resend';
 export { sendWelcomeEmail } from './welcome';
-export { sendPasswordSetupEmail } from './password-setup';
 export { sendReportCardEmail } from './report-card';
 export { sendFeedbackEmail } from './feedback';
 export type { FeedbackCategory, FeedbackIdentity, FeedbackContext, SendFeedbackEmailInput } from './feedback';


### PR DESCRIPTION
Knocks out audit **Dead Code** finding **D2** (`.turbo/audit.md`), non-engine scope.

## What changed
`frontend/lib/email/index.ts` re-exported `resend` and `sendPasswordSetupEmail`, but nothing imports either through the barrel:
- The Stripe webhook imports `sendPasswordSetupEmail` directly from `@/lib/email/password-setup`.
- The `resend` client is used from its own module.

The barrel now re-exports only the three helpers actually consumed through it (`sendWelcomeEmail`, `sendReportCardEmail`, `sendFeedbackEmail` + feedback types). Source modules untouched.

## Verification
Grepped the frontend for barrel imports — only `sendWelcomeEmail`, `sendReportCardEmail`, and `sendFeedbackEmail`/types are imported from `@/lib/email`. Removing the two dead re-exports has no consumers. CI typecheck confirms.

## Excluded (engine)
- **D1** (`supabase_to_v53e_format` in `src/rankings/data_adapter.py`) — rankings engine, frozen.
- **D3** (`src/etl/v53e.py`) — verdict Skip (intentionally kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)