### PR TITLE
feat(scrape): re-enqueue recently-active teams to catch in-tournament games

### DIFF
--- a/.github/workflows/enqueue-active-teams.yml
+++ b/.github/workflows/enqueue-active-teams.yml
@@ -1,0 +1,67 @@
+name: Enqueue Active Teams
+run-name: >-
+  Enqueue active teams · ${{
+    inputs.dry_run == true && 'DRY RUN' || 'live'
+  }}
+
+on:
+  schedule:
+    # 10:00 UTC daily — ~3h after the 07:00 yesterday-game enqueue so its
+    # enqueue + 15-min drain cycle has cleared first. GH Actions cron is
+    # UTC-only, so this drifts ±1h with DST.
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: log targets without enqueueing'
+        required: false
+        type: boolean
+        default: false
+      limit:
+        description: 'Max teams to enqueue (blank = 2000)'
+        required: false
+        type: string
+        default: ''
+      window_days:
+        description: 'Count a team active if it played within this many days (blank = 3)'
+        required: false
+        type: string
+        default: ''
+      cooldown_hours:
+        description: 'Skip teams scraped within this many hours (blank = 20)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: enqueue-active-teams
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DRY_RUN_FLAG: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+      LIMIT_FLAG: ${{ inputs.limit != '' && format('--limit {0}', inputs.limit) || '' }}
+      WINDOW_FLAG: ${{ inputs.window_days != '' && format('--window-days {0}', inputs.window_days) || '' }}
+      COOLDOWN_FLAG: ${{ inputs.cooldown_hours != '' && format('--cooldown-hours {0}', inputs.cooldown_hours) || '' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install supabase python-dotenv
+
+      - name: Enqueue active teams
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${PWD}"
+          python scripts/enqueue_active_teams.py $DRY_RUN_FLAG $LIMIT_FLAG $WINDOW_FLAG $COOLDOWN_FLAG

--- a/scripts/enqueue_active_teams.py
+++ b/scripts/enqueue_active_teams.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Active-teams enqueue: find GotSport teams that played in the last few days and
+re-enqueue them at priority 2 via the enqueue_scrape_request RPC (idempotent
+UPSERT-with-LEAST). Catches new games an actively-playing team accrues
+day-to-day — tournament bracket rounds, late-added fixtures — that the daily
+yesterday-game enqueue can't see (no in-DB fixture yet) and that discovery
+skips (team still has future games on record).
+
+Does NOT scrape. process_missing_games (every 15min, 200/run) drains.
+
+A per-team cooldown skips teams scraped within the last few hours so we don't
+waste scrape budget re-pulling a team we just scraped.
+
+Usage:
+    python scripts/enqueue_active_teams.py
+    python scripts/enqueue_active_teams.py --dry-run
+    python scripts/enqueue_active_teams.py --limit 500 --window-days 7 --cooldown-hours 24
+"""
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date
+
+# Windows SSL workaround. Optional — CI runners use the system trust store.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
+
+from dotenv import load_dotenv  # noqa: E402
+
+from supabase import create_client  # noqa: E402
+
+load_dotenv(".env.local")
+load_dotenv(".env")
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GOTSPORT_PROVIDER_CODE = "gotsport"
+PRIORITY_ACTIVE_TEAM = 2
+REQUEST_TYPE = "active_team"
+DEFAULT_LIMIT = 2000
+DEFAULT_WINDOW_DAYS = 3
+DEFAULT_COOLDOWN_HOURS = 20
+
+
+def get_gotsport_provider_id(supabase):
+    r = supabase.table("providers").select("id").eq("code", GOTSPORT_PROVIDER_CODE).single().execute()
+    if not r.data:
+        raise RuntimeError(f"Provider '{GOTSPORT_PROVIDER_CODE}' not found")
+    return r.data["id"]
+
+
+def find_teams_to_enqueue(
+    supabase,
+    gotsport_provider_id,
+    window_days=DEFAULT_WINDOW_DAYS,
+    cooldown_hours=DEFAULT_COOLDOWN_HOURS,
+    limit=DEFAULT_LIMIT,
+):
+    """GotSport teams active in the last window_days, scraped > cooldown_hours ago.
+    Uses find_recently_active_teams RPC."""
+    r = supabase.rpc(
+        "find_recently_active_teams",
+        {
+            "p_provider_id": gotsport_provider_id,
+            "p_active_window_days": window_days,
+            "p_cooldown_hours": cooldown_hours,
+            "p_row_limit": limit,
+        },
+    ).execute()
+    rows = r.data or []
+    seen = {}
+    for row in rows:
+        seen[row["team_id_master"]] = row
+    return list(seen.values())
+
+
+def enqueue_team(supabase, team_id_master, team_name, provider_id, provider_team_id):
+    """Call enqueue_scrape_request RPC at priority 2.
+
+    scrape_requests.game_date is NOT NULL, so we pass today's date as a placeholder.
+    The processor scrapes the team's full schedule (±90 days from this anchor), which
+    captures whatever new games the team has accrued. The RPC's UPDATE branch uses
+    COALESCE, so existing pending rows keep their original game_date when upserted.
+    """
+    return supabase.rpc(
+        "enqueue_scrape_request",
+        {
+            "p_team_id_master": team_id_master,
+            "p_team_name": team_name,
+            "p_provider_id": provider_id,
+            "p_provider_team_id": provider_team_id,
+            "p_game_date": date.today().isoformat(),
+            "p_request_type": REQUEST_TYPE,
+            "p_priority": PRIORITY_ACTIVE_TEAM,
+        },
+    ).execute()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Log targets without enqueueing")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_WINDOW_DAYS,
+        help="Count a team active if it played within this many days (default 3)",
+    )
+    parser.add_argument(
+        "--cooldown-hours",
+        type=int,
+        default=DEFAULT_COOLDOWN_HOURS,
+        help="Skip teams scraped within this many hours (default 20)",
+    )
+    args = parser.parse_args()
+
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        logger.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+        sys.exit(1)
+
+    supabase = create_client(url, key)
+    provider_id = get_gotsport_provider_id(supabase)
+
+    teams = find_teams_to_enqueue(
+        supabase,
+        provider_id,
+        window_days=args.window_days,
+        cooldown_hours=args.cooldown_hours,
+        limit=args.limit,
+    )
+    logger.info(
+        f"Active teams: {len(teams)} GotSport teams played in last {args.window_days}d "
+        f"and not scraped in last {args.cooldown_hours}h"
+    )
+
+    if args.dry_run:
+        for t in teams[:20]:
+            logger.info(f"  WOULD ENQUEUE: {t['team_id_master']} ({t.get('team_name', 'unknown')})")
+        logger.info(f"...({len(teams)} total)")
+        return
+
+    success, fail = 0, 0
+    for t in teams:
+        try:
+            enqueue_team(
+                supabase,
+                team_id_master=t["team_id_master"],
+                team_name=t.get("team_name"),
+                provider_id=provider_id,
+                provider_team_id=t.get("provider_team_id"),
+            )
+            success += 1
+        except Exception as e:
+            logger.warning(f"Failed to enqueue {t['team_id_master']}: {e}")
+            fail += 1
+
+    logger.info(f"Enqueued {success} teams at priority {PRIORITY_ACTIVE_TEAM}, {fail} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260622000000_find_recently_active_teams.sql
+++ b/supabase/migrations/20260622000000_find_recently_active_teams.sql
@@ -11,6 +11,10 @@
 -- than a teams-driven EXISTS, which times out at full team-table scale. The
 -- cooldown gate skips teams scraped very recently so we don't waste scrape budget.
 --
+-- Only past games count (game_date <= CURRENT_DATE): GotSport imports future
+-- scheduled fixtures, so without the upper bound any team with an upcoming game
+-- would qualify as "recently active" and crowd out teams that actually just played.
+--
 -- Filters mirror find_stale_teams: is_deprecated, GotSport provider, U8/U9 +
 -- U20+ age exclusions, 'unknown_*' placeholder exclusion. is_excluded games are
 -- ignored so excluded/futsal results don't count as activity (a deliberate
@@ -35,12 +39,14 @@ AS $$
         SELECT home_team_master_id AS master_id
         FROM games
         WHERE game_date >= CURRENT_DATE - make_interval(days => find_recently_active_teams.p_active_window_days)
+          AND game_date <= CURRENT_DATE
           AND is_excluded = false
           AND home_team_master_id IS NOT NULL
         UNION
         SELECT away_team_master_id AS master_id
         FROM games
         WHERE game_date >= CURRENT_DATE - make_interval(days => find_recently_active_teams.p_active_window_days)
+          AND game_date <= CURRENT_DATE
           AND is_excluded = false
           AND away_team_master_id IS NOT NULL
     )

--- a/supabase/migrations/20260622000000_find_recently_active_teams.sql
+++ b/supabase/migrations/20260622000000_find_recently_active_teams.sql
@@ -1,0 +1,68 @@
+-- RPC: find_recently_active_teams
+--
+-- Returns GotSport teams that played a game in the last p_active_window_days
+-- days and have NOT been scraped in the last p_cooldown_hours hours. Closes the
+-- gap where an actively-playing team's newly-created games (tournament bracket
+-- rounds, late-added fixtures) are re-queued by no other producer: the
+-- yesterday-game enqueue only sees games already in the DB, discovery only sees
+-- teams with no future games, and the safety net only fires at 90-day staleness.
+--
+-- Drives from games (games-first, like find_yesterday_null_score_teams) rather
+-- than a teams-driven EXISTS, which times out at full team-table scale. The
+-- cooldown gate skips teams scraped very recently so we don't waste scrape budget.
+--
+-- Filters mirror find_stale_teams: is_deprecated, GotSport provider, U8/U9 +
+-- U20+ age exclusions, 'unknown_*' placeholder exclusion. is_excluded games are
+-- ignored so excluded/futsal results don't count as activity (a deliberate
+-- addition the other finders don't have).
+--
+-- Ordering: oldest scraped first (NULLs first) so the row limit favors the teams
+-- most overdue for a re-scrape.
+--
+-- Used by scripts/enqueue_active_teams.py (priority 2).
+
+CREATE OR REPLACE FUNCTION find_recently_active_teams(
+    p_provider_id uuid,
+    p_active_window_days integer DEFAULT 3,
+    p_cooldown_hours integer DEFAULT 20,
+    p_row_limit integer DEFAULT 2000
+)
+RETURNS TABLE(team_id_master uuid, team_name text, provider_team_id text)
+LANGUAGE sql
+STABLE
+AS $$
+    WITH active_masters AS (
+        SELECT home_team_master_id AS master_id
+        FROM games
+        WHERE game_date >= CURRENT_DATE - make_interval(days => find_recently_active_teams.p_active_window_days)
+          AND is_excluded = false
+          AND home_team_master_id IS NOT NULL
+        UNION
+        SELECT away_team_master_id AS master_id
+        FROM games
+        WHERE game_date >= CURRENT_DATE - make_interval(days => find_recently_active_teams.p_active_window_days)
+          AND is_excluded = false
+          AND away_team_master_id IS NOT NULL
+    )
+    SELECT t.team_id_master, t.team_name, t.provider_team_id
+    FROM active_masters am
+    JOIN teams t ON t.team_id_master = am.master_id,
+         (SELECT EXTRACT(YEAR FROM NOW())::int AS yr) c
+    WHERE t.is_deprecated = false
+      AND t.provider_id = find_recently_active_teams.p_provider_id
+      AND (t.last_scraped_at IS NULL
+           OR t.last_scraped_at < NOW() - make_interval(hours => find_recently_active_teams.p_cooldown_hours))
+      -- Age filters: PitchRank supports U10-U19 only.
+      AND (t.age_group IS NULL OR UPPER(TRIM(t.age_group)) NOT IN ('U8','U-8','U9','U-9'))
+      AND (t.birth_year IS NULL OR t.birth_year NOT IN (c.yr - 21, c.yr - 20, c.yr - 9, c.yr - 8, c.yr - 7))
+      -- Placeholder unknown filter.
+      AND NOT (t.team_name = 'unknown_' || t.provider_team_id)
+    ORDER BY t.last_scraped_at ASC NULLS FIRST
+    LIMIT find_recently_active_teams.p_row_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION find_recently_active_teams(uuid, integer, integer, integer) TO authenticated, service_role;
+
+-- Forward-only refresh of the priority-ladder doc to register the new tier-2 producer.
+COMMENT ON COLUMN scrape_requests.priority IS
+  'Lower number = higher priority. 1=user-clicked, 2=daily yesterday-game + active-team, 3=discovery, 4=safety-net, 5=default';

--- a/tests/unit/test_enqueue_active_teams.py
+++ b/tests/unit/test_enqueue_active_teams.py
@@ -1,0 +1,77 @@
+"""Tests for the daily active-teams enqueue script."""
+
+import os
+import sys
+from datetime import date
+from unittest.mock import Mock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from scripts.enqueue_active_teams import (
+    DEFAULT_COOLDOWN_HOURS,
+    DEFAULT_LIMIT,
+    DEFAULT_WINDOW_DAYS,
+    PRIORITY_ACTIVE_TEAM,
+    enqueue_team,
+    find_teams_to_enqueue,
+)
+
+
+def test_priority_constant_is_2():
+    assert PRIORITY_ACTIVE_TEAM == 2
+
+
+def test_default_limit_is_2000():
+    assert DEFAULT_LIMIT == 2000
+
+
+def test_default_window_and_cooldown():
+    assert DEFAULT_WINDOW_DAYS == 3
+    assert DEFAULT_COOLDOWN_HOURS == 20
+
+
+def test_find_teams_to_enqueue_dedups_team_ids():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = [
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+        {"team_id_master": "t-2", "team_name": "B", "provider_team_id": "p-2"},
+        {"team_id_master": "t-1", "team_name": "A", "provider_team_id": "p-1"},
+    ]
+    teams = find_teams_to_enqueue(supabase, gotsport_provider_id="gp")
+    team_ids = [t["team_id_master"] for t in teams]
+    assert len(team_ids) == len(set(team_ids))
+
+
+def test_find_teams_passes_window_and_cooldown_params():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = []
+    find_teams_to_enqueue(supabase, gotsport_provider_id="gp", window_days=7, cooldown_hours=24, limit=500)
+    rpc_call = supabase.rpc.call_args
+    assert rpc_call.args[0] == "find_recently_active_teams"
+    payload = rpc_call.args[1]
+    assert payload["p_provider_id"] == "gp"
+    assert payload["p_active_window_days"] == 7
+    assert payload["p_cooldown_hours"] == 24
+    assert payload["p_row_limit"] == 500
+
+
+def test_enqueue_team_uses_priority_2_and_active_team_type():
+    supabase = Mock()
+    supabase.rpc.return_value.execute.return_value.data = "test-id"
+    enqueue_team(
+        supabase,
+        team_id_master="t-1",
+        team_name="Team A",
+        provider_id="gp",
+        provider_team_id="p-1",
+    )
+    rpc_call = supabase.rpc.call_args
+    assert rpc_call.args[0] == "enqueue_scrape_request"
+    payload = rpc_call.args[1]
+    assert payload["p_priority"] == 2
+    assert payload["p_request_type"] == "active_team"
+    assert payload["p_game_date"] == date.today().isoformat()
+    assert payload["p_team_id_master"] == "t-1"
+    assert payload["p_team_name"] == "Team A"
+    assert payload["p_provider_id"] == "gp"
+    assert payload["p_provider_team_id"] == "p-1"


### PR DESCRIPTION
## What

Adds a fourth automatic scrape-queue producer, `enqueue_active_teams`, that re-enqueues GotSport teams which played in the last few days but haven't been scraped recently, so newly-created games get picked up within a day.

## Why

None of the existing producers re-scrape a team that's actively playing to find games we don't have yet:

- `yesterday_game` only sees games already in our DB (NULL `home_score`).
- `discovery` only targets teams with no future games on record.
- `safety_net` only fires at 90 day staleness.

Tournament bracket games show up as rounds finish, so a team mid-tournament has no in-DB fixture to trip `yesterday_game`, isn't stale, and usually still has future games (so discovery skips it). It stays in a blind spot until someone clicks re-scrape. Real case: a team's Jun 19/20/21 SuperCopa games only landed in the DB on a manual Jun 22 re-scrape, about 3 days late.

## How

All four files mirror the existing `enqueue_*` producer trio.

- **`find_recently_active_teams` RPC**: games-first CTE (UNION home/away masters on `game_date`), join `teams`, gate on a per-team cooldown. Same shape as `find_yesterday_null_score_teams` (games-first, not a teams-driven EXISTS that times out at scale), same age/placeholder filters as `find_stale_teams`. Also refreshes the `scrape_requests.priority` ladder comment.
- **`enqueue_active_teams.py`**: priority 2, `request_type='active_team'`, defaults window 3 days / cooldown 20h / limit 2000, tunable via `--window-days` / `--cooldown-hours`. Enqueues through the idempotent `enqueue_scrape_request` RPC (LEAST priority promotion, one pending row per team), so overlap with the other producers is harmless.
- **`enqueue-active-teams.yml`**: daily at 10:00 UTC, plus `workflow_dispatch` (dry_run / limit / window_days / cooldown_hours).
- **`test_enqueue_active_teams.py`**: 6 unit tests, mirrors `test_enqueue_safety_net.py`.

Consumers are unchanged: `process_missing_games` (every 15 min) and the manual Help Clear Queue drain both consume the same queue.

## Verification

- Unit tests: 6/6.
- `EXPLAIN ANALYZE` on prod runs games-first (`idx_games_date_desc`), no timeout, and returns ~1,531 genuinely recently-played teams (well under the cap; future-dated fixtures are excluded via `game_date <= CURRENT_DATE`).
- Reviewed for correctness, security, API usage, consistency, and coverage. Nothing blocking.

## Before merge

The migration isn't auto-applied. Apply `supabase/migrations/20260622000000_find_recently_active_teams.sql` to prod (dashboard SQL editor) before or with the merge, otherwise the workflow's first run fails at the RPC call. Engine code is untouched.
