### PR TITLE
feat(outreach): contact-list build pipeline (scrape, enrich, verify, gate)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ beautifulsoup4>=4.12.0
 lxml>=4.9.0
 scrapy>=2.13.0  # For Modular11 scraper
 twisted>=25.0.0  # Required by Scrapy
+pyyaml>=6.0  # For outreach_scraper YAML source configs
 
 # Stripe billing reconciliation
 stripe>=8.0.0

--- a/scrapers/outreach_scraper/outreach_scraper/items.py
+++ b/scrapers/outreach_scraper/outreach_scraper/items.py
@@ -1,0 +1,21 @@
+"""
+Scrapy Item definition for the outreach_scraper project.
+
+Fields map 1:1 to the outreach_targets table. ``contact`` is nullable until
+the enrichment step (Hunter) resolves an email; ``link_url`` carries the public
+source page and ``personalization.state`` carries the state, so there are no
+top-level source_url/state fields.
+"""
+
+import scrapy
+
+
+class OutreachTargetItem(scrapy.Item):
+    """One scraped outreach target (an org/role inbox), pre-enrichment."""
+
+    segment = scrapy.Field()  # "associations" | "clubs" | "media" | "bloggers"
+    org = scrapy.Field()
+    contact = scrapy.Field()  # role inbox email, or None until enriched
+    source_domain = scrapy.Field()  # the org's domain — Hunter input + dedupe key
+    link_url = scrapy.Field()  # the public page the contact was found on
+    personalization = scrapy.Field()  # dict: state, league_mix, a team/standing signal

