### PR TITLE
refactor(auth): extract AuthCardShell shell component (audit consistency)

### DIFF
--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -6,7 +6,8 @@ import { createClientSupabase } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { AuthCardShell } from '@/components/auth/AuthCardShell';
 import { Loader2, Mail, CheckCircle2 } from 'lucide-react';
 
 export default function ForgotPasswordPage() {
@@ -48,83 +49,79 @@ export default function ForgotPasswordPage() {
 
   if (isSuccess) {
     return (
-      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-        <Card className="w-full max-w-md" variant="elevated">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
-              <CheckCircle2 className="h-6 w-6 text-green-600" />
-            </div>
-            <CardTitle className="text-2xl font-bold tracking-tight">Check your email</CardTitle>
-            <CardDescription className="text-base">
-              We&apos;ve sent a password reset link to <span className="font-medium text-foreground">{email}</span>
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="text-center">
-            <p className="text-sm text-muted-foreground">
-              Click the link in the email to reset your password. The link will expire in 1 hour.
-            </p>
-          </CardContent>
-          <CardFooter className="flex justify-center">
-            <Link href="/login">
-              <Button variant="outline">Back to login</Button>
-            </Link>
-          </CardFooter>
-        </Card>
-      </div>
+      <AuthCardShell>
+        <CardHeader className="space-y-1 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+            <CheckCircle2 className="h-6 w-6 text-green-600" />
+          </div>
+          <CardTitle className="text-2xl font-bold tracking-tight">Check your email</CardTitle>
+          <CardDescription className="text-base">
+            We&apos;ve sent a password reset link to <span className="font-medium text-foreground">{email}</span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-sm text-muted-foreground">
+            Click the link in the email to reset your password. The link will expire in 1 hour.
+          </p>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <Link href="/login">
+            <Button variant="outline">Back to login</Button>
+          </Link>
+        </CardFooter>
+      </AuthCardShell>
     );
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-      <Card className="w-full max-w-md" variant="elevated">
-        <CardHeader className="space-y-1 text-center">
-          <CardTitle className="text-2xl font-bold tracking-tight">Reset your password</CardTitle>
-          <CardDescription>
-            Enter your email address and we&apos;ll send you a link to reset your password
-          </CardDescription>
-        </CardHeader>
-        <form onSubmit={handleSubmit}>
-          <CardContent className="space-y-4">
-            {error && <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
+    <AuthCardShell>
+      <CardHeader className="space-y-1 text-center">
+        <CardTitle className="text-2xl font-bold tracking-tight">Reset your password</CardTitle>
+        <CardDescription>
+          Enter your email address and we&apos;ll send you a link to reset your password
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          {error && <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="pl-10"
-                  required
-                  autoComplete="email"
-                />
-              </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="pl-10"
+                required
+                autoComplete="email"
+              />
             </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-4">
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Sending reset link...
-                </>
-              ) : (
-                'Send reset link'
-              )}
-            </Button>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4">
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Sending reset link...
+              </>
+            ) : (
+              'Send reset link'
+            )}
+          </Button>
 
-            <p className="text-center text-sm text-muted-foreground">
-              Remember your password?{' '}
-              <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
-                Sign in
-              </Link>
-            </p>
-          </CardFooter>
-        </form>
-      </Card>
-    </div>
+          <p className="text-center text-sm text-muted-foreground">
+            Remember your password?{' '}
+            <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
+              Sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </AuthCardShell>
   );
 }

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -7,7 +7,8 @@ import { createClientSupabase } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { AuthCardShell } from '@/components/auth/AuthCardShell';
 import { Loader2, Mail, Lock, CheckCircle2 } from 'lucide-react';
 
 export default function LoginPage() {
@@ -63,92 +64,90 @@ function LoginForm() {
   };
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-      <Card data-testid="login-card" className="w-full max-w-md" variant="elevated">
-        <CardHeader className="space-y-1 text-center">
-          <CardTitle className="text-2xl font-bold tracking-tight">Welcome back</CardTitle>
-          <CardDescription>Sign in to your PitchRank account to access your watchlist</CardDescription>
-        </CardHeader>
-        <form onSubmit={handleEmailLogin}>
-          <CardContent className="space-y-4">
-            {successMessage && (
-              <div
-                data-testid="login-success"
-                className="flex items-center gap-2 rounded-md bg-green-500/10 p-3 text-sm text-green-700 dark:text-green-400"
-              >
-                <CheckCircle2 className="h-4 w-4 shrink-0" />
-                {successMessage}
-              </div>
+    <AuthCardShell data-testid="login-card">
+      <CardHeader className="space-y-1 text-center">
+        <CardTitle className="text-2xl font-bold tracking-tight">Welcome back</CardTitle>
+        <CardDescription>Sign in to your PitchRank account to access your watchlist</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleEmailLogin}>
+        <CardContent className="space-y-4">
+          {successMessage && (
+            <div
+              data-testid="login-success"
+              className="flex items-center gap-2 rounded-md bg-green-500/10 p-3 text-sm text-green-700 dark:text-green-400"
+            >
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              {successMessage}
+            </div>
+          )}
+          {error && (
+            <div data-testid="login-error" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="pl-10"
+                required
+                autoComplete="email"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="password"
+                type="password"
+                placeholder="Your password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="pl-10"
+                required
+                autoComplete="current-password"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Link
+              href="/forgot-password"
+              className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              Forgot password?
+            </Link>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4">
+          <Button data-testid="login-submit" type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Signing in...
+              </>
+            ) : (
+              'Sign in'
             )}
-            {error && (
-              <div data-testid="login-error" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
-              </div>
-            )}
+          </Button>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="pl-10"
-                  required
-                  autoComplete="email"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="Your password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="pl-10"
-                  required
-                  autoComplete="current-password"
-                />
-              </div>
-            </div>
-            <div className="flex justify-end">
-              <Link
-                href="/forgot-password"
-                className="text-sm font-medium text-primary underline-offset-4 hover:underline"
-              >
-                Forgot password?
-              </Link>
-            </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-4">
-            <Button data-testid="login-submit" type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Signing in...
-                </>
-              ) : (
-                'Sign in'
-              )}
-            </Button>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Don&apos;t have an account?{' '}
-              <Link href="/signup" className="font-medium text-primary underline-offset-4 hover:underline">
-                Sign up
-              </Link>
-            </p>
-          </CardFooter>
-        </form>
-      </Card>
-    </div>
+          <p className="text-center text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link href="/signup" className="font-medium text-primary underline-offset-4 hover:underline">
+              Sign up
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </AuthCardShell>
   );
 }

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -6,7 +6,8 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { AuthCardShell } from '@/components/auth/AuthCardShell';
 import { Loader2, Lock, CheckCircle2 } from 'lucide-react';
 import { updatePassword } from './actions';
 
