### PR TITLE
fix(rankings): case-insensitive gender match in evidence-gate frozen ref (Step 1.1)

### DIFF
--- a/src/rankings/calculator.py
+++ b/src/rankings/calculator.py
@@ -734,7 +734,7 @@ def _compute_same_age_evidence_metrics(
                     ref is not None
                     and cohort_age is not None
                     and _parse_age_number(ref["age_group"]) == cohort_age
-                    and str(ref["gender"]) == str(gender)
+                    and str(ref["gender"]).lower() == str(gender).lower()
                 ):
                     rank_map[opp_id] = int(ref["rank"])
                     frozen_used += 1

--- a/tests/unit/test_same_age_evidence_gates.py
+++ b/tests/unit/test_same_age_evidence_gates.py
@@ -214,9 +214,11 @@ def test_compute_same_age_evidence_metrics_freezes_opponent_rank_keeps_live_powe
 
     # B's prior published rank (150) drops it out of the top 100; C is absent from the
     # snapshot and falls back to its current-run rank, which is still top 100.
+    # The frozen ref mirrors real ranking_history: lowercase "male" gender (vs the
+    # teams' "Male") must still match — the cohort comparison is case-insensitive.
     frozen = (
         _compute_same_age_evidence_metrics(
-            games_used, teams, frozen_rank_lookup={"B": {"age_group": "u12", "gender": "Male", "rank": 150}}
+            games_used, teams, frozen_rank_lookup={"B": {"age_group": "u12", "gender": "male", "rank": 150}}
         )
         .set_index("team_id")
         .loc["A"]


### PR DESCRIPTION
Follow-up to #913. **The merged Step 1 flag is effectively non-functional until this lands.**

## Bug

The Step 1 cohort match (#913) compares **gender** with an exact `str==str`, but the two sides use different case:

| source | gender | age_group |
|---|---|---|
| `ranking_history` (frozen source) | `male` (lowercase) | `u12` |
| `teams` / `rankings_full` → `teams_combined` | `Male` (capitalized) | `u12` |

So every team fails the gender check → **~0% frozen-rank coverage** → `EVIDENCE_GATE_FROZEN_REF=true` would be a **complete silent no-op** (falls back to live ranks for everyone). This is exactly the "silent near-zero coverage" failure mode the review on #912 warned about — age was normalized via `_parse_age_number`, but gender was left case-sensitive.

## Fix

One line: compare gender case-insensitively (`.lower()` both sides), mirroring the age normalization.

## Evidence (real data, read-only probe)

Sampled 4,000 current Active teams, matched against the prior snapshot (~7d back):

```
in prior snapshot:                 3935/4000 (98.4%)
COVERAGE with fix (.lower):        3935/4000 (98.4%)   ← flag now works
COVERAGE as-merged (exact ==):        0/4000 ( 0.0%)   ← silent no-op
```

## Scope / safety

- 1-line code change + test update (the test now mirrors real lowercase `male` data, so it's a regression test for this bug).
- Flag default stays `False`; no behavior change in production until enabled.
- Full unit suite green (1646 passed) + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)