### PR TITLE
feat(marketing): revamp weekly Instagram posts into a 5-post week

### DIFF
--- a/.github/workflows/marketing-pipeline.yml
+++ b/.github/workflows/marketing-pipeline.yml
@@ -70,6 +70,7 @@ jobs:
           BEEHIIV_PUBLICATION_ID: ${{ secrets.BEEHIIV_PUBLICATION_ID }}
           POSTIZ_API_KEY: ${{ secrets.POSTIZ_API_KEY }}
           POSTIZ_DRAFTS_ENABLED: ${{ vars.POSTIZ_DRAFTS_ENABLED || 'true' }}
+          POSTIZ_TAG_INCLUDE_AUTO_APPROVED: 'true'
           PITCHRANK_URL: 'https://pitchrank.io'
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |

--- a/docs/superpowers/specs/2026-06-11-instagram-posts-revamp-design.md
+++ b/docs/superpowers/specs/2026-06-11-instagram-posts-revamp-design.md
@@ -1,0 +1,81 @@
+# Instagram Posts Revamp — Design
+
+**Date:** 2026-06-11
+**Status:** Approved by Dallas (brainstorming session with visual mockups)
+**Scope:** The Instagram posts drafted by `scripts/marketing_pipeline.py` (`generate_social_posts()`). Newsletter, blog, X thread, trend posts, and the Postiz approval gate are unchanged.
+
+## Goal
+
+Replace the current 3-post Instagram week (rankings-live, mover spotlight, state spotlight) with a 5-post week that drops all "jumped X spots" mover claims, showcases state top-10s with team tagging, and previews ranked-vs-ranked weekend matchups.
+
+## Weekly schedule (all drafted to Postiz, user approves before publish)
+
+| Day | Post | Image |
+|---|---|---|
+| Mon 12:00 PM MT | Rankings are Live | New generic "Rankings Live" graphic |
+| Tue 9:00 AM MT | State Top-10 #1 | Top-10 graphic (combo 1) |
+| Tue 12:00 PM MT | State Top-10 #2 | Top-10 graphic (combo 2) |
+| Tue 5:00 PM MT | State Top-10 #3 | Top-10 graphic (combo 3) |
+| Thu 7:30 PM MT | Big Games This Weekend | Matchup slate graphic |
+
+## Post 1 — Monday "Rankings are Live"
+
+**Captions.** Both `SOCIAL_TEMPLATES["rankings_live"]` variants lose all team-specific mover claims:
+
+- Variant 1: `New rankings are live.\n\nWhere does your team stand?\n\npitchrank.io/rankings\n\n#YouthSoccer #ClubSoccer #SoccerRankings`
+- Variant 2: `Monday means new rankings.\n\n{total_teams} teams updated.\n\npitchrank.io/rankings\n\n#YouthSoccer #SoccerRankings`
+
+`{total_teams}` is the existing live count (`rankings_full` excluding status `Not Enough Ranked Games`), formatted with thousands separators. If the count is unavailable (0/error), the count line is dropped entirely — never a made-up number. The other "25,000+" fallbacks in `marketing_pipeline.py` that feed user-facing copy get the same drop-the-line treatment.
+
+**Image.** New `/api/infographic/rankings-live` route: generic branded "New Rankings Are Live" graphic showing the live team count and week date. Replaces the movers infographic on this post. The `if top_climber` gate around Post 1 is removed (the post no longer depends on mover data).
+
+## Post set 2 — Tuesday State Top-10 (3 posts)
+
+**Rotation.** Each week pick 3 combos of (state, age group, gender):
+
+- State pool: the live state pillar list — `STATE_PILLAR_SLUGS` in `frontend/lib/cohort-seo.ts` (19 states as of 2026-06). The pipeline keeps its own mirror of this list (Python side); a comment in both files cross-references them.
+- Age pool: the platform's age groups u10–u19 (no u18 — merges into u19, per `AGE_GROUPS`).
+- Gender: boys/girls.
+- Selection is deterministic, seeded by ISO week number: states cycle so all 19 are covered before any repeats; age and gender assignments vary week to week. `--dry-run` prints the selected combos.
+- Viability: a combo needs ≥10 ranked teams in that state/age/gender; thin combos are deterministically re-picked.
+
+**Data.** Reuse the existing `get_state_rankings(p_state, p_age, p_gender, p_limit, p_offset)` RPC — it already returns `team_id_master`, team/club names, W-L-D, `power_score_final`, `rank_in_state_final`, and `status`. Apply the existing over-fetch + `status='Active'` filter so provisional teams never appear (as `/api/infographic/state` already does). No new RPC needed. *(Amended 2026-06-12: the originally planned `get_state_top10` RPC is unnecessary — verified against `origin/main`.)*
+
+**Graphic.** Reuse the existing `/api/infographic/state?state=&age=&gender=` next/og route on `origin/main` — it already renders "TOP 10 U{age} {GENDER} IN {STATE}" in the approved design (white+yellow PITCHRANK logo, gold/silver/bronze top-3, W-L-D + PowerScore columns) via the shared `_shared/{assets,components,theme}` modules. No new route needed. *(Amended 2026-06-12: the spec was drafted against a stale local branch; `origin/main` already has this route.)*
+
+**Caption.** Names the cohort (e.g. "New York U14 Boys — Top 10 in the state"), link, hashtags, then @mentions for each top-10 team via the existing `enrich_post_with_handles()` + `_resolve_tag_targets()` post-pass in `scripts/marketing_pipeline.py` — team-level handle preferred, club handle as fallback, teams with neither are listed on the graphic but skipped in the mention list. Handles with `review_status` of `confirmed` **or** `auto_approved` may be mentioned (`POSTIZ_TAG_INCLUDE_AUTO_APPROVED=true`); the Postiz draft review is the human gate. *(Amended 2026-06-12: tagging machinery already exists on `origin/main`; auto-approved handles enabled per Dallas.)*
+
+## Post 3 — Thursday "Big Games This Weekend"
+
+**Selection.** Scan upcoming Friday–Sunday games (relative to the Thursday post date; upcoming = `game_date > today` per platform convention) across every state/age/gender. A game qualifies when **both** teams are ranked top-25 in the same state cohort. Qualifying games are ordered by combined state rank (lower sum = bigger game) and the best are taken, up to 5. The post runs with as few as 1 qualifying matchup; with 0 it is skipped for the week (no padding with weak matchups).
+
+**Data.** New read-only RPC `get_big_weekend_games(p_start_date, p_end_date, p_rank_ceiling int default 25, p_limit int default 5)` returning, per game: both team names/clubs/team_ids, their state ranks, state, age group, gender, and game date. *(Amended 2026-06-12: no kickoff-time column exists on `games` — day labels only; state rank is computed per-candidate with a deterministic tiebreaker, mirroring the live state-rankings ordering. The RPC is called only by the pipeline with the service-role key — see Architecture.)*
+
+**Graphic.** New `/api/infographic/big-games` next/og route: slate layout with the brand header, "BIG GAMES THIS WEEKEND" title, date range, and one row per matchup — cohort + day label (FRI/SAT/SUN), both teams with their state ranks, and the yellow circular VS badge styled after the existing Head-to-Head infographic (`HeadToHeadPreview.tsx`). *(Amended 2026-06-12: the route is a pure renderer — the pipeline passes the matchups as a base64url JSON payload in the image URL; the route makes no database call.)*
+
+**Caption.** Hook line, then one `⚔️ @teamA vs @teamB (STATE AGE GENDER)` line per matchup (same handle precedence as the top-10 posts; teams without handles appear by name), link, hashtags.
+
+## Architecture
+
+- **Image generation:** new next/og edge routes alongside the existing `movers`/`spotlight`/`state` routes under `frontend/app/api/infographic/`. The rankings-live route queries via the anon key (lean count RPC); the big-games route is a **pure renderer** fed a payload by the pipeline — no database call, no timeout exposure. *(Amended 2026-06-12.)*
+- **Shared data:** caption and graphic draw from one source per post — the Tuesday posts and Monday count use the same RPCs as their routes; the big-games caption and payload are built from a single RPC result in the pipeline — so caption and graphic can never disagree. *(Amended 2026-06-12.)*
+- **Pipeline:** `generate_social_posts()` is rewritten around the new 5-post week. The retired `mover_spotlight` and `state_spotlight`/`data_flex` IG templates are removed along with their generation branches (after confirming no other consumer uses them).
+- **Scheduling:** all posts drafted to Postiz (existing client), publish windows per the schedule table.
+
+## Failure handling
+
+- Thin top-10 cohort → deterministic re-pick.
+- Zero qualifying weekend games → Thursday post skipped.
+- Team-count query failure → count line dropped from Monday caption.
+- Missing IG handle → no @mention for that team; graphic unaffected.
+- A single post failing to draft does not block the other posts (matches current behavior).
+
+## Out of scope / unchanged
+
+Newsletter, weekly blog post, X thread, trend posts, Postiz approval gate, `POSTIZ_DRAFTS_ENABLED` kill switch, `--dry-run` flag (extended to print the week's combos and matchups).
+
+## Verification
+
+- `--dry-run` shows: revised Monday captions with the real count, 3 deterministic top-10 combos with captions/mention lists, and the weekend slate (or an explicit skip notice).
+- New infographic routes render correctly in a browser for a known-good combo and for edge cases (long team names, 10-mention captions).
+- Re-running the pipeline for the same ISO week reproduces identical combo selections.

--- a/frontend/app/api/infographic/_shared/components.tsx
+++ b/frontend/app/api/infographic/_shared/components.tsx
@@ -2,6 +2,18 @@ import type { ReactNode } from 'react';
 import { COLORS } from './theme';
 import { wordmarkUrl, WORDMARK_ASPECT } from './assets';
 
+// Divider + pitchrank.io/rankings line that closes every infographic.
+export function Footer({ isStory }: { isStory: boolean }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', marginTop: isStory ? 28 : 18 }}>
+      <div style={{ display: 'flex', height: 2, background: COLORS.divider, marginBottom: 16 }} />
+      <div style={{ display: 'flex', justifyContent: 'center', fontSize: isStory ? 20 : 17, color: COLORS.club }}>
+        pitchrank.io/rankings
+      </div>
+    </div>
+  );
+}
+
 // Root frame: gradient + scan-line texture overlay + (consumer-supplied) content.
 export function Frame({ isStory, children }: { isStory: boolean; children: ReactNode }) {
   return (

--- a/frontend/app/api/infographic/big-games/route.tsx
+++ b/frontend/app/api/infographic/big-games/route.tsx
@@ -1,0 +1,182 @@
+import { ImageResponse } from 'next/og';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
+import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
+import { COLORS, platformDims } from '../_shared/theme';
+import { Frame, Header, Footer } from '../_shared/components';
+
+export const runtime = 'edge';
+
+interface MatchupTeam {
+  name: string;
+  club: string;
+  rank: number;
+}
+
+interface Matchup {
+  cohort: string;
+  day: string;
+  home: MatchupTeam;
+  away: MatchupTeam;
+  state: string;
+}
+
+interface BigGamesPayload {
+  v: number;
+  range: string;
+  games: Matchup[];
+}
+
+// The pipeline builds the payload with base64.urlsafe_b64encode, whose -/_
+// alphabet atob rejects, and club names can carry non-ASCII bytes that atob's
+// Latin-1 strings would mangle — translate to standard base64, re-pad, then
+// decode the bytes through TextDecoder.
+// A real payload (≤5 matchups) encodes to ~1.5KB; cap well above that but far
+// below any abuse blob so the decode+parse work on this public CPU-heavy route
+// stays bounded.
+const MAX_PAYLOAD_CHARS = 8192;
+
+function decodePayload(m: string): BigGamesPayload | null {
+  if (m.length > MAX_PAYLOAD_CHARS) return null;
+  try {
+    const b64 = m.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const bytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as BigGamesPayload;
+    if (payload.v !== 1 || !Array.isArray(payload.games) || payload.games.length === 0) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+function TeamBlock({
+  team,
+  state,
+  align,
+  isStory,
+}: {
+  team: MatchupTeam;
+  state: string;
+  align: 'left' | 'right';
+  isStory: boolean;
+}) {
+  const alignItems = align === 'left' ? 'flex-start' : 'flex-end';
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, alignItems, overflow: 'hidden' }}>
+      <div
+        style={{
+          display: 'flex',
+          fontFamily: 'Oswald',
+          fontWeight: 600,
+          fontSize: isStory ? 26 : 22,
+          color: COLORS.brightWhite,
+          textAlign: align,
+        }}
+      >
+        {team.name.toUpperCase()}
+      </div>
+      <div style={{ display: 'flex', fontSize: isStory ? 16 : 13, color: COLORS.club, marginTop: 3, textAlign: align }}>
+        {team.club}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: isStory ? 17 : 14,
+          fontWeight: 700,
+          color: COLORS.electricYellow,
+          marginTop: 4,
+        }}
+      >
+        {`#${team.rank} in ${state}`}
+      </div>
+    </div>
+  );
+}
+
+function MatchupRow({ matchup, isStory }: { matchup: Matchup; isStory: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        background: COLORS.rowDim,
+        borderLeft: `5px solid ${COLORS.rowBorderDim}`,
+        borderRadius: 10,
+        padding: isStory ? '14px 26px' : '12px 22px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontFamily: 'Oswald',
+          fontWeight: 700,
+          fontSize: isStory ? 18 : 15,
+          color: COLORS.electricYellow,
+          letterSpacing: 2,
+        }}
+      >
+        {`${matchup.cohort} · ${matchup.day}`}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', flex: 1, marginTop: 6 }}>
+        <TeamBlock team={matchup.home} state={matchup.state} align="left" isStory={isStory} />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: isStory ? 70 : 60,
+            height: isStory ? 70 : 60,
+            borderRadius: '50%',
+            background: COLORS.electricYellow,
+            margin: '0 16px',
+            flexShrink: 0,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'Oswald',
+              fontSize: isStory ? 26 : 22,
+              fontWeight: 700,
+              color: COLORS.darkGreen,
+            }}
+          >
+            VS
+          </span>
+        </div>
+        <TeamBlock team={matchup.away} state={matchup.state} align="right" isStory={isStory} />
+      </div>
+    </div>
+  );
+}
+
+export async function GET(request: Request) {
+  // CPU-heavy public image rendering - throttle to limit denial-of-wallet
+  if (!checkRateLimit(`infographic:${getClientIp(request)}`, 10, 60_000)) {
+    return new Response('Too many requests', { status: 429 });
+  }
+
+  const { searchParams, origin } = new URL(request.url);
+  const platform = searchParams.get('platform') || 'instagram';
+  const isStory = platform === 'story';
+  const d = platformDims(platform);
+
+  const payload = decodePayload(searchParams.get('m') || '');
+  if (!payload) return new Response('No matchup data available', { status: 404 });
+
+  const fonts = await loadBrandFonts(origin);
+  const games = payload.games.slice(0, 5);
+
+  return new ImageResponse(
+    <Frame isStory={isStory}>
+      <Header origin={origin} isStory={isStory} title="BIG GAMES THIS WEEKEND" subtitle={payload.range} />
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: isStory ? 14 : 10 }}>
+        {games.map((matchup, i) => (
+          <MatchupRow key={i} matchup={matchup} isStory={isStory} />
+        ))}
+      </div>
+      <Footer isStory={isStory} />
+    </Frame>,
+    { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
+  );
+}