@@ -52,97 +53,93 @@ export default function ResetPasswordPage() {
 
   if (isSuccess) {
     return (
-      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-        <Card className="w-full max-w-md" variant="elevated">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
-              <CheckCircle2 className="h-6 w-6 text-green-600" />
-            </div>
-            <CardTitle className="text-2xl font-bold tracking-tight">Password updated</CardTitle>
-            <CardDescription className="text-base">Your password has been successfully reset.</CardDescription>
-          </CardHeader>
-          <CardFooter className="flex justify-center">
-            <Button
-              onClick={() => {
-                router.push('/rankings');
-                router.refresh();
-              }}
-            >
-              Go to rankings
-            </Button>
-          </CardFooter>
-        </Card>
-      </div>
+      <AuthCardShell>
+        <CardHeader className="space-y-1 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+            <CheckCircle2 className="h-6 w-6 text-green-600" />
+          </div>
+          <CardTitle className="text-2xl font-bold tracking-tight">Password updated</CardTitle>
+          <CardDescription className="text-base">Your password has been successfully reset.</CardDescription>
+        </CardHeader>
+        <CardFooter className="flex justify-center">
+          <Button
+            onClick={() => {
+              router.push('/rankings');
+              router.refresh();
+            }}
+          >
+            Go to rankings
+          </Button>
+        </CardFooter>
+      </AuthCardShell>
     );
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-      <Card className="w-full max-w-md" variant="elevated">
-        <CardHeader className="space-y-1 text-center">
-          <CardTitle className="text-2xl font-bold tracking-tight">Set new password</CardTitle>
-          <CardDescription>Enter your new password below</CardDescription>
-        </CardHeader>
-        <form onSubmit={handleSubmit}>
-          <CardContent className="space-y-4">
-            {error && <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
+    <AuthCardShell>
+      <CardHeader className="space-y-1 text-center">
+        <CardTitle className="text-2xl font-bold tracking-tight">Set new password</CardTitle>
+        <CardDescription>Enter your new password below</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          {error && <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
 
-            <div className="space-y-2">
-              <Label htmlFor="password">New password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="At least 6 characters"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="pl-10"
-                  required
-                  minLength={6}
-                  autoComplete="new-password"
-                />
-              </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">New password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="password"
+                type="password"
+                placeholder="At least 6 characters"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="pl-10"
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
             </div>
+          </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm new password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  placeholder="Confirm your password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="pl-10"
-                  required
-                  minLength={6}
-                  autoComplete="new-password"
-                />
-              </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm new password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="confirmPassword"
+                type="password"
+                placeholder="Confirm your password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="pl-10"
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
             </div>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-4">
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Updating password...
-                </>
-              ) : (
-                'Update password'
-              )}
-            </Button>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4">
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Updating password...
+              </>
+            ) : (
+              'Update password'
+            )}
+          </Button>
 