--- a/scrapers/outreach_scraper/outreach_scraper/pipelines.py
+++ b/scrapers/outreach_scraper/outreach_scraper/pipelines.py
@@ -1,0 +1,149 @@
+"""
+Supabase sink pipeline for the outreach_scraper project.
+
+Replaces modular11_scraper's CSV pipeline. Writes scraped targets to the
+outreach_targets table as status='queued', verification_status='unverified',
+with Python-side dedupe on (segment, source_domain, org) plus a lower(contact)
+guard. The uq_outreach_targets_contact partial unique index is the DB safety net
+behind the in-memory email set. Runs are sequential, so this is race-free
+without DB-level claim machinery.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from scrapy import Spider
+
+from outreach_scraper.items import OutreachTargetItem
+from supabase import create_client
+
+logger = logging.getLogger(__name__)
+
+TABLE = "outreach_targets"
+INSERT_BATCH_SIZE = 100
+SELECT_PAGE_SIZE = 1000
+
+
+def _load_repo_env():
+    # pipelines.py -> outreach_scraper/ -> outreach_scraper/ -> scrapers/ -> repo root
+    repo_root = Path(__file__).resolve().parents[3]
+    load_dotenv(repo_root / ".env.local")
+    load_dotenv(repo_root / ".env")
+
+
+class OutreachSupabasePipeline:
+    """Dedupe scraped items and batch-insert new targets into outreach_targets."""
+
+    def __init__(self):
+        self.client = None
+        self.dry_run = False
+        self.seen_keys = set()  # (segment, source_domain, org)
+        self.seen_emails = set()  # lower(contact)
+        self.buffer = []
+        self.inserted = 0
+        self.skipped_dupes = 0
+
+    def open_spider(self, spider: Spider):
+        self.dry_run = bool(getattr(spider, "dry_run", False))
+
+        _load_repo_env()
+        url = os.getenv("SUPABASE_URL")
+        key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        if not url or not key:
+            raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set")
+        self.client = create_client(url, key)
+
+        self._load_dedupe_sets()
+        logger.info(
+            "OutreachSupabasePipeline open (dry_run=%s): %d existing keys, %d existing emails",
+            self.dry_run,
+            len(self.seen_keys),
+            len(self.seen_emails),
+        )
+
+    def _load_dedupe_sets(self):
+        offset = 0
+        while True:
+            res = (
+                self.client.table(TABLE)
+                .select("segment, source_domain, org, contact")
+                .order("id")
+                .range(offset, offset + SELECT_PAGE_SIZE - 1)
+                .execute()
+            )
+            rows = res.data or []
+            for row in rows:
+                self.seen_keys.add(self._dedupe_key(row))
+                if row.get("contact"):
+                    self.seen_emails.add(row["contact"].lower())
+            if len(rows) < SELECT_PAGE_SIZE:
+                break
+            offset += SELECT_PAGE_SIZE
+
+    @staticmethod
+    def _dedupe_key(row):
+        return (row.get("segment"), row.get("source_domain"), row.get("org"))
+
+    def process_item(self, item: OutreachTargetItem, spider: Spider) -> OutreachTargetItem:
+        key = self._dedupe_key(item)
+        email = (item.get("contact") or "").strip() or None
+
+        if key in self.seen_keys:
+            self.skipped_dupes += 1
+            return item
+        if email and email.lower() in self.seen_emails:
+            self.skipped_dupes += 1
+            return item
+
+        self.seen_keys.add(key)
+        if email:
+            self.seen_emails.add(email.lower())
+
+        self.buffer.append(
+            {
+                "segment": item.get("segment"),
+                "org": item.get("org"),
+                "contact": email,
+                "source_domain": item.get("source_domain"),
+                "link_url": item.get("link_url"),
+                "personalization": item.get("personalization") or {},
+                "status": "queued",
+                "verification_status": "unverified",
+            }
+        )
+        if len(self.buffer) >= INSERT_BATCH_SIZE:
+            self._flush()
+        return item
+
+    def close_spider(self, spider: Spider):
+        self._flush()
+        logger.info(
+            "OutreachSupabasePipeline closed: %d inserted, %d duplicates skipped",
+            self.inserted,
+            self.skipped_dupes,
+        )
+
+    def _flush(self):
+        if not self.buffer:
+            return
+        batch, self.buffer = self.buffer, []
+
+        if self.dry_run:
+            logger.info("[dry-run] would insert %d rows:", len(batch))
+            for row in batch:
+                logger.info(
+                    "[dry-run]   %s | %s | %s | contact=%s | %s",
+                    row["segment"],
+                    row["org"],
+                    row["source_domain"],
+                    row["contact"],
+                    row["personalization"],
+                )
+            return
+
+        # On failure, re-raise: a re-run reloads dedupe sets from the DB and
+        # re-scrapes only the rows that never persisted, so nothing is lost.
+        self.client.table(TABLE).insert(batch).execute()
+        self.inserted += len(batch)

--- a/scrapers/outreach_scraper/outreach_scraper/settings.py
+++ b/scrapers/outreach_scraper/outreach_scraper/settings.py
@@ -1,0 +1,49 @@
+"""
+Scrapy settings for outreach_scraper project.
+
+Contact-harvesting spiders for the authority/backlink program. Forked from
+modular11_scraper, with two deliberate differences:
+- ROBOTSTXT_OBEY is True (modular11 disables it for API access). This project
+  scrapes publicly-listed org/role inboxes and honors robots.txt.
+- The item pipeline writes to Supabase instead of CSV.
+"""
+
+BOT_NAME = "outreach_scraper"
+
+SPIDER_MODULES = ["outreach_scraper.spiders"]
+NEWSPIDER_MODULE = "outreach_scraper.spiders"
+
+# Identify the crawler honestly; this is outreach research, not stealth scraping.
+USER_AGENT = "PitchRankOutreachBot/1.0 (+https://pitchrank.io; outreach@pitchrank.io)"
+
+# Honor robots.txt — the compliance posture for harvesting public contact pages.
+ROBOTSTXT_OBEY = True
+
+# Be a polite guest on small club/association servers.
+CONCURRENT_REQUESTS = 4
+CONCURRENT_REQUESTS_PER_DOMAIN = 1
+DOWNLOAD_DELAY = 1.0
+COOKIES_ENABLED = False
+
+ITEM_PIPELINES = {
+    "outreach_scraper.pipelines.OutreachSupabasePipeline": 300,
+}
+
+FEED_EXPORT_ENCODING = "utf-8"
+LOG_LEVEL = "INFO"
+
+RETRY_ENABLED = True
+RETRY_TIMES = 3
+RETRY_HTTP_CODES = [500, 502, 503, 504, 408, 429]
+
+DOWNLOAD_TIMEOUT = 30
+
+AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_START_DELAY = 1.0
+AUTOTHROTTLE_MAX_DELAY = 10
+AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+
+REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"
+
+# Required for Windows compatibility (matches modular11_scraper).
+TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"

--- a/scrapers/outreach_scraper/outreach_scraper/spiders/associations.py
+++ b/scrapers/outreach_scraper/outreach_scraper/spiders/associations.py
@@ -1,0 +1,6 @@
+from outreach_scraper.spiders.base import OutreachSpider
+
+
+class AssociationsSpider(OutreachSpider):
+    name = "associations"
+    segment = "associations"

--- a/scrapers/outreach_scraper/outreach_scraper/spiders/base.py
+++ b/scrapers/outreach_scraper/outreach_scraper/spiders/base.py
@@ -1,0 +1,132 @@
+"""
+Config-driven base spider for outreach contact harvesting.
+
+Each segment spider loads ``sources/<segment>.yaml`` and, per listed site,
+fetches the page (directly, or through ZenRows when ``fetch: zenrows``),
+extracts publicly-listed role inboxes, and yields one OutreachTargetItem per
+contact (or a single contactless item when no email is public, leaving the
+email for the Hunter enrichment step). Keeping the site list in YAML lets one
+generic spider cover dozens of heterogeneous sites without bespoke code.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import scrapy
+import yaml
+
+from outreach_scraper.items import OutreachTargetItem
+from outreach_scraper.zenrows import zenrows_url
+
+logger = logging.getLogger(__name__)
+
+SOURCES_DIR = Path(__file__).resolve().parents[2] / "sources"
+
+# Publicly-listed role inboxes we are willing to harvest (never personal addresses).
+ROLE_INBOX_PREFIXES = (
+    "info",
+    "contact",
+    "hello",
+    "office",
+    "admin",
+    "doc",
+    "coaching",
+    "director",
+    "registrar",
+    "media",
+    "press",
+    "editor",
+    "editorial",
+    "news",
+    "tips",
+)
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+class OutreachSpider(scrapy.Spider):
+    """Loads a segment's YAML source list and harvests role inboxes."""
+
+    segment = None  # set by each subclass
+
+    def __init__(self, dry_run=False, sources=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dry_run = dry_run if isinstance(dry_run, bool) else str(dry_run).lower() in ("1", "true", "yes")
+        self.sources_path = Path(sources) if sources else SOURCES_DIR / f"{self.segment}.yaml"
+        self.sites = self._load_sites()
+
+    def _load_sites(self):
+        with open(self.sources_path, encoding="utf-8") as fh:
+            config = yaml.safe_load(fh) or {}
+        sites = config.get("sites") or []
+        logger.info("Loaded %d sources for '%s' from %s", len(sites), self.segment, self.sources_path)
+        return sites
+
+    async def start(self):
+        for site in self.sites:
+            target_url = site["start_url"]
+            if site.get("fetch") == "zenrows":
+                request_url = zenrows_url(target_url, js_render=bool(site.get("js_render", False)))
+            else:
+                request_url = target_url
+            yield scrapy.Request(request_url, callback=self.parse, meta={"site": site}, dont_filter=True)
+
+    def parse(self, response):
+        site = response.meta["site"]
+        personalization = dict(site.get("personalization") or {})
+        emails = self._extract_emails(response, site)
+
+        if not emails:
+            yield self._build_item(site, None, personalization)
+            return
+        for email in emails:
+            yield self._build_item(site, email, personalization)
+
+    def _extract_emails(self, response, site):
+        selector = (site.get("selectors") or {}).get("email")
+        if selector:
+            # An explicit selector means the operator targeted this address, so
+            # trust it (a masthead may publish an editor on a different domain).
+            candidates = list(response.css(selector).getall())
+            restrict_domain = None
+        else:
+            # The default heuristic scans the whole page, so restrict harvested
+            # addresses to the site's own domain — otherwise a third party's
+            # role inbox in the footer would be stored under the wrong org.
+            candidates = response.css("a[href^='mailto:']::attr(href)").getall()
+            candidates += EMAIL_RE.findall(response.text)
+            restrict_domain = (site.get("source_domain") or "").lower()
+
+        emails = []
+        seen = set()
+        for raw in candidates:
+            email = raw.replace("mailto:", "").split("?", 1)[0].strip().lower()
+            if not EMAIL_RE.fullmatch(email) or not self._is_role_inbox(email):
+                continue
+            if restrict_domain and not self._domain_matches(email, restrict_domain):
+                continue
+            if email not in seen:
+                seen.add(email)
+                emails.append(email)
+        return emails
+
+    @staticmethod
+    def _is_role_inbox(email):
+        local = email.split("@", 1)[0]
+        return any(local.startswith(prefix) for prefix in ROLE_INBOX_PREFIXES)
+
+    @staticmethod
+    def _domain_matches(email, domain):
+        email_domain = email.split("@", 1)[1]
+        return email_domain == domain or email_domain.endswith("." + domain)
+
+    def _build_item(self, site, email, personalization):
+        item = OutreachTargetItem()
+        item["segment"] = self.segment
+        item["org"] = site["org"]
+        item["contact"] = email
+        item["source_domain"] = site["source_domain"]
+        item["link_url"] = site["start_url"]
+        item["personalization"] = personalization
+        return item

--- a/scrapers/outreach_scraper/outreach_scraper/spiders/bloggers.py
+++ b/scrapers/outreach_scraper/outreach_scraper/spiders/bloggers.py
@@ -1,0 +1,6 @@
+from outreach_scraper.spiders.base import OutreachSpider
+
+
+class BloggersSpider(OutreachSpider):
+    name = "bloggers"
+    segment = "bloggers"

--- a/scrapers/outreach_scraper/outreach_scraper/spiders/clubs.py
+++ b/scrapers/outreach_scraper/outreach_scraper/spiders/clubs.py
@@ -1,0 +1,6 @@
+from outreach_scraper.spiders.base import OutreachSpider
+
+
+class ClubsSpider(OutreachSpider):
+    name = "clubs"
+    segment = "clubs"

--- a/scrapers/outreach_scraper/outreach_scraper/spiders/media.py
+++ b/scrapers/outreach_scraper/outreach_scraper/spiders/media.py
@@ -1,0 +1,6 @@
+from outreach_scraper.spiders.base import OutreachSpider
+
+
+class MediaSpider(OutreachSpider):
+    name = "media"
+    segment = "media"

--- a/scrapers/outreach_scraper/outreach_scraper/zenrows.py
+++ b/scrapers/outreach_scraper/outreach_scraper/zenrows.py
@@ -1,0 +1,51 @@
+"""
+Local ZenRows helper for the outreach_scraper project.
+
+Models the request shape used by ``src/scrapers/gotsport.py`` (apikey, url,
+js_render, premium_proxy, proxy_country) but is kept local here on purpose:
+gotsport.py has several ZenRows callers with intentionally different
+timeout/CAPTCHA handling, so this is a copy of the shape, not a shared import.
+
+Most outreach source pages are lightweight association/media sites that can be
+fetched directly (Scrapy with ROBOTSTXT_OBEY honors the target's robots.txt).
+Route a source through ZenRows only when it is behind anti-bot protection — note
+that proxying changes the request host, so robots.txt is then evaluated against
+the proxy, not the target. Reserve ``fetch: zenrows`` for sites you have
+confirmed are publicly listed and permit harvesting.
+"""
+
+import os
+from urllib.parse import urlencode
+
+import requests
+
+ZENROWS_ENDPOINT = "https://api.zenrows.com/v1/"
+
+
+def _zenrows_params(target_url, *, js_render=False, premium_proxy=None, proxy_country="us"):
+    api_key = os.getenv("ZENROWS_API_KEY")
+    if not api_key:
+        raise RuntimeError("ZENROWS_API_KEY is not set — required for fetch: zenrows sources")
+    # premium_proxy=true uses residential IPs (~25x datacenter cost); default
+    # follows the ZENROWS_PREMIUM_PROXY convention used by gotsport.py.
+    if premium_proxy is None:
+        premium_proxy = os.getenv("ZENROWS_PREMIUM_PROXY", "true").lower() == "true"
+    return {
+        "apikey": api_key,
+        "url": target_url,
+        "js_render": "true" if js_render else "false",
+        "premium_proxy": "true" if premium_proxy else "false",
+        "proxy_country": proxy_country,
+    }
+
+
+def zenrows_url(target_url, **kwargs) -> str:
+    """Build the proxied ZenRows URL so a Scrapy Request can fetch through it."""
+    return f"{ZENROWS_ENDPOINT}?{urlencode(_zenrows_params(target_url, **kwargs))}"
+
+
+def make_zenrows_request(target_url, *, session=None, timeout=30, **kwargs) -> requests.Response:
+    """GET ``target_url`` through the ZenRows proxy (for non-Scrapy callers)."""
+    params = _zenrows_params(target_url, **kwargs)
+    getter = session or requests
+    return getter.get(ZENROWS_ENDPOINT, params=params, timeout=timeout)

--- a/scrapers/outreach_scraper/scrapy.cfg
+++ b/scrapers/outreach_scraper/scrapy.cfg
@@ -1,0 +1,10 @@
+# Scrapy settings for outreach_scraper project
+#
+# Contact-harvesting spiders for the backlink/AI-citation authority program.
+# Forked from modular11_scraper; the CSV sink is replaced by a Supabase sink.
+
+[settings]
+default = outreach_scraper.settings
+
+[deploy]
+project = outreach_scraper

--- a/scrapers/outreach_scraper/sources/associations.yaml
+++ b/scrapers/outreach_scraper/sources/associations.yaml
@@ -1,0 +1,84 @@
+# Outreach sources: state/national youth soccer ASSOCIATIONS.
+#
+# Schema (per site):
+#   org:            organization name (used in dedupe + personalization)
+#   source_domain:  the org's domain (Hunter enrichment input + dedupe key)
+#   start_url:      public page to harvest (footer/contact pages list role inboxes)
+#   fetch:          "direct" (default) or "zenrows" for anti-bot-protected sites
+#   selectors:      optional CSS overrides, e.g. {email: "a.contact-email::attr(href)"}
+#   personalization: tokens for templating (state, league_mix, a standing signal)
+#
+# NOTE: verify domains/start_urls before a live run. The verification gate
+# (NeverBounce) is the backstop, but a wrong start_url just yields no contact.
+segment: associations
+sites:
+  - org: "Arizona Soccer Association"
+    source_domain: "arizonasoccer.org"
+    start_url: "https://www.arizonasoccer.org/"
+    personalization:
+      state: "AZ"
+  - org: "Cal North (California Youth Soccer Association, North)"
+    source_domain: "calnorth.org"
+    start_url: "https://www.calnorth.org/"
+    personalization:
+      state: "CA"
+  - org: "Cal South (California State Soccer Association, South)"
+    source_domain: "calsouth.com"
+    start_url: "https://www.calsouth.com/"
+    personalization:
+      state: "CA"
+  - org: "North Texas Soccer"
+    source_domain: "ntxsoccer.org"
+    start_url: "https://www.ntxsoccer.org/"
+    personalization:
+      state: "TX"
+  - org: "South Texas Youth Soccer Association"
+    source_domain: "stxsoccer.org"
+    start_url: "https://www.stxsoccer.org/"
+    personalization:
+      state: "TX"
+  - org: "Georgia Soccer"
+    source_domain: "georgiasoccer.org"
+    start_url: "https://www.georgiasoccer.org/"
+    personalization:
+      state: "GA"
+  - org: "Florida Youth Soccer Association"
+    source_domain: "fysa.com"
+    start_url: "https://www.fysa.com/"
+    personalization:
+      state: "FL"
+  - org: "Washington Youth Soccer"
+    source_domain: "washingtonyouthsoccer.org"
+    start_url: "https://www.washingtonyouthsoccer.org/"
+    personalization:
+      state: "WA"
+  - org: "Oregon Youth Soccer Association"
+    source_domain: "oregonyouthsoccer.org"
+    start_url: "https://www.oregonyouthsoccer.org/"
+    personalization:
+      state: "OR"
+  - org: "Colorado Soccer Association"
+    source_domain: "coloradosoccer.org"
+    start_url: "https://www.coloradosoccer.org/"
+    personalization:
+      state: "CO"
+  - org: "Michigan Youth Soccer Association"
+    source_domain: "michiganyouthsoccer.org"
+    start_url: "https://www.michiganyouthsoccer.org/"
+    personalization:
+      state: "MI"
+  - org: "Illinois Youth Soccer Association"
+    source_domain: "illinoisyouthsoccer.org"
+    start_url: "https://www.illinoisyouthsoccer.org/"
+    personalization:
+      state: "IL"
+  - org: "Virginia Youth Soccer Association"
+    source_domain: "vysa.com"
+    start_url: "https://www.vysa.com/"
+    personalization:
+      state: "VA"
+  - org: "US Club Soccer"
+    source_domain: "usclubsoccer.org"
+    start_url: "https://www.usclubsoccer.org/"
+    personalization:
+      state: "US"

--- a/scrapers/outreach_scraper/sources/bloggers.yaml
+++ b/scrapers/outreach_scraper/sources/bloggers.yaml
@@ -1,0 +1,12 @@
+# Outreach sources: independent BLOGGERS / desks covering youth soccer.
+# Schema documented in associations.yaml.
+#
+# Bloggers are added as relevant desks are identified (e.g. SB Nation team
+# desks covering academy/youth pipelines). Seed real targets below.
+segment: bloggers
+sites: []
+  # - org: "Example Soccer Blog"
+  #   source_domain: "exampleblog.com"
+  #   start_url: "https://www.exampleblog.com/about"
+  #   personalization:
+  #     beat: "academy & youth development"

--- a/scrapers/outreach_scraper/sources/clubs.yaml
+++ b/scrapers/outreach_scraper/sources/clubs.yaml
@@ -1,0 +1,14 @@
+# Outreach sources: youth soccer CLUBS.
+# Schema documented in associations.yaml.
+#
+# Club targets are best generated from the top-ranked clubs in rankings_full
+# (high-authority, relevance-aligned) rather than hand-listed. Seed real clubs
+# here as they are confirmed; the example below shows the expected shape.
+segment: clubs
+sites: []
+  # - org: "Example SC"
+  #   source_domain: "examplesc.org"
+  #   start_url: "https://www.examplesc.org/contact"
+  #   personalization:
+  #     state: "AZ"
+  #     league_mix: "ECNL / MLS NEXT"

--- a/scrapers/outreach_scraper/sources/media.yaml
+++ b/scrapers/outreach_scraper/sources/media.yaml
@@ -1,0 +1,19 @@
+# Outreach sources: youth-soccer MEDIA / mastheads.
+# Schema documented in associations.yaml. Target editorial/tips role inboxes.
+segment: media
+sites:
+  - org: "SoccerWire"
+    source_domain: "soccerwire.com"
+    start_url: "https://www.soccerwire.com/contact-us/"
+    personalization:
+      beat: "youth & club soccer"
+  - org: "TopDrawerSoccer"
+    source_domain: "topdrawersoccer.com"
+    start_url: "https://www.topdrawersoccer.com/contact/"
+    personalization:
+      beat: "youth & college soccer recruiting"
+  - org: "Soccer America"
+    source_domain: "socceramerica.com"
+    start_url: "https://www.socceramerica.com/contact"
+    personalization:
+      beat: "American soccer news"

--- a/scripts/build_outreach_list.py
+++ b/scripts/build_outreach_list.py
@@ -48,6 +48,24 @@ def segment_counts(client, segment):
     return counts
 
 
+def queued_slice_ids(client, segment, limit):
+    """The first ``limit`` queued rows for a segment, ordered for determinism.
+
+    Enrich and verify share this slice so a capped run advances the same rows
+    through both stages.
+    """
+    res = (
+        client.table(TABLE)
+        .select("id")
+        .eq("segment", segment)
+        .eq("status", "queued")
+        .order("id")
+        .limit(limit)
+        .execute()
+    )
+    return [row["id"] for row in (res.data or [])]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build the outreach target list for one segment.")
     parser.add_argument("--segment", required=True, choices=SEGMENTS)
@@ -60,10 +78,16 @@ def main():
         logger.info("dry-run: scrape only, skipping enrichment and verification")
         return
 
-    enrich_stats = enrich.enrich_queued(limit=args.limit, segment=args.segment)
-    gate_summary = verify.verify_and_gate(segment=args.segment, limit=args.limit)
+    client = get_client()
+    if args.limit:
+        slice_ids = queued_slice_ids(client, args.segment, args.limit)
+        enrich_stats = enrich.enrich_queued(client=client, ids=slice_ids)
+        gate_summary = verify.verify_and_gate(client=client, ids=slice_ids)
+    else:
+        enrich_stats = enrich.enrich_queued(client=client, segment=args.segment)
+        gate_summary = verify.verify_and_gate(client=client, segment=args.segment)
 
-    counts = segment_counts(get_client(), args.segment)
+    counts = segment_counts(client, args.segment)
     logger.info("=" * 60)
     logger.info("Segment: %s", args.segment)
     logger.info("Enrichment: %s", enrich_stats)

--- a/scripts/build_outreach_list.py
+++ b/scripts/build_outreach_list.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Build the outreach target list for one segment: scrape -> enrich -> verify+gate.
+
+Idempotent and resumable via the status fields — a crashed run is recovered by
+re-running (enrichment skips rows that already have a contact, verification
+skips rows that already have a verification_status, and the gate finalizes once
+the slice is fully verified). Run one segment at a time, sequentially; there is
+no lease/heartbeat/reaper because the pipeline is solo and sequential.
+"""
+
+import argparse
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(REPO_ROOT / ".env.local")
+load_dotenv(REPO_ROOT / ".env")
+
+from src.outreach import enrich, verify  # noqa: E402
+from src.outreach._db import TABLE, get_client  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("build_outreach_list")
+
+SEGMENTS = ("associations", "clubs", "media", "bloggers")
+SCRAPER_DIR = REPO_ROOT / "scrapers" / "outreach_scraper"
+
+
+def run_spider(segment, dry_run):
+    cmd = [sys.executable, "-m", "scrapy", "crawl", segment, "-a", f"dry_run={'1' if dry_run else '0'}"]
+    logger.info("Running spider: %s (cwd=%s)", " ".join(cmd), SCRAPER_DIR)
+    result = subprocess.run(cmd, cwd=SCRAPER_DIR)
+    if result.returncode != 0:
+        raise SystemExit(f"spider '{segment}' exited with code {result.returncode}")
+
+
+def segment_counts(client, segment):
+    rows = client.table(TABLE).select("status").eq("segment", segment).execute().data or []
+    counts = {}
+    for row in rows:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+    return counts
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build the outreach target list for one segment.")
+    parser.add_argument("--segment", required=True, choices=SEGMENTS)
+    parser.add_argument("--limit", type=int, default=None, help="Cap rows enriched/verified this run")
+    parser.add_argument("--dry-run", action="store_true", help="Scrape only; no DB writes, no enrich/verify")
+    args = parser.parse_args()
+
+    run_spider(args.segment, args.dry_run)
+    if args.dry_run:
+        logger.info("dry-run: scrape only, skipping enrichment and verification")
+        return
+
+    enrich_stats = enrich.enrich_queued(limit=args.limit, segment=args.segment)
+    gate_summary = verify.verify_and_gate(segment=args.segment, limit=args.limit)
+
+    counts = segment_counts(get_client(), args.segment)
+    logger.info("=" * 60)
+    logger.info("Segment: %s", args.segment)
+    logger.info("Enrichment: %s", enrich_stats)
+    logger.info("Gate: %s", gate_summary)
+    logger.info("Status counts: %s", counts)
+    logger.info("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/outreach/__init__.py
+++ b/src/outreach/__init__.py
@@ -1,0 +1,1 @@
+"""Outreach list-build pipeline: enrichment and verification of outreach_targets."""

--- a/src/outreach/_db.py
+++ b/src/outreach/_db.py
@@ -1,0 +1,30 @@
+"""Shared Supabase client + env loading for the outreach pipeline modules.
+
+Mirrors the script convention (inline ``load_dotenv(.env.local)`` then ``.env``
+from the repo root, then ``create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)``).
+The service-role key is required: outreach_targets is RLS service-role-only.
+"""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from supabase import create_client
+
+TABLE = "outreach_targets"
+
+
+def _load_repo_env():
+    repo_root = Path(__file__).resolve().parents[2]  # src/outreach/_db.py -> repo root
+    load_dotenv(repo_root / ".env.local")
+    load_dotenv(repo_root / ".env")
+
+
+def get_client():
+    _load_repo_env()
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set")
+    return create_client(url, key)

--- a/src/outreach/enrich.py
+++ b/src/outreach/enrich.py
@@ -32,15 +32,15 @@ def _hunter_key():
 
 
 def _pick_domain_email(emails):
-    """Prefer a generic/role inbox, highest Hunter confidence first."""
-    if not emails:
+    """Pick the highest-confidence generic/role inbox; skip personal addresses.
+
+    Outreach is scoped to publicly-listed role inboxes, so a domain search that
+    returns only personal addresses yields no contact (left for manual review).
+    """
+    generic = [e for e in emails if e.get("type") == "generic"]
+    if not generic:
         return None
-    ranked = sorted(
-        emails,
-        key=lambda e: (e.get("type") == "generic", e.get("confidence") or 0),
-        reverse=True,
-    )
-    return ranked[0]
+    return max(generic, key=lambda e: e.get("confidence") or 0)
 
 
 def find_email(source_domain, full_name=None):
@@ -92,12 +92,13 @@ def merge_confidence(personalization, confidence):
     return merged
 
 
-def enrich_queued(limit=None, client=None, segment=None):
+def enrich_queued(limit=None, client=None, segment=None, ids=None):
     """Find and write emails for queued rows missing a contact.
 
