### PR TITLE
test(api): cover internal-analytics admin gate + report factory (audit)

### DIFF
--- a/frontend/app/api/internal/analytics/chat/__tests__/route.test.ts
+++ b/frontend/app/api/internal/analytics/chat/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const { mockRequireAdmin } = vi.hoisted(() => ({ mockRequireAdmin: vi.fn() }));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+
+import { POST } from '../route';
+
+const URL = 'http://localhost/api/internal/analytics/chat';
+
+function textMessage(text: string) {
+  return { role: 'user', parts: [{ type: 'text', text }] };
+}
+
+function chatRequest(body: unknown): Request {
+  return new Request(URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A request whose declared content-length trips the 413 guard before parsing. */
+function oversizedRequest(): Request {
+  const req = new Request(URL, { method: 'POST', body: '{}' });
+  Object.defineProperty(req, 'headers', {
+    value: new Headers({ 'content-length': '600000' }),
+    configurable: true,
+  });
+  return req;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({
+    user: { id: 'admin-1', email: 'admin@pitchrank.io' },
+    supabase: {},
+    error: null,
+  });
+});
+
+describe('POST /api/internal/analytics/chat', () => {
+  it('returns the requireAdmin error for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST(chatRequest({ messages: [textMessage('hi')] }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an oversized payload by content-length before parsing it (413)', async () => {
+    const res = await POST(oversizedRequest());
+
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toMatch(/too large/i);
+  });
+
+  it('returns 400 when messages is empty', async () => {
+    const res = await POST(chatRequest({ messages: [] }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/messages array is required/i);
+  });
+
+  it('returns 400 when messages is missing entirely', async () => {
+    const res = await POST(chatRequest({ range: 'last_7_days' }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/messages array is required/i);
+  });
+
+  it('returns 400 when there are too many messages', async () => {
+    const res = await POST(chatRequest({ messages: Array.from({ length: 51 }, () => textMessage('hi')) }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/too many messages/i);
+  });
+
+  it('returns 400 when the total conversation text is too large', async () => {
+    const res = await POST(chatRequest({ messages: [textMessage('x'.repeat(100_001))] }));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/conversation too large/i);
+  });
+});

--- a/frontend/app/api/internal/analytics/meta/__tests__/route.test.ts
+++ b/frontend/app/api/internal/analytics/meta/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const { mockRequireAdmin } = vi.hoisted(() => ({ mockRequireAdmin: vi.fn() }));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+
+import { GET } from '../route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({
+    user: { id: 'admin-1', email: 'admin@pitchrank.io' },
+    supabase: {},
+    error: null,
+  });
+});
+
+describe('GET /api/internal/analytics/meta', () => {
+  it('returns the requireAdmin error for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the analytics config for an admin', async () => {
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ admin_email: 'admin@pitchrank.io', timezone: 'America/Phoenix' });
+    expect(Array.isArray(body.presets)).toBe(true);
+    expect(body.default_preset).toBeTruthy();
+    expect(body.ga4_property_id).toBeTruthy();
+    expect(body.gsc_site_url).toBeTruthy();
+  });
+
+  it('reports a null admin_email when the admin has no email', async () => {
+    mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1' }, supabase: {}, error: null });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).admin_email).toBeNull();
+  });
+});

--- a/frontend/app/api/internal/analytics/refresh/__tests__/route.test.ts
+++ b/frontend/app/api/internal/analytics/refresh/__tests__/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const { mockRequireAdmin, mockRevalidateTag } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockRevalidateTag: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('next/cache', () => ({ revalidateTag: mockRevalidateTag }));
+
+import { POST } from '../route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({
+    user: { id: 'admin-1', email: 'admin@pitchrank.io' },
+    supabase: {},
+    error: null,
+  });
+});
+
+describe('POST /api/internal/analytics/refresh', () => {
+  it('returns the requireAdmin error and revalidates nothing for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await POST();
+
+    expect(res.status).toBe(403);
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('busts both analytics cache tags and acknowledges for an admin', async () => {
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.refreshed_at).toBe('string');
+    expect(mockRevalidateTag).toHaveBeenCalledWith('analytics:ga4', 'max');
+    expect(mockRevalidateTag).toHaveBeenCalledWith('analytics:gsc', 'max');
+  });
+});

