### PR TITLE
fix(frontend): serve homepage stats from a daily-cached count

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1310,35 +1310,21 @@ export const api = {
    * @returns Object with totalGames and totalTeams counts
    */
   async getDbStats(): Promise<{ totalGames: number; totalTeams: number }> {
-    // Get total games count (only games with valid team IDs and scores)
-    const { count: gamesCount, error: gamesError } = await supabase
-      .from('games')
-      .select('*', { count: 'exact', head: true })
-      .not('home_team_master_id', 'is', null)
-      .not('away_team_master_id', 'is', null)
-      .not('home_score', 'is', null)
-      .not('away_score', 'is', null)
-      .eq('is_excluded', false);
+    // Read the daily-refreshed homepage_stats cache via get_db_stats(); an exact
+    // count over ~1.3M games can't finish under the anon role's 3s statement
+    // timeout, so it must be precomputed off the request path.
+    const { data, error } = await supabase.rpc('get_db_stats');
 
-    if (gamesError) {
-      console.error('Error fetching games count:', gamesError);
-      throw gamesError;
+    if (error) {
+      console.error('Error fetching db stats via RPC:', error);
+      throw error;
     }
 
-    // Get total ranked teams count from rankings_view (only active teams)
-    const { count: teamsCount, error: teamsError } = await supabase
-      .from('rankings_view')
-      .select('*', { count: 'exact', head: true })
-      .not('power_score_final', 'is', null);
-
-    if (teamsError) {
-      console.error('Error fetching teams count:', teamsError);
-      throw teamsError;
-    }
+    const stats = Array.isArray(data) ? data[0] : data;
 
     return {
-      totalGames: gamesCount || 0,
-      totalTeams: teamsCount || 0,
+      totalGames: Number(stats?.total_games) || 0,
+      totalTeams: Number(stats?.total_teams) || 0,
     };
   },
 

--- a/supabase/migrations/20260615200000_homepage_stats_cache.sql
+++ b/supabase/migrations/20260615200000_homepage_stats_cache.sql
@@ -1,0 +1,80 @@
+-- Cache the home page hero figures so the page render never runs the slow exact
+-- counts. The home page is statically rendered through the Data API under the
+-- anon role (3s statement_timeout); an exact COUNT(*) over ~1.3M games takes
+-- ~25s, so it timed out and froze the page on its hardcoded 16,000 / 2,800
+-- fallbacks. A daily job recomputes the exact counts off the request path and
+-- get_db_stats() serves the single cached row.
+
+CREATE TABLE IF NOT EXISTS homepage_stats (
+  id BOOLEAN PRIMARY KEY DEFAULT TRUE,
+  total_games BIGINT NOT NULL DEFAULT 0,
+  total_teams BIGINT NOT NULL DEFAULT 0,
+  refreshed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT homepage_stats_singleton CHECK (id)
+);
+
+-- Figures are public (rendered on the home page) but only ever written by the
+-- scheduled refresh and read through get_db_stats(); no direct Data API access.
+ALTER TABLE homepage_stats ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON homepage_stats
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE homepage_stats IS
+  'Single-row cache of the home page hero figures (games analyzed, active teams ranked). Recomputed daily by refresh_homepage_stats() so the render path never runs the slow exact counts.';
+
+-- Recompute the exact figures and upsert the singleton row. SECURITY DEFINER so
+-- the daily job bypasses RLS; raised statement_timeout because the exact games
+-- count runs ~25s, past any role default.
+CREATE OR REPLACE FUNCTION refresh_homepage_stats()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+SET statement_timeout = '300s'
+AS $$
+BEGIN
+  INSERT INTO public.homepage_stats (id, total_games, total_teams, refreshed_at)
+  VALUES (
+    TRUE,
+    (SELECT COUNT(*)
+       FROM public.games
+      WHERE home_team_master_id IS NOT NULL
+        AND away_team_master_id IS NOT NULL
+        AND home_score IS NOT NULL
+        AND away_score IS NOT NULL
+        AND is_excluded = FALSE),
+    (SELECT COUNT(*)
+       FROM public.rankings_full
+      WHERE status = 'Active'),
+    NOW()
+  )
+  ON CONFLICT (id) DO UPDATE
+    SET total_games = EXCLUDED.total_games,
+        total_teams = EXCLUDED.total_teams,
+        refreshed_at = EXCLUDED.refreshed_at;
+END;
+$$;
+
+-- Serve the cached row. Keeps the prior get_db_stats() shape (total_games,
+-- total_teams) so callers are unchanged.
+CREATE OR REPLACE FUNCTION get_db_stats()
+RETURNS TABLE (total_games BIGINT, total_teams BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT total_games, total_teams
+  FROM public.homepage_stats
+  WHERE id = TRUE;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_db_stats() TO anon;
+GRANT EXECUTE ON FUNCTION get_db_stats() TO authenticated;
+
+COMMENT ON FUNCTION get_db_stats() IS
+  'Returns the cached home page figures (games analyzed, active teams ranked) from homepage_stats; refreshed daily by refresh_homepage_stats().';
+
+-- Seed immediately so the row exists with real data before the first cron run.
+SELECT refresh_homepage_stats();

--- a/supabase/migrations/20260615200000_homepage_stats_cache.sql
+++ b/supabase/migrations/20260615200000_homepage_stats_cache.sql
@@ -45,8 +45,11 @@ BEGIN
         AND away_score IS NOT NULL
         AND is_excluded = FALSE),
     (SELECT COUNT(*)
-       FROM public.rankings_full
-      WHERE status = 'Active'),
+       FROM public.rankings_full rf
+       JOIN public.teams t ON t.team_id_master = rf.team_id
+      WHERE rf.status = 'Active'
+        AND t.is_deprecated IS NOT TRUE
+        AND rf.power_score_final IS NOT NULL),
     NOW()
   )
   ON CONFLICT (id) DO UPDATE