-    When ``segment`` is given, only that segment is enriched, so a ``limit`` is
-    spent on the segment the caller asked for (matching ``verify_and_gate``'s
-    scoping) rather than starving it with other segments' rows.
+    ``segment`` scopes to one segment. ``ids`` restricts to an explicit set of
+    rows so a capped run enriches and verifies the *same* slice (the runner
+    passes a shared slice for ``--limit``), rather than each stage taking its
+    own arbitrary slice.
     """
     client = client or get_client()
     query = (
@@ -105,6 +106,8 @@ def enrich_queued(limit=None, client=None, segment=None):
     )
     if segment:
         query = query.eq("segment", segment)
+    if ids is not None:
+        query = query.in_("id", ids)
     if limit:
         query = query.limit(limit)
     rows = query.execute().data or []

--- a/src/outreach/enrich.py
+++ b/src/outreach/enrich.py
@@ -1,0 +1,138 @@
+"""Email enrichment for queued outreach targets via Hunter.
+
+``enrich_queued`` resolves an email for each queued row missing a contact and
+writes it back, merging Hunter's confidence into ``personalization`` without
+clobbering scraped tokens (read-merge-write; safe because the runner is
+sequential). If writing the email hits the uq_outreach_targets_contact unique
+index (two orgs share a role inbox), that row is moved to ``held`` instead of
+crashing. Already-enriched rows have a contact and are skipped, so a re-run
+resumes cleanly.
+"""
+
+import logging
+import os
+
+import requests
+from postgrest.exceptions import APIError
+
+from src.outreach._db import TABLE, get_client
+from src.scrapers._http import retry_session_get
+
+logger = logging.getLogger(__name__)
+
+HUNTER_BASE = "https://api.hunter.io/v2"
+UNIQUE_VIOLATION = "23505"
+
+
+def _hunter_key():
+    key = os.getenv("HUNTER_API_KEY")
+    if not key:
+        raise RuntimeError("HUNTER_API_KEY is not set")
+    return key
+
+
+def _pick_domain_email(emails):
+    """Prefer a generic/role inbox, highest Hunter confidence first."""
+    if not emails:
+        return None
+    ranked = sorted(
+        emails,
+        key=lambda e: (e.get("type") == "generic", e.get("confidence") or 0),
+        reverse=True,
+    )
+    return ranked[0]
+
+
+def find_email(source_domain, full_name=None):
+    """Resolve an email for a domain. Returns ``(email|None, confidence)``.
+
+    Uses Hunter Email Finder when a name is known, else Domain Search for a role
+    inbox. ``confidence`` is Hunter's score (0-100).
+    """
+    key = _hunter_key()
+    session = requests.Session()
+
+    if full_name:
+        url = f"{HUNTER_BASE}/email-finder"
+        params = {"domain": source_domain, "full_name": full_name, "api_key": key}
+    else:
+        url = f"{HUNTER_BASE}/domain-search"
+        params = {"domain": source_domain, "api_key": key}
+
+    resp = retry_session_get(
+        session,
+        url,
+        attempts=4,
+        retry_delay=2.0,
+        baseline_bytes=None,
+        is_event_url=False,
+        provider="hunter",
+        params=params,
+        timeout=20,
+    )
+    resp.raise_for_status()
+    data = (resp.json() or {}).get("data") or {}
+
+    if full_name:
+        email, score = data.get("email"), data.get("score")
+    else:
+        chosen = _pick_domain_email(data.get("emails") or [])
+        email = chosen.get("value") if chosen else None
+        score = chosen.get("confidence") if chosen else None
+
+    if not email:
+        return None, 0.0
+    return email, float(score) if score is not None else 0.0
+
+
+def merge_confidence(personalization, confidence):
+    """Return personalization with ``enrich_confidence`` added, tokens preserved."""
+    merged = dict(personalization or {})
+    merged["enrich_confidence"] = confidence
+    return merged
+
+
+def enrich_queued(limit=None, client=None, segment=None):
+    """Find and write emails for queued rows missing a contact.
+
+    When ``segment`` is given, only that segment is enriched, so a ``limit`` is
+    spent on the segment the caller asked for (matching ``verify_and_gate``'s
+    scoping) rather than starving it with other segments' rows.
+    """
+    client = client or get_client()
+    query = (
+        client.table(TABLE).select("id, source_domain, personalization").eq("status", "queued").is_("contact", "null")
+    )
+    if segment:
+        query = query.eq("segment", segment)
+    if limit:
+        query = query.limit(limit)
+    rows = query.execute().data or []
+
+    stats = {"resolved": 0, "no_email": 0, "held_collision": 0}
+    for row in rows:
+        domain = row.get("source_domain")
+        if not domain:
+            stats["no_email"] += 1
+            continue
+
+        personalization = row.get("personalization") or {}
+        email, confidence = find_email(domain, full_name=personalization.get("contact_name"))
+        if not email:
+            stats["no_email"] += 1
+            continue
+
+        merged = merge_confidence(personalization, confidence)
+        try:
+            client.table(TABLE).update({"contact": email, "personalization": merged}).eq("id", row["id"]).execute()
+            stats["resolved"] += 1
+        except APIError as err:
+            if getattr(err, "code", None) == UNIQUE_VIOLATION:
+                client.table(TABLE).update({"status": "held"}).eq("id", row["id"]).execute()
+                stats["held_collision"] += 1
+                logger.info("held %s: email already tracked on another target", row["id"])
+            else:
+                raise
+
+    logger.info("enrich_queued: %s", stats)
+    return stats

--- a/src/outreach/verify.py
+++ b/src/outreach/verify.py
@@ -103,12 +103,19 @@ def decide_gate(rows, threshold=INVALID_RATE_THRESHOLD):
     }
 
 
-def verify_and_gate(*, segment=None, limit=None, client=None, threshold=INVALID_RATE_THRESHOLD):
-    """Verify a slice of queued rows and apply the invalid-rate gate."""
+def verify_and_gate(*, segment=None, limit=None, client=None, ids=None, threshold=INVALID_RATE_THRESHOLD):
+    """Verify a slice of queued rows and apply the invalid-rate gate.
+
+    ``ids`` restricts the slice to an explicit set of rows so a capped run gates
+    exactly the rows enrichment just processed (the runner passes a shared slice
+    for ``--limit``), so no un-enriched row is held as "no-email" prematurely.
+    """
     client = client or get_client()
     query = client.table(TABLE).select("id, contact, verification_status").eq("status", "queued")
     if segment:
         query = query.eq("segment", segment)
+    if ids is not None:
+        query = query.in_("id", ids)
     if limit:
         query = query.limit(limit)
     rows = query.execute().data or []

--- a/src/outreach/verify.py
+++ b/src/outreach/verify.py
@@ -1,0 +1,155 @@
+"""Address verification + the per-slice invalid-rate gate via NeverBounce.
+
+``verify_and_gate`` verifies the still-unverified rows in a slice (resumable:
+already-verified rows are skipped so a crashed run never re-charges
+NeverBounce), then gates on the hard-invalid fraction. A clean slice promotes
+``valid`` rows to ``verified`` and holds the rest; a dirty slice (> threshold)
+holds the whole slice and promotes nothing. ``held`` is terminal for the
+automated pipeline, so bad rows never loop.
+"""
+
+import logging
+import os
+
+import requests
+
+from src.outreach._db import TABLE, get_client
+from src.scrapers._http import retry_session_get
+
+logger = logging.getLogger(__name__)
+
+NEVERBOUNCE_SINGLE = "https://api.neverbounce.com/v4/single/check"
+INVALID_RATE_THRESHOLD = 0.03  # ~2-3% hard-invalid tolerance before holding the slice
+
+# NeverBounce result -> our verification_status
+NEVERBOUNCE_RESULT_MAP = {
+    "valid": "valid",
+    "invalid": "invalid",
+    "disposable": "invalid",
+    "catchall": "risky",
+    "unknown": "risky",
+}
+VERIFIED_STATUSES = ("valid", "invalid", "risky")
+
+
+def _neverbounce_key():
+    key = os.getenv("NEVERBOUNCE_API_KEY")
+    if not key:
+        raise RuntimeError("NEVERBOUNCE_API_KEY is not set")
+    return key
+
+
+def _map_result(result):
+    return NEVERBOUNCE_RESULT_MAP.get(result, "risky")
+
+
+def verify_email(email):
+    """Return a verification_status (valid|invalid|risky) for an address."""
+    key = _neverbounce_key()
+    session = requests.Session()
+    resp = retry_session_get(
+        session,
+        NEVERBOUNCE_SINGLE,
+        attempts=4,
+        retry_delay=2.0,
+        baseline_bytes=None,
+        is_event_url=False,
+        provider="neverbounce",
+        params={"key": key, "email": email},
+        timeout=20,
+    )
+    resp.raise_for_status()
+    body = resp.json() or {}
+    # NeverBounce signals auth/credit/throttle failures with HTTP 200 + a
+    # non-"success" status (and no result). Fail loudly so a bad key doesn't
+    # silently mark every address "risky" and hold the whole slice.
+    if body.get("status") != "success":
+        raise RuntimeError(f"NeverBounce check failed: status={body.get('status')!r} message={body.get('message')!r}")
+    return _map_result(body.get("result", "unknown"))
+
+
+def decide_gate(rows, threshold=INVALID_RATE_THRESHOLD):
+    """Pure gate decision over already-verified rows.
+
+    ``rows`` carry ``id`` and ``verification_status``. Returns the promote/hold
+    id lists, the hard-invalid fraction (over rows with a verification result),
+    and the gate outcome. The denominator is rows that actually have a result,
+    so no-email/unverified rows neither dilute nor block the rate.
+    """
+    verified = [r for r in rows if r.get("verification_status") in VERIFIED_STATUSES]
+    invalid_count = sum(1 for r in verified if r["verification_status"] == "invalid")
+    invalid_fraction = (invalid_count / len(verified)) if verified else None
+
+    if not verified or invalid_fraction > threshold:
+        return {
+            "gate": "held_slice",
+            "promote_ids": [],
+            "hold_ids": [r["id"] for r in rows],
+            "invalid_fraction": invalid_fraction,
+            "verified_count": len(verified),
+            "slice_size": len(rows),
+        }
+
+    promote_ids = [r["id"] for r in verified if r["verification_status"] == "valid"]
+    promote_set = set(promote_ids)
+    hold_ids = [r["id"] for r in rows if r["id"] not in promote_set]
+    return {
+        "gate": "passed",
+        "promote_ids": promote_ids,
+        "hold_ids": hold_ids,
+        "invalid_fraction": invalid_fraction,
+        "verified_count": len(verified),
+        "slice_size": len(rows),
+    }
+
+
+def verify_and_gate(*, segment=None, limit=None, client=None, threshold=INVALID_RATE_THRESHOLD):
+    """Verify a slice of queued rows and apply the invalid-rate gate."""
+    client = client or get_client()
+    query = client.table(TABLE).select("id, contact, verification_status").eq("status", "queued")
+    if segment:
+        query = query.eq("segment", segment)
+    if limit:
+        query = query.limit(limit)
+    rows = query.execute().data or []
+
+    if not rows:
+        return {
+            "gate": "noop",
+            "slice_size": 0,
+            "verified_count": 0,
+            "invalid_fraction": None,
+            "promoted": 0,
+            "held": 0,
+        }
+
+    for row in rows:
+        if row.get("verification_status") in VERIFIED_STATUSES:
+            continue
+        email = row.get("contact")
+        if not email:
+            continue
+        status = verify_email(email)
+        client.table(TABLE).update({"verification_status": status}).eq("id", row["id"]).execute()
+        row["verification_status"] = status
+
+    decision = decide_gate(rows, threshold=threshold)
+    _bulk_set_status(client, decision["promote_ids"], "verified")
+    _bulk_set_status(client, decision["hold_ids"], "held")
+
+    summary = {
+        "gate": decision["gate"],
+        "slice_size": decision["slice_size"],
+        "verified_count": decision["verified_count"],
+        "invalid_fraction": decision["invalid_fraction"],
+        "promoted": len(decision["promote_ids"]),
+        "held": len(decision["hold_ids"]),
+    }
+    logger.info("verify_and_gate: %s", summary)
+    return summary
+
+
+def _bulk_set_status(client, ids, status):
+    if not ids:
+        return
+    client.table(TABLE).update({"status": status}).in_("id", ids).execute()

--- a/supabase/migrations/20260615235417_extend_outreach_targets_for_list_build.sql
+++ b/supabase/migrations/20260615235417_extend_outreach_targets_for_list_build.sql
@@ -1,0 +1,22 @@
+-- Extend outreach_targets for the list-build pipeline: enrichment input,
+-- personalization tokens for templating, and a dedupe safety net on contact.
+
+ALTER TABLE outreach_targets
+  ADD COLUMN IF NOT EXISTS source_domain TEXT;
+
+ALTER TABLE outreach_targets
+  ADD COLUMN IF NOT EXISTS personalization JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- DB safety net guaranteeing no two targets share an email. Primary dedupe is
+-- Python-side on (segment, source_domain, org); this partial unique index backstops it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_outreach_targets_contact
+  ON outreach_targets (lower(contact)) WHERE contact IS NOT NULL;
+
+COMMENT ON COLUMN outreach_targets.status IS
+    'Pipeline stage (no CHECK by convention). List build: queued -> verified | held (held = invalid/catch-all/no-email/gate-failed; terminal for the automated pipeline). After verified, outreach follows: sent -> replied -> linked | declined. The verified stage means the contact passed the address-verification gate; the verifier result itself is in verification_status.';
+
+COMMENT ON COLUMN outreach_targets.source_domain IS
+    'The org''s web domain: Hunter enrichment input and part of the Python-side dedupe key (segment, source_domain, org).';
+
+COMMENT ON COLUMN outreach_targets.personalization IS
+    'Scraped tokens for outreach templating (e.g. state, league_mix, a team/standing signal) plus enrichment metadata such as enrich_confidence. Defaults to {}.';

--- a/tests/unit/test_outreach_enrich.py
+++ b/tests/unit/test_outreach_enrich.py
@@ -1,0 +1,219 @@
+"""Unit tests for outreach enrichment: merge, email pick, collision -> held, resumability."""
+
+from postgrest.exceptions import APIError
+
+from src.outreach import enrich
+
+
+def test_merge_confidence_preserves_tokens_and_does_not_mutate():
+    personalization = {"state": "AZ", "league_mix": "ECNL"}
+    merged = enrich.merge_confidence(personalization, 87.0)
+    assert merged == {"state": "AZ", "league_mix": "ECNL", "enrich_confidence": 87.0}
+    assert personalization == {"state": "AZ", "league_mix": "ECNL"}
+
+
+def test_pick_domain_email_prefers_generic_then_confidence():
+    emails = [
+        {"value": "coach@x.org", "type": "personal", "confidence": 90},
+        {"value": "info@x.org", "type": "generic", "confidence": 70},
+        {"value": "contact@x.org", "type": "generic", "confidence": 85},
+    ]
+    assert enrich._pick_domain_email(emails)["value"] == "contact@x.org"
+    assert enrich._pick_domain_email([]) is None
+
+
+# --- Minimal Supabase client fake (only the chains enrich_queued uses) ---
+
+
+class _Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Select:
+    def __init__(self, table):
+        self.table = table
+        self._limit = None
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def is_(self, *a, **k):
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def execute(self):
+        rows = [dict(r) for r in self.table.rows if r.get("status") == "queued" and r.get("contact") is None]
+        if self._limit:
+            rows = rows[: self._limit]
+        return _Result(rows)
+
+
+class _Update:
+    def __init__(self, table, values):
+        self.table = table
+        self.values = values
+        self._flt = None
+
+    def eq(self, col, val):
+        self._flt = (col, val)
+        return self
+
+    def execute(self):
+        self.table.apply_update(self.values, self._flt)
+        return _Result([])
+
+
+class _Table:
+    def __init__(self, rows, taken_emails=()):
+        self.rows = rows
+        self.taken = {e.lower() for e in taken_emails}
+
+    def select(self, *a, **k):
+        return _Select(self)
+
+    def update(self, values):
+        return _Update(self, values)
+
+    def apply_update(self, values, flt):
+        col, val = flt
+        for row in self.rows:
+            if row.get(col) == val:
+                if "contact" in values and values["contact"].lower() in self.taken:
+                    raise APIError({"code": "23505", "message": "duplicate key", "details": "", "hint": None})
+                row.update(values)
+
+
+class _Client:
+    def __init__(self, table):
+        self._table = table
+
+    def table(self, _name):
+        return self._table
+
+
+def test_enrich_resolves_and_merges(monkeypatch):
+    rows = [
+        {"id": "a", "status": "queued", "contact": None, "source_domain": "az.org", "personalization": {"state": "AZ"}},
+        {"id": "b", "status": "queued", "contact": None, "source_domain": "ga.org", "personalization": {"state": "GA"}},
+    ]
+    client = _Client(_Table(rows))
+    monkeypatch.setattr(enrich, "find_email", lambda domain, full_name=None: (f"info@{domain}", 80.0))
+
+    stats = enrich.enrich_queued(client=client)
+
+    assert stats == {"resolved": 2, "no_email": 0, "held_collision": 0}
+    assert rows[0]["contact"] == "info@az.org"
+    assert rows[0]["personalization"] == {"state": "AZ", "enrich_confidence": 80.0}
+
+
+def test_enrich_collision_sends_row_to_held(monkeypatch):
+    rows = [
+        {"id": "a", "status": "queued", "contact": None, "source_domain": "az.org", "personalization": {}},
+    ]
+    client = _Client(_Table(rows, taken_emails=["info@az.org"]))
+    monkeypatch.setattr(enrich, "find_email", lambda domain, full_name=None: ("info@az.org", 75.0))
+
+    stats = enrich.enrich_queued(client=client)
+
+    assert stats == {"resolved": 0, "no_email": 0, "held_collision": 1}
+    assert rows[0]["status"] == "held"
+    assert rows[0]["contact"] is None
+
+
+def test_enrich_skips_already_enriched_rows(monkeypatch):
+    rows = [
+        {"id": "a", "status": "queued", "contact": "info@az.org", "source_domain": "az.org", "personalization": {}},
+    ]
+    client = _Client(_Table(rows))
+
+    def _boom(*a, **k):
+        raise AssertionError("find_email should not be called for already-enriched rows")
+
+    monkeypatch.setattr(enrich, "find_email", _boom)
+
+    stats = enrich.enrich_queued(client=client)
+
+    assert stats == {"resolved": 0, "no_email": 0, "held_collision": 0}
+
+
+def test_enrich_no_source_domain_counts_no_email(monkeypatch):
+    rows = [{"id": "a", "status": "queued", "contact": None, "source_domain": None, "personalization": {}}]
+    client = _Client(_Table(rows))
+
+    def _boom(*a, **k):
+        raise AssertionError("find_email should not be called when source_domain is missing")
+
+    monkeypatch.setattr(enrich, "find_email", _boom)
+
+    stats = enrich.enrich_queued(client=client)
+
+    assert stats == {"resolved": 0, "no_email": 1, "held_collision": 0}
+    assert rows[0]["status"] == "queued" and rows[0]["contact"] is None
+
+
+def test_enrich_find_email_none_counts_no_email(monkeypatch):
+    rows = [
+        {"id": "a", "status": "queued", "contact": None, "source_domain": "az.org", "personalization": {"state": "AZ"}}
+    ]
+    client = _Client(_Table(rows))
+    monkeypatch.setattr(enrich, "find_email", lambda domain, full_name=None: (None, 0.0))
+
+    stats = enrich.enrich_queued(client=client)
+
+    assert stats == {"resolved": 0, "no_email": 1, "held_collision": 0}
+    assert rows[0]["status"] == "queued" and rows[0]["contact"] is None
+
+
+# --- find_email response parsing (monkeypatch the HTTP call, no network) ---
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_find_email_domain_search_picks_best_generic(monkeypatch):
+    monkeypatch.setenv("HUNTER_API_KEY", "x")
+    payload = {
+        "data": {
+            "emails": [
+                {"value": "info@az.org", "type": "generic", "confidence": 70},
+                {"value": "contact@az.org", "type": "generic", "confidence": 90},
+            ]
+        }
+    }
+    monkeypatch.setattr(enrich, "retry_session_get", lambda *a, **k: _FakeResp(payload))
+    assert enrich.find_email("az.org") == ("contact@az.org", 90.0)
+
+
+def test_find_email_name_branch_uses_email_finder(monkeypatch):
+    monkeypatch.setenv("HUNTER_API_KEY", "x")
+    payload = {"data": {"email": "jane@az.org", "score": 88}}
+    monkeypatch.setattr(enrich, "retry_session_get", lambda *a, **k: _FakeResp(payload))
+    assert enrich.find_email("az.org", full_name="Jane Doe") == ("jane@az.org", 88.0)
+
+
+def test_find_email_score_zero_is_kept(monkeypatch):
+    monkeypatch.setenv("HUNTER_API_KEY", "x")
+    payload = {"data": {"email": "info@az.org", "score": 0}}
+    monkeypatch.setattr(enrich, "retry_session_get", lambda *a, **k: _FakeResp(payload))
+    assert enrich.find_email("az.org", full_name="Jane Doe") == ("info@az.org", 0.0)
+
+
+def test_find_email_empty_data_returns_none(monkeypatch):
+    monkeypatch.setenv("HUNTER_API_KEY", "x")
+    monkeypatch.setattr(enrich, "retry_session_get", lambda *a, **k: _FakeResp({"data": {}}))
+    assert enrich.find_email("az.org") == (None, 0.0)

--- a/tests/unit/test_outreach_enrich.py
+++ b/tests/unit/test_outreach_enrich.py
@@ -22,6 +22,11 @@ def test_pick_domain_email_prefers_generic_then_confidence():
     assert enrich._pick_domain_email([]) is None
 
 
+def test_pick_domain_email_skips_personal_only():
+    personal = [{"value": "coach@x.org", "type": "personal", "confidence": 95}]
+    assert enrich._pick_domain_email(personal) is None
+
+
 # --- Minimal Supabase client fake (only the chains enrich_queued uses) ---
 
 
@@ -34,6 +39,7 @@ class _Select:
     def __init__(self, table):
         self.table = table
         self._limit = None
+        self._ids = None
 
     def select(self, *a, **k):
         return self
@@ -44,12 +50,22 @@ class _Select:
     def is_(self, *a, **k):
         return self
 
+    def in_(self, col, vals):
+        if col == "id":
+            self._ids = set(vals)
+        return self
+
+    def order(self, *a, **k):
+        return self
+
     def limit(self, n):
         self._limit = n
         return self
 
     def execute(self):
         rows = [dict(r) for r in self.table.rows if r.get("status") == "queued" and r.get("contact") is None]
+        if self._ids is not None:
+            rows = [r for r in rows if r.get("id") in self._ids]
         if self._limit:
             rows = rows[: self._limit]
         return _Result(rows)
@@ -141,6 +157,21 @@ def test_enrich_skips_already_enriched_rows(monkeypatch):
     stats = enrich.enrich_queued(client=client)
 
     assert stats == {"resolved": 0, "no_email": 0, "held_collision": 0}
+
+
+def test_enrich_queued_ids_restricts_to_slice(monkeypatch):
+    rows = [
+        {"id": "a", "status": "queued", "contact": None, "source_domain": "a.org", "personalization": {}},
+        {"id": "b", "status": "queued", "contact": None, "source_domain": "b.org", "personalization": {}},
+    ]
+    client = _Client(_Table(rows))
+    monkeypatch.setattr(enrich, "find_email", lambda domain, full_name=None: (f"info@{domain}", 70.0))
+
+    stats = enrich.enrich_queued(client=client, ids=["a"])
+
+    assert stats == {"resolved": 1, "no_email": 0, "held_collision": 0}
+    assert rows[0]["contact"] == "info@a.org"  # in slice -> enriched
+    assert rows[1]["contact"] is None  # outside slice -> untouched
 
 
 def test_enrich_no_source_domain_counts_no_email(monkeypatch):

--- a/tests/unit/test_outreach_spider.py
+++ b/tests/unit/test_outreach_spider.py
@@ -3,7 +3,14 @@
 import sys
 from pathlib import Path
 
-from scrapy.http import HtmlResponse
+import pytest
+
+# The Scrapy project and its YAML configs are heavy deps that live outside src/;
+# skip cleanly (rather than abort the whole suite) where they aren't installed.
+pytest.importorskip("scrapy")
+pytest.importorskip("yaml")
+
+from scrapy.http import HtmlResponse  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRAPER_DIR = REPO_ROOT / "scrapers" / "outreach_scraper"

--- a/tests/unit/test_outreach_spider.py
+++ b/tests/unit/test_outreach_spider.py
@@ -1,0 +1,138 @@
+"""Unit tests for the outreach spider's email extraction + role-inbox filter."""
+
+import sys
+from pathlib import Path
+
+from scrapy.http import HtmlResponse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRAPER_DIR = REPO_ROOT / "scrapers" / "outreach_scraper"
+if str(SCRAPER_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRAPER_DIR))
+
+from outreach_scraper.items import OutreachTargetItem  # noqa: E402
+from outreach_scraper.pipelines import OutreachSupabasePipeline  # noqa: E402
+from outreach_scraper.spiders.associations import AssociationsSpider  # noqa: E402
+
+
+def _spider():
+    return AssociationsSpider(sources=str(SCRAPER_DIR / "sources" / "associations.yaml"))
+
+
+def _response(html, url="https://example.org/contact"):
+    return HtmlResponse(url=url, body=html.encode("utf-8"), encoding="utf-8")
+
+
+def test_loads_seed_sources():
+    spider = _spider()
+    assert len(spider.sites) >= 10
+    assert all("source_domain" in site for site in spider.sites)
+
+
+def test_is_role_inbox_keeps_role_drops_personal():
+    spider = _spider()
+    assert spider._is_role_inbox("info@x.org")
+    assert spider._is_role_inbox("contact@x.org")
+    assert spider._is_role_inbox("director@x.org")
+    assert not spider._is_role_inbox("jane.doe@x.org")
+    assert not spider._is_role_inbox("john@x.org")
+
+
+def test_extract_emails_filters_to_role_inboxes():
+    html = """
+      <a href="mailto:info@az.org">Email us</a>
+      <a href="mailto:jane.smith@az.org">Jane</a>
+      <p>reach press@az.org for media inquiries</p>
+    """
+    spider = _spider()
+    site = {"org": "x", "source_domain": "az.org", "start_url": "u"}
+    emails = spider._extract_emails(_response(html), site)
+    assert "info@az.org" in emails
+    assert "press@az.org" in emails
+    assert "jane.smith@az.org" not in emails
+
+
+def test_build_item_maps_table_fields():
+    spider = _spider()
+    site = {"org": "X Assoc", "source_domain": "x.org", "start_url": "https://x.org/contact"}
+    item = spider._build_item(site, "info@x.org", {"state": "AZ"})
+    assert item["segment"] == "associations"
+    assert item["org"] == "X Assoc"
+    assert item["contact"] == "info@x.org"
+    assert item["source_domain"] == "x.org"
+    assert item["link_url"] == "https://x.org/contact"
+    assert item["personalization"] == {"state": "AZ"}
+
+
+def test_default_branch_filters_off_domain_emails():
+    html = '<a href="mailto:info@vendor.com">x</a><a href="mailto:info@az.org">y</a>'
+    spider = _spider()
+    site = {"org": "x", "source_domain": "az.org", "start_url": "u"}
+    emails = spider._extract_emails(_response(html), site)
+    assert "info@az.org" in emails
+    assert "info@vendor.com" not in emails  # third-party role inbox dropped
+
+
+def test_default_branch_keeps_subdomain_email():
+    html = '<a href="mailto:info@mail.az.org">x</a>'
+    spider = _spider()
+    site = {"org": "x", "source_domain": "az.org", "start_url": "u"}
+    assert spider._extract_emails(_response(html), site) == ["info@mail.az.org"]
+
+
+def test_selector_override_bypasses_domain_filter():
+    html = '<a class="c" href="mailto:info@thirdparty.com">x</a>'
+    spider = _spider()
+    site = {"org": "x", "source_domain": "az.org", "start_url": "u", "selectors": {"email": "a.c::attr(href)"}}
+    assert spider._extract_emails(_response(html), site) == ["info@thirdparty.com"]
+
+
+def test_no_role_email_returns_empty():
+    html = '<a href="mailto:jane.doe@az.org">x</a><p>just prose, no inbox</p>'
+    spider = _spider()
+    site = {"org": "x", "source_domain": "az.org", "start_url": "u"}
+    assert spider._extract_emails(_response(html), site) == []
+
+
+# --- Pipeline in-memory dedupe (no DB) ---
+
+
+class _StubSpider:
+    pass
+
+
+def _item(segment="associations", org="X", source_domain="x.org", contact=None):
+    item = OutreachTargetItem()
+    item["segment"] = segment
+    item["org"] = org
+    item["contact"] = contact
+    item["source_domain"] = source_domain
+    item["link_url"] = "u"
+    item["personalization"] = {}
+    return item
+
+
+def test_pipeline_dedupes_by_key_and_by_email():
+    pipeline = OutreachSupabasePipeline()
+    spider = _StubSpider()
+
+    pipeline.process_item(_item(contact="info@x.org"), spider)
+    assert len(pipeline.buffer) == 1 and pipeline.skipped_dupes == 0
+
+    # Same (segment, source_domain, org) -> skipped.
+    pipeline.process_item(_item(contact="other@x.org"), spider)
+    assert len(pipeline.buffer) == 1 and pipeline.skipped_dupes == 1
+
+    # Different org, same email (case-insensitive) -> skipped by the email set.
+    pipeline.process_item(_item(org="Y", source_domain="y.org", contact="INFO@x.org"), spider)
+    assert len(pipeline.buffer) == 1 and pipeline.skipped_dupes == 2
+
+    # New key and new email -> buffered.
+    pipeline.process_item(_item(org="Z", source_domain="z.org", contact="hi@z.org"), spider)
+    assert len(pipeline.buffer) == 2
+
+
+def test_pipeline_blank_contact_normalized_to_none():
+    pipeline = OutreachSupabasePipeline()
+    pipeline.process_item(_item(contact="   "), _StubSpider())
+    assert pipeline.buffer[0]["contact"] is None

