### PR TITLE
refactor(api): extract resolveMergedTeamIds helper (audit consistency)

### DIFF
--- a/frontend/app/api/insights/[teamId]/route.ts
+++ b/frontend/app/api/insights/[teamId]/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveMergedTeamIds } from '@/lib/team-merge';
 import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 import { generateAllInsights, type InsightInputData, type TeamInsightsResponse } from '@/lib/insights';
@@ -49,25 +50,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
     }
 
     // Resolve merged team IDs so games stored under deprecated IDs are included
-    // (mirrors api.getTeamGames). Without this, streak/consistency stop at the
-    // first gap caused by games scraped under a pre-merge team_id.
-    const { data: incomingMerge } = await supabase
-      .from('team_merge_map')
-      .select('canonical_team_id')
-      .eq('deprecated_team_id', teamId)
-      .maybeSingle();
-    const canonicalTeamId = (incomingMerge as { canonical_team_id?: string } | null)?.canonical_team_id ?? teamId;
-
-    const { data: mergedTeams } = await supabase
-      .from('team_merge_map')
-      .select('deprecated_team_id')
-      .eq('canonical_team_id', canonicalTeamId);
-
-    const teamIdsToQuery = new Set<string>([canonicalTeamId, teamId]);
-    ((mergedTeams || []) as { deprecated_team_id: string | null }[]).forEach((m) => {
-      if (m.deprecated_team_id) teamIdsToQuery.add(m.deprecated_team_id);
-    });
-    const teamIdList = Array.from(teamIdsToQuery);
+    // (without this, streak/consistency stop at the first pre-merge gap).
+    const { teamIdsToQuery, teamIdList } = await resolveMergedTeamIds(supabase, teamId);
 
     // Fetch games with opponent rankings (across canonical + all merged team IDs)
     const orConditions = teamIdList

--- a/frontend/app/api/teams/[teamId]/clutch/route.ts
+++ b/frontend/app/api/teams/[teamId]/clutch/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveMergedTeamIds } from '@/lib/team-merge';
 import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 
@@ -20,25 +21,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ teamId: 
       return NextResponse.json({ error: 'Invalid team ID' }, { status: 400 });
     }
 
-    // Resolve merged team IDs so games stored under deprecated IDs are included
-    // (mirrors /api/insights/[teamId]).
-    const { data: incomingMerge } = await supabase
-      .from('team_merge_map')
-      .select('canonical_team_id')
-      .eq('deprecated_team_id', teamId)
-      .maybeSingle();
-    const canonicalTeamId = (incomingMerge as { canonical_team_id?: string } | null)?.canonical_team_id ?? teamId;
-
-    const { data: mergedTeams } = await supabase
-      .from('team_merge_map')
-      .select('deprecated_team_id')
-      .eq('canonical_team_id', canonicalTeamId);
-
-    const teamIdsToQuery = new Set<string>([canonicalTeamId, teamId]);
-    ((mergedTeams || []) as { deprecated_team_id: string | null }[]).forEach((m) => {
-      if (m.deprecated_team_id) teamIdsToQuery.add(m.deprecated_team_id);
-    });
-    const teamIdList = Array.from(teamIdsToQuery);
+    // Resolve merged team IDs so games stored under deprecated IDs are included.
+    const { teamIdsToQuery, teamIdList } = await resolveMergedTeamIds(supabase, teamId);
 
     const orConditions = teamIdList
       .map((tid) => `home_team_master_id.eq.${tid},away_team_master_id.eq.${tid}`)

--- a/frontend/lib/team-merge.ts
+++ b/frontend/lib/team-merge.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface ResolvedTeamIds {
+  /** Canonical team_id_master after following any incoming merge. */
+  canonicalTeamId: string;
+  /** Canonical + original + all deprecated IDs, for membership checks. */
+  teamIdsToQuery: Set<string>;
+  /** Same set as an array, for building PostgREST `.or()` filters. */
+  teamIdList: string[];
+}
+
+/**
+ * Resolve a team_id_master to its canonical team plus every deprecated ID merged
+ * into it, so games stored under pre-merge IDs are still included in a team's
+ * history. Mirrors api.getTeamGames.
+ */
+export async function resolveMergedTeamIds(supabase: SupabaseClient, teamId: string): Promise<ResolvedTeamIds> {
+  const { data: incomingMerge } = await supabase
+    .from('team_merge_map')
+    .select('canonical_team_id')
+    .eq('deprecated_team_id', teamId)
+    .maybeSingle();
+  const canonicalTeamId = (incomingMerge as { canonical_team_id?: string } | null)?.canonical_team_id ?? teamId;
+
+  const { data: mergedTeams } = await supabase
+    .from('team_merge_map')
+    .select('deprecated_team_id')
+    .eq('canonical_team_id', canonicalTeamId);
+
+  const teamIdsToQuery = new Set<string>([canonicalTeamId, teamId]);
+  ((mergedTeams || []) as { deprecated_team_id: string | null }[]).forEach((m) => {
+    if (m.deprecated_team_id) teamIdsToQuery.add(m.deprecated_team_id);
+  });
+
+  return { canonicalTeamId, teamIdsToQuery, teamIdList: Array.from(teamIdsToQuery) };
+}


### PR DESCRIPTION
Second **Consistency** PR from the 2026-06-10 audit (`.turbo/audit.md`), non-engine scope.

## What changed
`clutch` and `insights` each inlined a byte-identical ~18-line block that resolves a team's canonical ID and gathers every deprecated merged ID into a `Set` (for membership checks) + array (for `.or()` filters). Extracted to `lib/team-merge.ts`:

```ts
export async function resolveMergedTeamIds(supabase, teamId): Promise<{
  canonicalTeamId: string; teamIdsToQuery: Set<string>; teamIdList: string[];
}>
```

Block moved **verbatim** — behavior identical. Net −34 lines.

## Audit correction
The audit listed 4 routes (clutch/insights/match-prediction/team-card). In current code, `match-prediction` and `team-card` don't do merge resolution, and the watchlist routes use `team_merge_map` for a *different* purpose (mapping/deletion), so **clutch + insights** is the real duplication.

## Verification
`tsc --noEmit` clean · eslint clean · **295/295 tests pass** · husky lint-staged passed on commit.

## Remaining Consistency PRs
watchlist default-resolution helper (×4 routes), GA4/GSC route factory (10 handlers), auth-card shell component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)