### PR TITLE
refactor(analytics): factory for internal GA4/GSC report routes (audit consistency)

### DIFF
--- a/frontend/app/api/internal/analytics/ga4/most-wanted-teams/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/most-wanted-teams/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('ga4_most_wanted_teams', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_most_wanted_teams', 'limit');

--- a/frontend/app/api/internal/analytics/ga4/overview/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/overview/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const compare = url.searchParams.get('compare') === '1';
-  try {
-    const data = await runReport('ga4_traffic_overview', { date_range: range, compare_to_previous: compare });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_traffic_overview', 'compare');

--- a/frontend/app/api/internal/analytics/ga4/top-pages/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/top-pages/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('ga4_top_pages', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_top_pages', 'limit');

--- a/frontend/app/api/internal/analytics/ga4/traffic-sources/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/traffic-sources/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('ga4_traffic_sources', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_traffic_sources', 'limit');

--- a/frontend/app/api/internal/analytics/ga4/upgrade-funnel/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/upgrade-funnel/route.ts
@@ -1,21 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  try {
-    const data = await runReport('ga4_upgrade_funnel', { date_range: range });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_upgrade_funnel');

--- a/frontend/app/api/internal/analytics/ga4/upgrade-sources/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/upgrade-sources/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('ga4_upgrade_sources', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_upgrade_sources', 'limit');

--- a/frontend/app/api/internal/analytics/ga4/upgrade-views/route.ts
+++ b/frontend/app/api/internal/analytics/ga4/upgrade-views/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const compare = url.searchParams.get('compare') === '1';
-  try {
-    const data = await runReport('ga4_upgrade_views', { date_range: range, compare_to_previous: compare });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('ga4_upgrade_views', 'compare');

--- a/frontend/app/api/internal/analytics/gsc/landing-pages/route.ts
+++ b/frontend/app/api/internal/analytics/gsc/landing-pages/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('gsc_landing_pages', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('gsc_landing_pages', 'limit');

--- a/frontend/app/api/internal/analytics/gsc/performance/route.ts
+++ b/frontend/app/api/internal/analytics/gsc/performance/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const compare = url.searchParams.get('compare') === '1';
-  try {
-    const data = await runReport('gsc_performance', { date_range: range, compare_to_previous: compare });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('gsc_performance', 'compare');

--- a/frontend/app/api/internal/analytics/gsc/top-queries/route.ts
+++ b/frontend/app/api/internal/analytics/gsc/top-queries/route.ts
@@ -1,22 +1,6 @@
-import { NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/supabase/admin';
-import { runReport } from '@/lib/internal-analytics/report-registry';
-import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+import { makeReportRoute } from '@/lib/internal-analytics/make-report-route';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: Request) {
-  const auth = await requireAdmin();
-  if (auth.error) return auth.error;
-  const url = new URL(req.url);
-  const range = url.searchParams.get('range') ?? 'last_7_days';
-  const limit = Number(url.searchParams.get('limit') ?? 10);
-  try {
-    const data = await runReport('gsc_top_queries', { date_range: range, limit });
-    return NextResponse.json(data);
-  } catch (e) {
-    if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
-    throw e;
-  }
-}
+export const GET = makeReportRoute('gsc_top_queries', 'limit');

--- a/frontend/lib/internal-analytics/make-report-route.ts
+++ b/frontend/lib/internal-analytics/make-report-route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/supabase/admin';
+import { runReport, type ReportKey } from '@/lib/internal-analytics/report-registry';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+type ExtraParam = 'limit' | 'compare' | 'none';
+
+/**
+ * Build the GET handler for an admin-only internal analytics report. Every such
+ * route shares the same admin gate, `range` parsing, and error taxonomy; they
+ * differ only in the report key and which optional query param they read
+ * (`limit` for top-N reports, `compare` for trend reports, or neither).
+ */
+export function makeReportRoute(report: ReportKey, extra: ExtraParam = 'none') {
+  return async function GET(req: Request) {
+    const auth = await requireAdmin();
+    if (auth.error) return auth.error;
+
+    const url = new URL(req.url);
+    const range = url.searchParams.get('range') ?? 'last_7_days';
+    const params: Record<string, unknown> = { date_range: range };
+    if (extra === 'limit') {
+      params.limit = Number(url.searchParams.get('limit') ?? 10);
+    } else if (extra === 'compare') {
+      params.compare_to_previous = url.searchParams.get('compare') === '1';
+    }
+
+    try {
+      const data = await runReport(report, params);
+      return NextResponse.json(data);
+    } catch (e) {
+      if (e instanceof TaxonomyAwareError) return NextResponse.json({ error: e.taxonomy }, { status: 500 });
+      throw e;
+    }
+  };
+}


### PR DESCRIPTION
Third **Consistency** PR from the 2026-06-10 audit (`.turbo/audit.md`), non-engine scope. The highest-duplication item — 10 byte-identical route handlers.

## What changed
The 10 admin-only internal-analytics handlers (7 GA4 + 3 GSC) were identical except for the report key and one optional query param. Added `lib/internal-analytics/make-report-route.ts`:

```ts
export function makeReportRoute(report: ReportKey, extra: 'limit' | 'compare' | 'none' = 'none')
```

…which owns the shared `requireAdmin()` gate, `range` parsing, optional `limit`/`compare` handling, and `TaxonomyAwareError` mapping. Each route is now one line, e.g.:

```ts
export const GET = makeReportRoute('gsc_top_queries', 'limit');
```

Report keys are **unchanged** (typecheck enforces they're valid `ReportKey`s); param handling is identical (6 routes take `limit`, 3 take `compare`, `upgrade-funnel` takes neither). **−159 lines.**

## Verification
`tsc --noEmit` clean · eslint clean · **295/295 tests pass** · husky lint-staged passed on commit. Subagent independently confirmed each route's original report key matched before rewriting.

## Remaining Consistency PRs
watchlist default-resolution helper (×4 routes), auth-card shell component (×5 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)