### PR TITLE
fix(rankings): roll back #885 publish-only SCF + centered tiers (incident containment)

### DIFF
--- a/src/etl/glicko_config.py
+++ b/src/etl/glicko_config.py
@@ -88,7 +88,12 @@ class GlickoConfig:
     # Dampened mu corrupts every downstream use of ratings (opponent credit, SOS,
     # cross-age global map); publish-only SCF won log-loss in every backtested
     # cohort/cutoff cell while keeping isolated teams out of the top ranks.
-    SCF_PUBLISH_ONLY: bool = True
+    # ROLLBACK 2026-06-15: disabled. The first published run on this flag (#885)
+    # scrambled standings — u14F non-playing teams moved a median of 387 ranks —
+    # because undampened mu fed Layer-13 and the self-referential same-age evidence
+    # gates. Re-enable only behind end-to-end publish-path validation
+    # (scripts/ranking_stability_check.py).
+    SCF_PUBLISH_ONLY: bool = False
     SCF_MIN_UNIQUE_STATES: int = 2
     SCF_DIVERSITY_DIVISOR: float = 4.0
     SCF_FLOOR: float = 0.4
@@ -114,7 +119,9 @@ class GlickoConfig:
     # Tier multiplier application. Centered keeps the intended discount relative to
     # the 1500 neutral rating (effective_mu = 1500 + (mu - 1500) * mult) instead of
     # scaling the raw rating, which over-discounts strong lower-league opponents.
-    TIER_MULT_CENTERED: bool = True
+    # ROLLBACK 2026-06-15: disabled alongside SCF_PUBLISH_ONLY to fully restore
+    # pre-#885 behavior during incident containment.
+    TIER_MULT_CENTERED: bool = False
 
     # SOS post-hoc adjustment (asymmetric scaling of mu before normalization)
     # Weak schedules get a larger shrinkage than strong schedules get a reward.

--- a/tests/unit/test_glicko_engine.py
+++ b/tests/unit/test_glicko_engine.py
@@ -811,8 +811,8 @@ class TestSigmoidZscoreNormalize:
 
 class TestApplyTierMult:
     def test_centered_discount_is_relative_to_neutral(self):
-        """Default centered mode: discount scales the distance from 1500, not the raw rating."""
-        cfg = GlickoConfig()
+        """Centered mode: discount scales the distance from 1500, not the raw rating."""
+        cfg = GlickoConfig(TIER_MULT_CENTERED=True)
         assert abs(_apply_tier_mult(1700.0, 0.95, cfg) - 1690.0) < 0.001
         assert abs(_apply_tier_mult(1300.0, 0.95, cfg) - 1310.0) < 0.001
         assert abs(_apply_tier_mult(1500.0, 0.95, cfg) - 1500.0) < 0.001
@@ -1018,8 +1018,8 @@ class TestSCF:
         return team_df, scf_data
 
     def test_scf_publish_only_leaves_mu_pure(self):
-        """Default SCF_PUBLISH_ONLY: mu is never dampened; dampening moves to the publish path."""
-        cfg = GlickoConfig()
+        """Publish-only SCF: mu is never dampened; dampening moves to the publish path."""
+        cfg = GlickoConfig(SCF_PUBLISH_ONLY=True)
         high_mu = 1700.0
         team_df, scf_data = self._scf_mu_dampening_fixture(high_mu, cfg)
 
@@ -1342,7 +1342,7 @@ class TestComputeRankingsV2:
         """Publish-only SCF: identical results give identical mu, but the isolated
         team's published score is pulled toward neutral. Covers both publish branches."""
         games, state_map = self._isolated_vs_connected_games()
-        cfg = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SOS_ADJ_ENABLED=sos_adj_enabled)
+        cfg = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SOS_ADJ_ENABLED=sos_adj_enabled, SCF_PUBLISH_ONLY=True)
         result = compute_rankings_v2(games, today=pd.Timestamp("2026-03-31"), cfg=cfg, team_state_map=state_map)
         teams = result["teams"].set_index("team_id")
 

--- a/tests/unit/test_glicko_sos_role.py
+++ b/tests/unit/test_glicko_sos_role.py
@@ -189,9 +189,9 @@ class TestGlickoSOSAblations:
         assert _max_abs_diff(teams_baseline, teams_altered, "power_score_final") > 1e-6
 
     def test_scf_is_post_convergence_sos_and_publish_dampening(self):
-        """Default SCF_PUBLISH_ONLY: SCF dampens SOS and the published score; mu stays pure."""
+        """Publish-only SCF: SCF dampens SOS and the published score; mu stays pure."""
         games, state_map = _build_isolated_bubble_fixture()
-        scf_on = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SCF_ENABLED=True)
+        scf_on = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SCF_ENABLED=True, SCF_PUBLISH_ONLY=True)
         scf_off = GlickoConfig(MIN_GAMES_PROVISIONAL=1, SCF_ENABLED=False)
 
         converged_on, _ = run_glicko2_cohort(games, scf_on, pd.Timestamp("2026-03-31"))


### PR DESCRIPTION
## Incident containment — rolls back #885

The first published run on #885 (publish-only SCF + centered tier multipliers, merged 2026-06-12) scrambled the standings. In u14F, teams that did **not play a single game** since the prior snapshot still moved a **median of 387 ranks** (avg 480; 88% moved ≥50, 79% ≥100). The whole top tier reshuffled — an 8-4-4 team published at #9, a 30-0-0 (raw glicko #1) demoted to #5.

## Root cause (publish path, not the Glicko core)
#885 stopped dampening internal `mu`. Undampened `mu` then flowed into:
- **Layer-13**, which re-fits an XGBoost residual model every run on `powerscore_adj` features — so the model re-fit and `ml_norm` swung; and
- the **self-referential same-age evidence gates** (`_compute_same_age_evidence_metrics`), whose opponent rank/power lookups are built from the current run's own `powerscore_adj`.

The ML adjustment is bounded (±0.04 in score space), but in a dense top cohort (top-25 within ~0.06 of `powerscore_adj`) a modest move reorders hundreds of teams, and the self-referential gates re-amplify. The engine-scope backtest never exercised this: Layer 13 was explicitly out of the loop and the end-to-end publish-path comparison was left an optional, skipped pre-merge gate.

## Change
Set `SCF_PUBLISH_ONLY=False` and `TIER_MULT_CENTERED=False` — the rollback path #885 designed. The cache fingerprint includes both flags, so the next run forces a clean recompute. No code removed; fully reversible.

## Verify after rerun
`python scripts/ranking_stability_check.py --prev-date <broken-run-date>` (added in #910). Expect non-playing-team churn to collapse toward ~0 and both FAILs to clear.

## Re-enable criteria
Only behind end-to-end publish-path validation (the gate added in #910) — not engine/mu-scope backtests alone.

Refs #885, #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)