### PR TITLE
refactor(api): extract shared UUID/email validators (audit consistency)

### DIFF
--- a/frontend/app/api/feedback/route.ts
+++ b/frontend/app/api/feedback/route.ts
@@ -3,6 +3,7 @@ import { parseJsonBody } from '@/lib/api/parseJsonBody';
 import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { createServerSupabase } from '@/lib/supabase/server';
 import { sendFeedbackEmail, type FeedbackCategory, type FeedbackIdentity } from '@/lib/email';
+import { isValidEmail } from '@/lib/validation';
 
 const VALID_CATEGORIES: readonly FeedbackCategory[] = [
   'cant-find-team',
@@ -19,7 +20,6 @@ const MAX_TEXT_FIELD = 512;
 const MIN_DWELL_MS = 2000;
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 interface IncomingBody {
   category?: unknown;
@@ -86,7 +86,7 @@ export async function POST(request: NextRequest) {
     // Optional anonymous email
     let anonymousEmail: string | undefined;
     if (body.email !== undefined && body.email !== null && body.email !== '') {
-      if (typeof body.email !== 'string' || !EMAIL_REGEX.test(body.email)) {
+      if (typeof body.email !== 'string' || !isValidEmail(body.email)) {
         return bad('Email is not valid');
       }
       anonymousEmail = body.email.trim();

--- a/frontend/app/api/game-explainability/[teamId]/route.ts
+++ b/frontend/app/api/game-explainability/[teamId]/route.ts
@@ -1,8 +1,8 @@
 import { createServiceSupabase } from '@/lib/supabase/service';
 import { requirePremium } from '@/lib/api/requirePremium';
+import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_GAME_IDS = 150;
 
 const SELECT_COLUMNS = [
@@ -35,7 +35,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ teamId:
     if (auth.error) return auth.error;
 
     const { teamId } = await params;
-    if (!UUID_REGEX.test(teamId)) {
+    if (!isValidUuid(teamId)) {
       return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
     }
     const supabase = createServiceSupabase();
@@ -50,7 +50,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ teamId:
     }
 
     const uniqueGameIds = Array.from(new Set(body.gameIds));
-    if (!uniqueGameIds.every((gameId) => typeof gameId === 'string' && UUID_REGEX.test(gameId))) {
+    if (!uniqueGameIds.every((gameId) => typeof gameId === 'string' && isValidUuid(gameId))) {
       return NextResponse.json({ error: 'All game IDs must be valid UUIDs' }, { status: 400 });
     }
     const validatedGameIds = uniqueGameIds as string[];

--- a/frontend/app/api/insights/[teamId]/route.ts
+++ b/frontend/app/api/insights/[teamId]/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 import { generateAllInsights, type InsightInputData, type TeamInsightsResponse } from '@/lib/insights';
 
@@ -21,8 +22,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     const { supabase } = auth;
 
     // Validate team ID format
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(teamId)) {
+    if (!isValidUuid(teamId)) {
       return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
     }
 

--- a/frontend/app/api/match-prediction/route.ts
+++ b/frontend/app/api/match-prediction/route.ts
@@ -4,9 +4,8 @@ import { requirePremium } from '@/lib/api/requirePremium';
 import { AppError } from '@/lib/errors';
 import { buildMatchPredictionWithShadowContext } from '@/lib/matchPredictionService';
 import { maybeLogMatchPredictionShadow } from '@/lib/matchPredictionShadow';
+import { isValidUuid } from '@/lib/validation';
 import { NextRequest, NextResponse } from 'next/server';
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface MatchPredictionRequest {
   teamAId?: string;
@@ -27,11 +26,11 @@ export async function POST(request: NextRequest) {
 
     const { teamAId, teamBId } = body.data;
 
-    if (!teamAId || typeof teamAId !== 'string' || !UUID_REGEX.test(teamAId)) {
+    if (!teamAId || typeof teamAId !== 'string' || !isValidUuid(teamAId)) {
       return NextResponse.json({ error: 'Invalid Team A ID' }, { status: 400 });
     }
 
-    if (!teamBId || typeof teamBId !== 'string' || !UUID_REGEX.test(teamBId)) {
+    if (!teamBId || typeof teamBId !== 'string' || !isValidUuid(teamBId)) {
       return NextResponse.json({ error: 'Invalid Team B ID' }, { status: 400 });
     }
 

--- a/frontend/app/api/newsletter/route.ts
+++ b/frontend/app/api/newsletter/route.ts
@@ -1,6 +1,7 @@
 import { createServerSupabase } from '@/lib/supabase/server';
 import { sendWelcomeEmail } from '@/lib/email';
 import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
+import { isValidEmail } from '@/lib/validation';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
@@ -18,8 +19,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Email is required' }, { status: 400 });
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (!isValidEmail(email)) {
       return NextResponse.json({ error: 'Please enter a valid email address' }, { status: 400 });
     }
 

--- a/frontend/app/api/reports/team-card/route.ts
+++ b/frontend/app/api/reports/team-card/route.ts
@@ -3,14 +3,12 @@ import { sendReportCardEmail } from '@/lib/email';
 import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { optionalAuth } from '@/lib/api/optionalAuth';
 import { subscribeFreeLead, enrollInAutomation } from '@/lib/beehiiv';
+import { isValidUuid, isValidEmail } from '@/lib/validation';
 import { NextRequest, NextResponse } from 'next/server';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { TeamReportCard } from '@/lib/pdf';
 import type { ReportCardGame } from '@/lib/pdf';
 import React from 'react';
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request: NextRequest) {
   try {
@@ -25,10 +23,10 @@ export async function POST(request: NextRequest) {
     const { teamId, email, role } = body;
 
     // Validate inputs
-    if (!teamId || typeof teamId !== 'string' || !UUID_REGEX.test(teamId)) {
+    if (!teamId || typeof teamId !== 'string' || !isValidUuid(teamId)) {
       return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
     }
-    if (!email || typeof email !== 'string' || !EMAIL_REGEX.test(email)) {
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
       return NextResponse.json({ error: 'Please enter a valid email address' }, { status: 400 });
     }
 

--- a/frontend/app/api/team-merge/route.ts
+++ b/frontend/app/api/team-merge/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { requireAdmin } from '@/lib/supabase/admin';
 import { createServiceSupabase } from '@/lib/supabase/service';
 import { parseJsonBody } from '@/lib/api/parseJsonBody';
+import { isValidUuid } from '@/lib/validation';
 
 /**
  * Team Merge API Endpoints
@@ -48,8 +49,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate UUIDs
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(deprecatedTeamId) || !uuidRegex.test(canonicalTeamId)) {
+    if (!isValidUuid(deprecatedTeamId) || !isValidUuid(canonicalTeamId)) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
@@ -157,8 +157,7 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Validate UUID
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(deprecatedTeamId)) {
+    if (!isValidUuid(deprecatedTeamId)) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
@@ -245,8 +244,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Validate UUID
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(teamId)) {
+    if (!isValidUuid(teamId)) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 

--- a/frontend/app/api/teams/[teamId]/clutch/route.ts
+++ b/frontend/app/api/teams/[teamId]/clutch/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 
 /**
@@ -15,8 +16,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     if (auth.error) return auth.error;
     const { supabase } = auth;
 
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(teamId)) {
+    if (!isValidUuid(teamId)) {
       return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
     }
 

--- a/frontend/app/api/watchlist/remove/route.ts
+++ b/frontend/app/api/watchlist/remove/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 
 /**
@@ -24,8 +25,7 @@ export async function POST(req: Request) {
 
     // Validate UUID — teamIdMaster is interpolated into the .or() filter below,
     // so reject anything that could carry PostgREST filter syntax
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(teamIdMaster)) {
+    if (!isValidUuid(teamIdMaster)) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 

--- a/frontend/app/teams/[id]/page.tsx
+++ b/frontend/app/teams/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react';
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { BASE_URL } from '@/lib/constants';
+import { isValidUuid } from '@/lib/validation';
 
 interface TeamPageProps {
   params: Promise<{
@@ -113,8 +114,7 @@ export default async function Page({ params }: TeamPageProps) {
       const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
       // Validate UUID format first (basic check)
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (!uuidRegex.test(resolvedParams.id)) {
+      if (!isValidUuid(resolvedParams.id)) {
         notFound();
       }
 

--- a/frontend/components/NewsletterSubscribe.tsx
+++ b/frontend/components/NewsletterSubscribe.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { isValidEmail } from '@/lib/validation';
 import { Mail, Check, AlertCircle } from 'lucide-react';
 
 export function NewsletterSubscribe() {
@@ -15,8 +16,7 @@ export function NewsletterSubscribe() {
     e.preventDefault();
 
     // Basic email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (!isValidEmail(email)) {
       setStatus('error');
       setErrorMessage('Please enter a valid email address');
       return;

--- a/frontend/lib/validation.ts
+++ b/frontend/lib/validation.ts
@@ -1,0 +1,13 @@
+/** UUID format check (case-insensitive 8-4-4-4-12 hex). */
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+/** Loose email shape check — local@domain.tld, no whitespace. */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}


### PR DESCRIPTION
First of several **Consistency** PRs from the 2026-06-10 audit (`.turbo/audit.md`), non-engine scope. Starts with the lowest-risk, highest-duplication win.

## What changed
The UUID-format regex was copy-pasted across **8 files / 10 call sites** (including 3 inline copies inside `team-merge/route.ts`), and the email regex across **3 files** — with inconsistent naming (`uuidRegex` vs `UUID_REGEX`). Added `lib/validation.ts`:

```ts
export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
export function isValidUuid(value: string): boolean { ... }
export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
export function isValidEmail(value: string): boolean { ... }
```

…and replaced every inline copy with `isValidUuid()` / `isValidEmail()`. The regexes were moved **verbatim** — behavior is identical. Net −5 lines across 11 consumers + the new util.

Consumers updated: watchlist/remove, insights, clutch, game-explainability, team-merge (×3), match-prediction, teams/[id] page, newsletter, NewsletterSubscribe, feedback, reports/team-card.

## Verification
`tsc --noEmit` clean · eslint clean on all 12 files · **295/295 tests pass** · husky lint-staged passed on commit. Grep confirms zero remaining inline copies (only the new util + `node_modules`).

## Coming in follow-up Consistency PRs
merged-team-ID resolution helper (×4 routes), watchlist default-resolution helper (×4), GA4/GSC route factory (10 handlers), auth-card shell component (×5 pages). Already-resolved/intentional items (infographic constants, Stripe price-IDs) are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)