### PR TITLE
fix(marketing): skip Beehiiv newsletter + CI-proof blog commits

### DIFF
--- a/.github/workflows/marketing-pipeline.yml
+++ b/.github/workflows/marketing-pipeline.yml
@@ -59,6 +59,20 @@ jobs:
           pip install supabase python-dotenv requests rich markdown
 
       # ---------------------------------------------------------------
+      # 3b. NODE SETUP (for blog formatting + llms.txt regeneration)
+      # ---------------------------------------------------------------
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      # ---------------------------------------------------------------
       # 4. RUN PIPELINE
       # ---------------------------------------------------------------
       - name: Run marketing pipeline
@@ -68,6 +82,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           BEEHIIV_API_KEY: ${{ secrets.BEEHIIV_API_KEY }}
           BEEHIIV_PUBLICATION_ID: ${{ secrets.BEEHIIV_PUBLICATION_ID }}
+          BEEHIIV_NEWSLETTER_ENABLED: ${{ vars.BEEHIIV_NEWSLETTER_ENABLED || 'false' }}
           POSTIZ_API_KEY: ${{ secrets.POSTIZ_API_KEY }}
           POSTIZ_DRAFTS_ENABLED: ${{ vars.POSTIZ_DRAFTS_ENABLED || 'true' }}
           POSTIZ_TAG_INCLUDE_AUTO_APPROVED: 'true'

--- a/frontend/content/blog/2026-06-15-massachusetts-youth-soccer-rankings.md
+++ b/frontend/content/blog/2026-06-15-massachusetts-youth-soccer-rankings.md
@@ -1,13 +1,13 @@
 ---
 title: "Massachusetts Youth Soccer Rankings: This Week's Top Movers"
-slug: "2026-06-15-massachusetts-youth-soccer-rankings"
+slug: '2026-06-15-massachusetts-youth-soccer-rankings'
 excerpt: "This week's MA youth soccer rankings update. See which MA teams moved the most across 92,331 ranked teams."
-author: "PitchRank Team"
-date: "2026-06-15"
-readingTime: "1 min read"
-tags: ["Rankings", "State Guide", "Massachusetts"]
-target_keyword: "massachusetts youth soccer rankings"
-image: "/api/infographic/movers?platform=twitter"
+author: 'PitchRank Team'
+date: '2026-06-15'
+readingTime: '1 min read'
+tags: ['Rankings', 'State Guide', 'Massachusetts']
+target_keyword: 'massachusetts youth soccer rankings'
+image: '/api/infographic/movers?platform=twitter'
 ---
 
 # Massachusetts Youth Soccer Rankings: This Week's Top Movers
@@ -17,23 +17,23 @@ We track 92,331 teams nationally, and here's what moved in MA this week.
 
 ## Top Movers in MA This Week
 
-| Rank | Team | State | Change |
-|------|------|-------|--------|
-| #22 | Scorpion SC 2012 ECNL | MA | +94 |
-| #26 | FC Stars ECNL 2013 | MA | +79 |
-| #16 | 2013 ECNL | MA | +74 |
-| #37 | 2013 GA Navy | MA | +66 |
-| #30 | West 2012 EDP | MA | +60 |
+| Rank | Team                  | State | Change |
+| ---- | --------------------- | ----- | ------ |
+| #22  | Scorpion SC 2012 ECNL | MA    | +94    |
+| #26  | FC Stars ECNL 2013    | MA    | +79    |
+| #16  | 2013 ECNL             | MA    | +74    |
+| #37  | 2013 GA Navy          | MA    | +66    |
+| #30  | West 2012 EDP         | MA    | +60    |
 
 ## Biggest Drops in MA
 
-| Rank | Team | State | Change |
-|------|------|-------|--------|
-| #42 | 2013 Elite White | MA | -36 |
-| #49 | FC Stars Acton 2012 White | MA | -36 |
-| #48 | FC Stars East 2012 Blue | MA | -34 |
-| #44 | FC Greater Boston Bolts U13 HD | MA | -33 |
-| #43 | NEFC - NEFC Blackstone Valley U16 Red | MA | -31 |
+| Rank | Team                                  | State | Change |
+| ---- | ------------------------------------- | ----- | ------ |
+| #42  | 2013 Elite White                      | MA    | -36    |
+| #49  | FC Stars Acton 2012 White             | MA    | -36    |
+| #48  | FC Stars East 2012 Blue               | MA    | -34    |
+| #44  | FC Greater Boston Bolts U13 HD        | MA    | -33    |
+| #43  | NEFC - NEFC Blackstone Valley U16 Red | MA    | -31    |
 
 ## How MA Compares Nationally
 

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -12,6 +12,7 @@ PitchRank provides the most accurate youth soccer rankings in the United States,
 ## Blog
 *State-specific guides are listed under State Pillars below.*
 