-            <p className="text-center text-sm text-muted-foreground">
-              <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
-                Back to login
-              </Link>
-            </p>
-          </CardFooter>
-        </form>
-      </Card>
-    </div>
+          <p className="text-center text-sm text-muted-foreground">
+            <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
+              Back to login
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </AuthCardShell>
   );
 }

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -7,7 +7,8 @@ import { createClientSupabase } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { AuthCardShell } from '@/components/auth/AuthCardShell';
 import { Loader2, Mail, Lock, CheckCircle2, AlertTriangle, RefreshCw } from 'lucide-react';
 
 /**
@@ -123,177 +124,172 @@ export default function SignupPage() {
 
   if (isSuccess) {
     return (
-      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-        <Card data-testid="signup-success-card" className="w-full max-w-md" variant="elevated">
-          <CardHeader className="space-y-1 text-center">
-            <div
-              className={`mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full ${emailSendFailed ? 'bg-yellow-500/10' : 'bg-green-500/10'}`}
-            >
-              {emailSendFailed ? (
-                <AlertTriangle className="h-6 w-6 text-yellow-600" />
-              ) : (
-                <CheckCircle2 className="h-6 w-6 text-green-600" />
-              )}
-            </div>
-            <CardTitle className="text-2xl font-bold tracking-tight">
-              {emailSendFailed ? 'Account created' : 'Check your email'}
-            </CardTitle>
-            <CardDescription className="text-base">
-              {emailSendFailed ? (
-                <>
-                  Your account has been created, but we had trouble sending the confirmation email to{' '}
-                  <span className="font-medium text-foreground">{email}</span>
-                </>
-              ) : (
-                <>
-                  We&apos;ve sent you a confirmation link to{' '}
-                  <span className="font-medium text-foreground">{email}</span>
-                </>
-              )}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="text-center space-y-3">
+      <AuthCardShell data-testid="signup-success-card">
+        <CardHeader className="space-y-1 text-center">
+          <div
+            className={`mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full ${emailSendFailed ? 'bg-yellow-500/10' : 'bg-green-500/10'}`}
+          >
+            {emailSendFailed ? (
+              <AlertTriangle className="h-6 w-6 text-yellow-600" />
+            ) : (
+              <CheckCircle2 className="h-6 w-6 text-green-600" />
+            )}
+          </div>
+          <CardTitle className="text-2xl font-bold tracking-tight">
+            {emailSendFailed ? 'Account created' : 'Check your email'}
+          </CardTitle>
+          <CardDescription className="text-base">
             {emailSendFailed ? (
               <>
-                <p className="text-sm text-muted-foreground">
-                  Click below to resend the confirmation email, or try again in a few minutes.
-                </p>
-                <Button variant="outline" onClick={handleResendConfirmation} disabled={isResending} className="mt-2">
-                  {isResending ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Sending...
-                    </>
-                  ) : (
-                    <>
-                      <RefreshCw className="mr-2 h-4 w-4" />
-                      Resend confirmation email
-                    </>
-                  )}
-                </Button>
+                Your account has been created, but we had trouble sending the confirmation email to{' '}
+                <span className="font-medium text-foreground">{email}</span>
               </>
             ) : (
+              <>
+                We&apos;ve sent you a confirmation link to <span className="font-medium text-foreground">{email}</span>
+              </>
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center space-y-3">
+          {emailSendFailed ? (
+            <>
               <p className="text-sm text-muted-foreground">
-                Click the link in the email to activate your account and start tracking your favorite teams.
+                Click below to resend the confirmation email, or try again in a few minutes.
               </p>
-            )}
-            {resendMessage && (
-              <p className={`text-sm ${resendMessage.includes('sent!') ? 'text-green-600' : 'text-muted-foreground'}`}>
-                {resendMessage}
-              </p>
-            )}
-          </CardContent>
-          <CardFooter className="flex justify-center">
-            <Link href="/login">
-              <Button variant="outline">Back to login</Button>
-            </Link>
-          </CardFooter>
-        </Card>
-      </div>
+              <Button variant="outline" onClick={handleResendConfirmation} disabled={isResending} className="mt-2">
+                {isResending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Resend confirmation email
+                  </>
+                )}
+              </Button>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Click the link in the email to activate your account and start tracking your favorite teams.
+            </p>
+          )}
+          {resendMessage && (
+            <p className={`text-sm ${resendMessage.includes('sent!') ? 'text-green-600' : 'text-muted-foreground'}`}>
+              {resendMessage}
+            </p>
+          )}
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <Link href="/login">
+            <Button variant="outline">Back to login</Button>
+          </Link>
+        </CardFooter>
+      </AuthCardShell>
     );
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
-      <Card data-testid="signup-card" className="w-full max-w-md" variant="elevated">
-        <CardHeader className="space-y-1 text-center">
-          <CardTitle className="text-2xl font-bold tracking-tight">Create an account</CardTitle>
-          <CardDescription>Sign up for PitchRank to save your favorite teams and track their rankings</CardDescription>
-        </CardHeader>
-        <form onSubmit={handleSignup}>
-          <CardContent className="space-y-4">
-            {error && (
-              <div data-testid="signup-error" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
-              </div>
+    <AuthCardShell data-testid="signup-card">
+      <CardHeader className="space-y-1 text-center">
+        <CardTitle className="text-2xl font-bold tracking-tight">Create an account</CardTitle>
+        <CardDescription>Sign up for PitchRank to save your favorite teams and track their rankings</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSignup}>
+        <CardContent className="space-y-4">
+          {error && (
+            <div data-testid="signup-error" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="pl-10"
+                required
+                autoComplete="email"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="password"
+                type="password"
+                placeholder="At least 6 characters"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="pl-10"
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm Password</Label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="confirmPassword"
+                type="password"
+                placeholder="Confirm your password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="pl-10"
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            By creating an account, you agree to PitchRank&apos;s{' '}
+            <Link href="/terms-of-service" className="text-primary underline-offset-4 hover:underline">
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link href="/privacy-policy" className="text-primary underline-offset-4 hover:underline">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4">
+          <Button data-testid="signup-submit" type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating account...
+              </>
+            ) : (
+              'Create account'
             )}
+          </Button>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="pl-10"
-                  required
-                  autoComplete="email"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="At least 6 characters"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="pl-10"
-                  required
-                  minLength={6}
-                  autoComplete="new-password"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm Password</Label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  placeholder="Confirm your password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="pl-10"
-                  required
-                  minLength={6}
-                  autoComplete="new-password"
-                />
-              </div>
-            </div>
-
-            <p className="text-xs text-muted-foreground">
-              By creating an account, you agree to PitchRank&apos;s{' '}
-              <Link href="/terms-of-service" className="text-primary underline-offset-4 hover:underline">
-                Terms of Service
-              </Link>{' '}
-              and{' '}
-              <Link href="/privacy-policy" className="text-primary underline-offset-4 hover:underline">
-                Privacy Policy
-              </Link>
-              .
-            </p>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-4">
-            <Button data-testid="signup-submit" type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Creating account...
-                </>
-              ) : (
-                'Create account'
-              )}
-            </Button>
-
-            <p className="text-center text-sm text-muted-foreground">
-              Already have an account?{' '}
-              <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
-                Sign in
-              </Link>
-            </p>
-          </CardFooter>
-        </form>
-      </Card>
-    </div>
+          <p className="text-center text-sm text-muted-foreground">
+            Already have an account?{' '}
+            <Link href="/login" className="font-medium text-primary underline-offset-4 hover:underline">
+              Sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </AuthCardShell>
   );
 }

--- a/frontend/components/auth/AuthCardShell.tsx
+++ b/frontend/components/auth/AuthCardShell.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { Card } from '@/components/ui/card';
+
+/**
+ * Shared outer shell for the auth pages (login, signup, forgot/reset password):
+ * a full-height centered layout wrapping an elevated max-w-md card. Children
+ * supply the CardHeader / CardContent / CardFooter.
+ */
+export function AuthCardShell({
+  children,
+  ...cardProps
+}: { children: ReactNode } & Omit<ComponentProps<typeof Card>, 'children'>) {
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-12">
+      <Card variant="elevated" {...cardProps} className="w-full max-w-md">
+        {children}
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Fourth **Consistency** PR from the 2026-06-10 audit (`.turbo/audit.md`), non-engine scope. Last of the safe presentational consolidations.

## What changed
`login`, `signup`, `forgot-password`, and `reset-password` each repeated the same outer auth-page shell — a full-height centered layout wrapping an elevated `max-w-md` Card. Extracted `components/auth/AuthCardShell.tsx` and used it in all **7 instances** (including the success states in signup/forgot/reset).

Each page's `CardHeader`/`CardContent`/`CardFooter` is untouched; only the shared wrapper moved. `data-testid` props (e.g. `login-card`) are forwarded onto the shell. The `Card` import was dropped from the four pages where it's now unused.

> The large raw line delta is **prettier re-indenting** the inner JSX one nesting level shallower. The whitespace-ignored diff is **−11 lines** — the substantive change is just the wrapper swaps + imports.

## Verification
`tsc --noEmit` clean · eslint clean · **295/295 tests pass** · husky lint-staged passed on commit. Whitespace-ignored diff confirms no inner-content changes.

## Consistency status
This closes the **safe** Consistency work. The one remaining item — the watchlist default-resolution helper — is intentionally deferred: its 4 copies diverge (resolve-or-empty vs resolve-or-create vs different fallback) and the routes are premium mutations with **zero tests**, so it should land on top of the watchlist test suite (PR5) as its safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)