@@ -55,6 +58,10 @@ BEGIN
         refreshed_at = EXCLUDED.refreshed_at;
 END;
 $$;
+
+-- Writer RPC: revoke the default PUBLIC execute so a public client can't drive the
+-- ~25s recompute onto the request path. The daily cron runs as the owner (postgres).
+REVOKE EXECUTE ON FUNCTION refresh_homepage_stats() FROM PUBLIC, anon, authenticated;
 
 -- Serve the cached row. Keeps the prior get_db_stats() shape (total_games,
 -- total_teams) so callers are unchanged.

--- a/supabase/migrations/20260615200001_schedule_homepage_stats_refresh.sql
+++ b/supabase/migrations/20260615200001_schedule_homepage_stats_refresh.sql
@@ -1,0 +1,12 @@
+-- Refresh the home page stats cache once a day, off the request path. pg_cron
+-- runs in-database (no GitHub Actions schedule drift); the offset minute keeps it
+-- off the top of the hour. cron.schedule upserts by job name, so this is
+-- idempotent on re-apply.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+SELECT cron.schedule(
+  'refresh-homepage-stats',
+  '13 8 * * *',
+  $$ SELECT public.refresh_homepage_stats(); $$
+);


### PR DESCRIPTION
## Problem
The homepage hero stats were stuck on the hardcoded `16,000 Games Analyzed / 2,800 Teams Ranked` fallbacks.

Root cause: #903 moved the stat fetch into the server-rendered, ISR-cached homepage. `api.getDbStats()` runs an exact `COUNT(*)` over ~1.3M `games` rows, which takes **~24.5s** (`EXPLAIN ANALYZE` confirmed). The static render runs under the Supabase **anon role (3s `statement_timeout`)**, so the query throws `57014`, the `try/catch` in `page.tsx` swallows it, and the fallback values get baked into the cached HTML — permanently.

## Fix
- **`homepage_stats`** single-row cache table (RLS on, service-role-only, mirrors `outreach_targets`).
- **`refresh_homepage_stats()`** recomputes the exact `games` count + `status='Active'` teams count off the request path (SECURITY DEFINER, raised `statement_timeout`).
- **`pg_cron`** job `refresh-homepage-stats` runs it daily at 08:13 UTC.
- **`get_db_stats()`** rewritten to read the cached row instantly (well under 3s).
- **`api.getDbStats()`** points at the RPC instead of the two slow exact-count queries.

Note: "Teams Ranked" now counts **active** teams (~59,555) rather than all rows with a power score (~124,800), per request.

## Result
Homepage shows the exact **1,272,204 Games Analyzed / 59,555 Teams Ranked**, served instantly, refreshed daily.

## Deploy state
Both migrations are **already applied to production** (cache seeded, cron scheduled, verified) — this PR tracks them in source control and ships the frontend change. After merge + Vercel deploy, the homepage uses the fast RPC; an ISR revalidation (or redeploy) replaces the baked-in fallback HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)