### PR TITLE
refactor(watchlist): shared resolveDefaultWatchlist helper + tests (audit)

### DIFF
--- a/frontend/app/api/watchlist/add/route.ts
+++ b/frontend/app/api/watchlist/add/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveDefaultWatchlist } from '@/lib/api/watchlist';
 import { NextResponse } from 'next/server';
 
 /**
@@ -37,34 +38,15 @@ export async function POST(req: Request) {
     // Get or create default watchlist
     let watchlistId: string;
 
-    const fetchResult = await supabase
-      .from('watchlists')
-      .select('id')
-      .eq('user_id', user.id)
-      .eq('is_default', true)
-      .single();
+    const { watchlist: existingWatchlist, error: fetchError } = await resolveDefaultWatchlist<{ id: string }>(
+      supabase,
+      user.id,
+      'id'
+    );
 
-    const fetchError = fetchResult.error;
-    let existingWatchlist = fetchResult.data;
-
-    if (fetchError && fetchError.code !== 'PGRST116') {
+    if (fetchError) {
       console.error('[Watchlist Add] Error fetching watchlist:', fetchError);
       return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
-    }
-
-    // If no default watchlist found, use most recent watchlist (fallback)
-    // This prevents creating duplicate watchlists when is_default flag is missing
-    if (!existingWatchlist && fetchError?.code === 'PGRST116') {
-      const { data: watchlists, error: listError } = await supabase
-        .from('watchlists')
-        .select('id')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false })
-        .limit(1);
-
-      if (!listError && watchlists && watchlists.length > 0) {
-        existingWatchlist = watchlists[0];
-      }
     }
 
     if (existingWatchlist) {

--- a/frontend/app/api/watchlist/init/route.ts
+++ b/frontend/app/api/watchlist/init/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveDefaultWatchlist } from '@/lib/api/watchlist';
 import { NextResponse } from 'next/server';
 
 /**
@@ -15,37 +16,12 @@ export async function POST() {
     if (auth.error) return auth.error;
     const { user, supabase } = auth;
 
-    // Check if user already has a default watchlist
-    const fetchResult = await supabase
-      .from('watchlists')
-      .select('*')
-      .eq('user_id', user.id)
-      .eq('is_default', true)
-      .single();
-    const fetchError = fetchResult.error;
-    let existingWatchlist = fetchResult.data;
+    // Resolve the user's default watchlist (falls back to most-recent).
+    const { watchlist: existingWatchlist, error: fetchError } = await resolveDefaultWatchlist(supabase, user.id);
 
-    if (fetchError && fetchError.code !== 'PGRST116') {
-      // PGRST116 = no rows returned, which is expected if no watchlist exists
+    if (fetchError) {
       console.error('Error fetching watchlist:', fetchError);
       return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
-    }
-
-    // If no default watchlist found, use most recent watchlist (fallback)
-    // This prevents creating duplicate watchlists when is_default flag is missing
-    if (!existingWatchlist && fetchError?.code === 'PGRST116') {
-      console.log('[Watchlist Init] No default watchlist found, trying most recent');
-      const { data: watchlists, error: listError } = await supabase
-        .from('watchlists')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false })
-        .limit(1);
-
-      if (!listError && watchlists && watchlists.length > 0) {
-        existingWatchlist = watchlists[0];
-        console.log('[Watchlist Init] Using most recent watchlist as fallback:', existingWatchlist.id);
-      }
     }
 
     // If watchlist exists, return it

--- a/frontend/app/api/watchlist/remove/route.ts
+++ b/frontend/app/api/watchlist/remove/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveDefaultWatchlist } from '@/lib/api/watchlist';
 import { isValidUuid } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 
@@ -29,31 +30,16 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Invalid team ID format' }, { status: 400 });
     }
 
-    // Get user's default watchlist
-    const { data: watchlist, error: watchlistError } = await supabase
-      .from('watchlists')
-      .select('id')
-      .eq('user_id', user.id)
-      .eq('is_default', true)
-      .single();
+    // Get user's default watchlist (falls back to most-recent).
+    const { watchlist: resolvedWatchlist, error: watchlistError } = await resolveDefaultWatchlist<{ id: string }>(
+      supabase,
+      user.id,
+      'id'
+    );
 
-    if (watchlistError && watchlistError.code !== 'PGRST116') {
+    if (watchlistError) {
       console.error('Error fetching watchlist:', watchlistError);
       return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
-    }
-
-    // Fallback: if no default watchlist found, try to find the most recent one
-    let resolvedWatchlist = watchlist;
-    if (!resolvedWatchlist) {
-      const { data: fallbackWatchlist } = await supabase
-        .from('watchlists')
-        .select('id')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false })
-        .limit(1)
-        .single();
-
-      resolvedWatchlist = fallbackWatchlist;
     }
 
     if (!resolvedWatchlist) {

--- a/frontend/app/api/watchlist/route.ts
+++ b/frontend/app/api/watchlist/route.ts
@@ -1,4 +1,5 @@
 import { requirePremium } from '@/lib/api/requirePremium';
+import { resolveDefaultWatchlist } from '@/lib/api/watchlist';
 import { NextResponse } from 'next/server';
 
 /**
@@ -59,33 +60,10 @@ export async function GET() {
     if (auth.error) return auth.error;
     const { user, supabase } = auth;
 
-    // Get user's default watchlist
-    // First try to find default watchlist
-    let { data: watchlist, error: watchlistError } = await supabase
-      .from('watchlists')
-      .select('*')
-      .eq('user_id', user.id)
-      .eq('is_default', true)
-      .single();
+    // Resolve the user's default watchlist (falls back to most-recent).
+    const { watchlist, error: watchlistError } = await resolveDefaultWatchlist(supabase, user.id);
 
-    // If no default watchlist found, get the most recent watchlist (fallback)
-    // This handles cases where watchlists exist but is_default flag is missing
-    if (!watchlist && watchlistError?.code === 'PGRST116') {
-      const { data: watchlists, error: listError } = await supabase
-        .from('watchlists')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false })
-        .limit(1);
-
-      if (listError) {
-        watchlistError = listError;
-      } else if (watchlists && watchlists.length > 0) {
-        watchlist = watchlists[0];
-      }
-    }
-
-    if (watchlistError && watchlistError.code !== 'PGRST116') {
+    if (watchlistError) {
       console.error('Error fetching watchlist:', watchlistError);
       return NextResponse.json({ error: 'Failed to fetch watchlist' }, { status: 500 });
     }

--- a/frontend/lib/api/__tests__/watchlist.test.ts
+++ b/frontend/lib/api/__tests__/watchlist.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveDefaultWatchlist } from '../watchlist';
+
+type QueryResult = { data: unknown; error: unknown };
+
+// supabase-like stub: chainable methods return the builder; the primary lookup
+// terminates on `.single()`, the fallback on `.limit()`.
+function makeSupabase(primary: QueryResult, fallback: QueryResult = { data: [], error: null }) {
+  const from = vi.fn(() => {
+    const builder: Record<string, unknown> = {};
+    for (const m of ['select', 'eq', 'order']) builder[m] = vi.fn(() => builder);
+    builder.single = vi.fn(() => Promise.resolve(primary));
+    builder.limit = vi.fn(() => Promise.resolve(fallback));
+    return builder;
+  });
+  return { from } as unknown as Parameters<typeof resolveDefaultWatchlist>[0];
+}
+
+describe('resolveDefaultWatchlist', () => {
+  it('returns the default watchlist when present (no fallback)', async () => {
+    const supabase = makeSupabase({ data: { id: 'wl-1' }, error: null });
+    const { watchlist, error } = await resolveDefaultWatchlist(supabase, 'user-1');
+    expect(watchlist).toEqual({ id: 'wl-1' });
+    expect(error).toBeNull();
+  });
+
+  it('surfaces a non-PGRST116 primary error for the caller to 500', async () => {
+    const dbError = { code: '42501', message: 'permission denied' };
+    const supabase = makeSupabase({ data: null, error: dbError });
+    const { watchlist, error } = await resolveDefaultWatchlist(supabase, 'user-1');
+    expect(watchlist).toBeNull();
+    expect(error).toEqual(dbError);
+  });
+
+  it('falls back to the most-recent watchlist when no default row exists', async () => {
+    const supabase = makeSupabase({ data: null, error: { code: 'PGRST116' } }, { data: [{ id: 'wl-2' }], error: null });
+    const { watchlist, error } = await resolveDefaultWatchlist(supabase, 'user-1');
+    expect(watchlist).toEqual({ id: 'wl-2' });
+    expect(error).toBeNull();
+  });
+
+  it('returns null when the user has no watchlists at all', async () => {
+    const supabase = makeSupabase({ data: null, error: { code: 'PGRST116' } }, { data: [], error: null });
+    const { watchlist, error } = await resolveDefaultWatchlist(supabase, 'user-1');
+    expect(watchlist).toBeNull();
+    expect(error).toBeNull();
+  });
+});

--- a/frontend/lib/api/watchlist.ts
+++ b/frontend/lib/api/watchlist.ts
@@ -1,0 +1,50 @@
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+
+export interface WatchlistRow {
+  id: string;
+  name: string;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Resolve a user's default watchlist: the `is_default` row if present, otherwise
+ * the most-recently-created watchlist (covers rows where the flag was never set),
+ * otherwise null.
+ *
+ * A non-"no rows" (PGRST116) error on the primary lookup is returned for the
+ * caller to surface as a 500; a failed *fallback* lookup yields null rather than
+ * an error (callers that need a watchlist create one).
+ *
+ * Consolidates a resolution block that had drifted across the watchlist
+ * GET/add/init/remove routes.
+ */
+export async function resolveDefaultWatchlist<T extends { id: string } = WatchlistRow>(
+  supabase: SupabaseClient,
+  userId: string,
+  columns = '*'
+): Promise<{ watchlist: T | null; error: PostgrestError | null }> {
+  const primary = await supabase
+    .from('watchlists')
+    .select(columns)
+    .eq('user_id', userId)
+    .eq('is_default', true)
+    .single();
+
+  if (primary.error && primary.error.code !== 'PGRST116') {
+    return { watchlist: null, error: primary.error };
+  }
+  if (primary.data) {
+    return { watchlist: primary.data as unknown as T, error: null };
+  }
+
+  const fallback = await supabase
+    .from('watchlists')
+    .select(columns)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  return { watchlist: (fallback.data?.[0] as unknown as T) ?? null, error: null };
+}