--- a/frontend/app/api/infographic/rankings-live/route.tsx
+++ b/frontend/app/api/infographic/rankings-live/route.tsx
@@ -1,0 +1,89 @@
+import { ImageResponse } from 'next/og';
+import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
+import { createClient } from '@supabase/supabase-js';
+import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
+import { COLORS, platformDims } from '../_shared/theme';
+import { Frame, Header, Footer } from '../_shared/components';
+
+export const runtime = 'edge';
+
+async function getActiveTeamCount(): Promise<number> {
+  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+
+  // Same RPC the pipeline uses for the Monday caption, so caption and graphic
+  // always show the same number.
+  const { data, error } = await supabase.rpc('get_national_active_count');
+  if (error || typeof data !== 'number') return 0;
+  return data;
+}
+
+export async function GET(request: Request) {
+  // CPU-heavy public image rendering - throttle to limit denial-of-wallet
+  if (!checkRateLimit(`infographic:${getClientIp(request)}`, 10, 60_000)) {
+    return new Response('Too many requests', { status: 429 });
+  }
+
+  const { searchParams, origin } = new URL(request.url);
+  const platform = searchParams.get('platform') || 'instagram';
+  const isStory = platform === 'story';
+  const d = platformDims(platform);
+
+  const [count, fonts] = await Promise.all([getActiveTeamCount(), loadBrandFonts(origin)]);
+  const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+  return new ImageResponse(
+    <Frame isStory={isStory}>
+      <Header origin={origin} isStory={isStory} title="NEW RANKINGS ARE LIVE" subtitle={`Week of ${dateStr}`} />
+      <div
+        style={{ display: 'flex', flexDirection: 'column', flex: 1, alignItems: 'center', justifyContent: 'center' }}
+      >
+        {count > 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div
+              style={{
+                display: 'flex',
+                fontFamily: 'Oswald',
+                fontWeight: 700,
+                fontSize: isStory ? 160 : 130,
+                color: COLORS.electricYellow,
+              }}
+            >
+              {count.toLocaleString('en-US')}
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                fontFamily: 'Oswald',
+                fontWeight: 700,
+                fontSize: isStory ? 44 : 36,
+                color: COLORS.brightWhite,
+                letterSpacing: 4,
+                marginTop: 8,
+              }}
+            >
+              TEAMS RANKED
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              fontFamily: 'Oswald',
+              fontWeight: 700,
+              fontSize: isStory ? 64 : 52,
+              color: COLORS.brightWhite,
+              letterSpacing: 3,
+            }}
+          >
+            WHERE DOES YOUR TEAM STAND?
+          </div>
+        )}
+        <div style={{ display: 'flex', fontSize: isStory ? 24 : 20, color: COLORS.date, marginTop: 36 }}>
+          Updated every Monday from real game data
+        </div>
+      </div>
+      <Footer isStory={isStory} />
+    </Frame>,
+    { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
+  );
+}

--- a/frontend/app/api/infographic/spotlight/route.tsx
+++ b/frontend/app/api/infographic/spotlight/route.tsx
@@ -3,7 +3,7 @@ import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, platformDims, formatScore, formatRecord } from '../_shared/theme';
-import { Frame, Header, StatBlock } from '../_shared/components';
+import { Frame, Header, Footer, StatBlock } from '../_shared/components';
 
 export const runtime = 'edge';
 
@@ -178,12 +178,7 @@ export async function GET(request: Request) {
         </div>
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', marginTop: isStory ? 28 : 18 }}>
-        <div style={{ display: 'flex', height: 2, background: COLORS.divider, marginBottom: 16 }} />
-        <div style={{ display: 'flex', justifyContent: 'center', fontSize: isStory ? 20 : 17, color: COLORS.club }}>
-          pitchrank.io/rankings
-        </div>
-      </div>
+      <Footer isStory={isStory} />
     </Frame>,
     { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
   );

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -3,7 +3,7 @@ import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, MEDAL, platformDims, formatScore, formatRecord } from '../_shared/theme';
-import { Frame, Header, RankRow, StatBlock } from '../_shared/components';
+import { Frame, Header, Footer, RankRow, StatBlock } from '../_shared/components';
 
 export const runtime = 'edge';
 