--- a/tests/unit/test_outreach_verify.py
+++ b/tests/unit/test_outreach_verify.py
@@ -1,0 +1,101 @@
+"""Unit tests for the outreach verification result mapping and invalid-rate gate."""
+
+import pytest
+
+from src.outreach import verify
+from src.outreach.verify import _map_result, decide_gate
+
+
+def _rows(*statuses):
+    return [{"id": i, "verification_status": s} for i, s in enumerate(statuses)]
+
+
+def test_map_result_covers_neverbounce_results():
+    assert _map_result("valid") == "valid"
+    assert _map_result("invalid") == "invalid"
+    assert _map_result("disposable") == "invalid"
+    assert _map_result("catchall") == "risky"
+    assert _map_result("unknown") == "risky"
+    assert _map_result("brand_new_result") == "risky"  # unmapped vendor result -> risky
+
+
+def test_clean_slice_promotes_valid_holds_risky_and_no_email():
+    rows = _rows("valid", "valid", "risky", None)  # None = no-email / unverified
+    decision = decide_gate(rows, threshold=0.03)
+    assert decision["gate"] == "passed"
+    assert set(decision["promote_ids"]) == {0, 1}
+    assert set(decision["hold_ids"]) == {2, 3}
+    assert decision["invalid_fraction"] == 0.0  # 0 invalid / 3 verified
+
+
+def test_dirty_slice_holds_everything():
+    rows = _rows("valid", "valid", "invalid")  # 1/3 = 33% > 3%
+    decision = decide_gate(rows, threshold=0.03)
+    assert decision["gate"] == "held_slice"
+    assert decision["promote_ids"] == []
+    assert set(decision["hold_ids"]) == {0, 1, 2}
+
+
+def test_denominator_is_rows_actually_verified():
+    # 10 verified rows, 1 invalid -> 10%, not diluted by anything else.
+    rows = _rows(*(["valid"] * 9 + ["invalid"]))
+    decision = decide_gate(rows, threshold=0.03)
+    assert decision["verified_count"] == 10
+    assert decision["invalid_fraction"] == 0.1
+    assert decision["gate"] == "held_slice"
+
+
+def test_threshold_boundary_promotes():
+    # Exactly at threshold: 1/100 = 1% <= 3% -> promote the valids.
+    rows = _rows(*(["valid"] * 99 + ["invalid"]))
+    decision = decide_gate(rows, threshold=0.03)
+    assert decision["gate"] == "passed"
+    assert len(decision["promote_ids"]) == 99
+    assert decision["hold_ids"] == [99]
+
+
+def test_all_no_email_holds_all_without_divide_by_zero():
+    rows = _rows(None, None, None)
+    decision = decide_gate(rows, threshold=0.03)
+    assert decision["invalid_fraction"] is None
+    assert decision["promote_ids"] == []
+    assert set(decision["hold_ids"]) == {0, 1, 2}
+
+
+# --- verify_email status guard (monkeypatch the HTTP call, no network) ---
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_verify_email_raises_on_non_success_status(monkeypatch):
+    monkeypatch.setenv("NEVERBOUNCE_API_KEY", "x")
+    monkeypatch.setattr(
+        verify, "retry_session_get", lambda *a, **k: _FakeResp({"status": "auth_failure", "message": "bad key"})
+    )
+    with pytest.raises(RuntimeError):
+        verify.verify_email("a@b.com")
+
+
+def test_verify_email_maps_result_on_success(monkeypatch):
+    monkeypatch.setenv("NEVERBOUNCE_API_KEY", "x")
+    monkeypatch.setattr(
+        verify, "retry_session_get", lambda *a, **k: _FakeResp({"status": "success", "result": "valid"})
+    )
+    assert verify.verify_email("a@b.com") == "valid"
+
+
+def test_verify_email_maps_catchall_to_risky(monkeypatch):
+    monkeypatch.setenv("NEVERBOUNCE_API_KEY", "x")
+    monkeypatch.setattr(
+        verify, "retry_session_get", lambda *a, **k: _FakeResp({"status": "success", "result": "catchall"})
+    )
+    assert verify.verify_email("a@b.com") == "risky"


