### PR TITLE
test(api): cover requireAuth, optionalAuth, parseJsonBody (audit)

### DIFF
--- a/frontend/lib/api/__tests__/auth-helpers.test.ts
+++ b/frontend/lib/api/__tests__/auth-helpers.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Hoisted so it's available inside the hoisted vi.mock factory.
+const { mockGetUser } = vi.hoisted(() => ({ mockGetUser: vi.fn() }));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabase: vi.fn(async () => ({ auth: { getUser: mockGetUser } }) as unknown as SupabaseClient),
+}));
+
+import { parseJsonBody } from '../parseJsonBody';
+import { requireAuth } from '../requireAuth';
+import { optionalAuth } from '../optionalAuth';
+
+function jsonRequest(raw: string): Request {
+  return new Request('http://localhost/api/x', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: raw,
+  });
+}
+
+describe('parseJsonBody', () => {
+  it('returns parsed data for a valid JSON body', async () => {
+    const result = await parseJsonBody<{ a: number }>(jsonRequest('{"a":1}'));
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ a: 1 });
+  });
+
+  it('returns a 400 NextResponse for malformed JSON', async () => {
+    const result = await parseJsonBody(jsonRequest('{not valid json'));
+    expect(result.data).toBeNull();
+    expect(result.error?.status).toBe(400);
+    expect(await result.error?.json()).toEqual({ error: 'Invalid request body' });
+  });
+});
+
+describe('requireAuth', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the user and supabase client when authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'a@b.com' } }, error: null });
+    const auth = await requireAuth();
+    expect(auth.error).toBeNull();
+    expect(auth.user).toEqual({ id: 'u1', email: 'a@b.com' });
+    expect(auth.supabase).toBeTruthy();
+  });
+
+  it('returns 401 when no user is present', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const auth = await requireAuth();
+    expect(auth.user).toBeNull();
+    expect(auth.supabase).toBeNull();
+    expect(auth.error?.status).toBe(401);
+  });
+
+  it('returns 401 when getUser reports an auth error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'bad jwt' } });
+    const auth = await requireAuth();
+    expect(auth.error?.status).toBe(401);
+  });
+
+  it('returns 500 when getUser throws', async () => {
+    mockGetUser.mockRejectedValue(new Error('network down'));
+    const auth = await requireAuth();
+    expect(auth.user).toBeNull();
+    expect(auth.error?.status).toBe(500);
+  });
+});
+
+describe('optionalAuth', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the user and supabase client when authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null });
+    const { user, supabase } = await optionalAuth();
+    expect(user).toEqual({ id: 'u1' });
+    expect(supabase).toBeTruthy();
+  });
+
+  it('returns nulls (no error) when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const { user, supabase } = await optionalAuth();
+    expect(user).toBeNull();
+    expect(supabase).toBeNull();
+  });
+
+  it('returns nulls (never throws) when getUser throws', async () => {
+    mockGetUser.mockRejectedValue(new Error('boom'));
+    const { user, supabase } = await optionalAuth();
+    expect(user).toBeNull();
+    expect(supabase).toBeNull();
+  });
+});


### PR DESCRIPTION
**PR5 (Test Coverage)** slice. Test-only — no source changes.

## What changed
The `lib/api` auth choke points (`requireAuth`, `optionalAuth`, `parseJsonBody`) had no direct tests despite gating most API routes. Added `lib/api/__tests__/auth-helpers.test.ts` (9 cases) by mocking `createServerSupabase().auth.getUser()`:

- **parseJsonBody** — valid body parses; malformed JSON → 400 `{ error: 'Invalid request body' }`.
- **requireAuth** — authed → `{ user, supabase }`; no user → 401; `getUser` auth error → 401; `getUser` throws → 500.
- **optionalAuth** — authed → `{ user, supabase }`; unauthed → nulls; throws → nulls (never errors).

## Verification
**308/308 tests pass** (9 new) · `tsc --noEmit` clean · eslint clean · husky lint-staged passed.

## PR5 remaining slices
team-mutation admin route tests, middleware plan-gate tests, internal-analytics "rejects non-admin" contract, `lib/watchlist`/`lib/admin` data-access, `getSubscriptionMetrics`. (`rateLimit.ts` already has tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)