@@ -133,12 +133,7 @@ export async function GET(request: Request) {
           </RankRow>
         ))}
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', marginTop: isStory ? 28 : 18 }}>
-        <div style={{ display: 'flex', height: 2, background: COLORS.divider, marginBottom: 16 }} />
-        <div style={{ display: 'flex', justifyContent: 'center', fontSize: isStory ? 20 : 17, color: COLORS.club }}>
-          pitchrank.io/rankings
-        </div>
-      </div>
+      <Footer isStory={isStory} />
     </Frame>,
     { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
   );

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -10,6 +10,7 @@ Run: python3 scripts/marketing_pipeline.py [--dry-run]
 """
 
 import argparse
+import base64
 import json
 import logging
 import os
@@ -54,23 +55,55 @@ POSTIZ_API_URL = "https://api.postiz.com/public/v1"
 # Beehiiv API
 BEEHIIV_API_URL = "https://api.beehiiv.com/v2"
 
-# State spotlight infographic — rotate the featured cohort each week so the Thursday
-# graphic cycles through age/gender groups (u14 boys, u14 girls, u15 boys, ...).
-# Ages limited to cohorts with enough ranked teams nationally to be worth posting.
-STATE_COHORT_ROTATION = [(age, gender) for age in (10, 11, 12, 13, 14, 15, 16, 17, 19) for gender in ("male", "female")]
-# Restrict the weekly state spotlight to deep states, where every age/gender cohort
-# has enough ranked teams to fill a clean Top 5. Small states surface provisional
-# ("Not Enough Ranked Games") teams, which we don't want in a public graphic.
+# Restrict the newsletter/blog state spotlight to deep states, where every age/gender
+# cohort has enough ranked teams to fill a clean Top 5. Small states surface provisional
+# ("Not Enough Ranked Games") teams, which we don't want in public copy.
 SPOTLIGHT_STATES = ("CA", "TX", "AZ", "FL", "PA", "NJ", "OK", "OH")
-# Fixed Monday epoch so the rotation advances exactly one cohort per week with no
+# Fixed Monday epoch so the rotation advances exactly one step per week with no
 # year-boundary jump.
 STATE_COHORT_EPOCH = datetime(2026, 1, 5)
 
+# States with a pillar guide — must stay in sync with STATE_PILLAR_SLUGS in
+# frontend/lib/cohort-seo.ts (19 states as of 2026-06).
+PILLAR_STATES = (
+    "AZ", "CA", "CO", "CT", "FL", "GA", "IL", "MA", "MD", "MI",
+    "MN", "NJ", "NY", "NC", "OH", "PA", "TX", "VA", "WA",
+)
+STATE_DISPLAY_NAMES = {
+    "AZ": "Arizona", "CA": "California", "CO": "Colorado", "CT": "Connecticut",
+    "FL": "Florida", "GA": "Georgia", "IL": "Illinois", "MA": "Massachusetts",
+    "MD": "Maryland", "MI": "Michigan", "MN": "Minnesota", "NJ": "New Jersey",
+    "NY": "New York", "NC": "North Carolina", "OH": "Ohio", "PA": "Pennsylvania",
+    "TX": "Texas", "VA": "Virginia", "WA": "Washington",
+}
+# Tuesday Top-10 age pool: u10-u17 + u19 (u18 merges into u19 platform-wide).
+TOP10_AGES = (10, 11, 12, 13, 14, 15, 16, 17, 19)
 
-def weekly_state_cohort(monday: datetime) -> tuple[int, str]:
-    """Return the (age, gender) cohort to feature for the week of the given Monday."""
-    weeks_since = (monday.date() - STATE_COHORT_EPOCH.date()).days // 7
-    return STATE_COHORT_ROTATION[weeks_since % len(STATE_COHORT_ROTATION)]
+# Thursday big-games slate is restricted to deeper states so matchups are
+# genuine marquee games, not thin small-state #1-vs-#2 pairings.
+BIG_GAMES_STATES = (
+    "CA", "MA", "TX", "FL", "NJ", "AZ", "PA", "GA", "VA", "MD",
+    "OH", "OK", "CO", "NC", "IL", "WA", "NV", "NY",
+)
+
+
+def weekly_top10_combos(monday: datetime) -> list[tuple[str, int, str]]:
+    """Return the week's 3 deterministic (state, age, gender) Top-10 combos.
+
+    States walk PILLAR_STATES in blocks of 3, so every 19 consecutive picks cover
+    all 19 states before any repeats (19 % 3 != 0 means one week per cycle mixes
+    the cycle boundary — expected, not a bug). Ages and genders shift by week so
+    cohorts vary.
+    """
+    week = (monday.date() - STATE_COHORT_EPOCH.date()).days // 7
+    return [
+        (
+            PILLAR_STATES[(week * 3 + i) % len(PILLAR_STATES)],
+            TOP10_AGES[(week + i) % len(TOP10_AGES)],
+            ("male", "female")[(week + i) % 2],
+        )
+        for i in range(3)
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -260,12 +293,140 @@ def fetch_ranking_highlights(supabase) -> dict:
         "date": datetime.now(MT_OFFSET),
     }
 
+    # Instagram week inputs: live Active count, Tuesday Top-10 cohorts, weekend slate
+    data["active_team_count"] = fetch_active_team_count(supabase)
+    data["top10_combos"] = weekly_top10_combos(data["date"])
+    data["top10_cohorts"] = fetch_top10_cohorts(supabase, data["top10_combos"])
+    data["big_games_window"] = next_weekend_window(datetime.now(MT_OFFSET))
+    data["big_games"] = fetch_big_weekend_games(supabase, *data["big_games_window"])
+
     log.info(
         f"Highlights: {len(climbers)} climbers, {len(fallers)} fallers, "
         f"{total_teams} total teams, spotlight: {spotlight_state}, "
-        f"{len(milestones)} milestone crossings"
+        f"{len(milestones)} milestone crossings, {data['active_team_count']} active teams, "
+        f"{len(data['top10_cohorts'])} top-10 cohorts, {len(data['big_games'])} big games"
     )
     return data
+
+
+def fetch_active_team_count(supabase) -> int:
+    """Live Active-team count via the same RPC the rankings-live graphic uses.
+
+    One shared source means the Monday caption and graphic can never disagree.
+    This is the published-rank denominator (Active only) — deliberately smaller
+    than the legacy total_teams count, which includes other statuses.
+    """
+    try:
+        resp = supabase.rpc("get_national_active_count").execute()
+        return int(resp.data or 0)
+    except Exception as e:
+        log.warning(f"Active team count RPC failed: {e}")
+        return 0
+
+
+def fetch_rankings_last_calculated(supabase) -> datetime | None:
+    """Return MAX(last_calculated) from rankings_full, or None when unavailable."""
+    try:
+        resp = (
+            supabase.table("rankings_full")
+            .select("last_calculated")
+            .order("last_calculated", desc=True)
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        raw = rows[0].get("last_calculated") if rows else None
+        if not raw:
+            return None
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except Exception as e:
+        log.warning(f"Rankings freshness lookup failed: {e}")
+        return None
+
+
+def rankings_are_stale(last_calculated: datetime | None, now: datetime | None = None, max_age_days: int = 8) -> bool:
+    """True when rankings are too old to announce as new.
+
+    The threshold is sized to the weekly recalc cadence plus margin — a healthy
+    dataset can legitimately be several days old by the time the pipeline runs.
+    """
+    if last_calculated is None:
+        return True
+    now = now or datetime.now(timezone.utc)
+    return now - last_calculated > timedelta(days=max_age_days)
+
+
+def fetch_top10_cohorts(supabase, combos: list[tuple[str, int, str]]) -> list[dict]:
+    """Resolve each (state, age, gender) combo to its state Top 10 via get_state_rankings.
+
+    Mirrors getStateTopTeams() in frontend/app/api/infographic/state/route.tsx:
+    over-fetch, keep Active teams with a state rank, slice 10. A combo with a thin
+    cohort advances deterministically to the next pillar state (same age/gender).
+    """
+    cohorts = []
+    for state, age, gender in combos:
+        start = PILLAR_STATES.index(state)
+        chosen = None
+        for step in range(len(PILLAR_STATES)):
+            candidate = PILLAR_STATES[(start + step) % len(PILLAR_STATES)]
+            try:
+                resp = supabase.rpc(
+                    "get_state_rankings",
+                    {
+                        "p_state": candidate,
+                        # Bare number, not "u14" — the RPC casts p_age::INTEGER
+                        "p_age": str(age),
+                        "p_gender": "M" if gender == "male" else "F",
+                        "p_limit": 55,
+                        "p_offset": 0,
+                    },
+                ).execute()
+            except Exception as e:
+                log.warning(f"get_state_rankings failed for {candidate} u{age} {gender}: {e}")
+                continue
+            teams = [
+                t
+                for t in (resp.data or [])
+                if t.get("status") == "Active" and t.get("rank_in_state_final") is not None
+            ][:10]
+            if len(teams) >= 10:
+                if step:
+                    log.info(f"Top-10 combo {state} u{age} {gender} thin; re-picked {candidate}")
+                chosen = {"state": candidate, "age": age, "gender": gender, "teams": teams}
+                break
+        if chosen:
+            cohorts.append(chosen)
+        else:
+            log.warning(f"No viable Top-10 cohort for u{age} {gender} in any pillar state")
+    return cohorts
+
+
+def next_weekend_window(now: datetime) -> tuple:
+    """Return (friday, sunday) dates of the next upcoming Fri-Sun window."""
+    days_to_friday = (4 - now.weekday()) % 7 or 7
+    friday = (now + timedelta(days=days_to_friday)).date()
+    return friday, friday + timedelta(days=2)
+
+
+def fetch_big_weekend_games(supabase, start_date, end_date, states=BIG_GAMES_STATES) -> list[dict]:
+    """Weekend games where both sides are ranked top-25 in the same state cohort.
+
+    Restricted to `states` (the bigger-state list) so the slate is marquee
+    matchups rather than thin small-state pairings.
+    """
+    try:
+        resp = supabase.rpc(
+            "get_big_weekend_games",
+            {
+                "p_start_date": start_date.isoformat(),
+                "p_end_date": end_date.isoformat(),
+                "p_states": list(states) if states else None,
+            },
+        ).execute()
+        return resp.data or []
+    except Exception as e:
+        log.warning(f"Big weekend games RPC failed: {e}")
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -335,7 +496,14 @@ def generate_newsletter_html(data: dict, blog_body_md: str) -> str:
 
     dt = data["date"]
     date_display = f"Week of {dt.strftime('%b %d, %Y')}"
-    total_teams = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
+    # Drop the count sentence entirely when the live count is unavailable —
+    # never a made-up number.
+    total_teams_line = (
+        f'<p style="margin:12px 0 0;font-size:13px;color:#888;">{data["total_teams"]:,} teams. '
+        "13-layer algorithm. Updated every Monday.</p>"
+        if data["total_teams"]
+        else ""
+    )
 
     blog_content_html = _markdown_to_email_html(blog_body_md)
 
@@ -352,7 +520,7 @@ def generate_newsletter_html(data: dict, blog_body_md: str) -> str:
     html = tmpl.safe_substitute(
         date_display=date_display,
         blog_content_html=blog_content_html,
-        total_teams=total_teams,
+        total_teams_line=total_teams_line,
         engagement_hook=engagement_hook,
     )
 
@@ -511,7 +679,9 @@ def _filter_by_state(teams: list[dict], state: str) -> list[dict]:
 def _build_blog_body(data: dict, topic: dict) -> str:
     """Build blog post body based on topic type."""
     topic_type = topic.get("type", "weekly_movers")
-    total = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
+    # None when unavailable; each branch drops its count sentence rather than
+    # publishing a made-up number.
+    total = f"{data['total_teams']:,}" if data["total_teams"] else None
     biggest = data.get("biggest_jump", 0)
     keyword = topic.get("target_keyword", "youth soccer rankings")
     climbers_table = _movers_table(data["climbers"], "up")
@@ -525,9 +695,14 @@ def _build_blog_body(data: dict, topic: dict) -> str:
         state_fallers = _filter_by_state(data["fallers"], state)
         ct = _movers_table(state_climbers or data["climbers"], "up")
         ft = _movers_table(state_fallers or data["fallers"], "down")
+        tracking_line = (
+            f"We track {total} teams nationally, and here's what moved in {state} this week.\n\n"
+            if total
+            else f"Here's what moved in {state} this week.\n\n"
+        )
         return (
             f"Every Monday, PitchRank updates {keyword} across all leagues.\n"
-            f"We track {total} teams nationally, and here's what moved in {state} this week.\n\n"
+            f"{tracking_line}"
             f"## Top Movers in {state} This Week\n\n{ct}\n\n"
             f"## Biggest Drops in {state}\n\n{ft}\n\n"
             f"## How {state} Compares Nationally\n\n"
@@ -543,10 +718,11 @@ def _build_blog_body(data: dict, topic: dict) -> str:
         )
 
     if topic_type == "league_comparison":
+        across = f" across {total} teams" if total else ""
         return (
             f"One of the most common questions in youth soccer: {keyword} — which\n"
             f"league is better? PitchRank's cross-league calibration makes a\n"
-            f"data-driven comparison possible across {total} teams.\n\n"
+            f"data-driven comparison possible{across}.\n\n"
             f"## This Week's Top Movers\n\n{climbers_table}\n\n"
             f"## How PitchRank Compares Leagues\n\n"
             f"PitchRank uses a 13-layer algorithm that normalizes across leagues.\n"
@@ -562,11 +738,13 @@ def _build_blog_body(data: dict, topic: dict) -> str:
         )
 
     if topic_type == "methodology":
+        ranked_intro = f"ranked {total} youth soccer teams" if total else "ranked youth soccer teams"
+        teams_bullet = f"- **{total}** teams ranked\n" if total else ""
         return (
-            f"This week, PitchRank ranked {total} youth soccer teams across\n"
+            f"This week, PitchRank {ranked_intro} across\n"
             f"all 50 states. Here's how we did it and what the data showed.\n\n"
             f"## This Week by the Numbers\n\n"
-            f"- **{total}** teams ranked\n"
+            f"{teams_bullet}"
             f"- **50** states covered\n"
             f"- **+{biggest}** biggest single rank jump\n"
             f"- Rankings updated every Monday\n\n"
@@ -582,8 +760,9 @@ def _build_blog_body(data: dict, topic: dict) -> str:
 
     if topic_type == "age_group":
         age_group = topic.get("age_group", "U14")
+        ranks_clause = f"ranks {total} teams" if total else "ranks teams"
         return (
-            f"Looking for the {keyword}? PitchRank ranks {total} teams across\n"
+            f"Looking for the {keyword}? PitchRank {ranks_clause} across\n"
             f"all age groups every Monday. Here's what moved at {age_group} this week.\n\n"
             f"## Top {age_group} Movers This Week\n\n{climbers_table}\n\n"
             f"## Biggest Drops at {age_group}\n\n{fallers_table}\n\n"
@@ -598,9 +777,10 @@ def _build_blog_body(data: dict, topic: dict) -> str:
     top_attr = ""
     if top:
         top_attr = f", earned by **{top.get('team_name', '')}** from {top.get('state_code') or top.get('state', '')}"
+    for_teams = f"for {total} teams" if total else "for teams"
     return (
-        f"Every Monday, PitchRank updates youth soccer rankings for {total}\n"
-        f"teams across all 50 states. Here are this week's biggest movers.\n\n"
+        f"Every Monday, PitchRank updates youth soccer rankings {for_teams}\n"
+        f"across all 50 states. Here are this week's biggest movers.\n\n"
         f"## Biggest Climbers\n\n{climbers_table}\n\n"
         f"## Biggest Drops\n\n{fallers_table}\n\n"
         f"## What Drove the Movement\n\n"
@@ -656,10 +836,15 @@ def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     week_num = dt.isocalendar()[1]
     date_str = dt.strftime("%Y-%m-%d")
     date_display = dt.strftime("%B %d, %Y")
-    total = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
+    total = f"{data['total_teams']:,}" if data["total_teams"] else None
 
     topic = get_next_blog_topic(week_num)
-    title = topic.get("title", "Youth Soccer Rankings Update").replace("{total}", total)
+    title = topic.get("title", "Youth Soccer Rankings Update")
+    if total:
+        title = title.replace("{total}", total)
+    else:
+        # Count-free title variant — collapse the placeholder and any doubled spaces
+        title = " ".join(title.replace("{total}", "").split())
     slug = f"{date_str}-{topic.get('slug_prefix', 'weekly-update')}"
     tags = topic.get("tags", ["Rankings"])
     target_keyword = topic.get("target_keyword", "youth soccer rankings")
@@ -686,14 +871,21 @@ def generate_blog_post(data: dict, supabase=None) -> tuple[str, str]:
     state = topic.get("state", "")
     age_group = topic.get("age_group", "")
     if state:
-        excerpt = (
-            f"This week's {state} youth soccer rankings update."
+        moved_clause = (
             f" See which {state} teams moved the most across {total} ranked teams."
+            if total
+            else f" See which {state} teams moved the most this week."
         )
+        excerpt = f"This week's {state} youth soccer rankings update.{moved_clause}"
     elif age_group:
-        excerpt = f"Best {age_group} soccer teams this week. Rankings for {total} teams updated every Monday."
-    else:
+        rankings_clause = (
+            f"Rankings for {total} teams updated every Monday." if total else "Rankings updated every Monday."
+        )
+        excerpt = f"Best {age_group} soccer teams this week. {rankings_clause}"
+    elif total:
         excerpt = f"Weekly youth soccer rankings update for {date_display}. {total} teams ranked across all 50 states."
+    else:
+        excerpt = f"Weekly youth soccer rankings update for {date_display}. Teams ranked across all 50 states."
 
     # Build full markdown with frontmatter
     frontmatter = {
@@ -782,62 +974,104 @@ SOCIAL_TEMPLATES = {
     "rankings_live": [
         (
             "New rankings are live.\n\n"
-            "{team_name} jumped {change} spots to #{rank}.\n\n"
             "Where does your team stand?\n\n"
             "pitchrank.io/rankings\n\n"
             "#YouthSoccer #ClubSoccer #SoccerRankings"
         ),
         (
             "Monday means new rankings.\n\n"
-            "Biggest move: {team_name} ({state}) climbed {change} spots.\n\n"
-            "25K+ teams updated.\n\n"
+            "{active_team_count} teams updated.\n\n"
             "pitchrank.io/rankings\n\n"
-            "#YouthSoccer #SoccerRankings"
-        ),
-    ],
-    "mover_spotlight": [
-        (
-            "{team_name} ({state}) climbed {change} spots this week.\n\n"
-            "Now #{rank} nationally.\n\n"
-            "Rankings built from real game data, not vibes.\n\n"
-            "pitchrank.io/rankings"
-        ),
-        (
-            "Big move alert: {team_name} is now #{rank} nationally.\n\n"
-            "+{change} spots this week.\n\n"
-            "Some rankings are vibes. Ours are receipts.\n\n"
-            "pitchrank.io/rankings"
-        ),
-    ],
-    "state_spotlight": [
-        (
-            "Top movers in {state} this week:\n\n"
-            "{mover_list}\n\n"
-            "Full state rankings at pitchrank.io/rankings\n\n"
-            "#{state}Soccer #YouthSoccer"
-        ),
-    ],
-    "data_flex": [
-        (
-            "{total_teams} teams. Updated every Monday.\n\n"
-            "Your team is in there.\n\n"
-            "pitchrank.io/rankings\n\n"
-            "#YouthSoccer #SoccerRankings #ClubSoccer"
-        ),
-        (
-            "We don't guess. We count.\n\n"
-            "Real match results.\n"
-            "Strength of schedule.\n"
-            "Updated weekly.\n\n"
-            "Find your team: pitchrank.io/rankings\n\n"
             "#YouthSoccer #SoccerRankings"
         ),
     ],
 }
 
 
+def format_rankings_live_caption(template: str, active_team_count: int) -> str:
+    """Fill the live count, or drop the count line entirely — never a made-up number."""
+    if "{active_team_count}" not in template:
+        return template
+    if active_team_count:
+        return template.format(active_team_count=f"{active_team_count:,}")
+    return "\n\n".join(seg for seg in template.split("\n\n") if "{active_team_count}" not in seg)
+
+
+def build_top10_caption(state: str, age: int, gender: str) -> str:
+    state_name = STATE_DISPLAY_NAMES.get(state, state)
+    gender_label = "Boys" if gender == "male" else "Girls"
+    return (
+        f"{state_name} U{age} {gender_label} — Top 10 in the state.\n\n"
+        "Full rankings: pitchrank.io/rankings\n\n"
+        f"#YouthSoccer #SoccerRankings #{state}Soccer"
+    )
+
+
+def _matchup_cohort_label(game: dict) -> str:
+    age = re.sub(r"\D", "", game.get("age_group") or "")
+    gender_label = "Boys" if game.get("gender") == "M" else "Girls"
+    return f"{game['state_code']} U{age} {gender_label}"
+
+
+def build_big_games_caption(games: list[dict]) -> str:
+    lines = "\n".join(
+        f"⚔️ {g['home_team_name']} vs {g['away_team_name']} ({_matchup_cohort_label(g)})" for g in games[:5]
+    )
+    return (
+        "Big games this weekend. Ranked vs ranked.\n\n"
+        f"{lines}\n\n"
+        "Full rankings: pitchrank.io/rankings\n\n"
+        "#YouthSoccer #SoccerRankings"
+    )
+
+
+# Explicit labels instead of strftime('%a') — day names must not vary with locale.
+_DAY_LABELS = ("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN")
+
+
+def _format_window_range(start_date, end_date) -> str:
+    if start_date.month == end_date.month:
+        return f"{start_date.strftime('%b')} {start_date.day}–{end_date.day}, {end_date.year}"
+    return f"{start_date.strftime('%b')} {start_date.day} – {end_date.strftime('%b')} {end_date.day}, {end_date.year}"
+
+
+def encode_big_games_payload(matchups: list[dict], start_date, end_date) -> str:
+    """Base64url JSON consumed by /api/infographic/big-games (a pure renderer).
+
+    Owns all label derivation: the RPC returns a bare DATE, so the day labels and
+    the human range string are formatted here and rendered verbatim by the route.
+    """
+    games = []
+    for m in matchups[:5]:
+        gd = m["game_date"]
+        if isinstance(gd, str):
+            gd = datetime.strptime(gd, "%Y-%m-%d").date()
+        age = re.sub(r"\D", "", m.get("age_group") or "")
+        gender_label = "BOYS" if m.get("gender") == "M" else "GIRLS"
+        games.append(
+            {
+                "cohort": f"{m['state_code']} · U{age} {gender_label}",
+                "day": _DAY_LABELS[gd.weekday()],
+                "home": {
+                    "name": m["home_team_name"],
+                    "club": m.get("home_club_name") or "",
+                    "rank": m["home_state_rank"],
+                },
+                "away": {
+                    "name": m["away_team_name"],
+                    "club": m.get("away_club_name") or "",
+                    "rank": m["away_state_rank"],
+                },
+                "state": m["state_code"],
+            }
+        )
+    payload = {"v": 1, "range": _format_window_range(start_date, end_date), "games": games}
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
 def generate_social_posts(data: dict) -> list[dict]:
-    """Generate social posts scheduled across the week."""
+    """Generate the 5-post Instagram week: Mon live, 3x Tue Top-10, Thu big games."""
     posts = []
     monday = data["date"].replace(hour=12, minute=0, second=0, microsecond=0)
 
@@ -845,77 +1079,61 @@ def generate_social_posts(data: dict) -> list[dict]:
     while monday.weekday() != 0:
         monday += timedelta(days=1)
 
-    wednesday = monday + timedelta(days=2, hours=-4, minutes=30)  # Wed 7:30 AM MT
-    thursday = monday + timedelta(days=3, hours=-4, minutes=30)  # Thu 7:30 AM MT
+    tuesday = monday + timedelta(days=1)
+    tuesday_slots = [
+        tuesday.replace(hour=9, minute=0),
+        tuesday.replace(hour=12, minute=0),
+        tuesday.replace(hour=17, minute=0),
+    ]
+    thursday = monday + timedelta(days=3, hours=7, minutes=30)  # Thu 7:30 PM MT
 
-    top_climber = data["climbers"][0] if data["climbers"] else {}
-    second_climber = data["climbers"][1] if len(data["climbers"]) > 1 else top_climber
-
-    # Post 1: Monday noon — Rankings announcement
-    if top_climber:
-        template = random.choice(SOCIAL_TEMPLATES["rankings_live"])
-        text = template.format(
-            team_name=top_climber.get("team_name", "A team"),
-            change=abs(top_climber.get("rank_change", 0)),
-            rank=top_climber.get("current_rank", "?"),
-            state=top_climber.get("state_code", top_climber.get("state", "")),
-        )
-        posts.append(
-            {
-                "text": text,
-                "media_url": f"{PITCHRANK_URL}/api/infographic/movers?platform=instagram",
-                "scheduled_at": monday,
-                "type": "rankings_live",
-            }
-        )
-
-    # Post 2: Wednesday — Mover spotlight (use second climber to avoid repeat)
-    target = second_climber or top_climber
-    if target:
-        template = random.choice(SOCIAL_TEMPLATES["mover_spotlight"])
-        text = template.format(
-            team_name=target.get("team_name", "A team"),
-            change=abs(target.get("rank_change", 0)),
-            rank=target.get("current_rank", "?"),
-            state=target.get("state_code", target.get("state", "")),
-        )
-        posts.append(
-            {
-                "text": text,
-                "media_url": f"{PITCHRANK_URL}/api/infographic/spotlight?platform=instagram",
-                "scheduled_at": wednesday,
-                "type": "mover_spotlight",
-            }
-        )
-
-    # Post 3: Thursday — State spotlight or data flex
-    cohort_age, cohort_gender = weekly_state_cohort(monday)
-    if data["spotlight_state"] and data["spotlight_teams"]:
-        mover_list = "\n".join(
-            f"{i + 1}. {t.get('team_name', '')} (+{abs(t.get('rank_change', 0))})"
-            for i, t in enumerate(data["spotlight_teams"][:3])
-        )
-        template = random.choice(SOCIAL_TEMPLATES["state_spotlight"])
-        text = template.format(
-            state=data["spotlight_state"],
-            mover_list=mover_list,
-        )
-    else:
-        template = random.choice(SOCIAL_TEMPLATES["data_flex"])
-        total = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
-        text = template.format(total_teams=total)
-
+    # Post 1: Monday noon — Rankings announcement (mover-independent)
+    template = random.choice(SOCIAL_TEMPLATES["rankings_live"])
     posts.append(
         {
-            "text": text,
-            "media_url": (
-                f"{PITCHRANK_URL}/api/infographic/state?state={data.get('spotlight_state', 'TX')}"
-                f"&age=u{cohort_age}&gender={cohort_gender}&platform=instagram"
-            ),
-            "scheduled_at": thursday,
-            "type": "state_spotlight" if data["spotlight_state"] else "data_flex",
+            "text": format_rankings_live_caption(template, data.get("active_team_count") or 0),
+            "media_url": f"{PITCHRANK_URL}/api/infographic/rankings-live?platform=instagram",
+            "scheduled_at": monday,
+            "type": "rankings_live",
         }
     )
+
+    # Posts 2-4: Tuesday — rotating state Top-10s with team tagging
+    for slot, cohort in zip(tuesday_slots, data.get("top10_cohorts") or []):
+        posts.append(
+            {
+                "text": build_top10_caption(cohort["state"], cohort["age"], cohort["gender"]),
+                "media_url": (
+                    f"{PITCHRANK_URL}/api/infographic/state?state={cohort['state']}"
+                    f"&age=u{cohort['age']}&gender={cohort['gender']}&platform=instagram"
+                ),
+                "scheduled_at": slot,
+                "type": "top10",
+                "_tag_target_ids": [t["team_id_master"] for t in cohort["teams"] if t.get("team_id_master")],
+            }
+        )
+
+    # Post 5: Thursday evening — big weekend games (skipped when nothing qualifies)
+    big_games = data.get("big_games") or []
+    if big_games:
+        window_start, window_end = data["big_games_window"]
+        payload = encode_big_games_payload(big_games, window_start, window_end)
+        posts.append(
+            {
+                "text": build_big_games_caption(big_games),
+                "media_url": f"{PITCHRANK_URL}/api/infographic/big-games?platform=instagram&m={payload}",
+                "scheduled_at": thursday,
+                "type": "big_games",
+                "_tag_target_ids": [
+                    g[k]
+                    for g in big_games[:5]
+                    for k in ("home_team_id_master", "away_team_id_master")
+                    if g.get(k)
+                ],
+            }
+        )
+    else:
+        log.info("Big-games post skipped: no qualifying matchups this weekend")
 
     log.info(f"Generated {len(posts)} social posts")
     return posts
@@ -1285,17 +1503,12 @@ def enrich_post_with_handles(post: dict, supabase, target_team_ids: list[str]) -
 
 
 def _resolve_tag_targets(post_type: str, data: dict) -> list[str]:
-    """Pick which team_ids to tag for a given post type."""
-    if post_type == "rankings_live":
-        return [c["team_id"] for c in data["climbers"][:3] if c.get("team_id")]
-    if post_type == "mover_spotlight":
-        target = (
-            data["climbers"][1] if len(data["climbers"]) > 1 else (data["climbers"][0] if data["climbers"] else None)
-        )
-        return [target["team_id"]] if target and target.get("team_id") else []
-    if post_type == "state_spotlight":
-        return [t["team_id"] for t in (data.get("spotlight_teams") or [])[:3] if t.get("team_id")]
-    return []  # data_flex, x_thread, trend — no tagging
+    """Tag targets for post types that don't carry their own _tag_target_ids.
+
+    rankings_live is generic (no team claims); top10/big_games supply their own
+    ids at generation. The remaining types (x_thread, trend) are never tagged.
+    """
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -1328,7 +1541,9 @@ def generate_x_thread_posts(data: dict) -> dict:
     Postiz translation reads `thread_parts` for chained replies.
     """
     milestones = data.get("milestones", [])
