### PR TITLE
test(api): cover admin mutation routes — merge/revert/create-team/link/unlink (audit)

### DIFF
--- a/frontend/app/api/create-team/__tests__/route.test.ts
+++ b/frontend/app/api/create-team/__tests__/route.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse, type NextRequest } from 'next/server';
+import { serviceClientMock } from '@/test/supabase-mock';
+
+const { mockRequireAdmin, mockCreateServiceSupabase } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockCreateServiceSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('@/lib/supabase/service', () => ({ createServiceSupabase: mockCreateServiceSupabase }));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/create-team', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+// Valid base payload: opponentProviderId matches the game's home side below.
+const validBody = {
+  gameId: 'game-1',
+  opponentProviderId: '999',
+  teamName: 'New Team FC',
+  ageGroup: 'u14',
+  gender: 'Male',
+};
+
+let svc: ReturnType<typeof serviceClientMock>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  svc = serviceClientMock();
+  mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1' }, supabase: {}, error: null });
+  mockCreateServiceSupabase.mockReturnValue(svc.client);
+});
+
+describe('POST /api/create-team', () => {
+  it('returns the requireAdmin error and never touches the database for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(403);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const { teamName: _omit, ...withoutName } = validBody;
+    const res = await POST(makeRequest(withoutName));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing required fields/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid gender', async () => {
+    const res = await POST(makeRequest({ ...validBody, gender: 'Coed' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/male.*female/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a malformed age group', async () => {
+    const res = await POST(makeRequest({ ...validBody, ageGroup: '14' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/age group/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the game does not exist', async () => {
+    svc.queueFrom('games', { data: null, error: { message: 'no rows' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/game not found/i);
+  });
+
+  it('returns 400 when the opponent provider id is not referenced by the game', async () => {
+    svc.queueFrom('games', {
+      data: { provider_id: null, home_provider_id: '111', away_provider_id: '222' },
+      error: null,
+    });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/does not match any team/i);
+    // Bailed before creating anything.
+    expect(svc.from).not.toHaveBeenCalledWith('teams');
+  });
+
+  it('returns 500 when the team insert fails', async () => {
+    svc.queueFrom('games', {
+      data: { provider_id: null, home_provider_id: '999', away_provider_id: '222' },
+      error: null,
+    });
+    svc.queueFrom('teams', { error: { message: 'duplicate key' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/failed to create team/i);
+  });
+
+  it('returns 500 when the alias mapping fails after the team is created', async () => {
+    svc.queueFrom('games', {
+      data: { provider_id: null, home_provider_id: '999', away_provider_id: '222' },
+      error: null,
+    });
+    svc.queueFrom('teams', { error: null });
+    svc.queueFrom('team_alias_map', { error: { message: 'conflict' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/alias mapping failed/i);
+  });
+
+  it('creates the team, backfills games, and reports the linked count', async () => {
+    svc.queueFrom(
+      'games',
+      { data: { provider_id: null, home_provider_id: '999', away_provider_id: '222' }, error: null }, // initial lookup
+      { data: [{ id: 'g1' }, { id: 'g2' }], error: null }, // home backfill (2 rows)
+      { data: [], error: null } // away backfill (0 rows)
+    );
+    svc.queueFrom('teams', { error: null });
+    svc.queueFrom('team_alias_map', { error: null });
+    svc.queueFrom('team_link_audit', { error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, teamName: 'New Team FC', gamesUpdated: 2 });
+    expect(body.teamIdMaster).toBeTruthy();
+    expect(svc.from).toHaveBeenCalledWith('teams');
+    expect(svc.from).toHaveBeenCalledWith('team_alias_map');
+    // provider_id was null, so the GotSport scrape enqueue is skipped.
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('enqueues a priority scrape when the new team belongs to a GotSport game', async () => {
+    svc.queueFrom(
+      'games',
+      { data: { provider_id: 'prov-1', home_provider_id: '999', away_provider_id: '222' }, error: null },
+      { data: [{ id: 'g1' }], error: null },
+      { data: [], error: null }
+    );
+    svc.queueFrom('teams', { error: null });
+    svc.queueFrom('team_alias_map', { error: null });
+    svc.queueFrom('team_link_audit', { error: null });
+    svc.queueFrom('providers', { data: { code: 'gotsport' }, error: null });
+    svc.queueRpc({ error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(200);
+    expect(svc.rpc).toHaveBeenCalledWith(
+      'enqueue_scrape_request',
+      expect.objectContaining({ p_priority: 1, p_request_type: 'new_team' })
+    );
+  });
+
+  it('still succeeds when the non-fatal scrape enqueue throws', async () => {
+    svc.queueFrom(
+      'games',
+      { data: { provider_id: 'prov-1', home_provider_id: '999', away_provider_id: '222' }, error: null },
+      { data: [{ id: 'g1' }], error: null },
+      { data: [], error: null }
+    );
+    svc.queueFrom('teams', { error: null });
+    svc.queueFrom('team_alias_map', { error: null });
+    svc.queueFrom('team_link_audit', { error: null });
+    svc.queueFrom('providers', { data: { code: 'gotsport' }, error: null });
+    svc.rpc.mockRejectedValueOnce(new Error('queue down'));
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+});

--- a/frontend/app/api/link-opponent/__tests__/route.test.ts
+++ b/frontend/app/api/link-opponent/__tests__/route.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse, type NextRequest } from 'next/server';
+import { serviceClientMock } from '@/test/supabase-mock';
+
+const { mockRequireAdmin, mockCreateServiceSupabase } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockCreateServiceSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('@/lib/supabase/service', () => ({ createServiceSupabase: mockCreateServiceSupabase }));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/link-opponent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+const TEAM = 'team-1';
+const validBody = { gameId: 'game-1', opponentProviderId: '999', teamIdMaster: TEAM };
+
+const linkedTeam = {
+  team_id_master: TEAM,
+  team_name: 'Linked FC',
+  club_name: 'Linked Club',
+  age_group: 'u14',
+  gender: 'Male',
+};
+
+// A game where provider 999 is the (still-unlinked) home side.
+function unlinkedHomeGame() {
+  return {
+    id: 'game-1',
+    provider_id: 'prov-1',
+    home_provider_id: '999',
+    away_provider_id: '222',
+    home_team_master_id: null,
+    away_team_master_id: null,
+  };
+}
+
+let svc: ReturnType<typeof serviceClientMock>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  svc = serviceClientMock();
+  mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1' }, supabase: {}, error: null });
+  mockCreateServiceSupabase.mockReturnValue(svc.client);
+});
+
+describe('POST /api/link-opponent', () => {
+  it('returns the requireAdmin error and never touches the database for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(403);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await POST(makeRequest({ gameId: 'game-1' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing required fields/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the team does not exist', async () => {
+    svc.queueFrom('teams', { data: null, error: { message: 'no rows' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/team not found/i);
+  });
+
+  it('returns 404 when the game does not exist', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom('games', { data: null, error: { message: 'no rows' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/game not found/i);
+  });
+
+  it('returns 400 when the opponent side is already linked', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom('games', { data: { ...unlinkedHomeGame(), home_team_master_id: 'someone-else' }, error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/already linked/i);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the provider id matches neither side of the game', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom('games', { data: { ...unlinkedHomeGame(), home_provider_id: '111' }, error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/does not match any team/i);
+  });
+
+  it('links the clicked game via the link_game_team RPC and creates the alias', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom(
+      'games',
+      { data: unlinkedHomeGame(), error: null }, // initial lookup
+      { data: { id: 'game-1', home_team_master_id: TEAM }, error: null } // verification re-fetch
+    );
+    svc.queueRpc({ data: true, error: null });
+    svc.queueFrom('team_alias_map', { error: null });
+    svc.queueFrom('team_link_audit', { error: null });
+
+    const res = await POST(makeRequest({ ...validBody, applyToAllGames: false }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      teamName: 'Linked FC',
+      gamesUpdated: 1,
+      aliasCreated: true,
+    });
+    expect(svc.rpc).toHaveBeenCalledWith(
+      'link_game_team',
+      expect.objectContaining({ p_game_id: 'game-1', p_team_id_master: TEAM, p_is_home_team: true })
+    );
+    expect(svc.from).toHaveBeenCalledWith('team_alias_map');
+  });
+
+  it('returns 500 when the database silently rejects the link (verification fails)', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom(
+      'games',
+      { data: unlinkedHomeGame(), error: null },
+      { data: { id: 'game-1', home_team_master_id: null }, error: null } // re-fetch shows no change
+    );
+    svc.queueRpc({ data: false, error: null }); // RPC reports no row affected
+
+    const res = await POST(makeRequest({ ...validBody, applyToAllGames: false }));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/rejected the change/i);
+    // Alias must NOT be written when the link could not be proven.
+    expect(svc.from).not.toHaveBeenCalledWith('team_alias_map');
+  });
+
+  it('returns 500 when the alias upsert fails after the game is linked', async () => {
+    svc.queueFrom('teams', { data: linkedTeam, error: null });
+    svc.queueFrom(
+      'games',
+      { data: unlinkedHomeGame(), error: null },
+      { data: { id: 'game-1', home_team_master_id: TEAM }, error: null }
+    );
+    svc.queueRpc({ data: true, error: null });
+    svc.queueFrom('team_alias_map', { error: { message: 'conflict' } });
+
+    const res = await POST(makeRequest({ ...validBody, applyToAllGames: false }));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/alias mapping failed/i);
+  });
+});

--- a/frontend/app/api/team-merge/__tests__/route.test.ts
+++ b/frontend/app/api/team-merge/__tests__/route.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse, type NextRequest } from 'next/server';
+import { serviceClientMock } from '@/test/supabase-mock';
+
+// Hoisted so they're available inside the hoisted vi.mock factories.
+const { mockRequireAdmin, mockCreateServiceSupabase } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockCreateServiceSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('@/lib/supabase/service', () => ({ createServiceSupabase: mockCreateServiceSupabase }));
+
+import { POST, DELETE } from '../route';
+
+const DEPRECATED = '11111111-1111-1111-1111-111111111111';
+const CANONICAL = '22222222-2222-2222-2222-222222222222';
+
+function makeRequest(method: 'POST' | 'DELETE', body: unknown) {
+  return new Request('http://localhost/api/team-merge', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+let svc: ReturnType<typeof serviceClientMock>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  svc = serviceClientMock();
+  mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1' }, supabase: {}, error: null });
+  mockCreateServiceSupabase.mockReturnValue(svc.client);
+});
+
+describe('POST /api/team-merge (execute merge)', () => {
+  it('returns the requireAdmin error and never touches the database for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when a malformed JSON body cannot be parsed', async () => {
+    const bad = new Request('http://localhost/api/team-merge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not json',
+    }) as NextRequest;
+
+    const res = await POST(bad);
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid request body/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await POST(makeRequest('POST', { deprecatedTeamId: DEPRECATED }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing required fields/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-UUID team id before any query', async () => {
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: 'not-a-uuid', canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid team id format/i);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when merging a team with itself', async () => {
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: DEPRECATED, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/with itself/i);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('executes the merge and returns both team names on success', async () => {
+    svc.queueRpc({ data: { success: true, merge_id: 'merge-1' }, error: null });
+    svc.queueFrom('teams', {
+      data: [
+        { team_id_master: DEPRECATED, team_name: 'Old FC' },
+        { team_id_master: CANONICAL, team_name: 'New FC' },
+      ],
+      error: null,
+    });
+
+    const res = await POST(
+      makeRequest('POST', {
+        deprecatedTeamId: DEPRECATED,
+        canonicalTeamId: CANONICAL,
+        mergedBy: 'admin-1',
+        mergeReason: 'dup',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      mergeId: 'merge-1',
+      deprecatedTeamName: 'Old FC',
+      canonicalTeamName: 'New FC',
+    });
+    // The merge must go through the SECURITY DEFINER RPC, not a raw update.
+    expect(svc.rpc).toHaveBeenCalledWith(
+      'execute_team_merge',
+      expect.objectContaining({
+        p_deprecated_team_id: DEPRECATED,
+        p_canonical_team_id: CANONICAL,
+        p_merged_by: 'admin-1',
+      })
+    );
+  });
+
+  it('maps an "already merged" RPC failure to 409', async () => {
+    svc.queueRpc({ data: { success: false, error: 'team is already deprecated' }, error: null });
+
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/already been merged/i);
+  });
+
+  it('maps a circular/chain RPC failure to 400', async () => {
+    svc.queueRpc({ data: { success: false, error: 'canonical team is marked as deprecated' }, error: null });
+
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/circular or chain/i);
+  });
+
+  it('maps a "does not exist" RPC failure to 404', async () => {
+    svc.queueRpc({ data: { success: false, error: 'team does not exist' }, error: null });
+
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 on an unexpected PostgREST error', async () => {
+    svc.queueRpc({ data: null, error: { message: 'connection reset' } });
+
+    const res = await POST(
+      makeRequest('POST', { deprecatedTeamId: DEPRECATED, canonicalTeamId: CANONICAL, mergedBy: 'admin-1' })
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/team-merge (revert merge)', () => {
+  it('returns the requireAdmin error for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Not authenticated' }, { status: 401 }),
+    });
+
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: DEPRECATED, revertedBy: 'admin-1' }));
+
+    expect(res.status).toBe(401);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: DEPRECATED }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing required fields/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-UUID team id', async () => {
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: 'nope', revertedBy: 'admin-1' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid team id format/i);
+  });
+
+  it('returns 404 when the team has no merge record', async () => {
+    svc.queueFrom('teams', { data: { team_name: 'Old FC' }, error: null });
+    svc.queueFrom('team_merge_map', { data: null, error: null });
+
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: DEPRECATED, revertedBy: 'admin-1' }));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/not currently merged/i);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the merge-record lookup errors', async () => {
+    svc.queueFrom('teams', { data: { team_name: 'Old FC' }, error: null });
+    svc.queueFrom('team_merge_map', { data: null, error: { message: 'boom' } });
+
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: DEPRECATED, revertedBy: 'admin-1' }));
+
+    expect(res.status).toBe(500);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('reverts the merge by resolved merge id and returns the team name', async () => {
+    svc.queueFrom('teams', { data: { team_name: 'Old FC' }, error: null });
+    svc.queueFrom('team_merge_map', { data: { id: 'merge-1' }, error: null });
+    svc.queueRpc({ data: { success: true }, error: null });
+
+    const res = await DELETE(
+      makeRequest('DELETE', { deprecatedTeamId: DEPRECATED, revertedBy: 'admin-1', revertReason: 'oops' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, teamName: 'Old FC' });
+    expect(svc.rpc).toHaveBeenCalledWith(
+      'revert_team_merge',
+      expect.objectContaining({ p_merge_id: 'merge-1', p_reverted_by: 'admin-1' })
+    );
+  });
+
+  it('maps a "not merged" revert RPC failure to 404', async () => {
+    svc.queueFrom('teams', { data: { team_name: 'Old FC' }, error: null });
+    svc.queueFrom('team_merge_map', { data: { id: 'merge-1' }, error: null });
+    svc.queueRpc({ data: { success: false, error: 'merge not found' }, error: null });
+
+    const res = await DELETE(makeRequest('DELETE', { deprecatedTeamId: DEPRECATED, revertedBy: 'admin-1' }));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/frontend/app/api/unlink-opponent/__tests__/route.test.ts
+++ b/frontend/app/api/unlink-opponent/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse, type NextRequest } from 'next/server';
+import { serviceClientMock } from '@/test/supabase-mock';
+
+const { mockRequireAdmin, mockCreateServiceSupabase } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockCreateServiceSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('@/lib/supabase/service', () => ({ createServiceSupabase: mockCreateServiceSupabase }));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/unlink-opponent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+const TEAM = 'team-1';
+const validBody = { gameId: 'game-1', opponentProviderId: '999', teamIdMaster: TEAM };
+
+// A game where provider 999 is the home side, currently linked to TEAM.
+function linkedHomeGame() {
+  return {
+    id: 'game-1',
+    provider_id: 'prov-1',
+    home_provider_id: '999',
+    away_provider_id: '222',
+    home_team_master_id: TEAM,
+    away_team_master_id: null,
+  };
+}
+
+let svc: ReturnType<typeof serviceClientMock>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  svc = serviceClientMock();
+  mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1' }, supabase: {}, error: null });
+  mockCreateServiceSupabase.mockReturnValue(svc.client);
+});
+
+describe('POST /api/unlink-opponent', () => {
+  it('returns the requireAdmin error and never touches the database for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(403);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await POST(makeRequest({ gameId: 'game-1' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing required fields/i);
+    expect(mockCreateServiceSupabase).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the game does not exist', async () => {
+    svc.queueFrom('games', { data: null, error: { message: 'no rows' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/game not found/i);
+  });
+
+  it('returns 400 when the game has no provider', async () => {
+    svc.queueFrom('games', { data: { ...linkedHomeGame(), provider_id: null }, error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/no provider/i);
+  });
+
+  it('returns 400 when the provider id matches neither side of the game', async () => {
+    svc.queueFrom('games', { data: { ...linkedHomeGame(), home_provider_id: '111' }, error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/does not match any team/i);
+  });
+
+  it('returns 400 when the linked team does not match the expected team', async () => {
+    svc.queueFrom('games', { data: { ...linkedHomeGame(), home_team_master_id: 'someone-else' }, error: null });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/team mismatch/i);
+    expect(svc.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the unlink RPC fails', async () => {
+    svc.queueFrom('games', { data: linkedHomeGame(), error: null });
+    svc.queueRpc({ error: { message: 'constraint violation', code: '23503' } });
+
+    const res = await POST(makeRequest(validBody));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/failed to unlink/i);
+  });
+
+  it('unlinks the single clicked game via RPC and removes the alias', async () => {
+    svc.queueFrom('games', { data: linkedHomeGame(), error: null });
+    svc.queueRpc({ error: null });
+    svc.queueFrom('team_alias_map', { error: null });
+    svc.queueFrom('team_link_audit', { error: null });
+
+    const res = await POST(makeRequest({ ...validBody, unlinkAllGames: false }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, gamesUpdated: 1, aliasRemoved: true });
+    expect(svc.rpc).toHaveBeenCalledWith(
+      'unlink_game_team',
+      expect.objectContaining({ p_game_id: 'game-1', p_team_id_master: TEAM, p_is_home_team: true })
+    );
+  });
+
+  it('also unlinks matching games and reports aliasRemoved false when the alias delete errors', async () => {
+    svc.queueFrom(
+      'games',
+      { data: linkedHomeGame(), error: null }, // initial lookup
+      { data: [{ id: 'g2' }], error: null }, // home bulk unlink (1 row)
+      { data: [], error: null } // away bulk unlink (0 rows)
+    );
+    svc.queueRpc({ error: null });
+    svc.queueFrom('team_alias_map', { error: { message: 'fk still referenced' } });
+    svc.queueFrom('team_link_audit', { error: null });
+
+    const res = await POST(makeRequest({ ...validBody, unlinkAllGames: true }));
+
+    expect(res.status).toBe(200);
+    // 1 clicked game + 1 matching game unlinked; alias delete failed (non-fatal).
+    expect(await res.json()).toMatchObject({ success: true, gamesUpdated: 2, aliasRemoved: false });
+  });
+});

--- a/frontend/test/supabase-mock.ts
+++ b/frontend/test/supabase-mock.ts
@@ -1,0 +1,57 @@
+import { vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type QueryResult = { data?: unknown; error?: unknown };
+
+/**
+ * A chainable Supabase query-builder mock.
+ *
+ * Filter/mutation methods (select, insert, eq, …) all return the same builder,
+ * so a route can chain them in any order. The builder is awaitable (thenable)
+ * and also exposes .single()/.maybeSingle(); all three resolve to the supplied
+ * result. This mirrors how a real PostgREST builder is consumed — either by
+ * awaiting the chain directly or by calling a row terminator.
+ */
+export function queryBuilder(result: QueryResult = { data: null, error: null }) {
+  const builder: Record<string, unknown> = {};
+  const resolved = Promise.resolve(result);
+  const chainable = ['select', 'insert', 'upsert', 'update', 'delete', 'eq', 'in', 'is', 'neq', 'order', 'limit'];
+  for (const method of chainable) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.single = vi.fn(() => resolved);
+  builder.maybeSingle = vi.fn(() => resolved);
+  builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+    resolved.then(onFulfilled, onRejected);
+  return builder;
+}
+
+/**
+ * A service-role Supabase client mock for admin route handlers.
+ *
+ * `.from(table)` returns the next queued result for that table (FIFO), and
+ * `.rpc(name)` returns the next queued RPC result. Both default to an empty
+ * success when nothing is queued. Queue results per test with
+ * queueFrom()/queueRpc(); assert interactions on the exposed `from`/`rpc` spies.
+ */
+export function serviceClientMock() {
+  const fromQueues: Record<string, QueryResult[]> = {};
+  const rpcQueue: QueryResult[] = [];
+
+  const from = vi.fn((table: string) =>
+    queryBuilder((fromQueues[table] ??= []).shift() ?? { data: null, error: null })
+  );
+  const rpc = vi.fn(() => Promise.resolve(rpcQueue.shift() ?? { data: null, error: null }));
+
+  return {
+    client: { from, rpc } as unknown as SupabaseClient,
+    from,
+    rpc,
+    queueFrom(table: string, ...results: QueryResult[]) {
+      (fromQueues[table] ??= []).push(...results);
+    },
+    queueRpc(...results: QueryResult[]) {
+      rpcQueue.push(...results);
+    },
+  };
+}


### PR DESCRIPTION
## What

Adds vitest coverage for the previously-untested **admin team-management mutation routes**, continuing the PR5 Test Coverage slice of the 2026-06-10 audit remediation. No production code changes — tests + one shared test helper only.

| Route | Methods covered |
|-------|-----------------|
| `app/api/team-merge` | POST (execute merge) + DELETE (revert) |
| `app/api/create-team` | POST |
| `app/api/link-opponent` | POST |
| `app/api/unlink-opponent` | POST |

## Coverage per route

- **team-merge** — admin gate; validation (missing fields, bad UUID, self-merge, malformed JSON); `execute_team_merge` / `revert_team_merge` happy paths; business-error mappings (409 already-merged, 404 not-found, 400 circular/chain, 500 PostgREST); revert lookup-error and not-merged branches.
- **create-team** — admin gate; field/gender/age-format validation; game-not-found; opponent mismatch; team-insert and alias-upsert failures; backfill happy path; GotSport priority-scrape enqueue hook (including its non-fatal failure path).
- **link-opponent** — admin gate; validation; team/game not found; already-linked; provider mismatch; `link_game_team` happy path; verification-failure and alias-upsert 500s.
- **unlink-opponent** — admin gate; validation; no-provider; provider mismatch; team mismatch; `unlink_game_team` single-game happy path; bulk unlink with non-fatal alias-delete failure.

Every route gates on `requireAdmin` and operates through the service-role client. The new `frontend/test/supabase-mock.ts` provides a chainable query-builder + service-client mock that queues results per-table (`.from`) and per-RPC (`.rpc`), keeping each suite terse and order-independent.

## Verification

- `vitest run` — 4 new files, **46 tests pass**; full suite **354 pass** (no regressions)
- `tsc --noEmit` clean · `eslint` clean · `prettier --check` clean

## Notes

- Engine untouched (frozen). This is a pure test/coverage PR.
- While writing the link-opponent happy path I noticed the success-response `gamesUpdated` count appears to over-count the clicked game by 1 when `applyToAllGames` is on (the specific game is added both via the `specificGameUpdated` flag and inside `homeUpdated`/`awayUpdated`). Display-only — the DB writes are correct. Left as-is here to keep this PR characterization-only; flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)