### PR TITLE
docs(agentic): fix seo-content skill frontmatter + README AI pointer (audit)

### DIFF
--- a/.claude/skills/seo-content/SKILL.md
+++ b/.claude/skills/seo-content/SKILL.md
@@ -1,4 +1,3 @@
-<!-- Updated: 2026-02-07 -->
 ---
 name: seo-content
 description: >
@@ -6,6 +5,8 @@ description: >
   Use when user says "content quality", "E-E-A-T", "content analysis",
   "readability check", "thin content", or "content audit".
 ---
+
+<!-- Updated: 2026-02-07 -->
 
 # Content Quality & E-E-A-T Analysis
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive ranking system for youth soccer teams with cross-age and cross-state support.
 
+> **Working with Claude Code or another AI agent?** Start with [`CLAUDE.md`](CLAUDE.md) for repo conventions, architecture, and workflow guidance — plus [`frontend/CLAUDE.md`](frontend/CLAUDE.md) for the Next.js app.
+
 ## 🎯 Features
 
 - **National Rankings**: Rankings by age group (U10-U19) and gender


### PR DESCRIPTION
## What

The two **safe** Agentic Setup leftovers from the 2026-06-10 audit — no tooling restructure.

- **`.claude/skills/seo-content/SKILL.md`**: an `<!-- Updated -->` HTML comment sat on line 1, *before* the `---`, so the YAML frontmatter wasn't at the start of the file and the skill's `name`/`description` didn't parse — leaving the skill undiscoverable. Moved the comment below the frontmatter; it now parses.
- **`README.md`**: added a short pointer directing AI agents to `CLAUDE.md` (and `frontend/CLAUDE.md`).

## Deferred (reshapes personal tooling — left for a deliberate pass)

Per discussion, these were intentionally **not** included since they change the shape of the `.claude/` setup:
- Rename the 7 flat `*.skill.md` → `name/SKILL.md` dirs (so Claude Code auto-discovers them)
- Add frontmatter to `pr/SKILL.md` (or retire it — `create-pr` already exists)
- Move safety hooks/formatters from gitignored `settings.local.json` into a committed `settings.json`
- A curated `docs/` key-index for the 128 docs files

## Verification

- seo-content frontmatter parses (name + description extracted); README links resolve to existing files.
- Docs/config only — no code, engine untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)