-    total = f"{data['total_teams']:,}" if data["total_teams"] else "25,000+"
+    # None when unavailable; count-bearing tweets get count-free variants instead
+    # of a made-up number.
+    total = f"{data['total_teams']:,}" if data["total_teams"] else None
     tweets: list[str] = []
 
     # Group milestones by tier
@@ -1390,12 +1605,12 @@ def generate_x_thread_posts(data: dict) -> dict:
 
     # If no milestones at all, fall back to a general tweet
     if len(tweets) == 1:
-        tweets.append(
-            f"Rankings updated for {total} teams across all 50 states.\n\nSame algorithm. Real game data. No opinions."
-        )
+        updated_for = f"Rankings updated for {total} teams" if total else "Rankings updated"
+        tweets.append(f"{updated_for} across all 50 states.\n\nSame algorithm. Real game data. No opinions.")
 
     # Tweet 4 (final): CTA
-    tweets.append(f"{total} teams ranked every Monday.\n\npitchrank.io/rankings")
+    cta_lead = f"{total} teams ranked every Monday." if total else "New rankings every Monday."
+    tweets.append(f"{cta_lead}\n\npitchrank.io/rankings")
 
     # Scheduled at Monday noon MT (same as the rankings_live post)
     monday = data["date"].replace(hour=12, minute=0, second=0, microsecond=0)