### PR DESCRIPTION
Adds the contact-list build pipeline for the backlink/AI-citation authority program. It scrapes candidate orgs, enriches missing emails, verifies deliverability, and gates the results into `outreach_targets`. This builds and qualifies the list only; sending happens later, from a separate domain.

**Pipeline**
- `scrapers/outreach_scraper/`: Scrapy project with config-driven per-segment spiders (each reads `sources/<segment>.yaml`) and a Supabase sink that dedupes on `(segment, source_domain, org)`. Honors robots.txt; a local ZenRows helper is available for protected sources.
- `src/outreach/enrich.py`: Hunter email finding, restricted to public role/generic inboxes.
- `src/outreach/verify.py`: NeverBounce verification plus a per-slice gate that holds the whole slice if the hard-invalid rate exceeds ~3%, so a bad batch cannot burn the sending domain.
- `scripts/build_outreach_list.py`: CLI (`--segment`, `--limit`, `--dry-run`) chaining spider, enrich, verify+gate. `--limit` advances one shared slice through both stages.

**Schema**

`supabase/migrations/20260615235417_extend_outreach_targets_for_list_build.sql` adds `source_domain`, a `personalization` JSONB column, and a partial unique index `uq_outreach_targets_contact` on `lower(contact)`. Already applied to the project.

**Lifecycle**

```mermaid
stateDiagram-v2
  [*] --> queued: scraped
  queued --> verified: enriched + passes the verify gate
  queued --> held: no email, risky, or gate failed
  verified --> [*]
  held --> [*]
```

Covered by 32 unit tests (gate math, enrichment merge/collision/slice, dedupe, spider extraction). Validated live on the associations segment: 3 verified role inboxes, no premature holds. `outreach_targets` stays RLS service-role-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
