### PR TITLE
fix(home): decouple stats from movers so a movers timeout can't blank stats

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,19 +14,29 @@ export const revalidate = 3600;
 
 export default async function Home() {
   // Fetch above-the-fold data server-side; degrade to fallbacks on failure so a
-  // Supabase hiccup never breaks the static render.
+  // Supabase hiccup never breaks the static render. Stats (a cheap cached read)
+  // and movers (a heavy national-cohort scan that can hit the anon statement
+  // timeout during the bulk static build) are fetched independently so a movers
+  // failure can't blank the stats.
   let totalGames: number | undefined;
   let totalTeams: number | undefined;
   let movers7d: RankingRow[] = [];
   let movers30d: RankingRow[] = [];
+
   try {
-    const [stats, national] = await Promise.all([api.getDbStats(), api.getRankings(null, 'u12', 'M')]);
+    const stats = await api.getDbStats();
     totalGames = stats.totalGames;
     totalTeams = stats.totalTeams;
+  } catch (e) {
+    console.error('[home] stats fetch failed, using fallbacks:', e);
+  }
+
+  try {
+    const national = await api.getRankings(null, 'u12', 'M');
     movers7d = selectTopMovers(national, '7d', 5);
     movers30d = selectTopMovers(national, '30d', 5);
   } catch (e) {
-    console.error('[home] server data fetch failed, using fallbacks:', e);
+    console.error('[home] movers fetch failed, using empty lists:', e);
   }
 
   return (


### PR DESCRIPTION
## Why the homepage still showed 16,000 after #906

#906 made `get_db_stats` instant, but the homepage was still serving the `16,000` / `2,800` fallbacks. The build log for the #906 production deploy shows the real reason:

```
Error fetching national rankings via RPC: { code: '57014', message: 'canceling statement due to statement timeout' }
[home] server data fetch failed, using fallbacks: {...}
```

The RSC fetched stats **and** the national movers cohort in one `Promise.all` with a single `catch`. During the bulk static build, hundreds of rankings pages hit Supabase concurrently under the anon 3s `statement_timeout`, so the heavy `get_national_rankings` (u12 boys, ~9k rows) times out — rejecting the whole `Promise.all` and baking the stat fallbacks into the static HTML.

## Fix
Split the two into independent `try/catch` blocks. The cached `getDbStats` read (single-row lookup) can't time out, so the hero stats render even when the movers cohort scan fails (movers degrade to empty lists).

## Follow-up (not in this PR)
The movers query itself still times out at build under load and should be made resilient separately (lighter fetch or a precomputed top-movers source). This PR only ensures it can no longer take the stats down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)