--- a/frontend/lib/internal-analytics/__tests__/make-report-route.test.ts
+++ b/frontend/lib/internal-analytics/__tests__/make-report-route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import { TaxonomyAwareError } from '@/lib/internal-analytics/queries/_error';
+
+const { mockRequireAdmin, mockRunReport } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockRunReport: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock('@/lib/internal-analytics/report-registry', () => ({ runReport: mockRunReport }));
+
+import { makeReportRoute } from '../make-report-route';
+
+// The factory is typed against ReportKey; tests use real keys so the param
+// assertions read naturally. Casting keeps the test independent of the registry.
+const OVERVIEW = 'ga4_traffic_overview' as Parameters<typeof makeReportRoute>[0];
+const TOP_PAGES = 'ga4_top_pages' as Parameters<typeof makeReportRoute>[0];
+
+function makeRequest(query = ''): Request {
+  return new Request(`http://localhost/api/internal/analytics/ga4/overview${query}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({ user: { id: 'admin-1', email: 'a@pitchrank.io' }, supabase: {}, error: null });
+  mockRunReport.mockResolvedValue({ rows: [] });
+});
+
+describe('makeReportRoute', () => {
+  it('returns the requireAdmin error and never runs the report for a non-admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      user: null,
+      supabase: null,
+      error: NextResponse.json({ error: 'Admin access required' }, { status: 403 }),
+    });
+
+    const res = await makeReportRoute(OVERVIEW)(makeRequest());
+
+    expect(res.status).toBe(403);
+    expect(mockRunReport).not.toHaveBeenCalled();
+  });
+
+  it('runs the report with the default range and returns its JSON', async () => {
+    mockRunReport.mockResolvedValue({ rows: [{ users: 5 }] });
+
+    const res = await makeReportRoute(OVERVIEW)(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ rows: [{ users: 5 }] });
+    expect(mockRunReport).toHaveBeenCalledWith(OVERVIEW, { date_range: 'last_7_days' });
+  });
+
+  it('passes the requested range through to the report', async () => {
+    await makeReportRoute(OVERVIEW)(makeRequest('?range=last_30_days'));
+
+    expect(mockRunReport).toHaveBeenCalledWith(OVERVIEW, { date_range: 'last_30_days' });
+  });
+
+  it('parses limit for top-N reports, defaulting to 10', async () => {
+    await makeReportRoute(TOP_PAGES, 'limit')(makeRequest('?limit=25'));
+    expect(mockRunReport).toHaveBeenCalledWith(TOP_PAGES, { date_range: 'last_7_days', limit: 25 });
+
+    mockRunReport.mockClear();
+    await makeReportRoute(TOP_PAGES, 'limit')(makeRequest());
+    expect(mockRunReport).toHaveBeenCalledWith(TOP_PAGES, { date_range: 'last_7_days', limit: 10 });
+  });
+
+  it('parses compare=1 into compare_to_previous for trend reports', async () => {
+    await makeReportRoute(OVERVIEW, 'compare')(makeRequest('?compare=1'));
+    expect(mockRunReport).toHaveBeenCalledWith(OVERVIEW, { date_range: 'last_7_days', compare_to_previous: true });
+
+    mockRunReport.mockClear();
+    await makeReportRoute(OVERVIEW, 'compare')(makeRequest('?compare=0'));
+    expect(mockRunReport).toHaveBeenCalledWith(OVERVIEW, { date_range: 'last_7_days', compare_to_previous: false });
+  });
+
+  it('maps a TaxonomyAwareError to a 500 carrying the taxonomy label', async () => {
+    mockRunReport.mockRejectedValue(
+      new TaxonomyAwareError({ type: 'AUTH', message: 'Google API authorization failed', retryable: false })
+    );
+
+    const res = await makeReportRoute(OVERVIEW)(makeRequest());
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: { type: 'AUTH', message: 'Google API authorization failed', retryable: false },
+    });
+  });
+
+  it('rethrows non-taxonomy errors so they surface as a framework 500', async () => {
+    mockRunReport.mockRejectedValue(new Error('unexpected boom'));
+
+    await expect(makeReportRoute(OVERVIEW)(makeRequest())).rejects.toThrow('unexpected boom');
+  });
+});


### PR DESCRIPTION
## What

Pins the **non-admin contract** and shared behavior of the admin-only internal analytics endpoints — the next PR5 Test Coverage slice of the 2026-06-10 audit. Tests only; no production code, engine untouched.

The 13 `app/api/internal/analytics/*` routes all gate on `requireAdmin` but had **zero route-level tests**. The 11 GA4/GSC report routes funnel through the `makeReportRoute` factory (from #894), so testing the factory once covers their shared contract; `meta`, `refresh`, and `chat` are covered directly.

## Coverage

- **make-report-route factory** — `requireAdmin` gate (the report never runs for a non-admin), `range` default + passthrough, `limit`/`compare` param parsing, `TaxonomyAwareError` → 500 carrying the taxonomy label, and non-taxonomy error rethrow (surfaces as a framework 500).
- **meta** — admin gate; config payload shape (presets, ids, `admin_email`, timezone), including the null-email case.
- **refresh** — admin gate (no cache bust for non-admins); both `analytics:ga4` / `analytics:gsc` tags revalidated on success.
- **chat** — admin gate plus the payload-DoS guards: **413** by `content-length` before parsing, and **400** for empty / too-many (>50) / too-large (>100k chars) histories. The `streamText` model path is intentionally out of scope.

## Verification

- `vitest run` — 4 new files, **18 tests pass**; full suite **372 pass** (was 354, no regressions)
- `tsc --noEmit` clean · `eslint` clean · `prettier --check` clean

## Notes

- Middleware plan-gate tests (the slice I'd named next) **already exist on main** and are comprehensive — skipped as already done; picked the genuinely-untested analytics routes instead.
- Engine untouched (frozen). Pure test/coverage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)