### PR TITLE
fix(rankings): keep scroll position when changing filters

### DIFF
--- a/frontend/components/RankingsFilter.tsx
+++ b/frontend/components/RankingsFilter.tsx
@@ -117,7 +117,9 @@ export function RankingsFilter({ onFilterChange }: RankingsFilterProps) {
     isNavigatingRef.current = true;
     targetPathRef.current = targetPath;
 
-    router.replace(targetPath);
+    // scroll: false keeps the user's scroll position on the filter card.
+    // Without it, App Router jumps to the top of the page on every filter change.
+    router.replace(targetPath, { scroll: false });
   }, [region, ageGroup, gender, router, pathname, onFilterChange]);
 
   return (


### PR DESCRIPTION
Changing the region, age group, or gender dropdown called `router.replace()` with no options, so App Router scrolled to the top of the page on every selection. Since the filter card sits below the H1, intro copy, and cohort SEO modules, each change bounced the user back to the top and forced them to scroll down again to pick the next filter.

Passing `{ scroll: false }` keeps the scroll position parked on the filter card while the route, table data, and SEO content still refresh. Mirrors the existing `DateRangePicker.tsx` pattern.