@@ -1473,32 +1688,44 @@ def main():
         log.error(f"Failed to fetch ranking data: {e}")
         sys.exit(1)
 
-    if not data["climbers"] and not data["fallers"]:
-        log.warning("No movers found — rankings may not have updated yet. Exiting.")
+    # Freshness gate: announcing "new rankings are live" on stale data is worse
+    # than skipping a week. Mover-emptiness is NOT the staleness signal — quiet
+    # weeks are legitimate; mover-centric outputs are gated separately below.
+    last_calculated = fetch_rankings_last_calculated(supabase)
+    if rankings_are_stale(last_calculated):
+        log.warning(f"Rankings look stale (last_calculated={last_calculated}) — not announcing. Exiting.")
         sys.exit(0)
 
-    # Step 2: Generate blog post (newsletter uses the same content)
+    has_movers = bool(data["climbers"] or data["fallers"])
+    if not has_movers:
+        log.warning("No movers this week — skipping blog/newsletter/X thread; IG posts still run.")
+
+    # Step 2: Generate blog post (newsletter uses the same content; both are
+    # mover-centric, so a quiet week skips them)
     blog_filename, blog_content, blog_body_md, blog_title = "", "", "", ""
-    try:
-        blog_filename, blog_content = generate_blog_post(data, supabase)
-        # Extract the markdown body (after frontmatter) for the newsletter
-        parts = blog_content.split("---", 2)
-        if len(parts) >= 3:
-            full_md = parts[2].strip()
-            # Strip the leading H1 (title) — it's in the subject line
-            lines = full_md.split("\n")
-            if lines and lines[0].startswith("# "):
-                blog_title = lines[0].lstrip("# ").strip()
-                blog_body_md = "\n".join(lines[1:]).strip()
-            else:
-                blog_body_md = full_md
-    except Exception as e:
-        log.error(f"Blog generation failed: {e}")
+    if has_movers:
+        try:
+            blog_filename, blog_content = generate_blog_post(data, supabase)
+            # Extract the markdown body (after frontmatter) for the newsletter
+            parts = blog_content.split("---", 2)
+            if len(parts) >= 3:
+                full_md = parts[2].strip()
+                # Strip the leading H1 (title) — it's in the subject line
+                lines = full_md.split("\n")
+                if lines and lines[0].startswith("# "):
+                    blog_title = lines[0].lstrip("# ").strip()
+                    blog_body_md = "\n".join(lines[1:]).strip()
+                else:
+                    blog_body_md = full_md
+        except Exception as e:
+            log.error(f"Blog generation failed: {e}")
 
     # Step 3: Generate newsletter from blog content
-    newsletter_html = generate_newsletter_html(data, blog_body_md)
-    subject = generate_newsletter_subject(data, blog_title)
-    log.info(f"Subject: {subject}")
+    newsletter_html, subject = "", ""
+    if has_movers:
+        newsletter_html = generate_newsletter_html(data, blog_body_md)
+        subject = generate_newsletter_subject(data, blog_title)
+        log.info(f"Subject: {subject}")
 
     # Step 4-5: Generate all social drafts (kill-switch gated)
     drafts_enabled = os.getenv("POSTIZ_DRAFTS_ENABLED", "true").lower() == "true"
@@ -1508,16 +1735,19 @@ def main():
     all_drafts: list[dict] = []
     if drafts_enabled:
         social_posts = generate_social_posts(data)
-        # Enrich IG-bound posts with team handles (post-pass; keeps generators platform-agnostic)
+        # Enrich IG-bound posts with team handles (post-pass; keeps generators
+        # platform-agnostic). Posts that know their own teams carry
+        # _tag_target_ids; the resolver is the fallback for the rest.
         for post in social_posts:
-            targets = _resolve_tag_targets(post["type"], data)
+            targets = post.get("_tag_target_ids") or _resolve_tag_targets(post["type"], data)
             if targets:
                 enrich_post_with_handles(post, supabase, targets)
-        try:
-            x_thread_post = generate_x_thread_posts(data)
-        except Exception as e:
-            log.error(f"X thread generation failed: {e}")
-            x_thread_post = {"thread_parts": []}
+        if has_movers:
+            try:
+                x_thread_post = generate_x_thread_posts(data)
+            except Exception as e:
+                log.error(f"X thread generation failed: {e}")
+                x_thread_post = {"thread_parts": []}
         trend_posts = generate_trend_posts(current_iso_week, data)
         all_drafts = list(social_posts)
         if x_thread_post.get("thread_parts"):
@@ -1538,10 +1768,24 @@ def main():
         if blog_filename:
             log.info(f"Blog post: {blog_filename} ({len(blog_content):,} bytes)")
         log.info("")
+        log.info(f"Top-10 combos: {data.get('top10_combos')}")
+        big_games = data.get("big_games") or []
+        if big_games:
+            for g in big_games:
+                log.info(
+                    f"Big game: {g['home_team_name']} (#{g['home_state_rank']}) vs "
+                    f"{g['away_team_name']} (#{g['away_state_rank']}) "
+                    f"[{g['state_code']} {g['age_group']} {g['gender']}] on {g['game_date']}"
+                )
+        else:
+            log.info("Big-games post skipped: no qualifying matchups")
+        log.info("")
         for post in social_posts:
             log.info(f"[{post['type']}] {post['scheduled_at'].strftime('%A %I:%M %p MT')}")
             if post.get("media_url"):
                 log.info(f"  Image: {post['media_url']}")
+            if post.get("_tag_stats"):
+                log.info(f"  Tags: {post['_tag_stats']}")
             log.info(post["text"])
             log.info("")
         if x_thread_post.get("thread_parts"):
@@ -1563,6 +1807,10 @@ def main():
     newsletter_ok = False
     if args.postiz_only:
         log.info("--postiz-only: skipping Beehiiv newsletter send")
+    elif not has_movers:
+        # Deliberate skip, not a failure — keep the exit-code guard meaningful
+        log.info("No movers: skipping Beehiiv newsletter send")
+        newsletter_ok = True
     else:
         try:
             newsletter_ok = publish_to_beehiiv(newsletter_html, subject)
@@ -1573,6 +1821,8 @@ def main():
     blog_ok = False
     if args.postiz_only:
         log.info("--postiz-only: skipping blog post commit")
+    elif not has_movers:
+        log.info("No movers: skipping blog post commit")
     else:
         try:
             if blog_filename and blog_content:

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -1660,6 +1660,20 @@ def save_artifacts(newsletter_html: str, drafts: list[dict], data: dict):
     log.info(f"Saved social posts JSON: {posts_path}")
 
 
