### PR TITLE
fix(infographic): size Instagram graphics to fit long team names

### DIFF
--- a/frontend/app/api/infographic/_shared/components.tsx
+++ b/frontend/app/api/infographic/_shared/components.tsx
@@ -117,6 +117,7 @@ export function RankRow({
   teamName,
   club,
   isStory,
+  fluid = false,
   children,
 }: {
   rank: number;
@@ -124,18 +125,23 @@ export function RankRow({
   teamName: string;
   club: string;
   isStory: boolean;
+  fluid?: boolean;
   children: ReactNode;
 }) {
+  const nameSize = isStory ? 28 : 23;
   return (
     <div
       style={{
         display: 'flex',
         alignItems: 'center',
-        flex: 1,
+        // Fluid rows size to their own content (1 or 2 lines) and stay vertically
+        // centered, so a long team name never clips or knocks the rank/stat columns
+        // out of alignment. Fixed layouts keep the original equal-height fill.
+        ...(fluid ? { flexShrink: 0 } : { flex: 1 }),
         background: accent ? COLORS.rowTop3 : COLORS.rowDim,
         borderLeft: `5px solid ${accent ?? COLORS.rowBorderDim}`,
         borderRadius: 10,
-        padding: isStory ? '0 26px' : '0 22px',
+        padding: fluid ? (isStory ? '16px 26px' : '13px 22px') : isStory ? '0 26px' : '0 22px',
       }}
     >
       <div
@@ -157,13 +163,25 @@ export function RankRow({
             display: 'flex',
             fontFamily: 'Oswald',
             fontWeight: 600,
-            fontSize: isStory ? 28 : 23,
+            fontSize: nameSize,
             color: COLORS.brightWhite,
+            // Cap at two lines so a pathologically long name can't grow unbounded.
+            ...(fluid ? { maxHeight: Math.round(nameSize * 1.3 * 2), overflow: 'hidden' } : {}),
           }}
         >
           {teamName}
         </div>
-        <div style={{ display: 'flex', fontSize: isStory ? 17 : 14, color: COLORS.club, marginTop: 3 }}>{club}</div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: isStory ? 17 : 14,
+            color: COLORS.club,
+            marginTop: 3,
+            ...(fluid ? { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' } : {}),
+          }}
+        >
+          {club}
+        </div>
       </div>
       {children}
     </div>

--- a/frontend/app/api/infographic/_shared/layout.ts
+++ b/frontend/app/api/infographic/_shared/layout.ts
@@ -1,0 +1,25 @@
+// Dynamic sizing for the Instagram (square-by-default) infographics.
+//
+// The feed image starts square (1080×1080) and grows toward portrait — capped at
+// Instagram's 4:5 limit (1080×1350) — only when long team names wrap to a second
+// line, so rows are never clipped and names are never truncated. Story and Twitter
+// keep their fixed dimensions and are unaffected.
+
+export const IG_MIN_HEIGHT = 1080;
+export const IG_MAX_HEIGHT = 1350; // Instagram 4:5 portrait cap
+
+// Oswald is condensed; this is the mean glyph advance as a fraction of the font
+// size, tuned against rendered output. Used only to estimate how many lines a
+// name will occupy so the canvas can be sized to fit it.
+const OSWALD_CHAR_RATIO = 0.52;
+
+export function lineCount(text: string, fontSize: number, maxWidth: number, maxLines = 2): number {
+  const charsPerLine = Math.max(1, Math.floor(maxWidth / (fontSize * OSWALD_CHAR_RATIO)));
+  const lines = Math.ceil((text?.length ?? 0) / charsPerLine);
+  return Math.min(maxLines, Math.max(1, lines));
+}
+
+// Clamp a computed content height into Instagram's allowed range.
+export function clampIgHeight(contentHeight: number): number {
+  return Math.max(IG_MIN_HEIGHT, Math.min(IG_MAX_HEIGHT, Math.round(contentHeight)));
+}

--- a/frontend/app/api/infographic/big-games/route.tsx
+++ b/frontend/app/api/infographic/big-games/route.tsx
@@ -114,9 +114,7 @@ function MatchupRow({ matchup, isStory, fluid = false }: { matchup: Matchup; isS
       style={{
         display: 'flex',
         flexDirection: 'column',
-        // Fluid rows size to their content so a long matchup name never clips the
-        // bottom of the image; fixed layouts keep the original equal-height fill.
-        ...(fluid ? { flexShrink: 0 } : { flex: 1 }),
+        flex: 1,
         background: COLORS.rowDim,
         borderLeft: `5px solid ${COLORS.rowBorderDim}`,
         borderRadius: 10,
@@ -184,23 +182,24 @@ export async function GET(request: Request) {
   const fonts = await loadBrandFonts(origin);
   const games = payload.games.slice(0, 5);
 
-  // Instagram grows from square to fit matchups whose team names wrap to a second
-  // line; story / twitter keep their fixed dimensions.
+  // The matchup rows fill the canvas equally (flex). A two-line matchup name needs
+  // ~150px of row height, so on Instagram the square grows toward the 4:5 cap only
+  // when a name wraps — keeping the rows evenly spread without clipping. Story /
+  // twitter keep their fixed dimensions.
   const fluid = platform === 'instagram';
   const NAME_WIDTH = (1080 - 112 - 44 - 60 - 32) / 2; // per side, minus padding + VS circle
-  const ROW_GAP = 10;
-  const rowsHeight = games.reduce((sum, g) => {
-    const lines = Math.max(lineCount(g.home.name, 22, NAME_WIDTH), lineCount(g.away.name, 22, NAME_WIDTH));
-    return sum + (lines > 1 ? 143 : 119);
-  }, 0);
+  const hasTwoLine = games.some(
+    (g) => Math.max(lineCount(g.home.name, 22, NAME_WIDTH), lineCount(g.away.name, 22, NAME_WIDTH)) > 1
+  );
   const overhead = 112 + (56 + 22 + 60 + 10 + 24 + 30) + 57;
+  const needed = overhead + games.length * (hasTwoLine ? 150 : 0) + Math.max(0, games.length - 1) * 10;
   const width = fluid ? 1080 : d.width;
-  const height = fluid ? clampIgHeight(overhead + rowsHeight + Math.max(0, games.length - 1) * ROW_GAP) : d.height;
+  const height = fluid ? clampIgHeight(needed) : d.height;
 
   return new ImageResponse(
     <Frame isStory={isStory}>
       <Header origin={origin} isStory={isStory} title="BIG GAMES THIS WEEKEND" subtitle={payload.range} />
-      <div style={{ display: 'flex', flexDirection: 'column', gap: isStory ? 14 : 10, ...(fluid ? {} : { flex: 1 }) }}>
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: isStory ? 14 : 10 }}>
         {games.map((matchup, i) => (
           <MatchupRow key={i} matchup={matchup} isStory={isStory} fluid={fluid} />
         ))}

--- a/frontend/app/api/infographic/big-games/route.tsx
+++ b/frontend/app/api/infographic/big-games/route.tsx
@@ -3,6 +3,7 @@ import { checkRateLimit, getClientIp } from '@/lib/api/rateLimit';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, platformDims } from '../_shared/theme';
 import { Frame, Header, Footer } from '../_shared/components';
+import { clampIgHeight, lineCount } from '../_shared/layout';
 
 export const runtime = 'edge';
 
@@ -54,13 +55,16 @@ function TeamBlock({
   state,
   align,
   isStory,
+  fluid = false,
 }: {
   team: MatchupTeam;
   state: string;
   align: 'left' | 'right';
   isStory: boolean;
+  fluid?: boolean;
 }) {
   const alignItems = align === 'left' ? 'flex-start' : 'flex-end';
+  const nameSize = isStory ? 26 : 22;
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1, alignItems, overflow: 'hidden' }}>
       <div
@@ -68,14 +72,25 @@ function TeamBlock({
           display: 'flex',
           fontFamily: 'Oswald',
           fontWeight: 600,
-          fontSize: isStory ? 26 : 22,
+          fontSize: nameSize,
           color: COLORS.brightWhite,
           textAlign: align,
+          // Cap at two lines so a long name can't grow the row unbounded.
+          ...(fluid ? { maxHeight: Math.round(nameSize * 1.3 * 2), overflow: 'hidden' } : {}),
         }}
       >
         {team.name.toUpperCase()}
       </div>
-      <div style={{ display: 'flex', fontSize: isStory ? 16 : 13, color: COLORS.club, marginTop: 3, textAlign: align }}>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: isStory ? 16 : 13,
+          color: COLORS.club,
+          marginTop: 3,
+          textAlign: align,
+          ...(fluid ? { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%' } : {}),
+        }}
+      >
         {team.club}
       </div>
       <div
@@ -93,13 +108,15 @@ function TeamBlock({
   );
 }
 
-function MatchupRow({ matchup, isStory }: { matchup: Matchup; isStory: boolean }) {
+function MatchupRow({ matchup, isStory, fluid = false }: { matchup: Matchup; isStory: boolean; fluid?: boolean }) {
   return (
     <div
       style={{
         display: 'flex',
         flexDirection: 'column',
-        flex: 1,
+        // Fluid rows size to their content so a long matchup name never clips the
+        // bottom of the image; fixed layouts keep the original equal-height fill.
+        ...(fluid ? { flexShrink: 0 } : { flex: 1 }),
         background: COLORS.rowDim,
         borderLeft: `5px solid ${COLORS.rowBorderDim}`,
         borderRadius: 10,
@@ -119,7 +136,7 @@ function MatchupRow({ matchup, isStory }: { matchup: Matchup; isStory: boolean }
         {`${matchup.cohort} · ${matchup.day}`}
       </div>
       <div style={{ display: 'flex', alignItems: 'center', flex: 1, marginTop: 6 }}>
-        <TeamBlock team={matchup.home} state={matchup.state} align="left" isStory={isStory} />
+        <TeamBlock team={matchup.home} state={matchup.state} align="left" isStory={isStory} fluid={fluid} />
         <div
           style={{
             display: 'flex',
@@ -144,7 +161,7 @@ function MatchupRow({ matchup, isStory }: { matchup: Matchup; isStory: boolean }
             VS
           </span>
         </div>
-        <TeamBlock team={matchup.away} state={matchup.state} align="right" isStory={isStory} />
+        <TeamBlock team={matchup.away} state={matchup.state} align="right" isStory={isStory} fluid={fluid} />
       </div>
     </div>
   );
@@ -167,16 +184,29 @@ export async function GET(request: Request) {
   const fonts = await loadBrandFonts(origin);
   const games = payload.games.slice(0, 5);
 
+  // Instagram grows from square to fit matchups whose team names wrap to a second
+  // line; story / twitter keep their fixed dimensions.
+  const fluid = platform === 'instagram';
+  const NAME_WIDTH = (1080 - 112 - 44 - 60 - 32) / 2; // per side, minus padding + VS circle
+  const ROW_GAP = 10;
+  const rowsHeight = games.reduce((sum, g) => {
+    const lines = Math.max(lineCount(g.home.name, 22, NAME_WIDTH), lineCount(g.away.name, 22, NAME_WIDTH));
+    return sum + (lines > 1 ? 143 : 119);
+  }, 0);
+  const overhead = 112 + (56 + 22 + 60 + 10 + 24 + 30) + 57;
+  const width = fluid ? 1080 : d.width;
+  const height = fluid ? clampIgHeight(overhead + rowsHeight + Math.max(0, games.length - 1) * ROW_GAP) : d.height;
+
   return new ImageResponse(
     <Frame isStory={isStory}>
       <Header origin={origin} isStory={isStory} title="BIG GAMES THIS WEEKEND" subtitle={payload.range} />
-      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: isStory ? 14 : 10 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: isStory ? 14 : 10, ...(fluid ? {} : { flex: 1 }) }}>
         {games.map((matchup, i) => (
-          <MatchupRow key={i} matchup={matchup} isStory={isStory} />
+          <MatchupRow key={i} matchup={matchup} isStory={isStory} fluid={fluid} />
         ))}
       </div>
       <Footer isStory={isStory} />
     </Frame>,
-    { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
+    { width, height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
   );
 }

--- a/frontend/app/api/infographic/state/route.tsx
+++ b/frontend/app/api/infographic/state/route.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 import { loadBrandFonts, INFOGRAPHIC_CACHE_CONTROL } from '../_shared/assets';
 import { COLORS, MEDAL, platformDims, formatScore, formatRecord } from '../_shared/theme';
 import { Frame, Header, Footer, RankRow, StatBlock } from '../_shared/components';
+import { clampIgHeight, lineCount } from '../_shared/layout';
 
 export const runtime = 'edge';
 
@@ -97,16 +98,26 @@ export async function GET(request: Request) {
   const stateName = STATE_NAMES[state] || state;
   const genderLabel = isGirls ? 'GIRLS' : 'BOYS';
   const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  const title = `TOP 10 U${age} ${genderLabel} IN ${stateName}`;
+
+  // Instagram grows from square to fit names that wrap to a second line; story /
+  // twitter keep their fixed dimensions. Heights below are the fluid row heights
+  // plus fixed header/footer/padding overhead, tuned against the rendered output.
+  const fluid = platform === 'instagram';
+  const NAME_WIDTH = 1080 - 112 - 54 - 18 - (110 + 92) - 44; // canvas minus rank, stat cols, padding
+  const ROW_GAP = 8;
+  const rowsHeight = teams.reduce(
+    (sum, t) => sum + (lineCount(t.team_name.toUpperCase(), 23, NAME_WIDTH) > 1 ? 105 : 75),
+    0
+  );
+  const overhead = 112 + (56 + 22 + lineCount(title, 50, 968) * 60 + 10 + 24 + 30) + 57;
+  const width = fluid ? 1080 : d.width;
+  const height = fluid ? clampIgHeight(overhead + rowsHeight + Math.max(0, teams.length - 1) * ROW_GAP) : d.height;
 
   return new ImageResponse(
     <Frame isStory={isStory}>
-      <Header
-        origin={origin}
-        isStory={isStory}
-        title={`TOP 10 U${age} ${genderLabel} IN ${stateName}`}
-        subtitle={`Rankings as of ${dateStr}`}
-      />
-      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: isStory ? 12 : 8 }}>
+      <Header origin={origin} isStory={isStory} title={title} subtitle={`Rankings as of ${dateStr}`} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: isStory ? 12 : 8, ...(fluid ? {} : { flex: 1 }) }}>
         {teams.map((team, i) => (
           <RankRow
             key={i}
@@ -115,6 +126,7 @@ export async function GET(request: Request) {
             teamName={team.team_name.toUpperCase()}
             club={team.club_name}
             isStory={isStory}
+            fluid={fluid}
           >
             <StatBlock
               value={formatRecord(team.wins, team.losses, team.draws)}
@@ -135,6 +147,6 @@ export async function GET(request: Request) {
       </div>
       <Footer isStory={isStory} />
     </Frame>,
-    { width: d.width, height: d.height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
+    { width, height, fonts, headers: { 'Cache-Control': INFOGRAPHIC_CACHE_CONTROL } }
   );
 }


### PR DESCRIPTION
The state **Top-10** and **Big Games** Instagram images used fixed-height flex layouts (`flex: 1` rows in a 1080×1080 square) with no single-line constraint on team names. A long name wraps to two lines and overflows its equal-height slot — throwing the rank/stat columns out of vertical alignment on the Top-10 (team #5 in the NC U16 Boys post) and **clipping the bottom matchup** on Big Games (the World Class FC row).

## Fix
Rather than truncating or shrinking, the Instagram canvas now **sizes to its content**:
- Rows size to their own height (1 or 2 lines, vertically centered) instead of an equal-height fill.
- The image grows from square toward Instagram's 4:5 portrait cap (**1080×1350**) only when names need the room.
- Names are capped at two lines so a pathological value can't grow unbounded.
- Gated behind a `fluid` flag set only for `platform=instagram` — **story, twitter, movers, and spotlight are unchanged**.

Verified by rendering the NC U16 Boys Top-10 and a long-name Big Games payload on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)