### PR DESCRIPTION
**PR5 (Test Coverage) — lead slice**, which also closes the final **Consistency** item from the audit.

## What changed
The "find the user's default watchlist, fall back to most-recent" block was copy-pasted across the watchlist **GET / add / init / remove** routes and had **drifted**: different fallback shapes (`.single()` vs `.limit()`), error checks before vs after the fallback, and gate conditions. Extracted `lib/api/watchlist.ts` `resolveDefaultWatchlist()` with one canonical behavior, added unit tests, and routed all four handlers through it.

**−78 lines** across the 4 routes.

## Behavior
- **Preserved**: add/init still create-on-miss; remove still returns "no watchlist" on miss; the primary-lookup non-PGRST116 error → 500 path is unchanged everywhere.
- **One intentional unification**: `GET /api/watchlist` now returns an empty watchlist (rather than 500) if the *fallback* lookup itself errors — a rare edge that was handled inconsistently across the four routes.

## Tests (the safety net I flagged)
New `lib/api/__tests__/watchlist.test.ts` covers the resolver's four paths: default present, non-PGRST116 error surfaced, fallback-to-most-recent, and no-watchlists-at-all. This is why the refactor is safe to make on these previously-untested premium routes.

## Verification
`tsc --noEmit` clean · eslint clean · **299/299 tests pass** (4 new) · the pre-existing `watchlist/remove` test still passes · husky lint-staged passed on commit.

## PR5 remaining slices (follow-ups)
team-mutation admin route tests, `lib/api` auth-helper tests, rateLimit boundary tests, middleware plan-gate tests, internal-analytics "rejects non-admin" contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)