+def live_run_failed(
+    newsletter_ok: bool, newsletter_skipped: bool, drafts_attempted: bool, draft_results: list[bool]
+) -> bool:
+    """True when a live run delivered nothing it attempted (the exit-1 condition).
+
+    A deliberately skipped newsletter (quiet week) is neither success nor failure:
+    it must not mask an all-drafts-failed outage, nor trip a failure on its own
+    when drafts went out.
+    """
+    attempted = (not newsletter_skipped) or drafts_attempted
+    succeeded = newsletter_ok or any(draft_results)
+    return attempted and not succeeded
+
+
 def main():
     parser = argparse.ArgumentParser(description="PitchRank Marketing Pipeline")
     parser.add_argument("--dry-run", action="store_true", help="Generate content without publishing")
@@ -1805,12 +1819,14 @@ def main():
 
     # Step 6: Publish newsletter to Beehiiv
     newsletter_ok = False
+    newsletter_skipped = False
     if args.postiz_only:
         log.info("--postiz-only: skipping Beehiiv newsletter send")
     elif not has_movers:
-        # Deliberate skip, not a failure — keep the exit-code guard meaningful
+        # Quiet week: the newsletter is mover-centric, so skip it. Track the skip
+        # separately from success so the exit guard doesn't read it as "delivered".
         log.info("No movers: skipping Beehiiv newsletter send")
-        newsletter_ok = True
+        newsletter_skipped = True
     else:
         try:
             newsletter_ok = publish_to_beehiiv(newsletter_html, subject)
@@ -1840,10 +1856,11 @@ def main():
         log.error(f"Postiz drafting failed: {e}")
 
     # Summary
+    newsletter_status = "SENT" if newsletter_ok else "SKIPPED" if newsletter_skipped else "FAILED"
     log.info("")
     log.info("=" * 60)
     log.info("PIPELINE COMPLETE")
-    log.info(f"  Newsletter: {'SENT' if newsletter_ok else 'FAILED'}")
+    log.info(f"  Newsletter: {newsletter_status}")
     log.info(f"  Blog: {'PUBLISHED' if blog_ok else 'SKIPPED'}")
     log.info(f"  Social Drafts: {sum(draft_results)}/{len(draft_results)} drafted to Postiz")
     log.info("=" * 60)
@@ -1857,10 +1874,11 @@ def main():
             sys.exit(1)
         return
 
-    # Live mode: exit 1 only if newsletter AND every draft failed — partial outages surface
-    # via non-zero entries in draft_results (collapsed from old Buffer + tweepy split, so
-    # X-thread failures now contribute to the exit code).
-    if not newsletter_ok and not any(draft_results):
+    # Live mode: exit 1 when nothing we attempted to deliver succeeded. A quiet-week
+    # newsletter skip is not a delivery, so an all-drafts-failed quiet week still exits
+    # non-zero instead of masking the outage; partial outages surface via the
+    # individual draft_results entries.
+    if live_run_failed(newsletter_ok, newsletter_skipped, bool(all_drafts), draft_results):
         sys.exit(1)
 
 

--- a/supabase/migrations/20260612233706_create_get_big_weekend_games.sql
+++ b/supabase/migrations/20260612233706_create_get_big_weekend_games.sql
@@ -140,11 +140,14 @@ $$;
 COMMENT ON FUNCTION get_big_weekend_games IS
   'Upcoming unplayed games in a date window where both teams are ranked top-N '
   '(default 25) in the same state/age/gender cohort, ordered by combined state '
-  'rank. Pipeline-only (service role); intentionally no anon grant.';
+  'rank. p_states optionally restricts to a set of state codes (NULL = all). '
+  'Pipeline-only (service role); intentionally no anon/authenticated grant.';
 
--- Postgres grants EXECUTE to PUBLIC by default; revoke so anon cannot reach a
--- function that does per-cohort ranking work.
+-- Pipeline-only: the marketing job calls this with the service-role key, and the
+-- big-games route is a pure renderer that never queries it. Grant service_role
+-- only; revoke PUBLIC/anon/authenticated so no signed-in user can spend the
+-- per-cohort ranking work.
 REVOKE ALL ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) FROM PUBLIC;
 REVOKE ALL ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) FROM anon;
-GRANT EXECUTE ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) TO authenticated;
+REVOKE ALL ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) FROM authenticated;
 GRANT EXECUTE ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) TO service_role;

--- a/supabase/migrations/20260612233706_create_get_big_weekend_games.sql
+++ b/supabase/migrations/20260612233706_create_get_big_weekend_games.sql
@@ -1,0 +1,150 @@
+-- Migration: Add get_big_weekend_games RPC
+-- Date: 2026-06-12
+-- Purpose: The weekly marketing pipeline's Thursday "Big Games This Weekend"
+--          Instagram post needs upcoming Fri-Sun games where BOTH teams are
+--          ranked top-N (default 25) in the same state cohort, ordered by
+--          combined state rank (lower sum = bigger game).
+--
+-- Design notes:
+--   * Called exclusively by the pipeline with the service-role key (no
+--     statement timeout). Deliberately NOT granted to anon: ranking work over
+--     candidate cohorts is too heavy for the 3s anon ceiling, and there is no
+--     public caller.
+--   * State rank is a ROW_NUMBER() window over ONLY the cohorts that contain a
+--     candidate game (a typical weekend has ~170 cohorts / ~28K rows; 657 ms
+--     measured live). A per-candidate correlated COUNT was tried first and
+--     measured 6-8 s because every same-cohort pair (~1.5K) paid a cohort scan
+--     before the rank ceiling could filter. The MATERIALIZED fences stop the
+--     planner from pushing rank work back into the pair join.
+--   * The window's ORDER BY carries a team_id tiebreaker, so ranks are
+--     deterministic; exact-tie labels may differ by a few places from
+--     get_state_rankings' ROW_NUMBER(), which has no tiebreaker. That is
+--     acceptable for selecting marquee matchups.
+--   * Cohort predicates mirror get_state_rankings' cohort/active_ranked CTEs
+--     (20260603000000): status = 'Active', power_score_final IS NOT NULL,
+--     teams.is_deprecated IS NOT TRUE, with state_code/age_group/gender read
+--     from rankings_full (never teams.state_code).
+--   * games.game_date is a DATE; there is no kickoff-time column, so callers
+--     can only derive day labels (FRI/SAT/SUN).
+--   * p_states optionally restricts matchups to a set of state codes (NULL = all
+--     states). The marketing pipeline passes its bigger-state list so the slate
+--     surfaces deep-cohort matchups rather than thin small-state #1-vs-#2 games.
+
+-- Adding p_states creates a new signature, so CREATE OR REPLACE alone would
+-- leave the old 4-arg overload callable; drop it explicitly.
+DROP FUNCTION IF EXISTS get_big_weekend_games(DATE, DATE, INT, INT);
+
+CREATE OR REPLACE FUNCTION get_big_weekend_games(
+    p_start_date DATE,
+    p_end_date DATE,
+    p_rank_ceiling INT DEFAULT 25,
+    p_limit INT DEFAULT 5,
+    p_states TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    game_date DATE,
+    home_team_id_master UUID,
+    home_team_name TEXT,
+    home_club_name TEXT,
+    home_state_rank BIGINT,
+    away_team_id_master UUID,
+    away_team_name TEXT,
+    away_club_name TEXT,
+    away_state_rank BIGINT,
+    state_code TEXT,
+    age_group TEXT,
+    gender TEXT
+) LANGUAGE sql STABLE AS $$
+    WITH candidate_games AS (
+        SELECT g.id, g.game_date, g.home_team_master_id, g.away_team_master_id
+        FROM games g
+        WHERE g.is_excluded = false
+          AND g.home_score IS NULL
+          AND g.game_date BETWEEN p_start_date AND p_end_date
+    ),
+    pairs AS MATERIALIZED (
+        SELECT
+            cg.game_date,
+            hrf.team_id AS home_team_id,
+            ht.team_name AS home_team_name,
+            ht.club_name AS home_club_name,
+            arf.team_id AS away_team_id,
+            awt.team_name AS away_team_name,
+            awt.club_name AS away_club_name,
+            hrf.state_code,
+            hrf.age_group,
+            hrf.gender AS raw_gender
+        FROM candidate_games cg
+        JOIN rankings_full hrf ON hrf.team_id = cg.home_team_master_id
+        JOIN teams ht ON ht.team_id_master = hrf.team_id
+        JOIN rankings_full arf ON arf.team_id = cg.away_team_master_id
+        JOIN teams awt ON awt.team_id_master = arf.team_id
+        WHERE hrf.status = 'Active'
+          AND arf.status = 'Active'
+          AND hrf.power_score_final IS NOT NULL
+          AND arf.power_score_final IS NOT NULL
+          AND ht.is_deprecated IS NOT TRUE
+          AND awt.is_deprecated IS NOT TRUE
+          AND hrf.state_code = arf.state_code
+          AND hrf.age_group = arf.age_group
+          AND hrf.gender = arf.gender
+          AND (p_states IS NULL OR hrf.state_code = ANY (p_states))
+    ),
+    cohorts AS (
+        SELECT DISTINCT p.state_code, p.age_group, p.raw_gender FROM pairs p
+    ),
+    cohort_ranks AS MATERIALIZED (
+        SELECT
+            rf.team_id,
+            ROW_NUMBER() OVER (
+                PARTITION BY rf.state_code, rf.age_group, rf.gender
+                ORDER BY rf.power_score_final DESC, rf.team_id ASC
+            ) AS state_rank
+        FROM rankings_full rf
+        JOIN teams t ON t.team_id_master = rf.team_id
+        JOIN cohorts c ON c.state_code = rf.state_code
+                      AND c.age_group = rf.age_group
+                      AND c.raw_gender = rf.gender
+        WHERE rf.status = 'Active'
+          AND rf.power_score_final IS NOT NULL
+          AND t.is_deprecated IS NOT TRUE
+    )
+    SELECT
+        p.game_date,
+        p.home_team_id AS home_team_id_master,
+        p.home_team_name,
+        p.home_club_name,
+        hr.state_rank AS home_state_rank,
+        p.away_team_id AS away_team_id_master,
+        p.away_team_name,
+        p.away_club_name,
+        ar.state_rank AS away_state_rank,
+        p.state_code,
+        p.age_group,
+        CASE
+            WHEN p.raw_gender = 'Male' THEN 'M'
+            WHEN p.raw_gender = 'Female' THEN 'F'
+            WHEN p.raw_gender = 'Boys' THEN 'M'
+            WHEN p.raw_gender = 'Girls' THEN 'F'
+            ELSE p.raw_gender
+        END AS gender
+    FROM pairs p
+    JOIN cohort_ranks hr ON hr.team_id = p.home_team_id
+    JOIN cohort_ranks ar ON ar.team_id = p.away_team_id
+    WHERE hr.state_rank <= p_rank_ceiling
+      AND ar.state_rank <= p_rank_ceiling
+    ORDER BY (hr.state_rank + ar.state_rank) ASC, p.game_date ASC, p.home_team_id ASC
+    LIMIT p_limit;
+$$;
+
+COMMENT ON FUNCTION get_big_weekend_games IS
+  'Upcoming unplayed games in a date window where both teams are ranked top-N '
+  '(default 25) in the same state/age/gender cohort, ordered by combined state '
+  'rank. Pipeline-only (service role); intentionally no anon grant.';
+
+-- Postgres grants EXECUTE to PUBLIC by default; revoke so anon cannot reach a
+-- function that does per-cohort ranking work.
+REVOKE ALL ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) FROM anon;
+GRANT EXECUTE ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_big_weekend_games(DATE, DATE, INT, INT, TEXT[]) TO service_role;