+- [Massachusetts Youth Soccer Rankings: This Week's Top Movers](https://www.pitchrank.io/blog/2026-06-15-massachusetts-youth-soccer-rankings): This week's MA youth soccer rankings update. See which MA teams moved the most across 92,331 ranked teams.
 - [Best Youth Soccer Ranking Websites for Parents (2026)](https://www.pitchrank.io/blog/best-youth-soccer-ranking-websites-2026): An honest comparison of youth soccer ranking sites — PitchRank, GotSport, SoccerWire, USARank, and TopDrawerSoccer. What each one does, how they work, and which is right for your family.
 - [Youth Soccer Levels Explained: ECNL, MLS NEXT, NPL](https://www.pitchrank.io/blog/youth-soccer-levels-explained): ECNL, MLS NEXT, NPL, GA, National League — what every US youth soccer level actually means for your kid. Plain English, no jargon.
 - [PA U10 Boys Soccer Rankings 2026: Top 25 Teams in Pennsylvania](https://www.pitchrank.io/blog/pa-u10-boys-soccer-rankings): The top 25 U10 boys soccer teams in Pennsylvania, ranked by PowerScore. FC DELCO, Philadelphia Union SWAG, Pittsburgh Riverhounds — see where your team stands.

--- a/scripts/marketing_pipeline.py
+++ b/scripts/marketing_pipeline.py
@@ -925,9 +925,31 @@ def commit_and_push_blog_post(filename: str, content: str) -> bool:
     filepath.write_text(content, encoding="utf-8")
     log.info(f"Wrote blog post: {filepath}")
 
+    frontend_dir = PROJECT_ROOT / "frontend"
+    llms_txt = frontend_dir / "public" / "llms.txt"
+
     try:
+        # Format the generated post and regenerate llms.txt before committing — the
+        # local Claude hook that normally does this doesn't run in CI, so an
+        # unformatted post or a stale llms.txt would fail the repo's checks.
         subprocess.run(
-            ["git", "add", str(filepath)],
+            ["npx", "prettier", "--write", str(filepath)],
+            check=True,
+            cwd=frontend_dir,
+            timeout=120,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["npm", "run", "generate-llms"],
+            check=True,
+            cwd=frontend_dir,
+            timeout=120,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "add", str(filepath), str(llms_txt)],
             check=True,
             cwd=PROJECT_ROOT,
             timeout=30,
@@ -960,9 +982,9 @@ def commit_and_push_blog_post(filename: str, content: str) -> bool:
         )
         log.info("Blog post committed and pushed to main")
         return True
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
         stderr = getattr(e, "stderr", "")
-        log.error(f"Git operation failed: {e}\n{stderr}")
+        log.error(f"Blog publish step failed: {e}\n{stderr}")
         return False
 
 
@@ -1817,11 +1839,17 @@ def main():
         log.info("Artifacts saved. No Postiz API calls made (Supabase reads ran for data fetch + handle enrichment).")
         return
 
-    # Step 6: Publish newsletter to Beehiiv
+    # Step 6: Publish newsletter to Beehiiv (disabled by default — Beehiiv's send
+    # endpoint requires the enterprise plan; set BEEHIIV_NEWSLETTER_ENABLED=true to
+    # re-enable once on a plan that allows API sends).
+    newsletter_enabled = os.getenv("BEEHIIV_NEWSLETTER_ENABLED", "false").lower() == "true"
     newsletter_ok = False
     newsletter_skipped = False
     if args.postiz_only:
         log.info("--postiz-only: skipping Beehiiv newsletter send")
+    elif not newsletter_enabled:
+        log.info("BEEHIIV_NEWSLETTER_ENABLED is not true — skipping Beehiiv newsletter send")
+        newsletter_skipped = True
     elif not has_movers:
         # Quiet week: the newsletter is mover-centric, so skip it. Track the skip
         # separately from success so the exit guard doesn't read it as "delivered".


### PR DESCRIPTION
The 2026-06-15 weekly marketing pipeline run (manual dispatch) surfaced several failures. This PR fixes the actionable ones and unblocks `main`.

## Changes

**1. Skip the Beehiiv newsletter (P0)**
The send returned `403 SEND_API_NOT_ENTERPRISE_PLAN` — `status="confirmed"` uses Beehiiv's enterprise-only Send API. Per Dallas, we're dropping the newsletter for now. The send is gated behind `BEEHIIV_NEWSLETTER_ENABLED` (default `false`, wired as a repo variable, mirroring `POSTIZ_DRAFTS_ENABLED`). Result: the newsletter is reported `SKIPPED`, not `FAILED`, and `live_run_failed` treats it as a non-delivery rather than an outage. Flip the repo var to re-enable if we ever move to a qualifying plan.

**2. CI-proof the weekly blog commit (P1)**
`commit_and_push_blog_post` pushed the generated markdown unformatted and never regenerated `llms.txt` — the local Claude hook that normally does this doesn't run on the GitHub Actions runner, so `prettier --check` and the `llms.txt` sync check went red. The function now runs `prettier --write` on the post and `npm run generate-llms`, then commits both. The workflow installed Python only, so it now also sets up Node + `npm ci`.

**3. Unblock current `main`**
The already-committed MA post is prettier-formatted and `llms.txt` regenerated (adds the MA entry). Content unchanged — frontmatter quote style + markdown table alignment only.

## Not included
- **Milestone-movers 400** (gracefully caught → 0 milestones): query logic is valid (reproduced 739 rows in SQL; the identical `status` filter succeeds elsewhere in the same run). Likely long-silent; left as-is per scope.
- **Trend-research `2026-W25.json` missing**: handled separately (data file, its own PR).

## Verification
- `prettier --check` passes on the MA post; `llms.txt` regen is deterministic.
- `py_compile` + `ruff check` clean on `marketing_pipeline.py`; workflow YAML parses.
- Committed markdown blob is LF (CI prettier-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)