--- a/templates/newsletter_weekly.html
+++ b/templates/newsletter_weekly.html
@@ -34,7 +34,7 @@
 <tr>
 <td style="padding:8px 30px 20px;text-align:center;">
   <a href="https://pitchrank.io/rankings" style="display:inline-block;padding:14px 32px;background-color:#F4D03F;color:#0B5345;font-size:16px;font-weight:700;text-decoration:none;border-radius:6px;letter-spacing:0.5px;">See Where Your Team Stands</a>
-  <p style="margin:12px 0 0;font-size:13px;color:#888;">$total_teams teams. 13-layer algorithm. Updated every Monday.</p>
+  $total_teams_line
 </td>
 </tr>
 

--- a/tests/unit/test_marketing_pipeline.py
+++ b/tests/unit/test_marketing_pipeline.py
@@ -122,49 +122,17 @@ def _data(climbers=None, spotlight_teams=None):
     }
 
 
-def test_resolve_tag_targets_rankings_live_picks_first_three_climbers():
-    data = _data(
-        climbers=[
-            {"team_id": "a"},
-            {"team_id": "b"},
-            {"team_id": "c"},
-            {"team_id": "d"},
-        ]
-    )
-    assert _resolve_tag_targets("rankings_live", data) == ["a", "b", "c"]
+def test_resolve_tag_targets_rankings_live_is_generic_no_tags():
+    data = _data(climbers=[{"team_id": "a"}, {"team_id": "b"}, {"team_id": "c"}])
+    assert _resolve_tag_targets("rankings_live", data) == []
 
 
-def test_resolve_tag_targets_rankings_live_skips_missing_team_ids():
-    data = _data(climbers=[{"team_id": "a"}, {"team_name": "no id"}, {"team_id": "c"}])
-    assert _resolve_tag_targets("rankings_live", data) == ["a", "c"]
-
-
-def test_resolve_tag_targets_mover_spotlight_prefers_second_climber():
-    data = _data(climbers=[{"team_id": "first"}, {"team_id": "second"}, {"team_id": "third"}])
-    assert _resolve_tag_targets("mover_spotlight", data) == ["second"]
-
-
-def test_resolve_tag_targets_mover_spotlight_falls_back_to_first_when_only_one():
-    data = _data(climbers=[{"team_id": "first"}])
-    assert _resolve_tag_targets("mover_spotlight", data) == ["first"]
-
-
-def test_resolve_tag_targets_mover_spotlight_empty_climbers():
+def test_resolve_tag_targets_rankings_live_empty_climbers():
     data = _data(climbers=[])
-    assert _resolve_tag_targets("mover_spotlight", data) == []
+    assert _resolve_tag_targets("rankings_live", data) == []
 
 
-def test_resolve_tag_targets_state_spotlight_picks_first_three():
-    data = _data(spotlight_teams=[{"team_id": "x"}, {"team_id": "y"}, {"team_id": "z"}, {"team_id": "w"}])
-    assert _resolve_tag_targets("state_spotlight", data) == ["x", "y", "z"]
-
-
-def test_resolve_tag_targets_state_spotlight_none_returns_empty():
-    data = {"climbers": [], "spotlight_teams": None}
-    assert _resolve_tag_targets("state_spotlight", data) == []
-
-
-@pytest.mark.parametrize("post_type", ["data_flex", "x_thread", "trend", "unknown_future_type"])
+@pytest.mark.parametrize("post_type", ["top10", "big_games", "x_thread", "trend", "unknown_future_type"])
 def test_resolve_tag_targets_other_types_return_empty(post_type):
     data = _data(climbers=[{"team_id": "a"}], spotlight_teams=[{"team_id": "b"}])
     assert _resolve_tag_targets(post_type, data) == []

--- a/tests/unit/test_marketing_pipeline_social.py
+++ b/tests/unit/test_marketing_pipeline_social.py
@@ -1,0 +1,361 @@
+"""Unit tests for the 5-post Instagram week helpers in scripts/marketing_pipeline.py."""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import date, datetime, timedelta, timezone
+
+from scripts.marketing_pipeline import (
+    PILLAR_STATES,
+    SOCIAL_TEMPLATES,
+    STATE_COHORT_EPOCH,
+    TOP10_AGES,
+    build_big_games_caption,
+    build_top10_caption,
+    encode_big_games_payload,
+    fetch_top10_cohorts,
+    format_rankings_live_caption,
+    generate_social_posts,
+    next_weekend_window,
+    rankings_are_stale,
+    weekly_top10_combos,
+)
+
+MT = timezone(timedelta(hours=-6))
+
+
+def _monday_of_week(week: int) -> datetime:
+    return STATE_COHORT_EPOCH + timedelta(weeks=week)
+
+
+# ---------------------------------------------------------------------------
+# weekly_top10_combos
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_top10_combos_same_week_is_identical():
+    monday = _monday_of_week(23)
+    assert weekly_top10_combos(monday) == weekly_top10_combos(monday)
+    # Any day within the same Mon-Sun week selects the same combos
+    assert weekly_top10_combos(monday + timedelta(days=3)) == weekly_top10_combos(monday)
+
+
+def test_weekly_top10_combos_covers_all_19_states_before_repeating():
+    picks = [combo[0] for week in range(7) for combo in weekly_top10_combos(_monday_of_week(week))]
+    assert set(picks[:19]) == set(PILLAR_STATES)
+    assert len(set(picks[:19])) == 19
+
+
+def test_weekly_top10_combos_ages_from_pool_no_u18():
+    ages = {combo[1] for week in range(30) for combo in weekly_top10_combos(_monday_of_week(week))}
+    assert ages <= set(TOP10_AGES)
+    assert 18 not in ages
+
+
+def test_weekly_top10_combos_genders_vary_within_week():
+    for week in range(5):
+        genders = {combo[2] for combo in weekly_top10_combos(_monday_of_week(week))}
+        assert genders == {"male", "female"}
+
+
+# ---------------------------------------------------------------------------
+# Caption builders
+# ---------------------------------------------------------------------------
+
+
+def test_rankings_live_count_variant_fills_live_count():
+    template = SOCIAL_TEMPLATES["rankings_live"][1]
+    text = format_rankings_live_caption(template, 59123)
+    assert "59,123 teams updated." in text
+
+
+def test_rankings_live_count_variant_drops_line_when_count_unavailable():
+    template = SOCIAL_TEMPLATES["rankings_live"][1]
+    text = format_rankings_live_caption(template, 0)
+    assert "teams updated" not in text
+    assert "{active_team_count}" not in text
+    assert "pitchrank.io/rankings" in text
+
+
+def test_rankings_live_plain_variant_passes_through():
+    template = SOCIAL_TEMPLATES["rankings_live"][0]
+    assert format_rankings_live_caption(template, 0) == template
+
+
+def test_build_top10_caption_format():
+    text = build_top10_caption("NY", 14, "male")
+    assert text.startswith("New York U14 Boys — Top 10 in the state.")
+    assert "#NYSoccer" in text
+    assert "pitchrank.io/rankings" in text
+
+
+def _matchup(i: int = 0, club: str = "Club") -> dict:
+    return {
+        "game_date": "2026-06-13",
+        "home_team_id_master": f"home-{i}",
+        "home_team_name": f"Home Team {i}",
+        "home_club_name": club,
+        "home_state_rank": 1 + i,
+        "away_team_id_master": f"away-{i}",
+        "away_team_name": f"Away Team {i}",
+        "away_club_name": club,
+        "away_state_rank": 2 + i,
+        "state_code": "PA",
+        "age_group": "u14",
+        "gender": "M",
+    }
+
+
+def test_build_big_games_caption_renders_one_line_per_matchup():
+    text = build_big_games_caption([_matchup(0), _matchup(1), _matchup(2)])
+    assert text.count("⚔️") == 3
+    assert "Home Team 0 vs Away Team 0 (PA U14 Boys)" in text
+
+
+# ---------------------------------------------------------------------------
+# encode_big_games_payload
+# ---------------------------------------------------------------------------
+
+
+def _decode(payload: str) -> dict:
+    padded = payload + "=" * ((4 - len(payload) % 4) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+
+
+def test_encode_big_games_payload_round_trips():
+    matchups = [_matchup(0), _matchup(1)]
+    decoded = _decode(encode_big_games_payload(matchups, date(2026, 6, 13), date(2026, 6, 14)))
+    assert decoded["v"] == 1
+    assert len(decoded["games"]) == 2
+    game = decoded["games"][0]
+    assert game["home"] == {"name": "Home Team 0", "club": "Club", "rank": 1}
+    assert game["away"] == {"name": "Away Team 0", "club": "Club", "rank": 2}
+    assert game["cohort"] == "PA · U14 BOYS"
+    assert game["state"] == "PA"
+
+
+def test_encode_big_games_payload_day_labels():
+    for game_date, label in [("2026-06-12", "FRI"), ("2026-06-13", "SAT"), ("2026-06-14", "SUN")]:
+        matchup = {**_matchup(), "game_date": game_date}
+        decoded = _decode(encode_big_games_payload([matchup], date(2026, 6, 12), date(2026, 6, 14)))
+        assert decoded["games"][0]["day"] == label
+
+
+def test_encode_big_games_payload_range_string():
+    decoded = _decode(encode_big_games_payload([_matchup()], date(2026, 6, 13), date(2026, 6, 14)))
+    assert decoded["range"] == "Jun 13–14, 2026"
+
+
+def test_encode_big_games_payload_range_string_cross_month():
+    decoded = _decode(encode_big_games_payload([_matchup()], date(2026, 7, 31), date(2026, 8, 2)))
+    assert decoded["range"] == "Jul 31 – Aug 2, 2026"
+
+
+def test_encode_big_games_payload_stays_small_with_long_unicode_names():
+    # Worst-case 70+ char names must stay far below the ~14KB edge URL ceiling
+    # (typical real payloads land around 1KB)
+    long_club = "Fußballverein Müller-Lüdenscheidt Süd-West Akademie 2012"
+    matchups = []
+    for i in range(5):
+        m = _matchup(i, club=long_club)
+        m["home_team_name"] = f"Extraordinarily Long Youth Soccer Association Team Name {i} Premier Gold"
+        m["away_team_name"] = f"Another Remarkably Long Club Academy Select Team Name {i} Elite Black"
+        matchups.append(m)
+    payload = encode_big_games_payload(matchups, date(2026, 6, 13), date(2026, 6, 14))
+    assert len(payload) < 4096
+
+
+# ---------------------------------------------------------------------------
+# Freshness gate + weekend window
+# ---------------------------------------------------------------------------
+
+
+def test_rankings_are_stale_none_is_stale():
+    assert rankings_are_stale(None) is True
+
+
+def test_rankings_are_stale_beyond_threshold():
+    now = datetime(2026, 6, 12, tzinfo=timezone.utc)
+    assert rankings_are_stale(now - timedelta(days=9), now=now) is True
+
+
+def test_rankings_are_stale_healthy_midweek_age_is_fresh():
+    now = datetime(2026, 6, 12, tzinfo=timezone.utc)
+    assert rankings_are_stale(now - timedelta(days=3, hours=12), now=now) is False
+
+
+def test_next_weekend_window_from_monday():
+    assert next_weekend_window(datetime(2026, 6, 8, 12, 0, tzinfo=MT)) == (date(2026, 6, 12), date(2026, 6, 14))
+
+
+def test_next_weekend_window_on_friday_skips_to_next_weekend():
+    assert next_weekend_window(datetime(2026, 6, 12, 12, 0, tzinfo=MT)) == (date(2026, 6, 19), date(2026, 6, 21))
+
+
+# ---------------------------------------------------------------------------
+# fetch_top10_cohorts
+# ---------------------------------------------------------------------------
+
+
+def _ranked_team(i: int, status: str = "Active", rank=None) -> dict:
+    return {
+        "team_id_master": f"team-{i}",
+        "status": status,
+        "rank_in_state_final": (i + 1) if rank is None else rank,
+    }
+
+
+class _FakeRpcResult:
+    def __init__(self, rows):
+        self.data = rows
+
+    def execute(self):
+        return self
+
+
+class _StubSupabase:
+    """Returns per-state get_state_rankings rows from a {state: rows} map.
+
+    A state mapped to the RAISE sentinel makes .execute() raise, exercising the
+    per-state failure-skip branch. Unmapped states return an empty list.
+    """
+
+    RAISE = object()
+
+    def __init__(self, by_state: dict):
+        self.by_state = by_state
+        self.calls = []
+
+    def rpc(self, fn_name, params):
+        state = params["p_state"]
+        self.calls.append(state)
+        rows = self.by_state.get(state, [])
+        if rows is _StubSupabase.RAISE:
+            raise RuntimeError("rpc boom")
+        return _FakeRpcResult(rows)
+
+
+def _full_cohort() -> list[dict]:
+    return [_ranked_team(i) for i in range(12)]
+
+
+def test_fetch_top10_cohorts_happy_path():
+    stub = _StubSupabase({"NY": _full_cohort()})
+    out = fetch_top10_cohorts(stub, [("NY", 14, "male")])
+    assert stub.calls == ["NY"]
+    assert len(out) == 1
+    assert out[0]["state"] == "NY"
+    assert len(out[0]["teams"]) == 10
+
+
+def test_fetch_top10_cohorts_filters_non_active_and_unranked():
+    rows = (
+        [_ranked_team(i) for i in range(8)]
+        + [_ranked_team(99, status="Not Enough Ranked Games")]
+        + [_ranked_team(98, rank=None)]
+        + [_ranked_team(i) for i in range(8, 11)]
+    )
+    stub = _StubSupabase({"NY": rows})
+    out = fetch_top10_cohorts(stub, [("NY", 14, "male")])
+    assert len(out[0]["teams"]) == 10
+    assert all(t["status"] == "Active" and t["rank_in_state_final"] is not None for t in out[0]["teams"])
+
+
+def test_fetch_top10_cohorts_repicks_next_pillar_state_when_thin():
+    start = PILLAR_STATES.index("AZ")
+    next_state = PILLAR_STATES[(start + 1) % len(PILLAR_STATES)]
+    stub = _StubSupabase({"AZ": [_ranked_team(i) for i in range(3)], next_state: _full_cohort()})
+    out = fetch_top10_cohorts(stub, [("AZ", 14, "male")])
+    assert stub.calls == ["AZ", next_state]
+    assert out[0]["state"] == next_state
+    assert len(out[0]["teams"]) == 10
+
+
+def test_fetch_top10_cohorts_skips_state_whose_rpc_raises():
+    start = PILLAR_STATES.index("AZ")
+    next_state = PILLAR_STATES[(start + 1) % len(PILLAR_STATES)]
+    stub = _StubSupabase({"AZ": _StubSupabase.RAISE, next_state: _full_cohort()})
+    out = fetch_top10_cohorts(stub, [("AZ", 14, "male")])
+    assert stub.calls == ["AZ", next_state]
+    assert out[0]["state"] == next_state
+
+
+def test_fetch_top10_cohorts_drops_combo_when_all_states_thin():
+    stub = _StubSupabase({state: [_ranked_team(i) for i in range(3)] for state in PILLAR_STATES})
+    out = fetch_top10_cohorts(stub, [("AZ", 14, "male")])
+    assert out == []
+    assert len(stub.calls) == len(PILLAR_STATES)
+
+
+# ---------------------------------------------------------------------------
+# generate_social_posts
+# ---------------------------------------------------------------------------
+
+
+def _cohort(state: str = "NY", age: int = 14, gender: str = "male") -> dict:
+    return {
+        "state": state,
+        "age": age,
+        "gender": gender,
+        "teams": [{"team_id_master": f"{state}-{i}"} for i in range(10)],
+    }
+
+
+def _week_data(big_games: list | None = None, cohorts: list | None = None) -> dict:
+    return {
+        "date": datetime(2026, 6, 8, 8, 0, tzinfo=MT),  # a Monday
+        "climbers": [],
+        "fallers": [],
+        "active_team_count": 59000,
+        "top10_combos": [("NY", 14, "male"), ("TX", 12, "female"), ("CA", 16, "male")],
+        "top10_cohorts": (
+            cohorts if cohorts is not None else [_cohort("NY"), _cohort("TX", 12, "female"), _cohort("CA", 16)]
+        ),
+        "big_games_window": (date(2026, 6, 12), date(2026, 6, 14)),
+        "big_games": big_games if big_games is not None else [_matchup(0), _matchup(1)],
+    }
+
+
+def test_generate_social_posts_full_week_is_five_posts_with_no_movers():
+    posts = generate_social_posts(_week_data())
+    assert [p["type"] for p in posts] == ["rankings_live", "top10", "top10", "top10", "big_games"]
+
+
+def test_generate_social_posts_schedule_slots():
+    posts = generate_social_posts(_week_data())
+    by_type = {}
+    for p in posts:
+        by_type.setdefault(p["type"], []).append(p["scheduled_at"])
+    assert by_type["rankings_live"] == [datetime(2026, 6, 8, 12, 0, tzinfo=MT)]
+    assert by_type["top10"] == [
+        datetime(2026, 6, 9, 9, 0, tzinfo=MT),
+        datetime(2026, 6, 9, 12, 0, tzinfo=MT),
+        datetime(2026, 6, 9, 17, 0, tzinfo=MT),
+    ]
+    assert by_type["big_games"] == [datetime(2026, 6, 11, 19, 30, tzinfo=MT)]
+
+
+def test_generate_social_posts_skips_big_games_when_empty():
+    posts = generate_social_posts(_week_data(big_games=[]))
+    assert [p["type"] for p in posts] == ["rankings_live", "top10", "top10", "top10"]
+
+
+def test_generate_social_posts_tag_targets():
+    posts = generate_social_posts(_week_data())
+    top10 = [p for p in posts if p["type"] == "top10"]
+    assert all(len(p["_tag_target_ids"]) == 10 for p in top10)
+    big = next(p for p in posts if p["type"] == "big_games")
+    assert big["_tag_target_ids"] == ["home-0", "away-0", "home-1", "away-1"]
+    live = next(p for p in posts if p["type"] == "rankings_live")
+    assert "_tag_target_ids" not in live
+
+
+def test_generate_social_posts_media_urls():
+    posts = generate_social_posts(_week_data())
+    live = next(p for p in posts if p["type"] == "rankings_live")
+    assert live["media_url"].endswith("/api/infographic/rankings-live?platform=instagram")
+    first_top10 = next(p for p in posts if p["type"] == "top10")
+    assert "/api/infographic/state?state=NY&age=u14&gender=male&platform=instagram" in first_top10["media_url"]
+    big = next(p for p in posts if p["type"] == "big_games")
+    assert "/api/infographic/big-games?platform=instagram&m=" in big["media_url"]

--- a/tests/unit/test_marketing_pipeline_social.py
+++ b/tests/unit/test_marketing_pipeline_social.py
@@ -17,6 +17,7 @@ from scripts.marketing_pipeline import (
     fetch_top10_cohorts,
     format_rankings_live_caption,
     generate_social_posts,
+    live_run_failed,
     next_weekend_window,
     rankings_are_stale,
     weekly_top10_combos,
@@ -191,6 +192,38 @@ def test_next_weekend_window_from_monday():
 
 def test_next_weekend_window_on_friday_skips_to_next_weekend():
     assert next_weekend_window(datetime(2026, 6, 12, 12, 0, tzinfo=MT)) == (date(2026, 6, 19), date(2026, 6, 21))
+
+
+# ---------------------------------------------------------------------------
+# live_run_failed (exit-code guard)
+# ---------------------------------------------------------------------------
+
+
+def test_live_run_failed_normal_week_everything_failed():
+    assert live_run_failed(False, False, True, [False, False]) is True
+
+
+def test_live_run_failed_normal_week_newsletter_sent():
+    assert live_run_failed(True, False, True, [False]) is False
+
+
+def test_live_run_failed_normal_week_drafts_succeeded():
+    assert live_run_failed(False, False, True, [True, False]) is False
+
+
+def test_live_run_failed_quiet_week_drafts_succeeded():
+    assert live_run_failed(False, True, True, [True]) is False
+
+
+def test_live_run_failed_quiet_week_all_drafts_failed():
+    # Quiet week: IG drafts are the only deliverable, so a total draft failure
+    # must exit non-zero rather than be masked by the skipped newsletter.
+    assert live_run_failed(False, True, True, [False, False]) is True
+
+
+def test_live_run_failed_quiet_week_nothing_attempted():
+    # Kill switch on a quiet week: no newsletter, no drafts — nothing was due.
+    assert live_run_failed(False, True, False, []) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces the three mover-claim Instagram posts with a 5-post week and drops every "jumped X spots" framing.

**The week:**
- **Mon** "Rankings Are Live": new generic graphic, real Active-only team count (no fabricated numbers, count line drops when unavailable)
- **Tue x3** state Top-10 posts with team @mentions: reuses the existing `state` route + `get_state_rankings`, deterministic rotation across the 19 pillar states with a thin-cohort re-pick
- **Thu** "Big Games This Weekend": ranked-vs-ranked weekend slate where both teams sit top-25 in the same state cohort, ordered by combined rank, restricted to 18 deeper states so the matchups are marquee rather than thin small-state pairings

**New infrastructure:**
- `get_big_weekend_games` RPC (service-role only, no anon grant). Already applied to prod. Computes per-cohort ranks with materialized CTEs + a windowed `ROW_NUMBER()`; a correlated-subquery first pass ran 6-8s, this runs ~657ms.
- Two `next/og` routes: `rankings-live` and `big-games`. The big-games route is a pure renderer fed a base64url JSON payload by the pipeline, so it makes no DB call.
- Shared `Footer` extracted across all four infographic routes.
- A rankings-freshness gate replaces the no-movers early exit: it aborts only when the data is genuinely stale (>8 days), so quiet weeks still post the IG set but skip the mover-centric blog/newsletter/X-thread.

```mermaid
sequenceDiagram
  participant Pipeline as marketing_pipeline.py
  participant RPC as get_big_weekend_games
  participant Route as /api/infographic/big-games
  participant Postiz
  Pipeline->>RPC: rpc(window, p_states=18 states)
  RPC-->>Pipeline: top-25-vs-top-25 matchups
  Pipeline->>Pipeline: encode_big_games_payload (base64url)
  Pipeline->>Postiz: draft post, media_url=?m=<payload>
  Postiz->>Route: GET (fetch image bytes)
  Route-->>Postiz: rendered PNG (no DB call)
```

**Verification:** 62 unit tests pass (5 new for the cohort re-pick loop), ruff/tsc/eslint clean, RPC checked against `get_state_rankings` on live data, all four routes render and the big-games 404 guards hold, dry-run produces the full week.

**Operational note:** the marketing workflow is still manual-dispatch-only from the Postiz-migration validation period, so this won't auto-fire until that `if:` guard is restored.
